### PR TITLE
Use new diffie-hellman defaults

### DIFF
--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -2,17 +2,6 @@
 #include <mbedtls/error.h>
 #include <mbedtls/net.h>
 
-// --------------------------------------------------------------------------
-const char* g_S_dhm_P = "E4004C1F94182000103D883A448B3F80"
-                        "2CE4B44A83301270002C20D0321CFD00"
-                        "11CCEF784C26A400F43DFB901BCA7538"
-                        "F2C6B176001CF5A0FD16D2C48B1D0C1C"
-                        "F6AC8E1DA6BCC3B4E1F96B0564965300"
-                        "FFA1D0B601EB2800F489AA512C4B248C"
-                        "01F76949A60BB7F00A40B1EAB64BDD48"
-                        "E8A700D60B7F1200FA8E77B0A979DABF";
-const char* g_S_dhm_G = "4";
-
 SSSLState::SSSLState() {
     mbedtls_ssl_init(&ssl);
     mbedtls_ssl_config_init(&conf);
@@ -47,7 +36,6 @@ SSSLState* SSSLOpen(int s, SX509* x509) {
         // Add the certificate
         mbedtls_ssl_conf_ca_chain(&state->conf, x509->srvcert.next, 0);
         SASSERT(mbedtls_ssl_conf_own_cert(&state->conf, &x509->srvcert, &x509->pk) == 0);
-        SASSERT(mbedtls_ssl_conf_dh_param(&state->conf, g_S_dhm_P, g_S_dhm_G) == 0);
     }
     return state;
 }

--- a/libstuff/SSSLState.h
+++ b/libstuff/SSSLState.h
@@ -26,8 +26,3 @@ extern bool SSSLRecvAppend(SSSLState* ssl, string& recvBuffer);
 extern string SSSLGetState(SSSLState* ssl);
 extern void SSSLShutdown(SSSLState* ssl);
 extern void SSSLClose(SSSLState* ssl);
-
-// Pre-computed DH-1024 prime
-// **FIXME: This is XySSL default -- change
-extern const char* g_S_dhm_P;
-extern const char* g_S_dhm_G;


### PR DESCRIPTION
Assigning @quinthar 

Fixes: https://github.com/Expensify/Expensify/issues/37090

There's a great page here by the mbedtls developers on what they recommend for this:
https://tls.mbed.org/kb/cryptography/providing-diffie-hellman-or-dhm-parameters

To sum it up, they basically say:
If you're using 1024 bit primes, generate your own. If you're using 2048 bit primes, then you should be safe with the defaults. Also, if you use Elliptic Curve Diffie-Hellman, these primes are no longer relevant.

So, since 2.0, the mbedtls defaults have been 2048 bits (and we just upgraded to 2.3), so I've switched to the new defaults. Also, we *do* support Elliptic Curve Diffie-Hellman, and in general it will be preferred to the older ciphersuite, so unless we're connecting to very old clients or servers, the primes we use are probably irrelevant anyway.

So, the simplest solution was just to take delete our own code for handling this at all.