### PR TITLE
Removes SDELETE and its uses.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -335,13 +335,13 @@ BedrockServer::~BedrockServer() {
     // Shut down the threads
     SINFO("Closing write thread '" << _writeThread->name << "'");
     SThreadClose(_writeThread->thread);
-    SDELETE(_writeThread);
+    delete _writeThread;
     SFOREACH (list<Thread*>, _readThreadList, readThreadIt) {
         // Close this thread
         Thread* readThread = *readThreadIt;
         SINFO("Closing read thread '" << readThread->name << "'");
         SThreadClose(readThread->thread);
-        SDELETE(readThread);
+        delete readThread;
     }
     _readThreadList.clear();
     SINFO("Threads closed.");

--- a/BedrockTest.cpp
+++ b/BedrockTest.cpp
@@ -83,7 +83,8 @@ void BedrockTester::stopServer() {
     SSendSignal(SIGTERM);
     while (!server->shutdownComplete())
         loop(nextActivity);
-    SDELETE(server);
+    delete server;
+    server = 0;
 }
 
 void BedrockTester::waitForResponses() {
@@ -226,6 +227,7 @@ void BedrockTest(SData& trueArgs) {
     });
 
     // All done!
-    SDELETE(tester);
+    delete tester;
+    tester = 0;
     SINFO("Finished BedrockTest");
 }

--- a/libstuff/SDataClient.cpp
+++ b/libstuff/SDataClient.cpp
@@ -41,7 +41,7 @@ SDataClient::~SDataClient() {
         SWARN("Prematurely closing connection to '" << connection->host << "' while waiting for response to '"
                                                     << connection->request.methodLine << "'");
         closeSocket(connection->s);
-        SDELETE(connection);
+        delete connection;
     }
     activeConnectionList.clear();
     SFOREACH (list<Connection*>, idleConnectionList, connectionIt) {
@@ -49,7 +49,7 @@ SDataClient::~SDataClient() {
         Connection* connection = *connectionIt;
         SINFO("Closing connection to '" << connection->host << "'");
         closeSocket(connection->s);
-        SDELETE(connection);
+        delete connection;
     }
     idleConnectionList.clear();
 }
@@ -91,7 +91,7 @@ void SDataClient::postSelect(fd_map& fdm) {
 
             // Clean it up
             closeSocket(connection->s);
-            SDELETE(connection);
+            delete connection;
             activeConnectionList.erase(lastConnectionIt);
         }
     }
@@ -106,7 +106,7 @@ void SDataClient::postSelect(fd_map& fdm) {
             // Clean this up
             SDEBUG("Idle connection to '" << connection->host << "' died, closing.");
             closeSocket(connection->s);
-            SDELETE(connection);
+            delete connection;
             idleConnectionList.erase(lastConnectionIt);
         }
     }

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -36,7 +36,7 @@ void SHTTPSManager::closeTransaction(Transaction* transaction) {
     if (transaction->s)
         closeSocket(transaction->s);
     transaction->s = 0;
-    SDELETE(transaction);
+    delete transaction;
 }
 
 // --------------------------------------------------------------------------

--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -142,7 +142,7 @@ void SSSLClose(SSSLState* ssl) {
     // Just clean up
     SASSERT(ssl);
     mbedtls_ssl_free(&ssl->ssl);
-    SDELETE(ssl);
+    delete ssl;
 }
 
 // --------------------------------------------------------------------------

--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -258,7 +258,7 @@ void STCPManager::closeSocket(Socket* socket) {
     if (socket->ssl) {
         SSSLClose(socket->ssl);
     }
-    SDELETE(socket);
+    delete socket;
 }
 
 // --------------------------------------------------------------------------

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -21,7 +21,7 @@ STCPNode::~STCPNode() {
         Peer* peer = *peerIt;
         if (peer->s)
             closeSocket(peer->s);
-        SDELETE(peer);
+        delete peer;
     }
     peerList.clear();
 }

--- a/libstuff/SX509.cpp
+++ b/libstuff/SX509.cpp
@@ -43,5 +43,5 @@ void SX509Close(SX509* x509) {
     // Clean up
     mbedtls_x509_crt_free(&x509->srvcert);
     mbedtls_pk_free(&x509->pk);
-    SDELETE(x509);
+    delete x509;
 }

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -372,14 +372,6 @@ template <typename T> class SSynchronized {
 // --------------------------------------------------------------------------
 // Memory stuff
 // --------------------------------------------------------------------------
-// Macros for ensuring allocated memory is cleaned up right
-#define SDELETE(_PTR_)                                                                                                 \
-    do {                                                                                                               \
-        if (_PTR_) {                                                                                                   \
-            delete _PTR_;                                                                                              \
-            _PTR_ = 0;                                                                                                 \
-        }                                                                                                              \
-    } while (false)
 #define SZERO(_OBJ_) memset(&_OBJ_, 0, sizeof(_OBJ_))
 
 // --------------------------------------------------------------------------

--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -110,7 +110,7 @@ string BedrockPlugin_Cache::LRUMap::popLRU() {
     _lruList.erase(entry->listIt);
     _lruMap.erase(entry->mapIt);
     string nameCopy = entry->name;
-    SDELETE(entry);
+    delete entry;
     return nameCopy;
 }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -451,7 +451,7 @@ void SQLiteNode::closeCommand(Command* command) {
 
     // Finish the cleanup
     _processedCommandList.remove(command);
-    SDELETE(command);
+    delete command;
 }
 
 // --------------------------------------------------------------------------
@@ -596,11 +596,11 @@ void SQLiteNode::_finishCommand(Command* command) {
         escalate["ID"] = command->id;
         escalate.content = command->response.serialize();
         _sendToPeer(command->initiator, escalate);
-        SDELETE(command);
+        delete command;
     } else if (SIEquals(command->request.methodLine, "UpgradeDatabase")) {
         // Special command, just delete it.
         SINFO("Database upgrade complete");
-        SDELETE(command);
+        delete command;
     } else {
         // Locally-initiated command -- hold onto it until the caller cleans up.
         _processedCommandList.push_back(command);
@@ -2306,7 +2306,7 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
                 SASSERTWARN(_state == SQLC_MASTERING || _state == SQLC_STANDINGDOWN);
                 SASSERTWARN(SIEquals((*peer)["State"], "SLAVING"));
                 commandList->erase(commandIt);
-                SDELETE(command);
+                delete command;
             }
         }
     }
@@ -2338,7 +2338,8 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
                 SASSERT(peer->s);
                 _sendToPeer(peer, rollback);
             }
-        SDELETE(_currentCommand);
+        delete _currentCommand;
+        _currentCommand = 0;
     }
 }
 
@@ -2431,7 +2432,7 @@ void SQLiteNode::_changeState(SQLCState newState) {
                         aborted["Reason"] = "Standing down";
                         _sendToPeer(command->initiator, aborted);
                         commandList->erase(commandIt);
-                        SDELETE(command);
+                        delete command;
                     }
                 }
             }

--- a/sqlitecluster/SQLiteTest.cpp
+++ b/sqlitecluster/SQLiteTest.cpp
@@ -228,7 +228,7 @@ struct SQLiteTester {
     ~SQLiteTester() {
         for (size_t c = 0; c < _nodeArray.size(); ++c)
             if (_nodeArray[c])
-                SDELETE(_nodeArray[c]);
+                delete _nodeArray[c];
     }
 
     // ---------------------------------------------------------------------
@@ -353,8 +353,10 @@ struct SQLiteTester {
             }
 
             // Hard kill it, if not graceful
-            if (!graceful)
-                SDELETE(_nodeArray[c]);
+            if (!graceful) {
+                delete _nodeArray[c];
+                _nodeArray[c] = 0;
+            }
         } else {
             // Add a new peer
             SHMMM(">>>>>>>>>>>>>>>>>>> Adding server #" << c << ">>>>>>>>>>>>>>>>>>>>>");
@@ -385,7 +387,8 @@ struct SQLiteTester {
                 if (_nodeArray[c]->shutdownComplete()) {
                     // Graceful shutdown has completed
                     SINFO("<<<<<<<<<<<<<<<< Graceful shutdown complete #" << c << "<<<<<<<<<<<<<");
-                    SDELETE(_nodeArray[c]);
+                    delete _nodeArray[c];
+                    _nodeArray[c] = 0;
                 } else {
                     // Alive, process
                     maxS = SMax(maxS, _nodeArray[c]->preSelect(fdm));


### PR DESCRIPTION
Assigning @flodnv 

This PR addresses this issue:
https://github.com/Expensify/Bedrock/issues/42

`SDELETE` does do an unnecessary check for null before calling `delete`.  Further, I think `SDELETE` is unnecessary itself. It does two things (aside from the redundant check for null), which is call `delete` and then zero the pointer we deleted. Occasionally, "delete and 0" is a useful thing to do, and it prevents the possibility of doing a double `delete` on a given pointer. 

But mostly we just use it like a standard `delete` (for example, here: https://github.com/Expensify/Bedrock/compare/remove-sdelete-macro?expand=1#diff-90c0ce5c887dbfab22b710517c35a8e7R344) where we call it on a pointer that immediately goes out of scope anyway (and thus, zeroing it has no lasting effect).

In a couple places, we do want to make sure the underlying pointer is zeroed (like here: https://github.com/Expensify/Bedrock/compare/remove-sdelete-macro?expand=1#diff-8cedd3ddeacf06893e88f34f9a1f7326L2341) because the pointer is long-lived and used to indicate whether or not there is a `_currentCommand`. In these cases, I've just replaced the use of `SDELETE` with a separate `delete` and assignment to 0, which I actually find easier to follow, because anyone who knows C++ can do it, rather than requiring people to be familiar with our special library, and easier to write consistently, because you can't forget that "oh yeah, there's a special `SWHATEVER` macro that combines these two lines that I should use."

In general, I'm in favor of using more standard language features and fewer custom functions unless they have more to offer than saving `varname = 0;` a couple times in the codebase.