### PR TITLE
Demote benign 'warn' to 'hmmm'

### DIFF
--- a/libstuff/STCPServer.cpp
+++ b/libstuff/STCPServer.cpp
@@ -37,7 +37,7 @@ void STCPServer::closePorts() {
         }
         portList.clear();
     } else {
-        SWARN("Ports already closed.");
+        SHMMM("Ports already closed.");
     }
 }
 


### PR DESCRIPTION
@tylerkaraszewski 

We determined that the only time we see this warning is in "normal operation": the code is calling it twice in a row, but this shouldn't warn us: when calling this method, you expect ports to close, so if they're already closed, all is good. 

Demoting to `hmmm` rather than `info` so that it can still stand out in the logs, but not at a warning level. 