### PR TITLE
Allow plugins to report info such as version, report that in Status

### DIFF
--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -46,7 +46,7 @@ BedrockPlugin* BedrockPlugin::getPlugin(const string& name) {
 void BedrockPlugin::enable(bool enabled) { _enabled = enabled; }
 bool BedrockPlugin::enabled() { return _enabled; }
 string BedrockPlugin::getName() { SERROR("No name defined by this plugin, aborting."); }
-string BedrockPlugin::getVersion() { return ""; }
+const STable& BedrockPlugin::getInfo() { return pluginInfo; }
 void BedrockPlugin::initialize(const SData& args) {}
 bool BedrockPlugin::peekCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command) { return false; }
 bool BedrockPlugin::processCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command) { return false; }

--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -46,6 +46,7 @@ BedrockPlugin* BedrockPlugin::getPlugin(const string& name) {
 void BedrockPlugin::enable(bool enabled) { _enabled = enabled; }
 bool BedrockPlugin::enabled() { return _enabled; }
 string BedrockPlugin::getName() { SERROR("No name defined by this plugin, aborting."); }
+string BedrockPlugin::getVersion() { return ""; }
 void BedrockPlugin::initialize(const SData& args) {}
 bool BedrockPlugin::peekCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command) { return false; }
 bool BedrockPlugin::processCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command) { return false; }

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -28,6 +28,9 @@ class BedrockPlugin {
     // Returns a short, descriptive name of this plugin
     virtual string getName();
 
+    // Returns a version string indicating the version of this plugin.
+    virtual string getVersion();
+
     // Initializes it with command-line arguments
     virtual void initialize(const SData& args);
 

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -29,7 +29,7 @@ class BedrockPlugin {
     virtual string getName();
 
     // Returns a version string indicating the version of this plugin.
-    virtual string getVersion();
+    virtual const STable& getInfo();
 
     // Initializes it with command-line arguments
     virtual void initialize(const SData& args);
@@ -85,6 +85,8 @@ class BedrockPlugin {
   protected:
     // Attributes
     bool _enabled;
+
+    STable pluginInfo;
 
   public:
     // Global static attributes

--- a/plugins/Status.cpp
+++ b/plugins/Status.cpp
@@ -85,14 +85,13 @@ bool BedrockPlugin_Status::peekCommand(BedrockNode* node, SQLite& db, BedrockNod
         // - Status( )
         //
         //     Give us some data on this server.
-
         list<string> plugins;
         for_each(g_registeredPluginList->begin(), g_registeredPluginList->end(), [&](BedrockPlugin* plugin){
             STable pluginData;
             pluginData["name"] = plugin->getName();
-            if (!plugin->getVersion().empty()) {
-                pluginData["version"] = plugin->getVersion();
-            }
+            for_each(plugin->getInfo().begin(), plugin->getInfo().end(), [&](pair<string, string> row){
+                pluginData[row.first] = row.second;
+            });
             plugins.push_back(SComposeJSONObject(pluginData));
         });
         content["plugins"] = SComposeJSONArray(plugins);

--- a/plugins/Status.cpp
+++ b/plugins/Status.cpp
@@ -85,7 +85,18 @@ bool BedrockPlugin_Status::peekCommand(BedrockNode* node, SQLite& db, BedrockNod
         // - Status( )
         //
         //     Give us some data on this server.
-        //
+
+        list<string> plugins;
+        for_each(g_registeredPluginList->begin(), g_registeredPluginList->end(), [&](BedrockPlugin* plugin){
+            STable pluginData;
+            pluginData["name"] = plugin->getName();
+            if (!plugin->getVersion().empty()) {
+                pluginData["version"] = plugin->getVersion();
+            }
+            plugins.push_back(SComposeJSONObject(pluginData));
+        });
+        content["plugins"] = SComposeJSONArray(plugins);
+
         content["state"] = SQLCStateNames[node->getState()];
         content["hash"] = node->getHash();
         content["commitCount"] = SToStr(node->getCommitCount());


### PR DESCRIPTION
Adds a virtual function to the `BedrockPlugin` class to allow plugins to report their version or other info about themselves.

Updates the `Status` plugin to report the compiled-in plugins, with their versions, if available. This results in output like (note: whitespace added for display, not in actual command output):

```
{
  "commitCount": 49459,
  "escalatedCommandList": [],
  "hash": "DCD509830940FE37E3152C72F1359ACFF7CE59E2",
  "isMaster": true,
  "peerList": [],
  "plugins": [
    {
      "name": "Cache"
    },
    {
      "name": "DB"
    },
    {
      "name": "Jobs"
    },
    {
      "name": "MySQL"
    },
    {
      "name": "Status"
    },
    {
      "name": "Auth",
      "version": "3df0282b8b1b20c6d37861ca56c45f8d4e810eec"
    }
  ],
  "priority": 200,
  "processedCommandList": [],
  "queuedCommandList": [],
  "state": "MASTERING",
  "version": "7cde42bf2afb103c164ad883e033027f79c97fbc"
}
```
The above was created with an experimental change to the Auth plugin, which will get it's own PR.

Tests:
No tests.