### PR TITLE
Break if timeout hit.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -23,7 +23,7 @@
 ///
 /// **FIXME**: Add test to measure how long it takes for master to stabalize
 ///
-/// **FIXME**: Add 'nextActivity' to update()
+/// **FIXME**: Add 'nextActivity' to update() [TYLER: Partially addressed?]
 ///
 /// **FIXME**: If master dies before sending ESCALATE_RESPONSE (or if slave dies
 ///            before receiving it), then a command might have been committed to
@@ -1397,6 +1397,11 @@ bool SQLiteNode::update(uint64_t& nextActivity) {
 
                                 // By returning 'true', we update the FSM immediately, and thus evaluate whether or not
                                 // we need to wait for quorum.  This keeps all the quorum logic in the same place.
+                                if (STimeNow() > nextActivity) {
+                                    SINFO("Timeout reached while processing (transaction) commands. Exceeded by "
+                                          << (STimeNow() - nextActivity) << "us");
+                                    return false;
+                                }
                                 return true;
                             } else {
                                 // Doesn't need to commit anything; done processing.
@@ -1409,6 +1414,11 @@ bool SQLiteNode::update(uint64_t& nextActivity) {
                             }
 
                             // **NOTE: This loops back and starts the next command of the same priority immediately
+                            if (STimeNow() > nextActivity) {
+                                SINFO("Timeout reached while processing commands. Exceeded by "
+                                      << (STimeNow() - nextActivity) << "us");
+                                return false;
+                            }
                         }
                     }
 


### PR DESCRIPTION
@quinthar @righdforsa @cead22 

This is basically the same as @mcnamamj's [PR](https://github.com/Expensify/Bedrock/pull/74), except that it performs the timeout check in two locations (including the one more likely to be hit).

See [the issue](https://github.com/Expensify/Expensify/issues/42345) for the full discussion.

Tests:

Spam bedrock with a ton of commands of the same priority (enough to make it take over 1 second to process the queue), and watch the logs for one of the newly added log lines.
