### PR TITLE
Add Poll Timer

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -190,7 +190,9 @@ void BedrockServer_WorkerThread(void* _data) {
             maxS = max(queuedEscalatedRequests.preSelect(fdm), maxS);
             maxS = max(directMessages.preSelect(fdm), maxS);
             const uint64_t now = STimeNow();
+            data->server->pollTimer.startPoll();
             S_poll(fdm, max(nextActivity, now) - now);
+            data->server->pollTimer.stopPoll();
             nextActivity = STimeNow() + STIME_US_PER_S; // 1s max period
 
             // Handle any HTTPS requests from our plugins.
@@ -238,6 +240,9 @@ void BedrockServer_WorkerThread(void* _data) {
                 node.closeCommand(command);
             }
         }
+
+        // We're shutting down, do the final performance log.
+        data->server->pollTimer.stopPoll(true);
 
         // Update the state one last time when the writing replication thread exits.
         SQLCState state = node.getState();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -242,7 +242,7 @@ void BedrockServer_WorkerThread(void* _data) {
         }
 
         // We're shutting down, do the final performance log.
-        data->server->pollTimer.stopPoll(true);
+        data->server->pollTimer.log();
 
         // Update the state one last time when the writing replication thread exits.
         SQLCState state = node.getState();

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -3,6 +3,7 @@
 #include <libstuff/libstuff.h>
 #include "BedrockNode.h"
 #include "BedrockPlugin.h"
+#include "PollTimer.h"
 
 /////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
@@ -112,6 +113,9 @@ class BedrockServer : public STCPServer {
     // Each plugin can register as many httpsManagers as it likes. They'll all get checked for activity in the
     // read loop on the write thread.
     list<list<SHTTPSManager*>> httpsManagers;
+
+    // Keeps track of the time we spend idle.
+    PollTimer pollTimer;
 
   private: // Internal Bedrock
     // Attributes

--- a/PollTimer.cpp
+++ b/PollTimer.cpp
@@ -1,12 +1,8 @@
 #include "PollTimer.h"
 
 PollTimer::PollTimer(uint64_t logIntervalSeconds)
-  : _logPeriod(logIntervalSeconds * STIME_US_PER_S),
-    _lastStart(0),
-    _lastStop(0),
-    _lastLogStart(0),
-    _timeInPoll(0),
-    _timeNotInPoll(0) { }
+    : _logPeriod(logIntervalSeconds * STIME_US_PER_S), _lastStart(0), _lastStop(0), _lastLogStart(0), _timeInPoll(0),
+      _timeNotInPoll(0) {}
 
 void PollTimer::startPoll() {
     uint64_t timestamp = STimeNow();
@@ -34,9 +30,8 @@ void PollTimer::stopPoll(bool force) {
         double percentage = 100.0 * ((double)_timeNotInPoll / (_timeInPoll + _timeNotInPoll));
         char buffer[7];
         snprintf(buffer, 7, "%.2f", percentage);
-        SINFO("[performance] " << (_timeInPoll + _timeNotInPoll) << "us elapsed, " << _timeInPoll
-              << "us in poll(), " << _timeNotInPoll << "us busy. " << buffer << "% busy."
-              << (force ? " (forced)" : ""));
+        SINFO("[performance] " << (_timeInPoll + _timeNotInPoll) << "us elapsed, " << _timeInPoll << "us in poll(), "
+                               << _timeNotInPoll << "us busy. " << buffer << "% busy." << (force ? " (forced)" : ""));
 
         // Reset this to our period after our previous start time, not after the current time, to prevent slow skew as
         // poll doesn't return precisely on these boundaries.

--- a/PollTimer.cpp
+++ b/PollTimer.cpp
@@ -1,3 +1,4 @@
+#include <libstuff/libstuff.h>
 #include "PollTimer.h"
 
 PollTimer::PollTimer(uint64_t logIntervalSeconds)
@@ -7,36 +8,53 @@ PollTimer::PollTimer(uint64_t logIntervalSeconds)
 void PollTimer::startPoll() {
     uint64_t timestamp = STimeNow();
 
+    // We're about to enter poll(), so if we've exited poll() before, then increment the time spent not polling. This
+    // should always be true except the first time this is called.
     if (_lastStop) {
         _timeNotInPoll += timestamp - _lastStop;
     }
 
+    // Record the last time startPoll was called (i.e., right now).
     _lastStart = timestamp;
+
+    // This records the time that we first start running this timer, if it's never been set before. From here forward,
+    // we'll record a log line every "_logPeriod" microseconds.
     if (!_lastLogStart) {
         _lastLogStart = timestamp;
     }
 }
 
-void PollTimer::stopPoll(bool force) {
+void PollTimer::stopPoll() {
     uint64_t timestamp = STimeNow();
 
+    // We just exited poll(), so if we've recorded the time when we entered poll(), we'll increment the time spent
+    // polling. Note that if `_lastStart` isn't set at this point, this class is being used incorrectly (i.e, you
+    // called stopPoll() without calling startPoll().
     if (_lastStart) {
         _timeInPoll += timestamp - _lastStart;
     }
 
+    // Record the last time stopPoll was called (i.e., right now).
     _lastStop = timestamp;
 
-    if (force || _lastLogStart + _logPeriod < timestamp) {
-        double percentage = 100.0 * ((double)_timeNotInPoll / (_timeInPoll + _timeNotInPoll));
-        char buffer[7];
-        snprintf(buffer, 7, "%.2f", percentage);
-        SINFO("[performance] " << (_timeInPoll + _timeNotInPoll) << "us elapsed, " << _timeInPoll << "us in poll(), "
-                               << _timeNotInPoll << "us busy. " << buffer << "% busy." << (force ? " (forced)" : ""));
-
+    // If it's been longer than our log period, log our current statistics and start over on the next iteration.
+    if (_lastLogStart + _logPeriod < timestamp) {
+        log();
         // Reset this to our period after our previous start time, not after the current time, to prevent slow skew as
         // poll doesn't return precisely on these boundaries.
         _lastLogStart += _logPeriod;
         _timeInPoll = 0;
         _timeNotInPoll = 0;
     }
+}
+
+void PollTimer::log() {
+    // Compute the percentage of time we've been busy since the last log period started, as a friendly floating point
+    // number with two decimal places.
+    double percentage = 100.0 * ((double)_timeNotInPoll / (_timeInPoll + _timeNotInPoll));
+    char buffer[7];
+    snprintf(buffer, 7, "%.2f", percentage);
+    // Log both raw numbers and our friendly percentage.
+    SINFO("[performance] " << (_timeInPoll + _timeNotInPoll) << "us elapsed, " << _timeInPoll << "us in poll(), "
+                           << _timeNotInPoll << "us busy. " << buffer << "% busy.");
 }

--- a/PollTimer.cpp
+++ b/PollTimer.cpp
@@ -1,0 +1,47 @@
+#include "PollTimer.h"
+
+PollTimer::PollTimer(uint64_t logIntervalSeconds)
+  : _logPeriod(logIntervalSeconds * STIME_US_PER_S),
+    _lastStart(0),
+    _lastStop(0),
+    _lastLogStart(0),
+    _timeInPoll(0),
+    _timeNotInPoll(0) { }
+
+void PollTimer::startPoll() {
+    uint64_t timestamp = STimeNow();
+
+    if (_lastStop) {
+        _timeNotInPoll += timestamp - _lastStop;
+    }
+
+    _lastStart = timestamp;
+    if (!_lastLogStart) {
+        _lastLogStart = timestamp;
+    }
+}
+
+void PollTimer::stopPoll(bool force) {
+    uint64_t timestamp = STimeNow();
+
+    if (_lastStart) {
+        _timeInPoll += timestamp - _lastStart;
+    }
+
+    _lastStop = timestamp;
+
+    if (force || _lastLogStart + _logPeriod < timestamp) {
+        double percentage = 100.0 * ((double)_timeNotInPoll / (_timeInPoll + _timeNotInPoll));
+        char buffer[7];
+        snprintf(buffer, 7, "%.2f", percentage);
+        SINFO("[performance] " << (_timeInPoll + _timeNotInPoll) << "us elapsed, " << _timeInPoll
+              << "us in poll(), " << _timeNotInPoll << "us busy. " << buffer << "% busy."
+              << (force ? " (forced)" : ""));
+
+        // Reset this to our period after our previous start time, not after the current time, to prevent slow skew as
+        // poll doesn't return precisely on these boundaries.
+        _lastLogStart += _logPeriod;
+        _timeInPoll = 0;
+        _timeNotInPoll = 0;
+    }
+}

--- a/PollTimer.h
+++ b/PollTimer.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <libstuff/libstuff.h>
+class PollTimer {
+  public:
+    PollTimer(uint64_t logIntervalSeconds = 60);
+    void startPoll();
+    void stopPoll(bool force = false);
+
+  private:
+    uint64_t _logPeriod;
+    uint64_t _lastStart;
+    uint64_t _lastStop;
+    uint64_t _lastLogStart;
+    uint64_t _timeInPoll;
+    uint64_t _timeNotInPoll;
+};

--- a/PollTimer.h
+++ b/PollTimer.h
@@ -1,10 +1,10 @@
 #pragma once
-#include <libstuff/libstuff.h>
 class PollTimer {
   public:
     PollTimer(uint64_t logIntervalSeconds = 60);
     void startPoll();
-    void stopPoll(bool force = false);
+    void stopPoll();
+    void log();
 
   private:
     uint64_t _logPeriod;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -174,7 +174,7 @@ void BedrockTester::startServer() {
 }
 
 void BedrockTester::stopServer(int pid) {
-    kill(pid, SIGKILL);
+    kill(pid, SIGINT);
     int status;
     waitpid(pid, &status, 0);
     serverPIDs.erase(pid);


### PR DESCRIPTION
@quinthar 
cc @mcnamamj @cead22 @flodnv 

This adds a small timer class that wraps our calls to `poll` in the write thread, counting µs spent in and out of the `poll` call, and recording a log line indicating the percentage of time spent waiting every minute (and one final line at shutdown).

Example log lines, from running the test suite:
```
Nov  9 18:16:51 vagrant-ubuntu-trusty-64 bedrock: xxxxx (PollTimer.cpp:39) stopPoll [write0] [info] [performance] 9719486us elapsed, 5008569us in poll(), 4710917us busy. 48.47% busy. (forced)
Nov  9 18:16:55 vagrant-ubuntu-trusty-64 bedrock: xxxxx (PollTimer.cpp:39) stopPoll [write0] [info] [performance] 4306773us elapsed, 4122512us in poll(), 184261us busy. 4.28% busy. (forced)
Nov  9 18:17:01 vagrant-ubuntu-trusty-64 bedrock: xxxxx (PollTimer.cpp:39) stopPoll [write0] [info] [performance] 4226299us elapsed, 4075146us in poll(), 151153us busy. 3.58% busy. (forced)
Nov  9 18:17:05 vagrant-ubuntu-trusty-64 bedrock: xxxxx (PollTimer.cpp:39) stopPoll [write0] [info] [performance] 4272521us elapsed, 4076733us in poll(), 195788us busy. 4.58% busy. (forced)
```

These all indicate "forced" as they're logging at shutdown, because none of the bedrock instances started in the test suite run for over a minute. Testing locally by making a test just do 10,000 writes in a row, I see log lines like:
```
Nov  9 18:28:51 vagrant-ubuntu-trusty-64 bedrock: xxxxx (PollTimer.cpp:39) stopPoll [write0] [info] [performance] 60011318us elapsed, 1147322us in poll(), 58863996us busy. 98.09% busy.
```

And adding a 1 second `sleep` after every 100th write, a line like:
```
Nov  9 18:33:26 vagrant-ubuntu-trusty-64 bedrock: xxxxx (PollTimer.cpp:39) stopPoll [write0] [info] [performance] 60882773us elapsed, 37044667us in poll(), 23838106us busy. 39.15% busy.
```

These indicate what I'd think, in terms of monitoring. Running thousands of commands in a row shows us very busy. Adding some breaks in there shows us significantly less busy. It's just a sanity check but seems to work reasonably.