### PR TITLE
Copy/pasted without changing false to true

### DIFF
--- a/BedrockNode.cpp
+++ b/BedrockNode.cpp
@@ -205,7 +205,7 @@ void BedrockNode::_processCommand(SQLite& db, Command* command) {
     } catch (const char* e) {
         handleCommandException(db, command, e, true);
     } catch (const string e) {
-        handleCommandException(db, command, e, false);
+        handleCommandException(db, command, e, true);
     } catch (...) {
         handleCommandException(db, command, "", true);
     }


### PR DESCRIPTION
@cead22 

This is a symptom of rushing. I added the extra exception handling for strings, but copy/pasted a line from `peek` to `process` and forgot to change the flag that said we were processing from `false` to `true`.