### PR TITLE
Replaces PCRE with std::regex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ libbedrock.a: $(LIBBEDROCKOBJ)
 
 # We use the same library paths and required libraries for both binaries.
 LIBPATHS =-Lmbedtls/library -L$(PROJECT)
-LIBRARIES =-lbedrock -lstuff -ldl -lpcrecpp -lpthread -lmbedtls -lmbedx509 -lmbedcrypto -lz
+LIBRARIES =-lbedrock -lstuff -ldl -lpthread -lmbedtls -lmbedx509 -lmbedcrypto -lz
 
 # The prerequisites for both binaries are the same. We only include one of the mbedtls libs to avoid building three
 # times in parallel.

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2267,3 +2267,7 @@ bool SQVerifyTable(sqlite3* db, const string& tableName, const string& sql) {
         return false; // Table already exists with correct definition
     }
 }
+
+bool SREMatch(const string& regExp, const string& s) {
+    return regex_match(s, regex(regExp));
+}

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -12,7 +12,6 @@
 #include <syslog.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <pcrecpp.h> // sudo apt-get install libpcre++-dev
 #include <poll.h>
 #include <time.h>
 #include <libgen.h>   // for basename()
@@ -42,6 +41,7 @@ void SInitialize();
 #include <stdlib.h>
 #include <mutex>
 #include <cctype>
+#include <regex>
 using namespace std;
 
 // Useful STL macros
@@ -415,10 +415,7 @@ bool SConstantTimeEquals(const string& secret, const string& userInput);
 bool SConstantTimeIEquals(const string& secret, const string& userInput);
 
 // Perform a full regex match. The '^' and '$' symbols are implicit.
-inline bool SREMatch(const string& regExp, const string& s) { return pcrecpp::RE(regExp).FullMatch(s); }
-inline bool SREMatch(const string& regExp, const string& s, string& match) {
-    return pcrecpp::RE(regExp).FullMatch(s, &match);
-}
+bool SREMatch(const string& regExp, const string& s);
 
 // Case testing and conversion
 string SToLower(string value);

--- a/plugins/MySQL.cpp
+++ b/plugins/MySQL.cpp
@@ -177,9 +177,11 @@ bool BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
             SINFO("Processing query '" << query << "'");
 
             // See if it's asking for a global variable
-            string varName;
-            string regExp = "^(?:(?:SELECT\\s+)?@@(?:\\w+\\.)?|SHOW VARIABLES LIKE ')(\\w+).*$";
-            if (pcrecpp::RE(regExp, pcrecpp::RE_Options().set_caseless(true)).FullMatch(query, &varName)) {
+            regex regExp = regex("^(?:(?:SELECT\\s+)?@@(?:\\w+\\.)?|SHOW VARIABLES LIKE ')(\\w+).*$",
+                                 regex_constants::ECMAScript | regex_constants::icase);
+            smatch results;
+            if (regex_match(query, results, regExp)) {
+                string varName = results[1];
                 // Loop across and look for it
                 SQResult result;
                 result.headers.push_back(varName);


### PR DESCRIPTION
@cead22 

This is a simple change to remove PCRE and use std::regex in it's place. Except for one instance in the MySQL plugin, this is just limited to the implementation of `SREMatch`, and thus is quite straightforward.