### PR TITLE
Revert "Replaces PCRE with std::regex"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ libbedrock.a: $(LIBBEDROCKOBJ)
 
 # We use the same library paths and required libraries for both binaries.
 LIBPATHS =-Lmbedtls/library -L$(PROJECT)
-LIBRARIES =-lbedrock -lstuff -ldl -lpthread -lmbedtls -lmbedx509 -lmbedcrypto -lz
+LIBRARIES =-lbedrock -lstuff -ldl -lpcrecpp -lpthread -lmbedtls -lmbedx509 -lmbedcrypto -lz
 
 # The prerequisites for both binaries are the same. We only include one of the mbedtls libs to avoid building three
 # times in parallel.

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2267,7 +2267,3 @@ bool SQVerifyTable(sqlite3* db, const string& tableName, const string& sql) {
         return false; // Table already exists with correct definition
     }
 }
-
-bool SREMatch(const string& regExp, const string& s) {
-    return regex_match(s, regex(regExp));
-}

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -12,6 +12,7 @@
 #include <syslog.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <pcrecpp.h> // sudo apt-get install libpcre++-dev
 #include <poll.h>
 #include <time.h>
 #include <libgen.h>   // for basename()
@@ -41,7 +42,6 @@ void SInitialize();
 #include <stdlib.h>
 #include <mutex>
 #include <cctype>
-#include <regex>
 using namespace std;
 
 // Useful STL macros
@@ -415,7 +415,10 @@ bool SConstantTimeEquals(const string& secret, const string& userInput);
 bool SConstantTimeIEquals(const string& secret, const string& userInput);
 
 // Perform a full regex match. The '^' and '$' symbols are implicit.
-bool SREMatch(const string& regExp, const string& s);
+inline bool SREMatch(const string& regExp, const string& s) { return pcrecpp::RE(regExp).FullMatch(s); }
+inline bool SREMatch(const string& regExp, const string& s, string& match) {
+    return pcrecpp::RE(regExp).FullMatch(s, &match);
+}
 
 // Case testing and conversion
 string SToLower(string value);

--- a/plugins/MySQL.cpp
+++ b/plugins/MySQL.cpp
@@ -177,11 +177,9 @@ bool BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
             SINFO("Processing query '" << query << "'");
 
             // See if it's asking for a global variable
-            regex regExp = regex("^(?:(?:SELECT\\s+)?@@(?:\\w+\\.)?|SHOW VARIABLES LIKE ')(\\w+).*$",
-                                 regex_constants::ECMAScript | regex_constants::icase);
-            smatch results;
-            if (regex_match(query, results, regExp)) {
-                string varName = results[1];
+            string varName;
+            string regExp = "^(?:(?:SELECT\\s+)?@@(?:\\w+\\.)?|SHOW VARIABLES LIKE ')(\\w+).*$";
+            if (pcrecpp::RE(regExp, pcrecpp::RE_Options().set_caseless(true)).FullMatch(query, &varName)) {
                 // Loop across and look for it
                 SQResult result;
                 result.headers.push_back(varName);


### PR DESCRIPTION
@mcnamamj 

Reverts Expensify/Bedrock#62

Turns out std::regex is like (literally) 300x slower than PCRE.

Timing info:
```
10,000 Regex matches, timing:

Two runs, std::regex
23.666745s
23.441512s

Two runs, PCRE
00.065080s
00.063167s

```