### PR TITLE
Add an optional repeat param to UpdateJob

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -373,7 +373,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         if (!db.write("UPDATE jobs "
                       "SET data=" +
                       SQ(request["data"]) + " " +
-                      (request.isSet("repeat") ? ", data=" + SQ(SToUpper(request["repeat"])) : "") +
+                      (request.isSet("repeat") ? ", repeat=" + SQ(SToUpper(request["repeat"])) : "") +
                           "WHERE jobID=" +
                       SQ(request.calc64("jobID")) + ";")) {
             throw "502 Update failed";

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -372,9 +372,9 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         // Update the data
         if (!db.write("UPDATE jobs "
                       "SET data=" +
-                      SQ(request["data"]) + " "
-                      (request.isSet("repat") ? ", repeat=" + SQ(SToUpper(request["repeat"]))) : "") +
-                                            "WHERE jobID=" +
+                      SQ(request["data"]) + " " +
+                      (request.isSet("repeat") ? ", data=" + SQ(SToUpper(request["repeat"])) : "") +
+                          "WHERE jobID=" +
                       SQ(request.calc64("jobID")) + ";")) {
             throw "502 Update failed";
         }


### PR DESCRIPTION
# Test

```
CreateJob
name: repeattest1
data: {1:1}
repeat: finished, +1 minute

200 OK
commitCount: 356
nodeName: bedrock
processingTime: 7
totalTime: 9
waitTime: 1
Content-Length: 11

{"jobID":9}

QueryJob
jobID: 9

200 OK
commitCount: 356
nodeName: bedrock
processingTime: 3
totalTime: 4
waitTime: 0
Content-Length: 172

{"created":"2017-01-26 18:43:00","data":"{1:1}","jobID":9,"lastRun":"","name":"repeattest1","nextRun":"2017-01-26 18:43:00","repeat":"FINISHED, +1 MINUTE","state":"QUEUED"}

#  Test against regressions by not using the repeat param
UpdateJob
jobID: 9
data: {2:2}

200 OK
commitCount: 357
nodeName: bedrock
processingTime: 3
totalTime: 4
waitTime: 0
Content-Length: 0

QueryJob
jobID: 9

200 OK
commitCount: 357
nodeName: bedrock
processingTime: 5
totalTime: 5
waitTime: 0
Content-Length: 172

{"created":"2017-01-26 18:43:00","data":"{2:2}","jobID":9,"lastRun":"","name":"repeattest1","nextRun":"2017-01-26 18:43:00","repeat":"FINISHED, +1 MINUTE","state":"QUEUED"}

# Test the new param that the repeat column is updated properly
UpdateJob
jobID: 9
data: {3:3}
repeat: started, +2 minute

200 OK
commitCount: 358
nodeName: bedrock
processingTime: 7
totalTime: 9
waitTime: 2
Content-Length: 0

QueryJob
jobID: 9

200 OK
commitCount: 358
nodeName: bedrock
processingTime: 3
totalTime: 3
waitTime: 0
Content-Length: 171

{"created":"2017-01-26 18:43:00","data":"{3:3}","jobID":9,"lastRun":"","name":"repeattest1","nextRun":"2017-01-26 18:43:00","repeat":"STARTED, +2 MINUTE","state":"QUEUED"}


```

Signed-off-by: Tim Golen <tgolen@expensify.com>