### PR TITLE
Use std::thread instead of pthreads

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -58,215 +58,6 @@ void BedrockServer_WorkerThread_ProcessDirectMessages(BedrockNode& node, Bedrock
 }
 
 // --------------------------------------------------------------------------
-void BedrockServer_WorkerThread(void* _data) {
-    // Initialize this thread
-    SInitialize();
-    SLogSetThreadPrefix("xxxxx ");
-    BedrockServer::Thread* data = (BedrockServer::Thread*)_data;
-    const SData& args = data->args;
-    bool readOnly = args.test("-readOnly");
-    BedrockServer::MessageQueue& queuedRequests = data->queuedRequests;
-    BedrockServer::MessageQueue& queuedEscalatedRequests = data->queuedEscalatedRequests;
-    BedrockServer::MessageQueue& processedResponses = data->processedResponses;
-    BedrockServer::MessageQueue& directMessages = data->directMessages;
-    SINFO("Starting " << (readOnly ? "read-only" : "read/write") << " worker thread for '" << data->name << "'");
-
-    // Create the actual node
-    SINFO("Starting BedrockNode: " << args.serialize());
-    BedrockNode node(args, data->server);
-    SINFO("Node created, ready for action.");
-    data->ready.set(true);
-
-    if (readOnly) {
-        for (;;) {
-            // Set the read-only node's state/master status coming from the replication thread.
-            // Only read-only nodes will allow an external party to set these properties.
-            SQLCState replicationState = data->replicationState.get();
-            const string masterVersion = data->masterVersion.get();
-            node.setState(replicationState);
-            node.setMasterVersion(masterVersion);
-
-            // Block until work is available.
-            fd_map fdm;
-            int maxS = queuedRequests.preSelect(fdm);
-            maxS = max(directMessages.preSelect(fdm), maxS);
-            S_poll(fdm, STIME_US_PER_S);
-            queuedRequests.postSelect(fdm);
-            directMessages.postSelect(fdm);
-
-            // If we've been instructed to shutdown and there are no more requests waiting
-            // to be processed, then exit the loop. Main thread will join us and continue
-            // the shutdown process.
-            bool shutdown = data->gracefulShutdown.get();
-            if (shutdown && queuedRequests.empty())
-                break;
-
-            // Process any direct messages from the main thread to us
-            BedrockServer_WorkerThread_ProcessDirectMessages(node, directMessages);
-
-            // Now try to get a request to work on.  If None available (either select
-            // timed out or another thread 'stole' it, go to the top and wait again.
-            SData request = queuedRequests.pop();
-            if (request.empty())
-                continue;
-
-            // Set the priority if supplied by the message.
-            SAUTOPREFIX(request["requestID"]);
-            SDEBUG("Worker thread unblocked!");
-            int priority = SPRIORITY_NORMAL;
-            if (!request["priority"].empty()) {
-                // Make sure the priority is valid.
-                if (SWITHIN(SPRIORITY_MIN, request.calc("priority"), SPRIORITY_MAX))
-                    priority = request.calc("priority");
-                else
-                    SWARN("Invalid priority " << request["priority"] << ". Ignoring");
-            }
-
-            // Open this command -- it'll be peeked immediately
-            const int64_t creationTimestamp = request.calc64("creationTimestamp");
-            SINFO("Dispatching request '" << request.methodLine << "' (Connection: " << request["Connection"]
-                                          << ", creationTimestamp: " << creationTimestamp
-                                          << ", priority: " << priority << ")");
-
-            node.openCommand(request, priority, false, creationTimestamp);
-
-            // Now pull that same command off the internal queue and put it on the appropriate external (threaded) queue
-            BedrockNode::Command* command = nullptr;
-            if ((command = node.getProcessedCommand())) {
-                // If it was fully processed in openCommand(), that means it was peeked successfully.
-                SINFO("Peek successful. Putting command '" << command->id << "' on processed list.");
-                BedrockServer_PrepareResponse(command);
-                processedResponses.push(command->response);
-
-            } else if ((command = node.getQueuedCommand(priority))) {
-                // Otherwise, it must be unpeekable -- make sure it didn't open any secondary request, and send to
-                // the write thread.
-                SASSERT(!command->httpsRequest);
-                SINFO("Peek unsuccessful. Signaling replication thread to process command '" << command->id << "'.");
-                queuedEscalatedRequests.push(request);
-            } else
-                SERROR("[dmb] Lost command after read-only peek. This should never happen");
-
-            // Close the command to remove it from any internal queues.
-            node.closeCommand(command);
-        }
-    } else {
-        // Add peers
-        list<string> parsedPeerList = SParseList(args["-peerList"]);
-        for (const string& peer : parsedPeerList) {
-            // Get the params from this peer, if any
-            string host;
-            STable params;
-            SASSERT(SParseURIPath(peer, host, params));
-            node.addPeer(SGetDomain(host), host, params);
-        }
-
-        // Get any HTTPSManagers that plugins registered with the server.
-        list<list<SHTTPSManager*>>& httpsManagers = data->server->httpsManagers;
-
-        // Main event loop for replication thread.
-        uint64_t nextActivity = STimeNow();
-        while (!node.shutdownComplete()) {
-            // Update shared var so all threads have awareness of the current replication state
-            // and version as determined by the replication node.
-            data->replicationState.set(node.getState());
-            data->replicationCommitCount.set(node.getCommitCount());
-            data->masterVersion.set(node.getMasterVersion());
-
-            // If we've been instructed to shutdown and we haven't yet, do it.
-            if (data->gracefulShutdown.get())
-                node.beginShutdown();
-
-            // Wait and process
-            fd_map fdm;
-
-            // Handle any HTTPS requests from our plugins.
-            for (list<SHTTPSManager*>& managerList : httpsManagers) { 
-                for (SHTTPSManager* manager : managerList) {
-                    manager->preSelect(fdm);
-                }
-            }
-
-            int maxS = node.preSelect(fdm);
-            maxS = max(queuedEscalatedRequests.preSelect(fdm), maxS);
-            maxS = max(directMessages.preSelect(fdm), maxS);
-            const uint64_t now = STimeNow();
-            data->server->pollTimer.startPoll();
-            S_poll(fdm, max(nextActivity, now) - now);
-            data->server->pollTimer.stopPoll();
-            nextActivity = STimeNow() + STIME_US_PER_S; // 1s max period
-
-            // Handle any HTTPS requests from our plugins.
-            for (list<SHTTPSManager*>& managerList : httpsManagers) { 
-                for (SHTTPSManager* manager : managerList) {
-                    manager->postSelect(fdm, nextActivity);
-                }
-            }
-
-            node.postSelect(fdm, nextActivity);
-            queuedEscalatedRequests.postSelect(fdm);
-            directMessages.postSelect(fdm);
-
-            // Process any direct messages from the main thread to us
-            BedrockServer_WorkerThread_ProcessDirectMessages(node, directMessages);
-
-            // Check for available work.
-            while (true) {
-                // Try to get some work
-                const SData& request = queuedEscalatedRequests.pop();
-                if (request.empty())
-                    break;
-
-                // Open the command -- no need to retain the pointer, the node
-                // will keep a list internally.
-                int priority = request.calc("priority");
-                bool unique = request.test("unique");
-                int64_t commandExecutionTime = request.calc64("commandExecuteTime");
-                node.openCommand(request, priority, unique, commandExecutionTime);
-            }
-
-            // Let the node process any new commands we've opened or existing
-            // commands outstanding
-            while (node.update(nextActivity))
-                ;
-
-            // Put everything the replication node has finished on the threaded queue.
-            BedrockNode::Command* command = nullptr;
-            while ((command = node.getProcessedCommand())) {
-                SAUTOPREFIX(command->request["requestID"]);
-                SINFO("Putting escalated command '" << command->id << "' on processed list.");
-                BedrockServer_PrepareResponse(command);
-                processedResponses.push(command->response);
-
-                // Close the command to remove it from any internal queues.
-                node.closeCommand(command);
-            }
-        }
-
-        // We're shutting down, do the final performance log.
-        data->server->pollTimer.log();
-
-        // Update the state one last time when the writing replication thread exits.
-        SQLCState state = node.getState();
-        if (state > SQLC_WAITING) {
-            // This is because the graceful shutdown timer fired and node.shutdownComplete() returned `true` above, but
-            // the server still thinks it's in some other state. We can only exit if we're in state <= SQLC_SEARCHING,
-            // (per BedrockServer::shutdownComplete()), so we force that state here to allow the shutdown to proceed.
-            SWARN("Write thread exiting in state " << state << ". Setting to SQLC_SEARCHING.");
-            state = SQLC_SEARCHING;
-        } else {
-            SINFO("Write thread exiting, setting state to: " << state);
-        }
-        data->replicationState.set(state);
-        data->replicationCommitCount.set(node.getCommitCount());
-    }
-
-    // Done!
-    SINFO("Thread exiting");
-    data->finished = true;
-}
-
-// --------------------------------------------------------------------------
 BedrockServer::BedrockServer(const SData& args)
     : STCPServer(""), _args(args), _requestCount(0), _writeThread(nullptr), _replicationState(SQLC_SEARCHING),
       _replicationCommitCount(0), _nodeGracefulShutdown(false), _masterVersion(""), _suppressCommandPort(false),
@@ -306,8 +97,8 @@ BedrockServer::BedrockServer(const SData& args)
                               _masterVersion, _queuedRequests, _queuedEscalatedRequests, _processedResponses, this);
     _writeThread->args["-readOnly"] = "false";
     SINFO("Lauching write thread '" << _writeThread->name << "'");
-    _writeThread->thread = SThreadOpen(BedrockServer_WorkerThread, _writeThread, _writeThread->name);
-    while (!_writeThread->ready.get()) {
+    _writeThread->threadInstance = move(thread([=] { threadWriter(_writeThread); }));
+    while (!_writeThread->ready.get()) {    // TODO: use a semaphore?
         // Wait a bit longer
         SINFO("Waiting for '" << _writeThread->name << "' to be ready to continue.");
         SThreadSleep(STIME_US_PER_S);
@@ -324,7 +115,7 @@ BedrockServer::BedrockServer(const SData& args)
         readThread->args.erase("-nodeHost");
         readThread->args["-readOnly"] = "true";
         SINFO("Launching read thread '" << readThread->name << "'");
-        readThread->thread = SThreadOpen(BedrockServer_WorkerThread, readThread, readThread->name);
+        readThread->threadInstance = move(thread([=] { threadReader(readThread); }));
         _readThreadList.push_back(readThread);
     }
 }
@@ -345,18 +136,254 @@ BedrockServer::~BedrockServer() {
 
     // Shut down the threads
     SINFO("Closing write thread '" << _writeThread->name << "'");
-    SThreadClose(_writeThread->thread);
+    if (_writeThread->threadInstance.joinable()) {
+        _writeThread->threadInstance.join();
+    }
     delete _writeThread;
+
     for (Thread* readThread : _readThreadList) {
         // Close this thread
         SINFO("Closing read thread '" << readThread->name << "'");
-        SThreadClose(readThread->thread);
+        if (readThread->threadInstance.joinable()) {
+            readThread->threadInstance.join();
+        }
         delete readThread;
     }
     _readThreadList.clear();
     SINFO("Threads closed.");
 }
 
+// --------------------------------------------------------------------------
+void BedrockServer::threadWriter(Thread* context) {
+    // Initialize this thread
+    SInitialize(context->name);
+    SLogSetThreadPrefix("xxxxx ");
+    BedrockServer::Thread* data = context;
+    const SData& args = data->args;
+    bool readOnly = args.test("-readOnly");
+    BedrockServer::MessageQueue& queuedRequests = data->queuedRequests;
+    BedrockServer::MessageQueue& queuedEscalatedRequests = data->queuedEscalatedRequests;
+    BedrockServer::MessageQueue& processedResponses = data->processedResponses;
+    BedrockServer::MessageQueue& directMessages = data->directMessages;
+    SINFO("Starting " << (readOnly ? "read-only" : "read/write") << " worker thread for '" << data->name << "'");
+
+    // Create the actual node
+    SINFO("Starting BedrockNode: " << args.serialize());
+    BedrockNode node(args, data->server);
+    SINFO("Node created, ready for action.");
+    data->ready.set(true);
+
+    // Add peers
+    list<string> parsedPeerList = SParseList(args["-peerList"]);
+    for (const string& peer : parsedPeerList) {
+        // Get the params from this peer, if any
+        string host;
+        STable params;
+        SASSERT(SParseURIPath(peer, host, params));
+        node.addPeer(SGetDomain(host), host, params);
+    }
+
+    // Get any HTTPSManagers that plugins registered with the server.
+    list<list<SHTTPSManager*>>& httpsManagers = data->server->httpsManagers;
+
+    // Main event loop for replication thread.
+    uint64_t nextActivity = STimeNow();
+    while (!node.shutdownComplete()) {
+        // Update shared var so all threads have awareness of the current replication state
+        // and version as determined by the replication node.
+        data->replicationState.set(node.getState());
+        data->replicationCommitCount.set(node.getCommitCount());
+        data->masterVersion.set(node.getMasterVersion());
+
+        // If we've been instructed to shutdown and we haven't yet, do it.
+        if (data->gracefulShutdown.get())
+            node.beginShutdown();
+
+        // Wait and process
+        fd_map fdm;
+
+        // Handle any HTTPS requests from our plugins.
+        for (list<SHTTPSManager*>& managerList : httpsManagers) { 
+            for (SHTTPSManager* manager : managerList) {
+                manager->preSelect(fdm);
+            }
+        }
+
+        int maxS = node.preSelect(fdm);
+        maxS = max(queuedEscalatedRequests.preSelect(fdm), maxS);
+        maxS = max(directMessages.preSelect(fdm), maxS);
+        const uint64_t now = STimeNow();
+        data->server->pollTimer.startPoll();
+        S_poll(fdm, max(nextActivity, now) - now);
+        data->server->pollTimer.stopPoll();
+        nextActivity = STimeNow() + STIME_US_PER_S; // 1s max period
+
+        // Handle any HTTPS requests from our plugins.
+        for (list<SHTTPSManager*>& managerList : httpsManagers) { 
+            for (SHTTPSManager* manager : managerList) {
+                manager->postSelect(fdm, nextActivity);
+            }
+        }
+
+        node.postSelect(fdm, nextActivity);
+        queuedEscalatedRequests.postSelect(fdm);
+        directMessages.postSelect(fdm);
+
+        // Process any direct messages from the main thread to us
+        BedrockServer_WorkerThread_ProcessDirectMessages(node, directMessages);
+
+        // Check for available work.
+        while (true) {
+            // Try to get some work
+            const SData& request = queuedEscalatedRequests.pop();
+            if (request.empty())
+                break;
+
+            // Open the command -- no need to retain the pointer, the node
+            // will keep a list internally.
+            int priority = request.calc("priority");
+            bool unique = request.test("unique");
+            int64_t commandExecutionTime = request.calc64("commandExecuteTime");
+            node.openCommand(request, priority, unique, commandExecutionTime);
+        }
+
+        // Let the node process any new commands we've opened or existing
+        // commands outstanding
+        while (node.update(nextActivity))
+            ;
+
+        // Put everything the replication node has finished on the threaded queue.
+        BedrockNode::Command* command = nullptr;
+        while ((command = node.getProcessedCommand())) {
+            SAUTOPREFIX(command->request["requestID"]);
+            SINFO("Putting escalated command '" << command->id << "' on processed list.");
+            BedrockServer_PrepareResponse(command);
+            processedResponses.push(command->response);
+
+            // Close the command to remove it from any internal queues.
+            node.closeCommand(command);
+        }
+    }
+
+    // We're shutting down, do the final performance log.
+    data->server->pollTimer.log();
+
+    // Update the state one last time when the writing replication thread exits.
+    SQLCState state = node.getState();
+    if (state > SQLC_WAITING) {
+        // This is because the graceful shutdown timer fired and node.shutdownComplete() returned `true` above, but
+        // the server still thinks it's in some other state. We can only exit if we're in state <= SQLC_SEARCHING,
+        // (per BedrockServer::shutdownComplete()), so we force that state here to allow the shutdown to proceed.
+        SWARN("Write thread exiting in state " << state << ". Setting to SQLC_SEARCHING.");
+        state = SQLC_SEARCHING;
+    } else {
+        SINFO("Write thread exiting, setting state to: " << state);
+    }
+    data->replicationState.set(state);
+    data->replicationCommitCount.set(node.getCommitCount());
+
+    // Done!
+    SINFO("Thread exiting");
+    data->finished = true;
+}
+
+// --------------------------------------------------------------------------
+void BedrockServer::threadReader(Thread* context) {
+    // Initialize this thread
+    SInitialize(context->name);
+    SLogSetThreadPrefix("xxxxx ");
+    BedrockServer::Thread* data = context;
+    const SData& args = data->args;
+    bool readOnly = args.test("-readOnly");
+    BedrockServer::MessageQueue& queuedRequests = data->queuedRequests;
+    BedrockServer::MessageQueue& queuedEscalatedRequests = data->queuedEscalatedRequests;
+    BedrockServer::MessageQueue& processedResponses = data->processedResponses;
+    BedrockServer::MessageQueue& directMessages = data->directMessages;
+    SINFO("Starting " << (readOnly ? "read-only" : "read/write") << " worker thread for '" << data->name << "'");
+
+    // Create the actual node
+    SINFO("Starting BedrockNode: " << args.serialize());
+    BedrockNode node(args, data->server);
+    SINFO("Node created, ready for action.");
+    data->ready.set(true);
+
+    for (;;) {
+        // Set the read-only node's state/master status coming from the replication thread.
+        // Only read-only nodes will allow an external party to set these properties.
+        SQLCState replicationState = data->replicationState.get();
+        const string masterVersion = data->masterVersion.get();
+        node.setState(replicationState);
+        node.setMasterVersion(masterVersion);
+
+        // Block until work is available.
+        fd_map fdm;
+        int maxS = queuedRequests.preSelect(fdm);
+        maxS = max(directMessages.preSelect(fdm), maxS);
+        S_poll(fdm, STIME_US_PER_S);
+        queuedRequests.postSelect(fdm);
+        directMessages.postSelect(fdm);
+
+        // If we've been instructed to shutdown and there are no more requests waiting
+        // to be processed, then exit the loop. Main thread will join us and continue
+        // the shutdown process.
+        bool shutdown = data->gracefulShutdown.get();
+        if (shutdown && queuedRequests.empty())
+            break;
+
+        // Process any direct messages from the main thread to us
+        BedrockServer_WorkerThread_ProcessDirectMessages(node, directMessages);
+
+        // Now try to get a request to work on.  If None available (either select
+        // timed out or another thread 'stole' it, go to the top and wait again.
+        SData request = queuedRequests.pop();
+        if (request.empty())
+            continue;
+
+        // Set the priority if supplied by the message.
+        SAUTOPREFIX(request["requestID"]);
+        SDEBUG("Worker thread unblocked!");
+        int priority = SPRIORITY_NORMAL;
+        if (!request["priority"].empty()) {
+            // Make sure the priority is valid.
+            if (SWITHIN(SPRIORITY_MIN, request.calc("priority"), SPRIORITY_MAX))
+                priority = request.calc("priority");
+            else
+                SWARN("Invalid priority " << request["priority"] << ". Ignoring");
+        }
+
+        // Open this command -- it'll be peeked immediately
+        const int64_t creationTimestamp = request.calc64("creationTimestamp");
+        SINFO("Dispatching request '" << request.methodLine << "' (Connection: " << request["Connection"]
+                                        << ", creationTimestamp: " << creationTimestamp
+                                        << ", priority: " << priority << ")");
+
+        node.openCommand(request, priority, false, creationTimestamp);
+
+        // Now pull that same command off the internal queue and put it on the appropriate external (threaded) queue
+        BedrockNode::Command* command = nullptr;
+        if ((command = node.getProcessedCommand())) {
+            // If it was fully processed in openCommand(), that means it was peeked successfully.
+            SINFO("Peek successful. Putting command '" << command->id << "' on processed list.");
+            BedrockServer_PrepareResponse(command);
+            processedResponses.push(command->response);
+
+        } else if ((command = node.getQueuedCommand(priority))) {
+            // Otherwise, it must be unpeekable -- make sure it didn't open any secondary request, and send to
+            // the write thread.
+            SASSERT(!command->httpsRequest);
+            SINFO("Peek unsuccessful. Signaling replication thread to process command '" << command->id << "'.");
+            queuedEscalatedRequests.push(request);
+        } else
+            SERROR("[dmb] Lost command after read-only peek. This should never happen");
+
+        // Close the command to remove it from any internal queues.
+        node.closeCommand(command);
+    }
+
+    // Done!
+    SINFO("Thread exiting");
+    data->finished = true;
+}
 // --------------------------------------------------------------------------
 bool BedrockServer::shutdownComplete() {
     // Shut down if requested and in the right state

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -54,9 +54,8 @@ class BedrockServer : public STCPServer {
                MessageQueue& queuedRequests_, // Shared external queue between threads. Queued for read-only thread(s)
                MessageQueue&
                    queuedEscalatedRequests_, // Shared external queue between threads. Queued for replication thread
-               MessageQueue& processedResponses_, // Shared external queue between threads. Finished commands ready to
+               MessageQueue& processedResponses_) // Shared external queue between threads. Finished commands ready to
                                                   // return to client.
-               BedrockServer* server_)            // The server spawning the thread.
             : name(name_),
               args(args_),
               replicationState(replicationState_),
@@ -66,8 +65,7 @@ class BedrockServer : public STCPServer {
               queuedRequests(queuedRequests_),
               queuedEscalatedRequests(queuedEscalatedRequests_),
               processedResponses(processedResponses_),
-              ready(false),
-              server(server_) {
+              ready(false) {
             // Initialized above
         }
 
@@ -84,7 +82,6 @@ class BedrockServer : public STCPServer {
         MessageQueue directMessages;
         thread threadInstance;
         SSynchronized<bool> ready;
-        BedrockServer* server;  // FIXME: looks obsolete
         bool finished = false;
     };
 
@@ -93,8 +90,8 @@ class BedrockServer : public STCPServer {
     virtual ~BedrockServer();
 
     // Thread functions
-    void threadWriter(Thread* context);
-    void threadReader(Thread* context);
+    void threadWriter(Thread* data);
+    void threadReader(Thread* data);
 
     // Accessors
     SQLCState getState() { return _replicationState.get(); }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -82,15 +82,19 @@ class BedrockServer : public STCPServer {
         MessageQueue& queuedEscalatedRequests;
         MessageQueue& processedResponses;
         MessageQueue directMessages;
-        void* thread;
+        thread threadInstance;
         SSynchronized<bool> ready;
-        BedrockServer* server;
+        BedrockServer* server;  // FIXME: looks obsolete
         bool finished = false;
     };
 
     // Constructor / Destructor
     BedrockServer(const SData& args);
     virtual ~BedrockServer();
+
+    // Thread functions
+    void threadWriter(Thread* context);
+    void threadReader(Thread* context);
 
     // Accessors
     SQLCState getState() { return _replicationState.get(); }

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -43,6 +43,8 @@ void SInitialize();
 #include <stdlib.h>
 #include <mutex>
 #include <cctype>
+#include <thread>
+
 using namespace std;
 
 // --------------------------------------------------------------------------

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -19,13 +19,12 @@
 #include <libgen.h>   // for basename()
 #include <sys/time.h> // for gettimeofday()
 #include <signal.h>
-#include <pthread.h>
 
 // --------------------------------------------------------------------------
 // Initialization / Shutdown
 // --------------------------------------------------------------------------
 // Initialize libstuff on every thread before calling any of its functions
-void SInitialize();
+void SInitialize(const string& name);
 
 // --------------------------------------------------------------------------
 // Standard Template Library stuff
@@ -275,15 +274,11 @@ void SLogStackTrace();
 // Thread stuff
 // --------------------------------------------------------------------------
 // Light wrapper around thread functions
-void* SThreadOpen(void (*proc)(void* procData), void* procData, const string& threadName = "", size_t stackSize = 0);
-void SThreadClose(void* thread);
 void SThreadSleep(uint64_t delay);
 
 // Thread local storage
 struct SThreadLocalStorage {
     // Attributes
-    void (*proc)(void* procData);
-    void* procData;
     string name;
     string logPrefix;
     SData data;

--- a/main.cpp
+++ b/main.cpp
@@ -160,7 +160,7 @@ set<string> loadPlugins(SData& args) {
 extern void BedrockTest(SData& trueArgs);
 int main(int argc, char* argv[]) {
     // Start libstuff
-    SInitialize();
+    SInitialize("main");
     SLogLevel(LOG_INFO);
     SLogSetThreadPrefix("xxxxx ");
 


### PR DESCRIPTION
Due to big code moves I advice to review the PR commit-by-commit.
All unittests works fine, `./bedrock -clean` also works w/o visible changes in logs.
Didn't test distributed deployment, but changes shouldn't affect it.