### PR TITLE
restored code reverted in MySQL change

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -693,6 +693,16 @@ void BedrockServer::postSelect(fd_map& fdm, uint64_t& nextActivity) {
             _requestCountSocketMap.erase(socketIt);
         }
     }
+
+    // If any plugin timers are firing, let the plugins know.
+    for_each(BedrockPlugin::g_registeredPluginList->begin(), BedrockPlugin::g_registeredPluginList->end(),
+             [&](BedrockPlugin* plugin) {
+                 for_each(plugin->timers.begin(), plugin->timers.end(), [&](SStopwatch* timer) {
+                     if (timer->ding()) {
+                         plugin->timerFired(timer);
+                     }
+                 });
+             });
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
@mcnamamj 

This restores code that was accidentally removed here:
https://github.com/Expensify/Bedrock/pull/16/files#diff-90c0ce5c887dbfab22b710517c35a8e7L623

It doesn't affect anything in bedrock or the included plugins, but can break third-party plugins.

It breaks auth, as long as this is merged before the next time auth is built/deployed, we should be fine.