### PR TITLE
Make plugin info threadsafe

### DIFF
--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -3,7 +3,6 @@
 
 // Global static values
 list<BedrockPlugin*>* BedrockPlugin::g_registeredPluginList = 0;
-mutex BedrockPlugin::_pluginMutex;
 
 BedrockPlugin::BedrockPlugin() : _enabled(false) {
     // Auto-register this instance into the global static list, initializing the list if that hasn't yet been done.
@@ -43,14 +42,10 @@ BedrockPlugin* BedrockPlugin::getPlugin(const string& name) {
     return (plugin == g_registeredPluginList->end()) ? 0 : *plugin;
 }
 
-STable BedrockPlugin::getInfo() {
-    lock_guard<mutex> lock(_pluginMutex);
-    return _pluginInfo;
-}
-
 // One-liner default implementations.
 void BedrockPlugin::enable(bool enabled) { _enabled = enabled; }
 bool BedrockPlugin::enabled() { return _enabled; }
+STable BedrockPlugin::getInfo() { return _pluginInfo.get(); }
 string BedrockPlugin::getName() { SERROR("No name defined by this plugin, aborting."); }
 void BedrockPlugin::initialize(const SData& args) {}
 bool BedrockPlugin::peekCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command) { return false; }

--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -3,6 +3,7 @@
 
 // Global static values
 list<BedrockPlugin*>* BedrockPlugin::g_registeredPluginList = 0;
+mutex BedrockPlugin::_pluginMutex;
 
 BedrockPlugin::BedrockPlugin() : _enabled(false) {
     // Auto-register this instance into the global static list, initializing the list if that hasn't yet been done.
@@ -42,11 +43,15 @@ BedrockPlugin* BedrockPlugin::getPlugin(const string& name) {
     return (plugin == g_registeredPluginList->end()) ? 0 : *plugin;
 }
 
+STable BedrockPlugin::getInfo() {
+    lock_guard<mutex> lock(_pluginMutex);
+    return _pluginInfo;
+}
+
 // One-liner default implementations.
 void BedrockPlugin::enable(bool enabled) { _enabled = enabled; }
 bool BedrockPlugin::enabled() { return _enabled; }
 string BedrockPlugin::getName() { SERROR("No name defined by this plugin, aborting."); }
-const STable& BedrockPlugin::getInfo() { return pluginInfo; }
 void BedrockPlugin::initialize(const SData& args) {}
 bool BedrockPlugin::peekCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command) { return false; }
 bool BedrockPlugin::processCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command) { return false; }

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "BedrockNode.h"
-#include <mutex>
 
 // BREGISTER_PLUGIN is a macro to auto-instantiate a global instance of a plugin (_CT_). This lets plugin implementors
 // just write `BREGISTER_PLUGIN(MyPluginName)` at the bottom of an implementation cpp file and get the plugin
@@ -86,8 +85,7 @@ class BedrockPlugin {
   protected:
     // Attributes
     bool _enabled;
-    STable _pluginInfo;
-    static mutex _pluginMutex;
+    SSynchronized<STable> _pluginInfo;
 
   public:
     // Global static attributes

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "BedrockNode.h"
+#include <mutex>
 
 // BREGISTER_PLUGIN is a macro to auto-instantiate a global instance of a plugin (_CT_). This lets plugin implementors
 // just write `BREGISTER_PLUGIN(MyPluginName)` at the bottom of an implementation cpp file and get the plugin
@@ -29,7 +30,7 @@ class BedrockPlugin {
     virtual string getName();
 
     // Returns a version string indicating the version of this plugin.
-    virtual const STable& getInfo();
+    virtual STable getInfo();
 
     // Initializes it with command-line arguments
     virtual void initialize(const SData& args);
@@ -85,8 +86,8 @@ class BedrockPlugin {
   protected:
     // Attributes
     bool _enabled;
-
-    STable pluginInfo;
+    STable _pluginInfo;
+    static mutex _pluginMutex;
 
   public:
     // Global static attributes

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -17,7 +17,6 @@ class BedrockServer : public STCPServer {
       public:
         // Constructor / Destructor
         MessageQueue();
-        ~MessageQueue();
 
         // Wait for something to be put onto the queue
         int preSelect(fd_map& fdm);
@@ -32,7 +31,7 @@ class BedrockServer : public STCPServer {
       private:
         // Private state
         list<SData> _queue;
-        void* _queueMutex;
+        mutex _queueMutex;
         int _pipeFD[2];
     };
 

--- a/BedrockServer_MessageQueue.cpp
+++ b/BedrockServer_MessageQueue.cpp
@@ -8,18 +8,10 @@
 // --------------------------------------------------------------------------
 BedrockServer::MessageQueue::MessageQueue() {
     // Initialize
-    _queueMutex = SMutexOpen();
-
     // Open up a pipe for communication and set the nonblocking reads.
     SASSERT(0 == pipe(_pipeFD));
     int flags = fcntl(_pipeFD[0], F_GETFL, 0);
     fcntl(_pipeFD[0], F_SETFL, flags | O_NONBLOCK);
-}
-
-// --------------------------------------------------------------------------
-BedrockServer::MessageQueue::~MessageQueue() {
-    // Clean up
-    SMutexClose(_queueMutex);
 }
 
 // --------------------------------------------------------------------------

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2261,44 +2261,6 @@ void SThreadSleep(uint64_t duration) {
     select(0, &readfds, &writefds, &exceptfds, &tv);
 }
 
-// --------------------------------------------------------------------------
-void* SMutexOpen() {
-    // Enable re-entrant locking
-    pthread_mutexattr_t attr;
-    SASSERT(!pthread_mutexattr_init(&attr));
-    SASSERT(!pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP));
-
-    // Create a new mutex and initialize it
-    pthread_mutex_t* pmutex = new pthread_mutex_t;
-    SASSERT(!pthread_mutex_init(pmutex, &attr));
-    SASSERT(!pthread_mutexattr_destroy(&attr));
-    return (void*)pmutex;
-}
-
-// --------------------------------------------------------------------------
-void SMutexLock(void* mutex) {
-    SASSERT(mutex);
-    // Lock this section
-    pthread_mutex_t* pmutex = (pthread_mutex_t*)mutex;
-    SASSERT(!pthread_mutex_lock(pmutex));
-}
-
-// --------------------------------------------------------------------------
-void SMutexUnlock(void* mutex) {
-    SASSERT(mutex);
-    // Unlock this mutex
-    pthread_mutex_t* pmutex = (pthread_mutex_t*)mutex;
-    SASSERT(!pthread_mutex_unlock(pmutex));
-}
-
-// --------------------------------------------------------------------------
-void SMutexClose(void* mutex) {
-    SASSERT(mutex);
-    pthread_mutex_t* pmutex = (pthread_mutex_t*)mutex;
-    SASSERT(!pthread_mutex_destroy(pmutex));
-    SDELETE(pmutex);
-}
-
 /////////////////////////////////////////////////////////////////////////////
 // SQLite Stuff
 /////////////////////////////////////////////////////////////////////////////

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -355,11 +355,11 @@ template <typename T> class SSynchronized {
 
     // Getter and setter
     T get() {
-        lock_guard<mutex> lock(_mutex);
+        SAUTOLOCK(_mutex);
         return _synchronizedValue;
     }
     void set(const T& val) {
-        lock_guard<mutex> lock(_mutex);
+        SAUTOLOCK(_mutex);
         _synchronizedValue = val;
     }
 

--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -44,7 +44,7 @@ class BedrockPlugin_Cache : public BedrockPlugin {
         };
 
         // Attributes
-        void* _mutex;
+        mutex _mutex;
         list<Entry*> _lruList;
         map<string, Entry*> _lruMap;
     };
@@ -60,7 +60,6 @@ BREGISTER_PLUGIN(BedrockPlugin_Cache);
 // ==========================================================================
 BedrockPlugin_Cache::LRUMap::LRUMap() {
     // Initialize
-    _mutex = SMutexOpen();
 }
 
 // ==========================================================================
@@ -70,9 +69,6 @@ BedrockPlugin_Cache::LRUMap::~LRUMap() {
         // Pop it off
         popLRU();
     }
-
-    // Clean up the mutex
-    SMutexClose(_mutex);
 }
 
 // ==========================================================================

--- a/plugins/Status.cpp
+++ b/plugins/Status.cpp
@@ -89,7 +89,8 @@ bool BedrockPlugin_Status::peekCommand(BedrockNode* node, SQLite& db, BedrockNod
         for_each(g_registeredPluginList->begin(), g_registeredPluginList->end(), [&](BedrockPlugin* plugin){
             STable pluginData;
             pluginData["name"] = plugin->getName();
-            for_each(plugin->getInfo().begin(), plugin->getInfo().end(), [&](pair<string, string> row){
+            STable pluginInfo = plugin->getInfo();
+            for_each(pluginInfo.begin(), pluginInfo.end(), [&](pair<string, string> row){
                 pluginData[row.first] = row.second;
             });
             plugins.push_back(SComposeJSONObject(pluginData));


### PR DESCRIPTION
@quinthar 
cc @cead22 @flodnv 

This addresses @quinthar's comment here:
https://github.com/Expensify/Bedrock/pull/41#discussion_r84563244

While I think the chances that anyone would implement pluginInfo in a way that would be likely to cause problems here are low, the existing code *was* non-threadsafe, so this fixes that.

I debated about using our traditional `void*` mutexes with `pthreads` for consistency's sake, but I think the new C++11 `mutex`es are so much nicer and more straightforward to work with, I decided this would be a good place to introduce them. I'd be up for replacing all of our existing mutex code with the stuff that's not in `<mutex>`.