### PR TITLE
Fix response on exceptions

### DIFF
--- a/BedrockNode.cpp
+++ b/BedrockNode.cpp
@@ -235,7 +235,7 @@ void BedrockNode::handleCommandException(SQLite& db, Command* command, const str
 
     // If the command set a response before throwing an exception, we'll keep that as our response to use. Otherwise,
     // we'll use the text of the error.
-    if (command->response.methodLine == "") {
+    if (command->response.methodLine == "" || command->response.methodLine == "200 OK") {
         command->response.methodLine = e;
     }
 }


### PR DESCRIPTION
@tylerkaraszewski 

We are always returning 200 OK, because we never set the response [here](https://github.com/Expensify/Bedrock/blob/4a9246176cefdeae26be37f012f8090b55f08fcf/BedrockNode.cpp#L239-L239) because we initialize the response as `200 OK` [here](https://github.com/Expensify/Bedrock/blob/4a9246176cefdeae26be37f012f8090b55f08fcf/BedrockNode.cpp#L89-L89)
I moved the default response to after we ran the command and only if one wasn't already set.

Tests: 
- Ran integration tests on web pr https://github.com/Expensify/Web-Expensify/pull/15050
- Ran auth tests.