### PR TITLE
Refactor Bedrock Plugin Code

### DIFF
--- a/BedrockNode.cpp
+++ b/BedrockNode.cpp
@@ -90,7 +90,7 @@ bool BedrockNode::_peekCommand(SQLite& db, Command* command) {
     try {
         // Loop across the plugins to see which wants to take this
         bool pluginPeeked = false;
-        SFOREACH (list<BedrockPlugin*>, BedrockPlugin::g_registeredPluginList, pluginIt) {
+        SFOREACH (list<BedrockPlugin*>, *BedrockPlugin::g_registeredPluginList, pluginIt) {
             // See if it peeks this
             BedrockPlugin* plugin = *pluginIt;
             if (plugin->enabled() && plugin->peekCommand(this, db, command)) {
@@ -158,7 +158,7 @@ void BedrockNode::_processCommand(SQLite& db, Command* command) {
             // database.  This command is triggered only on the MASTER, and only
             // upon it step up in the MASTERING state.
             SINFO("Upgrading database");
-            for_each(BedrockPlugin::g_registeredPluginList.begin(), BedrockPlugin::g_registeredPluginList.end(),
+            for_each(BedrockPlugin::g_registeredPluginList->begin(), BedrockPlugin::g_registeredPluginList->end(),
                      [this, &db](BedrockPlugin* plugin) {
                          // See if it processes this
                          if (plugin->enabled()) {
@@ -170,7 +170,7 @@ void BedrockNode::_processCommand(SQLite& db, Command* command) {
             // --------------------------------------------------------------------------
             // Loop across the plugins to see which wants to take this
             bool pluginProcessed = false;
-            SFOREACH (list<BedrockPlugin*>, BedrockPlugin::g_registeredPluginList, pluginIt) {
+            SFOREACH (list<BedrockPlugin*>, *BedrockPlugin::g_registeredPluginList, pluginIt) {
                 // See if it processes this
                 BedrockPlugin* plugin = *pluginIt;
                 if (plugin->enabled() && plugin->processCommand(this, db, command)) {

--- a/BedrockNode.h
+++ b/BedrockNode.h
@@ -1,69 +1,15 @@
-// BedrockNode.h
-#ifndef _BEDROCKNODE_H
-#define _BEDROCKNODE_H
+#pragma once
 #include <sqlitecluster/SQLiteNode.h>
 
 class BedrockServer;
-
-/////////////////////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////////////////////
+class BedrockPlugin;
 struct BedrockTester; // Defined in BedrockTester.h, but can't include else circular
+
 class BedrockNode : public SQLiteNode {
   public:
     // Construct the base class
     BedrockNode(const SData& args, BedrockServer* server_);
     virtual ~BedrockNode();
-
-    // Simple plugin system to add functionality to a node at runtime
-    class Plugin {
-      public:
-        // --- Parent interface ---
-        Plugin();
-
-        // --- Child interface ---
-        // Returns a short, descriptive name of this plugin
-        virtual string getName() { SERROR("No name defined by this plugin, aborting."); }
-
-        // Initializes it with command-line arguments
-        virtual void initialize(const SData& args) {}
-
-        // Optionally updates the schema as necessary to support this plugin
-        virtual void upgradeDatabase(BedrockNode* node, SQLite& db) {}
-
-        // Optionally "peeks" at a command to process it in a read-only manner
-        virtual bool peekCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command) { return false; }
-
-        // Optionally "processes" a command in a read/write manner, triggering
-        // a distributed transaction if necessary
-        virtual bool processCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command) { return false; }
-
-        // Enable this plugin for active operation
-        virtual void enable(bool enabled) { _enabled = enabled; }
-        virtual bool enabled() { return _enabled; }
-
-        // Allow this node to do a self-test
-        virtual void test(BedrockTester* tester) {}
-
-        // The plugin can add as many of these as it needs in it's initialize function. The server will then add those
-        // to it's own global list. Note that this is the *only* time these can be added, once `initialize` completes,
-        // the server maintains a copy of this list. This also means that these managers need to live for the life of
-        // the application.
-        list<SHTTPSManager*> httpsManagers;
-
-        // The plugin can register any number of timers it wants. When any of them `ding`, then the `timerFired`
-        // function will be called, and passed the timer that is dinging.
-        set<SStopwatch*> timers;
-        virtual void timerFired(SStopwatch* timer) {}
-
-      protected:
-        // Attributes
-        bool _enabled;
-
-      public:
-        // Global static attributes
-        static list<Plugin*>* g_registeredPluginList;
-    };
 
     BedrockServer* server;
 
@@ -78,6 +24,3 @@ class BedrockNode : public SQLiteNode {
     virtual void _abortCommand(SQLite& db, Command* command);
     virtual void _cleanCommand(Command* command);
 };
-
-// BedrockNode.h
-#endif

--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -1,0 +1,44 @@
+#include <libstuff/libstuff.h>
+#include "BedrockPlugin.h"
+
+// Global static values
+list<BedrockPlugin*> BedrockPlugin::g_registeredPluginList;
+
+BedrockPlugin::BedrockPlugin() : _enabled(false) {
+    /* Auto-register this instance into the global static list. This just makes it available for enabling via the
+     * command line: by default all plugins start out disabled.
+     *
+     * NOTE: This code runs *before* main(). This means that libstuff hasn't yet been initialized, so there is no
+     * logging.
+     */
+    g_registeredPluginList.push_back(this);
+}
+
+void BedrockPlugin::verifyAttributeInt64(const SData& request, const string& name, size_t minSize) {
+    if (request[name].size() < minSize) {
+        throw "402 Missing " + name;
+    }
+    if (!request[name].empty() && request[name] != SToStr(SToInt64(request[name]))) {
+        throw "402 Malformed " + name;
+    }
+}
+
+void BedrockPlugin::verifyAttributeSize(const SData& request, const string& name, size_t minSize, size_t maxSize) {
+    if (request[name].size() < minSize) {
+        throw "402 Missing " + name;
+    }
+    if (request[name].size() > maxSize) {
+        throw "402 Malformed " + name;
+    }
+}
+
+// One-liner default implementations.
+void BedrockPlugin::enable(bool enabled) { _enabled = enabled; }
+bool BedrockPlugin::enabled() { return _enabled; }
+string BedrockPlugin::getName() { SERROR("No name defined by this plugin, aborting."); }
+void BedrockPlugin::initialize(const SData& args) {}
+bool BedrockPlugin::peekCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command) { return false; }
+bool BedrockPlugin::processCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command) { return false; }
+void BedrockPlugin::test(BedrockTester* tester) {}
+void BedrockPlugin::timerFired(SStopwatch* timer) {}
+void BedrockPlugin::upgradeDatabase(BedrockNode* node, SQLite& db) {}

--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -2,16 +2,18 @@
 #include "BedrockPlugin.h"
 
 // Global static values
-list<BedrockPlugin*> BedrockPlugin::g_registeredPluginList;
+list<BedrockPlugin*>* BedrockPlugin::g_registeredPluginList = 0;
 
 BedrockPlugin::BedrockPlugin() : _enabled(false) {
-    /* Auto-register this instance into the global static list. This just makes it available for enabling via the
-     * command line: by default all plugins start out disabled.
-     *
-     * NOTE: This code runs *before* main(). This means that libstuff hasn't yet been initialized, so there is no
-     * logging.
-     */
-    g_registeredPluginList.push_back(this);
+    // Auto-register this instance into the global static list, initializing the list if that hasn't yet been done.
+    // This just makes it available for enabling via the command line: by default all plugins start out disabled.
+    //
+    // NOTE: This code runs *before* main(). This means that libstuff hasn't yet been initialized, so there is no
+    // logging.
+    if (!g_registeredPluginList) {
+        g_registeredPluginList = new list<BedrockPlugin*>;
+    }
+    g_registeredPluginList->push_back(this);
 }
 
 void BedrockPlugin::verifyAttributeInt64(const SData& request, const string& name, size_t minSize) {

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -1,12 +1,11 @@
 #pragma once
 #include "BedrockNode.h"
 
-/* BREGISTER_PLUGIN is a macro to auto-instantiate a global instance of a plugin (_CT_). This lets plugin implementors
- * just write `BREGISTER_PLUGIN(MyPluginName)` at the bottom of an implementation cpp file and get the plugin
- * automatically registered with Bedrock.
- * Why the weird `EXPAND{N}` macros? Because the pre-processor doesn't do recursive macro expansion with concatenation.
- * See: http://stackoverflow.com/questions/1597007/
- */
+// BREGISTER_PLUGIN is a macro to auto-instantiate a global instance of a plugin (_CT_). This lets plugin implementors
+// just write `BREGISTER_PLUGIN(MyPluginName)` at the bottom of an implementation cpp file and get the plugin
+// automatically registered with Bedrock.
+// Why the weird `EXPAND{N}` macros? Because the pre-processor doesn't do recursive macro expansion with concatenation.
+// See: http://stackoverflow.com/questions/1597007/
 #define BREGISTER_PLUGIN_EXPAND2(_CT_, _NUM_) _CT_ __BREGISTER_PLUGIN_##_CT_##_NUM_
 #define BREGISTER_PLUGIN_EXPAND1(_CT_, _NUM_) BREGISTER_PLUGIN_EXPAND2(_CT_, _NUM_)
 #define BREGISTER_PLUGIN(_CT_) BREGISTER_PLUGIN_EXPAND1(_CT_, __COUNTER__)
@@ -14,9 +13,8 @@
 // Simple plugin system to add functionality to a node at runtime
 class BedrockPlugin {
   public:
-    /* We use these sizes to make sure the storage engine does not silently truncate data. We throw an exception
-     * instead.
-     */
+    // We use these sizes to make sure the storage engine does not silently truncate data. We throw an exception
+    // instead.
     static constexpr int64_t MAX_SIZE_NONCOLUMN = 1024 * 1024 * 1024;
     static constexpr int64_t MAX_SIZE_QUERY = 1024 * 1024;
     static constexpr int64_t MAX_SIZE_BLOB = 1024 * 1024;
@@ -67,5 +65,5 @@ class BedrockPlugin {
 
   public:
     // Global static attributes
-    static list<BedrockPlugin*> g_registeredPluginList;
+    static list<BedrockPlugin*>* g_registeredPluginList;
 };

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -1,66 +1,71 @@
-// BedrockPlugin.h
-#ifndef _BEDROCKPLUGIN_H
-#define _BEDROCKPLUGIN_H
+#pragma once
 #include "BedrockNode.h"
 
-// Define some helpful constants and macros
-#define BVERIFY_ATTRIBUTE_INT(_ATTR_, _MIN_SIZE_)                                                                      \
-    do {                                                                                                               \
-        if (request[_ATTR_].size() < _MIN_SIZE_)                                                                       \
-            throw "402 Missing " _ATTR_;                                                                               \
-        if (!request[_ATTR_].empty() && request[_ATTR_] != SToStr(SToInt(request[_ATTR_])))                            \
-            throw "402 Malformed " _ATTR_;                                                                             \
-    } while (false)
-#define BVERIFY_ATTRIBUTE_INT64(_ATTR_, _MIN_SIZE_)                                                                    \
-    do {                                                                                                               \
-        if (request[_ATTR_].size() < _MIN_SIZE_)                                                                       \
-            throw "402 Missing " _ATTR_;                                                                               \
-        if (!request[_ATTR_].empty() && request[_ATTR_] != SToStr(SToInt64(request[_ATTR_])))                          \
-            throw "402 Malformed " _ATTR_;                                                                             \
-    } while (false)
-#define BVERIFY_ATTRIBUTE_SIZE(_ATTR_, _MIN_SIZE_, _MAX_SIZE_)                                                         \
-    do {                                                                                                               \
-        if (request[_ATTR_].size() < _MIN_SIZE_)                                                                       \
-            throw "402 Missing " _ATTR_;                                                                               \
-        if (request[_ATTR_].size() > _MAX_SIZE_)                                                                       \
-            throw "402 Malformed " _ATTR_;                                                                             \
-    } while (false)
-#define BVERIFY_ATTRIBUTE_DATE(_ATTR_, _MIN_SIZE_)                                                                     \
-    do {                                                                                                               \
-        if (request[_ATTR_].size() < _MIN_SIZE_)                                                                       \
-            throw "402 Missing " _ATTR_;                                                                               \
-        if (!request[_ATTR_].empty() && !SREMatch("^\\d{4}-\\d{2}-\\d{2}( \\d{2}:\\d{2}:\\d{2})?$", request[_ATTR_]))  \
-            throw "402 Malformed " _ATTR_;                                                                             \
-    } while (false)
-#define BTOLOWER_ATTRIBUTE(_ATTR_)                                                                                     \
-    do {                                                                                                               \
-        if (request.isSet(_ATTR_))                                                                                     \
-            request[_ATTR_] = SToLower(request[_ATTR_]);                                                               \
-    } while (false)
-#define BTOUPPER_ATTRIBUTE(_ATTR_)                                                                                     \
-    do {                                                                                                               \
-        if (request.isSet(_ATTR_))                                                                                     \
-            request[_ATTR_] = SToUpper(request[_ATTR_]);                                                               \
-    } while (false)
-
-// We use these sizes to make sure the storage engine does not silently
-// truncate data.  We throw an exception instead.  Clearly, if saving JSON, a
-// truncation would be a disaster.
-// Common max sizes
-#define BMAX_SIZE_NONCOLUMN 1024 * 1024 * 1024 // No need to restrict size on these inputs.
-#define BMAX_SIZE_QUERY 1024 * 1024            // 1MB seems large enough for a query
-#define BMAX_SIZE_BLOB 1024 * 1024             // 1MB seems large enough for a general blob
-#define BMAX_SIZE_SMALL 255                    // Most string columns are this.
-
-// BREGISTER_PLUGIN is a macro to auto-instantiate a global instance of a plugin (_CT_). This lets plugin implementors
-// just write `BREGISTER_PLUGIN(MyPluginName)` at the bottom of an implementation cpp file and get the plugin
-// automatically registered with Bedrock.
-//
-// Why the weird `EXPAND{N}` macros? Because the pre-processor doesn't do recursive macro expansion with concatenation.
-// See: http://stackoverflow.com/questions/1597007/
+/* BREGISTER_PLUGIN is a macro to auto-instantiate a global instance of a plugin (_CT_). This lets plugin implementors
+ * just write `BREGISTER_PLUGIN(MyPluginName)` at the bottom of an implementation cpp file and get the plugin
+ * automatically registered with Bedrock.
+ * Why the weird `EXPAND{N}` macros? Because the pre-processor doesn't do recursive macro expansion with concatenation.
+ * See: http://stackoverflow.com/questions/1597007/
+ */
 #define BREGISTER_PLUGIN_EXPAND2(_CT_, _NUM_) _CT_ __BREGISTER_PLUGIN_##_CT_##_NUM_
 #define BREGISTER_PLUGIN_EXPAND1(_CT_, _NUM_) BREGISTER_PLUGIN_EXPAND2(_CT_, _NUM_)
 #define BREGISTER_PLUGIN(_CT_) BREGISTER_PLUGIN_EXPAND1(_CT_, __COUNTER__)
 
-// BedrockPlugin.h
-#endif
+// Simple plugin system to add functionality to a node at runtime
+class BedrockPlugin {
+  public:
+    /* We use these sizes to make sure the storage engine does not silently truncate data. We throw an exception
+     * instead.
+     */
+    static constexpr int64_t MAX_SIZE_NONCOLUMN = 1024 * 1024 * 1024;
+    static constexpr int64_t MAX_SIZE_QUERY = 1024 * 1024;
+    static constexpr int64_t MAX_SIZE_BLOB = 1024 * 1024;
+    static constexpr int64_t MAX_SIZE_SMALL = 255;
+
+    static void verifyAttributeInt64(const SData& request, const string& name, size_t minSize);
+    static void verifyAttributeSize(const SData& request, const string& name, size_t minSize, size_t maxSize);
+
+    BedrockPlugin();
+
+    // Returns a short, descriptive name of this plugin
+    virtual string getName();
+
+    // Initializes it with command-line arguments
+    virtual void initialize(const SData& args);
+
+    // Optionally updates the schema as necessary to support this plugin
+    virtual void upgradeDatabase(BedrockNode* node, SQLite& db);
+
+    // Optionally "peeks" at a command to process it in a read-only manner
+    virtual bool peekCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command);
+
+    // Optionally "processes" a command in a read/write manner, triggering
+    // a distributed transaction if necessary
+    virtual bool processCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command);
+
+    // Enable this plugin for active operation
+    virtual void enable(bool enabled);
+    virtual bool enabled();
+
+    // Allow this node to do a self-test
+    virtual void test(BedrockTester* tester);
+
+    // The plugin can add as many of these as it needs in it's initialize function. The server will then add those
+    // to it's own global list. Note that this is the *only* time these can be added, once `initialize` completes,
+    // the server maintains a copy of this list. This also means that these managers need to live for the life of
+    // the application.
+    list<SHTTPSManager*> httpsManagers;
+
+    // The plugin can register any number of timers it wants. When any of them `ding`, then the `timerFired`
+    // function will be called, and passed the timer that is dinging.
+    set<SStopwatch*> timers;
+    virtual void timerFired(SStopwatch* timer);
+
+  protected:
+    // Attributes
+    bool _enabled;
+
+  public:
+    // Global static attributes
+    static list<BedrockPlugin*> g_registeredPluginList;
+};

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -262,7 +262,7 @@ BedrockServer::BedrockServer(const SData& args)
 
     // Output the list of plugins compiled in
     map<string, BedrockPlugin*> registeredPluginMap;
-    SFOREACH (list<BedrockPlugin*>, BedrockPlugin::g_registeredPluginList, pluginIt) {
+    SFOREACH (list<BedrockPlugin*>, *BedrockPlugin::g_registeredPluginList, pluginIt) {
         // Add one more plugin
         BedrockPlugin* plugin = *pluginIt;
         const string& pluginName = SToLower(plugin->getName());
@@ -621,7 +621,7 @@ void BedrockServer::postSelect(fd_map& fdm, uint64_t& nextActivity) {
     }
 
     // If any plugin timers are firing, let the plugins know.
-    for_each(BedrockPlugin::g_registeredPluginList.begin(), BedrockPlugin::g_registeredPluginList.end(),
+    for_each(BedrockPlugin::g_registeredPluginList->begin(), BedrockPlugin::g_registeredPluginList->end(),
              [&](BedrockPlugin* plugin) {
                  for_each(plugin->timers.begin(), plugin->timers.end(), [&](SStopwatch* timer) {
                      if (timer->ding()) {

--- a/BedrockTest.cpp
+++ b/BedrockTest.cpp
@@ -207,7 +207,7 @@ void BedrockTest(SData& trueArgs) {
     }
 
     // Test each of the plugins
-    for_each(Plugin::g_registeredPluginList.begin(), Plugin::g_registeredPluginList.end(), [&](Plugin* plugin) {
+    for_each(Plugin::g_registeredPluginList->begin(), Plugin::g_registeredPluginList->end(), [&](Plugin* plugin) {
         // Do we need to clean up?
         if (tester->server) {
             // Stop the server to provide a clean test environment for the next plugin

--- a/BedrockTest.cpp
+++ b/BedrockTest.cpp
@@ -1,8 +1,8 @@
-/// bedrock/BedrockTest.cpp
 #include <libstuff/libstuff.h>
+#include "BedrockPlugin.h"
 #include "BedrockTest.h"
 
-using Plugin = BedrockNode::Plugin;
+using Plugin = BedrockPlugin;
 
 BedrockTester::BedrockTester() {
     // Initialize
@@ -207,7 +207,7 @@ void BedrockTest(SData& trueArgs) {
     }
 
     // Test each of the plugins
-    for_each(Plugin::g_registeredPluginList->begin(), Plugin::g_registeredPluginList->end(), [&](Plugin* plugin) {
+    for_each(Plugin::g_registeredPluginList.begin(), Plugin::g_registeredPluginList.end(), [&](Plugin* plugin) {
         // Do we need to clean up?
         if (tester->server) {
             // Stop the server to provide a clean test environment for the next plugin

--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -1,4 +1,3 @@
-/// /src/bedrock/BedrockPlugin_Cache.cpp
 #include <libstuff/libstuff.h>
 #include "../BedrockPlugin.h"
 #include "../BedrockTest.h"
@@ -218,7 +217,7 @@ bool BedrockPlugin_Cache::peekCommand(BedrockNode* node, SQLite& db, BedrockNode
         //         . value - raw value associated with that name (in the body of the response)
         //     - 404 - No cache found
         //
-        BedrockPlugin::verifyAttributeSize(request, "name", 1, BedrockPlugin::MAX_SIZE_SMALL);
+        verifyAttributeSize(request, "name", 1, MAX_SIZE_SMALL);
         const string& name = request["name"];
 
         // Get the list
@@ -276,11 +275,11 @@ bool BedrockPlugin_Cache::processCommand(BedrockNode* node, SQLite& db, BedrockN
         //     (64MB max)
         //     - invalidateName - A name pattern to erase from the cache (optional)
         //
-        BedrockPlugin::verifyAttributeSize(request, "name", 1, BedrockPlugin::MAX_SIZE_SMALL);
+        verifyAttributeSize(request, "name", 1, MAX_SIZE_SMALL);
         const string& valueHeader = request["value"];
         if (!valueHeader.empty()) {
             // Value is provided via the header -- make sure it's not too long
-            if (valueHeader.size() > BedrockPlugin::MAX_SIZE_BLOB) {
+            if (valueHeader.size() > MAX_SIZE_BLOB) {
                 throw "402 Value too large, 1MB max -- use content body";
             }
         } else if (!request.content.empty()) {

--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -4,7 +4,7 @@
 #include "../BedrockTest.h"
 
 // Declare the class we're going to implement below
-class BedrockPlugin_Cache : public BedrockNode::Plugin {
+class BedrockPlugin_Cache : public BedrockPlugin {
   public:
     // Constructor / Destructor
     BedrockPlugin_Cache();
@@ -218,7 +218,7 @@ bool BedrockPlugin_Cache::peekCommand(BedrockNode* node, SQLite& db, BedrockNode
         //         . value - raw value associated with that name (in the body of the response)
         //     - 404 - No cache found
         //
-        BVERIFY_ATTRIBUTE_SIZE("name", 1, BMAX_SIZE_SMALL);
+        BedrockPlugin::verifyAttributeSize(request, "name", 1, BedrockPlugin::MAX_SIZE_SMALL);
         const string& name = request["name"];
 
         // Get the list
@@ -276,11 +276,11 @@ bool BedrockPlugin_Cache::processCommand(BedrockNode* node, SQLite& db, BedrockN
         //     (64MB max)
         //     - invalidateName - A name pattern to erase from the cache (optional)
         //
-        BVERIFY_ATTRIBUTE_SIZE("name", 1, BMAX_SIZE_SMALL);
+        BedrockPlugin::verifyAttributeSize(request, "name", 1, BedrockPlugin::MAX_SIZE_SMALL);
         const string& valueHeader = request["value"];
         if (!valueHeader.empty()) {
             // Value is provided via the header -- make sure it's not too long
-            if (valueHeader.size() > BMAX_SIZE_BLOB) {
+            if (valueHeader.size() > BedrockPlugin::MAX_SIZE_BLOB) {
                 throw "402 Value too large, 1MB max -- use content body";
             }
         } else if (!request.content.empty()) {

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -1,4 +1,3 @@
-/// /src/bedrock/plugins/DB.cpp
 #include <libstuff/libstuff.h>
 #include "../BedrockPlugin.h"
 
@@ -47,7 +46,7 @@ bool BedrockPlugin_DB::peekCommand(BedrockNode* node, SQLite& db, BedrockNode::C
         //
         //     Executes a simple query
         //
-        BedrockPlugin::verifyAttributeSize(request, "query", 1, BedrockPlugin::MAX_SIZE_QUERY);
+        verifyAttributeSize(request, "query", 1, MAX_SIZE_QUERY);
 
         // See if it's read-only (and thus safely peekable) or read-write
         // (and thus requires processing).
@@ -113,7 +112,7 @@ bool BedrockPlugin_DB::processCommand(BedrockNode* node, SQLite& db, BedrockNode
         //
         //     Executes a simple read/write query
         //
-        BedrockPlugin::verifyAttributeSize(request, "query", 1, BedrockPlugin::MAX_SIZE_QUERY);
+        verifyAttributeSize(request, "query", 1, MAX_SIZE_QUERY);
 
         // Attempt the query
         const string& query = request["query"] + ";";

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -6,7 +6,7 @@
 #define SLOGPREFIX "{" << node->name << ":" << getName() << "} "
 
 // Declare the class we're going to implement below
-class BedrockPlugin_DB : public BedrockNode::Plugin {
+class BedrockPlugin_DB : public BedrockPlugin {
   public:
     virtual string getName() { return "DB"; }
     virtual bool peekCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command);
@@ -47,7 +47,7 @@ bool BedrockPlugin_DB::peekCommand(BedrockNode* node, SQLite& db, BedrockNode::C
         //
         //     Executes a simple query
         //
-        BVERIFY_ATTRIBUTE_SIZE("query", 1, BMAX_SIZE_QUERY);
+        BedrockPlugin::verifyAttributeSize(request, "query", 1, BedrockPlugin::MAX_SIZE_QUERY);
 
         // See if it's read-only (and thus safely peekable) or read-write
         // (and thus requires processing).
@@ -113,7 +113,7 @@ bool BedrockPlugin_DB::processCommand(BedrockNode* node, SQLite& db, BedrockNode
         //
         //     Executes a simple read/write query
         //
-        BVERIFY_ATTRIBUTE_SIZE("query", 1, BMAX_SIZE_QUERY);
+        BedrockPlugin::verifyAttributeSize(request, "query", 1, BedrockPlugin::MAX_SIZE_QUERY);
 
         // Attempt the query
         const string& query = request["query"] + ";";

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1,4 +1,3 @@
-/// /src/bedrock/BedrockPlugin_Jobs.cpp
 #include <libstuff/libstuff.h>
 #include "../BedrockPlugin.h"
 
@@ -81,7 +80,7 @@ bool BedrockPlugin_Jobs::peekCommand(BedrockNode* node, SQLite& db, BedrockNode:
         //     - 303 - Timeout
         //     - 404 - No jobs found
         //
-        BedrockPlugin::verifyAttributeSize(request, "name", 1, BedrockPlugin::MAX_SIZE_SMALL);
+        verifyAttributeSize(request, "name", 1, MAX_SIZE_SMALL);
 
         // Get the list
         SQResult result;
@@ -141,7 +140,7 @@ bool BedrockPlugin_Jobs::peekCommand(BedrockNode* node, SQLite& db, BedrockNode:
         //         . data - JSON data associated with this job
         //     - 404 - No jobs found
         //
-        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
+        verifyAttributeInt64(request, "jobID", 1);
 
         // Verify there is a job like this
         SQResult result;
@@ -218,7 +217,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         //     Returns:
         //     - jobID - Unique identifier of this job
         //
-        BedrockPlugin::verifyAttributeSize(request, "name", 1, BedrockPlugin::MAX_SIZE_SMALL);
+        verifyAttributeSize(request, "name", 1, MAX_SIZE_SMALL);
 
         // If unique flag was passed and the job exist in the DB, then we can finish the command without escalating to
         // master.
@@ -349,8 +348,8 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         //     - jobID - ID of the job to delete
         //     - data  - A JSON object describing work to be done
         //
-        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
-        BedrockPlugin::verifyAttributeSize(request, "data", 1, BedrockPlugin::MAX_SIZE_BLOB);
+        verifyAttributeInt64(request, "jobID", 1);
+        verifyAttributeSize(request, "data", 1, MAX_SIZE_BLOB);
 
         // Verify there is a job like this
         SQResult result;
@@ -400,7 +399,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         //     - jobID  - ID of the job to finish
         //     - data   - Data to associate with this finsihed job
         //
-        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
+        verifyAttributeInt64(request, "jobID", 1);
 
         // Verify there is a job like this and it's running
         SQResult result;
@@ -485,7 +484,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         //     - jobID - ID of the job to fail
         //     - data  - Data to associate with this failed job
         //
-        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
+        verifyAttributeInt64(request, "jobID", 1);
 
         // Verify there is a job like this and it's running
         SQResult result;
@@ -537,7 +536,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         //     Parameters:
         //     - jobID - ID of the job to delete
         //
-        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
+        verifyAttributeInt64(request, "jobID", 1);
 
         // Verify there is a job like this and it's not running
         SQResult result;

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -8,7 +8,7 @@
 #define JOBS_DEFAULT_PRIORITY 500
 
 // Declare the class we're going to implement below
-class BedrockPlugin_Jobs : public BedrockNode::Plugin {
+class BedrockPlugin_Jobs : public BedrockPlugin {
   public:
     // Implement base class interface
     virtual string getName() { return "Jobs"; }
@@ -81,7 +81,7 @@ bool BedrockPlugin_Jobs::peekCommand(BedrockNode* node, SQLite& db, BedrockNode:
         //     - 303 - Timeout
         //     - 404 - No jobs found
         //
-        BVERIFY_ATTRIBUTE_SIZE("name", 1, BMAX_SIZE_SMALL);
+        BedrockPlugin::verifyAttributeSize(request, "name", 1, BedrockPlugin::MAX_SIZE_SMALL);
 
         // Get the list
         SQResult result;
@@ -141,7 +141,7 @@ bool BedrockPlugin_Jobs::peekCommand(BedrockNode* node, SQLite& db, BedrockNode:
         //         . data - JSON data associated with this job
         //     - 404 - No jobs found
         //
-        BVERIFY_ATTRIBUTE_INT64("jobID", 1);
+        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
 
         // Verify there is a job like this
         SQResult result;
@@ -218,7 +218,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         //     Returns:
         //     - jobID - Unique identifier of this job
         //
-        BVERIFY_ATTRIBUTE_SIZE("name", 1, BMAX_SIZE_SMALL);
+        BedrockPlugin::verifyAttributeSize(request, "name", 1, BedrockPlugin::MAX_SIZE_SMALL);
 
         // If unique flag was passed and the job exist in the DB, then we can finish the command without escalating to
         // master.
@@ -349,8 +349,8 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         //     - jobID - ID of the job to delete
         //     - data  - A JSON object describing work to be done
         //
-        BVERIFY_ATTRIBUTE_INT64("jobID", 1);
-        BVERIFY_ATTRIBUTE_SIZE("data", 1, BMAX_SIZE_BLOB);
+        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
+        BedrockPlugin::verifyAttributeSize(request, "data", 1, BedrockPlugin::MAX_SIZE_BLOB);
 
         // Verify there is a job like this
         SQResult result;
@@ -400,7 +400,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         //     - jobID  - ID of the job to finish
         //     - data   - Data to associate with this finsihed job
         //
-        BVERIFY_ATTRIBUTE_INT64("jobID", 1);
+        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
 
         // Verify there is a job like this and it's running
         SQResult result;
@@ -485,7 +485,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         //     - jobID - ID of the job to fail
         //     - data  - Data to associate with this failed job
         //
-        BVERIFY_ATTRIBUTE_INT64("jobID", 1);
+        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
 
         // Verify there is a job like this and it's running
         SQResult result;
@@ -537,7 +537,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         //     Parameters:
         //     - jobID - ID of the job to delete
         //
-        BVERIFY_ATTRIBUTE_INT64("jobID", 1);
+        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
 
         // Verify there is a job like this and it's not running
         SQResult result;

--- a/plugins/Status.cpp
+++ b/plugins/Status.cpp
@@ -7,7 +7,7 @@
 #define SLOGPREFIX "{" << node->name << ":" << getName() << "} "
 
 // Declare the class we're going to implement below
-class BedrockPlugin_Status : public BedrockNode::Plugin {
+class BedrockPlugin_Status : public BedrockPlugin {
   public:
     virtual string getName() { return "Status"; }
     virtual bool peekCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command);


### PR DESCRIPTION
@flodnv 
cc @cead22 @quinthar 

Ok, so this didn't *need* to be done, but I was looking at how best to make it possible for a plugin to choose whether or not the BedrockServer would log when it's commands are too slow, and I just decided I'd refactor this a bit to make it easier to work on.

This:

* Moves `BedrockNode::Plugin` to `BedrockPlugin.h`, and in doing so, *renames it `BedrockPlugin`*. I feel like this might be controversial (I'm not sure if it will be, but I'll try and justify it anyway), I feel like as we've moved auth into being a Bedrock plugin, we've enabled more communication between plugins and BedrockServer, which to me makes it not a plugin to a Node, so much as a plugin to Bedrock itself, so I think the name is actually more accurate. Further, nested classes are often just confusing, and I feel like this is more straightforward to understand.
* Removes some unused macros, turns others into static functions and constants.
* <del>Makes the global list of plugins not a pointer (it doesn't need to be).</del>
* Cleans up some comments and formatting.

Hopefully people agree that this looks nicer and is easier to understand.

There will be another PR for Auth that depends on this, as the plugin now needs to inherit from `BedrockPlugin` instead of `BedrockNode::Plugin`.