### PR TITLE
Change to recursive mutexes

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -31,7 +31,7 @@ class BedrockServer : public STCPServer {
       private:
         // Private state
         list<SData> _queue;
-        mutex _queueMutex;
+        recursive_mutex _queueMutex;
         int _pipeFD[2];
     };
 

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -340,7 +340,7 @@ struct SAutoThreadPrefix {
 #define SAUTOPREFIX(_PREFIX_) SAutoThreadPrefix __SAUTOPREFIX##__LINE__(_PREFIX_)
 
 // Automatically locks/unlocks a mutex by scope
-#define SAUTOLOCK(_MUTEX_) lock_guard<mutex> __SAUTOLOCK_##__LINE__(_MUTEX_);
+#define SAUTOLOCK(_MUTEX_) lock_guard<recursive_mutex> __SAUTOLOCK_##__LINE__(_MUTEX_);
 
 // Convenient interface for multi-threaded, synchronized variables.
 template <typename T> class SSynchronized {
@@ -366,7 +366,7 @@ template <typename T> class SSynchronized {
   private:
     // Attributes
     T _synchronizedValue;
-    mutex _mutex;
+    recursive_mutex _mutex;
 };
 
 // --------------------------------------------------------------------------

--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -44,7 +44,7 @@ class BedrockPlugin_Cache : public BedrockPlugin {
         };
 
         // Attributes
-        mutex _mutex;
+        recursive_mutex _mutex;
         list<Entry*> _lruList;
         map<string, Entry*> _lruMap;
     };


### PR DESCRIPTION
@quinthar 

I should have looked at this more carefully yesterday, but I thought of it today and went back to look at the old code, and it looks like the raw pthreads code I replaced in this PR: https://github.com/Expensify/Bedrock/pull/45 used recursive mutexes. I replaced it with a standard (non-recursive) mutex. I'm not sure if we actually need the recursive functionality there (the tests all pass, at least, but they're not heavy on multi-threading), but I'd rather be safe than introduce a potential deadlock situation in case there's anywhere the same thread can try and lock a mutex twice. 

So this PR just replaces `mutex` with `recursive_mutex`.