### PR TITLE
Fixed warning '#pragma once in main file'

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -1,7 +1,8 @@
 // --------------------------------------------------------------------------
 // libstuff.h
 // --------------------------------------------------------------------------
-#pragma once
+#ifndef LIBSTUFF_H
+#define LIBSTUFF_H
 
 // Include relevant headers
 #include <stdio.h>
@@ -814,3 +815,5 @@ struct STestTimer {
 
 // Other libstuff headers.
 #include "SRandom.h"
+
+#endif	// LIBSTUFF_H


### PR DESCRIPTION
Due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47857 compilation of headers goes with warning.
The same bug at clang: https://llvm.org/bugs/show_bug.cgi?id=16686

This PR intended to get clean build log.

before:

```
vadius@vadius-db83:~/_tmp/Bedrock$ GXX=g++ make
...
g++ -g -std=gnu++11 -DSVERSION="\"fde915a93981f5d106bbc83912c04004ad3417dc\"" -Wall -I/home/vadius/_tmp/Bedrock -I/home/vadius/_tmp/Bedrock/mbedtls/include -MMD -MF libstuff/libstuff.d -MT libstuff/libstuff.h.gch -c libstuff/libstuff.h
libstuff/libstuff.h:4:9: warning: #pragma once in main file
 #pragma once
         ^
```

after:
```
vadius@vadius-db83:~/_tmp/Bedrock$ GXX=g++ make
...
g++ -g -std=gnu++11 -DSVERSION="\"fde915a93981f5d106bbc83912c04004ad3417dc\"" -Wall -I/home/vadius/_tmp/Bedrock -I/home/vadius/_tmp/Bedrock/mbedtls/include -MMD -MF libstuff/libstuff.d -MT libstuff/libstuff.h.gch -c libstuff/libstuff.h
```