### PR TITLE
Make the mandatory transaction owner actually mandatory.

### DIFF
--- a/BedrockNode.cpp
+++ b/BedrockNode.cpp
@@ -256,11 +256,7 @@ void BedrockNode::_abortCommand(SQLite& db, Command* command) {
 
 void BedrockNode::_cleanCommand(Command* command) {
     if (command->httpsRequest) {
-        if (command->httpsRequest->owner) {
-            command->httpsRequest->owner->closeTransaction(command->httpsRequest);
-        } else {
-            SERROR("No owner for this https request " << command->httpsRequest->fullResponse.methodLine);
-        }
+        command->httpsRequest->owner.closeTransaction(command->httpsRequest);
         command->httpsRequest = 0;
     }
 }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -18,6 +18,10 @@ class BedrockServer : public STCPServer {
       public:
         // Constructor / Destructor
         MessageQueue();
+        ~MessageQueue();
+
+        // Explicitly delete copy constructor so it can't accidentally get called.
+        MessageQueue(const MessageQueue& other) = delete;
 
         // Wait for something to be put onto the queue
         int preSelect(fd_map& fdm);
@@ -33,13 +37,13 @@ class BedrockServer : public STCPServer {
         // Private state
         list<SData> _queue;
         recursive_mutex _queueMutex;
-        int _pipeFD[2];
+        int _pipeFD[2] = {-1, -1};
     };
 
     // All the data required for a thread to create an BedrockNode
     // and coordinate with other threads.
     struct Thread {
-        Thread(const string& name_,                         // Thraed name
+        Thread(const string& name_,                         // Thread name
                SData args_,                                 // Command line args passed in.
                SSynchronized<SQLCState>& replicationState_, // Shared var for communicating replication thread's status.
                SSynchronized<uint64_t>& replicationCommitCount_, // Shared var for communicating replication thread's

--- a/BedrockServer_MessageQueue.cpp
+++ b/BedrockServer_MessageQueue.cpp
@@ -15,6 +15,16 @@ BedrockServer::MessageQueue::MessageQueue() {
 }
 
 // --------------------------------------------------------------------------
+BedrockServer::MessageQueue::~MessageQueue() {
+    if (_pipeFD[0] != -1) {
+        close(_pipeFD[0]);
+    }
+    if (_pipeFD[1] != -1) {
+        close(_pipeFD[0]);
+    }
+}
+
+// --------------------------------------------------------------------------
 int BedrockServer::MessageQueue::preSelect(fd_map& fdm) {
     // Put the read-side of the pipe into the fd set.
     // **NOTE: This is *not* synchronized.  All threads use the same pipes.

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -102,7 +102,7 @@ SHTTPSManager::Transaction* SHTTPSManager::_createErrorTransaction() {
     // Sometimes we have to create transactions without an attempted
     // connect.  This could happen if we dont have the host or service id yet.
     SWARN("We had to create an error transaction instead of attempting a real one.");
-    Transaction* transaction = new Transaction();
+    Transaction* transaction = new Transaction(*this);
     transaction->response = 503;
     transaction->finished = STimeNow();
     _completedTransactionList.push_front(transaction);
@@ -124,7 +124,7 @@ SHTTPSManager::Transaction* SHTTPSManager::_httpsSend(const string& url, const S
         return _createErrorTransaction();
 
     // Wrap in a transaction
-    Transaction* transaction = new Transaction();
+    Transaction* transaction = new Transaction(*this);
     transaction->s = s;
     transaction->fullRequest = request;
 

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -5,7 +5,7 @@ class SHTTPSManager : public STCPManager {
     // Transaction
     struct Transaction {
         // Constructor/Destructor
-        Transaction() {
+        Transaction(SHTTPSManager& owner_) : owner(owner_) {
             s = 0;
             created = STimeNow();
             finished = 0;
@@ -21,8 +21,7 @@ class SHTTPSManager : public STCPManager {
         SData fullResponse;
         int response;
         STable values;
-        SHTTPSManager* owner;                   // pointer to the object that owns this transaction. Can be null.
-        vector<vector<string>> transactionList; // **FIXME: move this into values.
+        SHTTPSManager& owner;
     };
 
     // Constructor/Destructor


### PR DESCRIPTION
@flodnv 
cc @cead22 

This enables plugins that use HTTPSManagers to have much cleaner code that doesn't need to set this particular attribute all over the place.