### PR TITLE
Update how we choose the fastest peer to sync from.

### DIFF
--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -164,11 +164,12 @@ void STCPNode::postSelect(fd_map& fdm, uint64_t& nextActivity) {
                             pong["Timestamp"] = message["Timestamp"];
                             peer->s->send(pong.serialize());
                         } else if (SIEquals(message.methodLine, "PONG")) {
-                            // Recevied the PONG; update our latency
-                            // estimate for this peer
-                            peer->latency = STimeNow() - message.calc64("Timestamp");
-                            SINFO("Received PONG from peer '" << peer->name << "' (" << peer->latency / STIME_US_PER_MS
-                                                              << "ms latency)");
+                            // Recevied the PONG; update our latency estimate for this peer.
+                            // We set a lower bound on this at 1, because even though it should be pretty impossible
+                            // for this to be 0 (it's in us), we rely on it being non-zero in order to connect to
+                            // peers.
+                            peer->latency = max(STimeNow() - message.calc64("Timestamp"), 1ul);
+                            SINFO("Received PONG from peer '" << peer->name << "' (" << peer->latency << "us latency)");
                         } else {
                             // Not a PING or PONG; pass to the child class
                             _onMESSAGE(peer, message);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -203,6 +203,15 @@ class SQLiteNode : public STCPNode {
     void setQuroumCheckpoint(const int quroumCheckpoint) { _quorumCheckpoint = quroumCheckpoint; };
     int getQuorumCheckpoint() { return _quorumCheckpoint; };
 
+    // The peer we should sync from is recalculated every time we call this. If no other peer is logged in, or no
+    // logged in peer has a higher commitCount that we do, this will return null.
+    Peer* updateSyncPeer();
+
+    // Sorts peer/latency pairs by latency. Used internally by updateSyncPeer().
+    // Returns true if lhs is "closer" than rhs. Closer is the one with the lowest latency. Latency of 0 is higher than
+    // any other latency. If two peers have equal latency, the one with a higher CommitCount is closer.
+    static bool peerClosenessSort(const Peer* lhs, const Peer* rhs);
+
   protected:
     bool _readOnly;
     SQLite _db;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -210,7 +210,8 @@ class SQLiteNode : public STCPNode {
 
     // The peer we should sync from is recalculated every time we call this. If no other peer is logged in, or no
     // logged in peer has a higher commitCount that we do, this will return null.
-    Peer* _updateSyncPeer();
+    void _updateSyncPeer();
+    Peer* _syncPeer;
 
   private: // Internal API
     // Attributes
@@ -223,7 +224,6 @@ class SQLiteNode : public STCPNode {
     SQLCState _state;
     map<string, Command*> _escalatedCommandMap; // commandID -> Command* map
     list<Command*> _processedCommandList;
-    Peer* _syncPeer;
     Peer* _masterPeer;
     uint64_t _stateTimeout;
     int _commandCount;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -203,19 +203,14 @@ class SQLiteNode : public STCPNode {
     void setQuroumCheckpoint(const int quroumCheckpoint) { _quorumCheckpoint = quroumCheckpoint; };
     int getQuorumCheckpoint() { return _quorumCheckpoint; };
 
-    // The peer we should sync from is recalculated every time we call this. If no other peer is logged in, or no
-    // logged in peer has a higher commitCount that we do, this will return null.
-    Peer* updateSyncPeer();
-
-    // Sorts peer/latency pairs by latency. Used internally by updateSyncPeer().
-    // Returns true if lhs is "closer" than rhs. Closer is the one with the lowest latency. Latency of 0 is higher than
-    // any other latency. If two peers have equal latency, the one with a higher CommitCount is closer.
-    static bool peerClosenessSort(const Peer* lhs, const Peer* rhs);
-
   protected:
     bool _readOnly;
     SQLite _db;
     map<int, list<Command*>> _queuedCommandMap; // priority  -> list<Command*> map
+
+    // The peer we should sync from is recalculated every time we call this. If no other peer is logged in, or no
+    // logged in peer has a higher commitCount that we do, this will return null.
+    Peer* _updateSyncPeer();
 
   private: // Internal API
     // Attributes

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -10,6 +10,8 @@ struct TestSQLiteNode : public SQLiteNode {
     void _processCommand(SQLite&, SQLiteNode::Command*) {}
     void _abortCommand(SQLite&, SQLiteNode::Command*) {}
     void _cleanCommand(SQLiteNode::Command*) {}
+
+    Peer* updateSyncPeer() {return _updateSyncPeer();}
 };
 
 struct SQLiteNodeTest : tpunit::TestFixture {

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -11,7 +11,8 @@ struct TestSQLiteNode : public SQLiteNode {
     void _abortCommand(SQLite&, SQLiteNode::Command*) {}
     void _cleanCommand(SQLiteNode::Command*) {}
 
-    Peer* updateSyncPeer() {return _updateSyncPeer();}
+    void updateSyncPeer() {_updateSyncPeer();}
+    Peer* getSyncPeer() {return _syncPeer;}
 };
 
 struct SQLiteNodeTest : tpunit::TestFixture {
@@ -38,7 +39,6 @@ struct SQLiteNodeTest : tpunit::TestFixture {
             int peerNum = peer->name[4] - 48;
             (*peer)["LoggedIn"] = "true";
             (*peer)["CommitCount"] = to_string(10000000 + peerNum);
-            (*peer)["State"] = "SLAVING";
 
             // 0, 100, 200, 300.
             peer->latency = (peerNum - 1) * 100;
@@ -48,7 +48,8 @@ struct SQLiteNodeTest : tpunit::TestFixture {
                 fastest = peer;
             }
         }
-        ASSERT_EQUAL(testNode.updateSyncPeer(), fastest);
+        testNode.updateSyncPeer();
+        ASSERT_EQUAL(testNode.getSyncPeer(), fastest);
 
         // See what happens when another peer becomes faster.
         for (auto peer : testNode.peerList) {
@@ -58,7 +59,8 @@ struct SQLiteNodeTest : tpunit::TestFixture {
                 fastest = peer;
             }
         }
-        ASSERT_EQUAL(testNode.updateSyncPeer(), fastest);
+        testNode.updateSyncPeer();
+        ASSERT_EQUAL(testNode.getSyncPeer(), fastest);
 
         // And see what happens if our fastest peer logs out.
         for (auto peer : testNode.peerList) {
@@ -72,7 +74,8 @@ struct SQLiteNodeTest : tpunit::TestFixture {
                 fastest = peer;
             }
         }
-        ASSERT_EQUAL(testNode.updateSyncPeer(), fastest);
+        testNode.updateSyncPeer();
+        ASSERT_EQUAL(testNode.getSyncPeer(), fastest);
 
         // And then if our previously 0 latency peer gets (fast) latency data.
         for (auto peer : testNode.peerList) {
@@ -82,7 +85,8 @@ struct SQLiteNodeTest : tpunit::TestFixture {
                 fastest = peer;
             }
         }
-        ASSERT_EQUAL(testNode.updateSyncPeer(), fastest);
+        testNode.updateSyncPeer();
+        ASSERT_EQUAL(testNode.getSyncPeer(), fastest);
 
         // Now none of our peers have latency data, but one has more commits.
         for (auto peer : testNode.peerList) {
@@ -93,7 +97,8 @@ struct SQLiteNodeTest : tpunit::TestFixture {
                 fastest = peer;
             }
         }
-        ASSERT_EQUAL(testNode.updateSyncPeer(), fastest);
+        testNode.updateSyncPeer();
+        ASSERT_EQUAL(testNode.getSyncPeer(), fastest);
     }
 
 } __SQLiteNodeTest;

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -1,0 +1,97 @@
+#include <libstuff/libstuff.h>
+#include <sqlitecluster/SQLiteNode.h>
+#include <test/lib/BedrockTester.h>
+
+struct TestSQLiteNode : public SQLiteNode {
+    TestSQLiteNode() : SQLiteNode(":memory:", "test", "localhost:9999", 1, 1, 1, 1000000000, "1.0") { }
+
+    // Useless implementations that at least define the methods.
+    bool _peekCommand(SQLite&, SQLiteNode::Command*) {return true;}
+    void _processCommand(SQLite&, SQLiteNode::Command*) {}
+    void _abortCommand(SQLite&, SQLiteNode::Command*) {}
+    void _cleanCommand(SQLiteNode::Command*) {}
+};
+
+struct SQLiteNodeTest : tpunit::TestFixture {
+    SQLiteNodeTest() : tpunit::TestFixture(
+                                    TEST(SQLiteNodeTest::testFindSyncPeer))
+    {
+        NAME(SQLiteNode);
+    }
+
+    void testFindSyncPeer() {
+
+        // This exposes just enough to test the peer selection logic.
+        TestSQLiteNode testNode;
+
+        STable dummyParams;
+        testNode.addPeer("peer1", "host1.fake:5555", dummyParams);
+        testNode.addPeer("peer2", "host2.fake:6666", dummyParams);
+        testNode.addPeer("peer3", "host3.fake:7777", dummyParams);
+        testNode.addPeer("peer4", "host4.fake:8888", dummyParams);
+
+        // Do a base test, with one peer with no latency.
+        SQLiteNode::Peer* fastest = 0;
+        for (auto peer : testNode.peerList) {
+            int peerNum = peer->name[4] - 48;
+            (*peer)["LoggedIn"] = "true";
+            (*peer)["CommitCount"] = to_string(10000000 + peerNum);
+            (*peer)["State"] = "SLAVING";
+
+            // 0, 100, 200, 300.
+            peer->latency = (peerNum - 1) * 100;
+
+            // Our fastest should be `peer2`, it has lowest non-zero latency.
+            if (peer->name == "peer2") {
+                fastest = peer;
+            }
+        }
+        ASSERT_EQUAL(testNode.updateSyncPeer(), fastest);
+
+        // See what happens when another peer becomes faster.
+        for (auto peer : testNode.peerList) {
+            // New fastest is peer 3.
+            if (peer->name == "peer3") {
+                peer->latency = 50;
+                fastest = peer;
+            }
+        }
+        ASSERT_EQUAL(testNode.updateSyncPeer(), fastest);
+
+        // And see what happens if our fastest peer logs out.
+        for (auto peer : testNode.peerList) {
+            if (peer->name == "peer3") {
+                (*peer)["LoggedIn"] = "false";
+                peer->latency = 50;
+            }
+
+            // 2 is fastest again.
+            if (peer->name == "peer2") {
+                fastest = peer;
+            }
+        }
+        ASSERT_EQUAL(testNode.updateSyncPeer(), fastest);
+
+        // And then if our previously 0 latency peer gets (fast) latency data.
+        for (auto peer : testNode.peerList) {
+            // New fastest is peer 3.
+            if (peer->name == "peer1") {
+                peer->latency = 75;
+                fastest = peer;
+            }
+        }
+        ASSERT_EQUAL(testNode.updateSyncPeer(), fastest);
+
+        // Now none of our peers have latency data, but one has more commits.
+        for (auto peer : testNode.peerList) {
+            peer->latency = 0;
+
+            // 4 had highest commit count.
+            if (peer->name == "peer4") {
+                fastest = peer;
+            }
+        }
+        ASSERT_EQUAL(testNode.updateSyncPeer(), fastest);
+    }
+
+} __SQLiteNodeTest;


### PR DESCRIPTION
@quinthar - please review this.

Fixes:
https://github.com/Expensify/Expensify/issues/28461

This addresses the potential race condition where we choose a sync peer before we have complete information about peers, by causing us to re-select the peer to sync from after every `SYNCHRONIZE` message. We will continually switch to faster peers whenever they become available. The fastest peer is the one with the lowest latency. `0` is not a valid latency and is thus slowest. When two peers have equal latency, the one with a higher commit count is faster.
