### PR TITLE
Add `GetJobs`

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -16,6 +16,12 @@ Bedrock::Jobs is a plugin to the [Bedrock data foundation](../README.md) that ma
    * *connection* - (optional) If set to "wait", will wait up to "timeout" ms for the match
    * *timeout* - (optional) Number of ms to wait for a match
 
+ * **GetJobs( name, numResults [connection: wait, [timeout] ] )** - Waits for a match (if requested) and atomically dequeues up to the number of requested jobs.
+   * *name* - A pattern to match in GLOB syntax (eg, "Foo*" will get the first job whose name starts with "Foo")
+   * *numResults* - Maximum number of jobs to dequeue
+   * *connection* - (optional) If set to "wait", will wait up to "timeout" ms for the match
+   * *timeout* - (optional) Number of ms to wait for a match
+
  * **UpdateJob( jobID, data )** - Updates the data associated with a job.
    * *jobID* - Identifier of the job to update
    * *data* - New data object to associate with the job

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -53,6 +53,7 @@ bool BedrockPlugin_Jobs::peekCommand(BedrockNode* node, SQLite& db, BedrockNode:
         //     Parameters:
         //     - name - name pattern of jobs to match
         //     - numResults - maximum number of jobs to dequeue
+        //     - connection - (optional) If "wait" will pause up to "timeout" for a match
         //     - timeout - (optional) maximum time (in ms) to wait, default forever
         //
         //     Returns:
@@ -714,7 +715,8 @@ string BedrockPlugin_Jobs::_constructNextRunDATETIME(const string& lastScheduled
 
 // ==========================================================================
 bool BedrockPlugin_Jobs::_hasPendingChildJobs(SQLite& db, int64_t jobID) {
-    // Returns true if there are any children of this jobID in a RUNNING or QUEUED state.
+    // Returns true if there are any children of this jobID in a "pending" (eg,
+    // running or yet to run) state
     SQResult result;
     if (!db.read("SELECT 1 "
                  "FROM jobs "


### PR DESCRIPTION
This adds a plural `GetJobs` command that returns an array of jobs, all in one call.  The singular `GetJob` command is retained unchanged for backwards compatibility.

Tests:
----
Here is a test session, walking it through its paces:

```
vagrant@vagrant-ubuntu-trusty-64:/vagrant/Bedrock$ nc localhost 8888
GetJob   
name: asdf

404 No job found
commitCount: 1
nodeName: vagrant-ubuntu-trusty-64
processingTime: 3
totalTime: 3
waitTime: 0
Content-Length: 0

GetJobs
name: asdf

402 Missing numResults
commitCount: 1
nodeName: vagrant-ubuntu-trusty-64
processingTime: 0
totalTime: 0
waitTime: 0
Content-Length: 0

GetJobs
name: asdf
numResults: 10

404 No job found
commitCount: 1
nodeName: vagrant-ubuntu-trusty-64
processingTime: 0
totalTime: 1
waitTime: 0
Content-Length: 0

CreateJob
name: asdf

200 OK
commitCount: 2
nodeName: vagrant-ubuntu-trusty-64
processingTime: 2
totalTime: 3
waitTime: 1
Content-Length: 11

{"jobID":1}

GetJob
name: asdf

200 OK
commitCount: 2
nodeName: vagrant-ubuntu-trusty-64
processingTime: 3
totalTime: 5
waitTime: 2
Content-Length: 35

{"data":{},"jobID":1,"name":"asdf"}

RetryJob
jobID: 1

200 OK
commitCount: 3
nodeName: vagrant-ubuntu-trusty-64
processingTime: 0
totalTime: 3
waitTime: 2
Content-Length: 0

GetJobs
name: asdf
numResults: 10

200 OK
commitCount: 4
nodeName: vagrant-ubuntu-trusty-64
processingTime: 6
totalTime: 8
waitTime: 2
Content-Length: 46

{"jobs":[{"data":{},"jobID":1,"name":"asdf"}]}

CreateJob
name: parent
data: {"foo":1} 

200 OK
commitCount: 5
nodeName: vagrant-ubuntu-trusty-64
processingTime: 1
totalTime: 3
waitTime: 2
Content-Length: 11

{"jobID":2}

CreateJob
name: child
data: {"bar":2} 
parentJobID: 2

200 OK
commitCount: 6
nodeName: vagrant-ubuntu-trusty-64
processingTime: 1
totalTime: 3
waitTime: 1
Content-Length: 11

{"jobID":3}

query: select * from jobs;

200 OK
commitCount: 7
nodeName: vagrant-ubuntu-trusty-64
processingTime: 0
totalTime: 1
waitTime: 1
Content-Length: 372

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID
2017-01-29 21:30:47 | 1 | RUNNING | asdf | 2017-01-29 21:31:01 | 2017-01-29 21:31:07 |  | {} | 0 | 0
2017-01-29 21:31:30 | 2 | QUEUED | parent | 2017-01-29 21:31:30 |  |  | {"foo":1} | 0 | 0
2017-01-29 21:31:43 | 3 | QUEUED | child | 2017-01-29 21:31:43 |  |  | {"bar":2} | 0 | 2


GetJobs
name: *
numResults: 10

200 OK
commitCount: 7
nodeName: vagrant-ubuntu-trusty-64
processingTime: 3
totalTime: 6
waitTime: 2
Content-Length: 138

{"jobs":[{"data":{"foo":1},"jobID":2,"name":"parent"},{"data":{"bar":2},"jobID":3,"name":"child","parentData":{"foo":1},"parentJobID":2}]}

GetJob
connection: wait
name: qwer

200 OK
commitCount: 8
nodeName: vagrant-ubuntu-trusty-64
processingTime: 6
totalTime: 36562
waitTime: 36556
Content-Length: 35

{"data":{},"jobID":4,"name":"qwer"}

GetJobs
connection: wait
name: zxcv

402 Missing numResults
commitCount: 10
nodeName: vagrant-ubuntu-trusty-64
processingTime: 0
totalTime: 0
waitTime: 0
Content-Length: 0

GetJobs
connection: wait
name: zxcv
numResults: 10

200 OK
commitCount: 10
nodeName: vagrant-ubuntu-trusty-64
processingTime: 5
totalTime: 11305
waitTime: 11299
Content-Length: 46

{"jobs":[{"data":{},"jobID":5,"name":"zxcv"}]}
```

Cc: @tylerkaraszewski @mcnamamj 