### PR TITLE
Add priority to logging

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -123,7 +123,8 @@ void BedrockServer_WorkerThread(void* _data) {
             // Open this command -- it'll be peeked immediately
             const int64_t creationTimestamp = request.calc64("creationTimestamp");
             SINFO("Dispatching request '" << request.methodLine << "' (Connection: " << request["Connection"]
-                                          << ", creationTimestamp: " << creationTimestamp << ")");
+                                          << ", creationTimestamp: " << creationTimestamp
+                                          << ", priority: " << priority << ")");
 
             node.openCommand(request, priority, false, creationTimestamp);
 


### PR DESCRIPTION
@tylerkaraszewski 

This just satisfies my own curiosity and doesn't appear to be logged elsewhere.  Should have no performance impact.  Adds a priority line to the Dispatching request log line.

Tested:
Dec 28 11:10:06 vagrant-ubuntu-trusty-64 bedrock: kyQsRM (BedrockServer.cpp:127) BedrockServer_WorkerThread [read0] [info] Dispatching request 'Get' (Connection: , creationTimestamp: 0, priority: 500)


