### PR TITLE
Minor tuning

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -170,16 +170,16 @@ bool SIContains(const string& lhs, const string& rhs) {
 // --------------------------------------------------------------------------
 string STrim(const string& lhs) {
     // Just trim off the front and back whitespace
-    size_t front = 0;
-    while (front < lhs.size() && isspace(lhs[front]))
-        ++front;
-    size_t back = lhs.size() - 1;
-    while (back != string::npos && isspace(lhs[back]))
-        --back;
-    if (front <= back)
-        return lhs.substr(front, back - front + 1);
-    else
-        return "";
+    if(!lhs.empty()) {
+        const char* front(lhs.data());
+        const char* back(&lhs.back());
+        while(*front && isspace(*front))
+            ++front;
+        while(back > front && isspace(*back))
+            --back;
+        return string(front, ++back);
+    }
+    return "";
 }
 
 // --------------------------------------------------------------------------

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -111,6 +111,7 @@ string SToHex(uint64_t value, int digits) {
 string SToHex(const string& value) {
     // Fill from front to back
     string working;
+    working.reserve(value.size() * 2);
     for (size_t c = 0; c < value.size(); ++c) {
         // Add two digits per byte
         unsigned char digit = (unsigned char)value[c];
@@ -143,7 +144,8 @@ uint64_t SFromHex(const string& value) {
 
 string SStrFromHex(const string& buffer) {
     string retVal;
-    for(size_t i = 0; i < buffer.length(); i += 2) {
+    retVal.reserve(buffer.size() / 2);
+    for(size_t i = 0; i < buffer.size(); i += 2) {
         retVal.push_back((char)strtol(buffer.substr(i, 2).c_str(), 0, 16));
     }
     return retVal;
@@ -360,6 +362,7 @@ string SReplace(const string& value, const string& find, const string& replace) 
 
     // Keep going until we find no more
     string out;
+    out.reserve(value.size());
     size_t skip = 0;
     while (true) {
         // Look for the next match
@@ -381,9 +384,10 @@ string SReplace(const string& value, const string& find, const string& replace) 
 string SReplaceAllBut(const string& value, const string& safeChars, char replaceChar) {
     // Loop across the string and replace any invalid character
     string out;
-    for (size_t c = 0; c < value.size(); ++c)
-        if (safeChars.find(value[c]) != string::npos)
-            out += value[c];
+    out.reserve(value.size());
+    for (const char* c(value.data()); *c; ++c)
+        if (safeChars.find(*c) != string::npos)
+            out += *c;
         else
             out += replaceChar;
     return out;
@@ -393,9 +397,10 @@ string SReplaceAllBut(const string& value, const string& safeChars, char replace
 string SReplaceAll(const string& value, const string& unsafeChars, char replaceChar) {
     // Loop across the string and replace any invalid character
     string out;
-    for (size_t c = 0; c < value.size(); ++c)
-        if (unsafeChars.find(value[c]) == string::npos)
-            out += value[c];
+    out.reserve(value.size());
+    for (const char* c(value.data()); *c; ++c)
+        if (unsafeChars.find(*c) == string::npos)
+            out += *c;
         else
             out += replaceChar;
     return out;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -217,12 +217,13 @@ string SStrip(const string& lhs) {
 string SStrip(const string& lhs, const string& chars, bool charsAreSafe) {
     // Strip out all unsafe characters
     string working;
-    for (int c = 0; c < (int)lhs.size(); ++c) {
+    working.reserve(lhs.size());
+    for (const char* c(lhs.data()); *c; ++c) {
         // If the characters are in the set and are safe, then add.
         // Otherwise, if the characters are unsafe but not in the set, still add.
-        bool inSet = (chars.find(lhs[c]) != string::npos);
+        bool inSet = (chars.find(*c) != string::npos);
         if (inSet == charsAreSafe)
-            working += lhs[c];
+            working += *c;
     }
     return working;
 }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -186,16 +186,17 @@ string STrim(const string& lhs) {
 string SCollapse(const string& lhs) {
     // Collapse all whitespace into a single space
     string out;
+    out.reserve(lhs.size());
     bool inWhite = false;
-    for (size_t c = 0; c < lhs.size(); ++c)
-        if (isspace(lhs[c])) {
+    for (const char* c(lhs.data()); *c; ++c)
+        if (isspace(*c)) {
             // Only add if not already whitespace
             if (!inWhite)
-                out += lhs[c];
+                out += *c;
             inWhite = true;
         } else {
             // Not whitespace,a dd
-            out += lhs[c];
+            out += *c;
             inWhite = false;
         }
     return out;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -206,9 +206,10 @@ string SCollapse(const string& lhs) {
 string SStrip(const string& lhs) {
     // Strip out all non-printable characters
     string working;
-    for (int c = 0; c < (int)lhs.size(); ++c)
-        if (isprint(lhs[c]))
-            working += lhs[c];
+    working.reserve(lhs.size());
+    for (const char* c(lhs.data()); *c; ++c)
+        if (isprint(*c))
+            working += *c;
     return working;
 }
 

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -160,9 +160,14 @@ struct LibStuff : tpunit::TestFixture {
     }
 
     void testStrip() {
+        // simple SStrip
         ASSERT_EQUAL("", SStrip(""));
         ASSERT_EQUAL("   ", SStrip("   "));
         ASSERT_EQUAL("", SStrip("\t\n\r\x0b\x1f"));
+
+        // SStrip(lhr, chars, charsAreSafe)
+        ASSERT_EQUAL("FooBr", SStrip("Foo Bar", " a", false));
+        ASSERT_EQUAL(" a", SStrip("Foo Bar", " a", true));
     }
 
     void testChunkedEncoding() {

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -9,6 +9,7 @@ struct LibStuff : tpunit::TestFixture {
                                     TEST(LibStuff::testJSONDecode),
                                     TEST(LibStuff::testJSON),
                                     TEST(LibStuff::testEscapeUnescape),
+                                    TEST(LibStuff::testTrim),
                                     TEST(LibStuff::testChunkedEncoding),
                                     TEST(LibStuff::testDaysInMonth),
                                     TEST(LibStuff::testGZip),
@@ -136,6 +137,15 @@ struct LibStuff : tpunit::TestFixture {
         ASSERT_EQUAL(SUnescape("\\u00b7"), "\xc2\xb7");     // 2 Byte
         ASSERT_EQUAL(SUnescape("\\uc2b7"), "\xec\x8a\xb7"); // 3 Byte
         ASSERT_EQUAL(SUnescape("\\u05c0"), "\xd7\x80");     // 2 Byte, bottom 0
+    }
+
+    void testTrim() {
+        ASSERT_EQUAL("", STrim(""));
+        ASSERT_EQUAL("", STrim(" \t\n\r"));
+        ASSERT_EQUAL("FooBar", STrim("FooBar"));
+        ASSERT_EQUAL("FooBar", STrim(" FooBar"));
+        ASSERT_EQUAL("FooBar", STrim("FooBar "));
+        ASSERT_EQUAL("FooBar", STrim(" FooBar "));
     }
 
     void testChunkedEncoding() {

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -11,6 +11,7 @@ struct LibStuff : tpunit::TestFixture {
                                     TEST(LibStuff::testEscapeUnescape),
                                     TEST(LibStuff::testTrim),
                                     TEST(LibStuff::testCollapse),
+                                    TEST(LibStuff::testStrip),
                                     TEST(LibStuff::testChunkedEncoding),
                                     TEST(LibStuff::testDaysInMonth),
                                     TEST(LibStuff::testGZip),
@@ -156,6 +157,12 @@ struct LibStuff : tpunit::TestFixture {
         ASSERT_EQUAL("Lorem ipsum", SCollapse("Lorem ipsum"));
         ASSERT_EQUAL("Lorem ipsum", SCollapse("Lorem \r\t\nipsum"));
         ASSERT_EQUAL(" Lorem ipsum ", SCollapse("  Lorem \r\t\nipsum \r\n"));
+    }
+
+    void testStrip() {
+        ASSERT_EQUAL("", SStrip(""));
+        ASSERT_EQUAL("   ", SStrip("   "));
+        ASSERT_EQUAL("", SStrip("\t\n\r\x0b\x1f"));
     }
 
     void testChunkedEncoding() {

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -10,6 +10,7 @@ struct LibStuff : tpunit::TestFixture {
                                     TEST(LibStuff::testJSON),
                                     TEST(LibStuff::testEscapeUnescape),
                                     TEST(LibStuff::testTrim),
+                                    TEST(LibStuff::testCollapse),
                                     TEST(LibStuff::testChunkedEncoding),
                                     TEST(LibStuff::testDaysInMonth),
                                     TEST(LibStuff::testGZip),
@@ -146,6 +147,15 @@ struct LibStuff : tpunit::TestFixture {
         ASSERT_EQUAL("FooBar", STrim(" FooBar"));
         ASSERT_EQUAL("FooBar", STrim("FooBar "));
         ASSERT_EQUAL("FooBar", STrim(" FooBar "));
+    }
+
+    void testCollapse() {
+        ASSERT_EQUAL("", SCollapse(""));
+        ASSERT_EQUAL(" ", SCollapse("   "));
+        ASSERT_EQUAL("\t", SCollapse("\t  "));
+        ASSERT_EQUAL("Lorem ipsum", SCollapse("Lorem ipsum"));
+        ASSERT_EQUAL("Lorem ipsum", SCollapse("Lorem \r\t\nipsum"));
+        ASSERT_EQUAL(" Lorem ipsum ", SCollapse("  Lorem \r\t\nipsum \r\n"));
     }
 
     void testChunkedEncoding() {


### PR DESCRIPTION
All unittests succeeded.
But, maybe, some helpers can accept strings with 0x00 in the middle, in this case my modifications will break it. In this case corresponding unittests must be completed with such input binary data.