### PR TITLE
Experimental precompiled header support. Saves about 25% compile time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ bedrock
 bin-*
 libstuff/libstuff.a
 sqlitecluster/sqlitecluster
+
+libstuff/libstuff.d
+libstuff/libstuff.h.gch


### PR DESCRIPTION
@cead22 

This is a first pass at adding support for pre-compiled headers in our project. This just pre-compiles `libstuff.h`, so that it doesn't get re-compiled for every cpp file that includes it. It makes compilation ~25% faster in my testing.

I'd like to incorporate this into a bit of an overhaul of how we do builds now that we have multiple repos to work in.