### PR TITLE
Log errors with strings as well

### DIFF
--- a/BedrockNode.cpp
+++ b/BedrockNode.cpp
@@ -122,6 +122,8 @@ bool BedrockNode::_peekCommand(SQLite& db, Command* command) {
         }
     } catch (const char* e) {
         handleCommandException(db, command, e, false);
+    } catch (const string e) {
+        handleCommandException(db, command, e, false);
     } catch (...) {
         handleCommandException(db, command, "", false);
     }
@@ -202,6 +204,8 @@ void BedrockNode::_processCommand(SQLite& db, Command* command) {
         }
     } catch (const char* e) {
         handleCommandException(db, command, e, true);
+    } catch (const string e) {
+        handleCommandException(db, command, e, false);
     } catch (...) {
         handleCommandException(db, command, "", true);
     }


### PR DESCRIPTION
We can catch strings and keep the error messages as well.