### PR TITLE
Make plugin versions part of the version string

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -271,7 +271,7 @@ BedrockServer::BedrockServer(const SData& args)
     _suppressCommandPort = false;
     _suppressCommandPortManualOverride = false;
 
-    _version = args.isSet("-versionOverride") ? args["-versionOverride"] : SVERSION;
+    _version = args.isSet("-versionOverride") ? args["-versionOverride"] : args["version"];
 
     // Output the list of plugins compiled in
     map<string, BedrockPlugin*> registeredPluginMap;
@@ -294,7 +294,6 @@ BedrockServer::BedrockServer(const SData& args)
             SERROR("Cannot find plugin '" << pluginName << "', aborting.");
         SINFO("Enabling plugin '" << pluginName << "'");
         plugin->enable(true);
-        plugin->initialize(args);
 
         // Add the plugin's SHTTPSManagers to our list.
         // As this is a list of lists, push_back will push a *copy* of the list onto our local list, meaning that the

--- a/main.cpp
+++ b/main.cpp
@@ -139,7 +139,7 @@ list<string> loadPlugins(SData& args) {
         auto info = plugin->getInfo();
         auto iterator = info.find("version");
         if (iterator != info.end()) {
-            versions.push_back(iterator->second);
+            versions.push_back(plugin->getName() + "_" + iterator->second);
         }
     }
     sort(versions.begin(), versions.end());

--- a/main.cpp
+++ b/main.cpp
@@ -73,7 +73,9 @@ void BackupDB(const string& dbPath) {
     }
 }
 
-list<string> loadPlugins(list<string> plugins) {
+
+list<string> loadPlugins(SData& args) {
+    list<string> plugins = SParseList(args["-plugins"]);
 
     // We'll return the names of the plugins we've loaded, which don't necessarily match the file names we're passed.
     // Those are stored here. TODO: It would probably make more sense for this to be a set, to avoid duplicates.
@@ -87,11 +89,12 @@ list<string> loadPlugins(list<string> plugins) {
         {"CACHE",  new BedrockPlugin_Cache()},
         {"MYSQL",  new BedrockPlugin_MySQL()}
     };
-    for_each(plugins.begin(), plugins.end(), [&](string pluginName) {
+
+    for (string pluginName : plugins) {
         // If it's one of our standard plugins, pass it's name through to postProcessedNames and move on.
         if (standardPluginMap.find(SToUpper(pluginName)) != standardPluginMap.end()) {
             postProcessedNames.push_back(pluginName);
-            return;
+            continue;
         }
 
         // Any non-standard plugin is loaded from a shared library. If a name is passed without a trailing '.so', we
@@ -126,7 +129,22 @@ list<string> loadPlugins(list<string> plugins) {
                 ((void(*)()) sym)();
             }
         }
-    });
+    }
+
+    // Initialize our version string.
+    vector<string> versions = {SVERSION};
+    for (BedrockPlugin* plugin : *BedrockPlugin::g_registeredPluginList) {
+        // We need to call initialize to let the plugin set its version info.
+        plugin->initialize(args);
+        auto info = plugin->getInfo();
+        auto iterator = info.find("version");
+        if (iterator != info.end()) {
+            versions.push_back(iterator->second);
+        }
+    }
+    sort(versions.begin(), versions.end());
+    args["version"] = SComposeList(versions, ":");
+
     return postProcessedNames;
 }
 
@@ -265,7 +283,7 @@ int main(int argc, char* argv[]) {
     SETDEFAULT("-maxJournalSize", "1000000");
     SETDEFAULT("-queryLog", "queryLog.csv");
 
-    args["-plugins"] = SComposeList(loadPlugins(SParseList(args["-plugins"])));
+    args["-plugins"] = SComposeList(loadPlugins(args));
 
     // Reset the database if requested
     if (args.isSet("-clean")) {

--- a/plugins/Status.cpp
+++ b/plugins/Status.cpp
@@ -87,7 +87,7 @@ bool BedrockPlugin_Status::peekCommand(BedrockNode* node, SQLite& db, BedrockNod
         content["state"] = SQLCStateNames[node->getState()];
         content["hash"] = node->getHash();
         content["commitCount"] = SToStr(node->getCommitCount());
-        content["version"] = SVERSION;
+        content["version"] = _args ? (*_args)["version"] : "";
         content["priority"] = SToStr(node->getPriority());
         list<string> peerList;
         SFOREACH (list<BedrockNode::Peer*>, node->peerList, it) {
@@ -105,4 +105,12 @@ bool BedrockPlugin_Status::peekCommand(BedrockNode* node, SQLite& db, BedrockNod
 
     // Didn't recognize this command
     return false;
+}
+
+// Because we don't have 'node' here.
+#undef SLOGPREFIX
+#define SLOGPREFIX "{:" << getName() << "} "
+void BedrockPlugin_Status::initialize(const SData& args) {
+    SWARN("[TYLER] Initializing status.");
+    _args = &args;
 }

--- a/plugins/Status.cpp
+++ b/plugins/Status.cpp
@@ -111,6 +111,5 @@ bool BedrockPlugin_Status::peekCommand(BedrockNode* node, SQLite& db, BedrockNod
 #undef SLOGPREFIX
 #define SLOGPREFIX "{:" << getName() << "} "
 void BedrockPlugin_Status::initialize(const SData& args) {
-    SWARN("[TYLER] Initializing status.");
     _args = &args;
 }

--- a/plugins/Status.h
+++ b/plugins/Status.h
@@ -8,4 +8,8 @@ class BedrockPlugin_Status : public BedrockPlugin {
   public:
     virtual string getName() { return "Status"; }
     virtual bool peekCommand(BedrockNode* node, SQLite& db, BedrockNode::Command* command);
+    void initialize(const SData& args);
+
+  private:
+    const SData* _args = 0;
 };


### PR DESCRIPTION
@cead22 @quinthar 

Fixes: https://github.com/Expensify/Expensify/issues/43084

This change updates our version string to be the concatenation of the version string from bedrock, and from any plugins that provide a version string (joined with a `:`). This allows bedrock to keep its command port closed when it has a *plugin* (i.e., auth) with a different version than master's, thus preventing potential problems where two identical versions of bedrock are running in the same cluster, but have loaded plugins of different versions.