### PR TITLE
Add logging when shutting down to diagnose what blocks.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -242,7 +242,7 @@ void BedrockServer_WorkerThread(void* _data) {
         // Update the state one last time when the writing replication thread exits.
         SQLCState state = node.getState();
         data->replicationState.set(state);
-        SINFO("Write thread exiting, setting state to: " << state << endl;
+        SINFO("Write thread exiting, setting state to: " << state);
         data->replicationCommitCount.set(node.getCommitCount());
     }
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -80,6 +80,7 @@ class BedrockServer : public STCPServer {
         void* thread;
         SSynchronized<bool> ready;
         BedrockServer* server;
+        bool finished = false;
     };
 
     // Constructor / Destructor


### PR DESCRIPTION
@cead22 

Occasionally, we have a bedrock server fail to shutdown gracefully. From my investigation so far, it seems that each individual thread (both read and write) successfully shuts down, but the BedrockServer object [we create in main.cpp](https://github.com/Expensify/Bedrock/blob/master/main.cpp#L229) is never destroyed. The most obvious possible culprit is that we never exit the loop [here](https://github.com/Expensify/Bedrock/blob/master/main.cpp#L231) that would cause this to go out of scope and be destroyed. 

This change adds logging that, once `_nodeGracefulShutdown` has been set, will record the specific conditions that would cause this loop condition to prevent us from shutting down.