### PR TITLE
Update path in index.markdown

### DIFF
--- a/sqlitecluster/index.markdown
+++ b/sqlitecluster/index.markdown
@@ -1,4 +1,4 @@
-/svn/src/sqlitecluster
+Bedrock/sqlitecluster
 ======================
 A general purpose clustered SQL database designed for embedding into servers to achieve high fault-tolerance and seamless failover/recovery.  Consists of two primary classes:
 


### PR DESCRIPTION
It appears to have an old path from Subversion. It now reflects the git path in Bedrock.