### PR TITLE
Add comments regarding external stats tracking

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -665,6 +665,7 @@ void BedrockServer::postSelect(fd_map& fdm, uint64_t& nextActivity) {
         //          job to a dead socket -- that job will never get done.
 
         // Log some performance and diagnostic data
+        // Note: be mindful of external stats aggregation scripts/services that parse these messages
         const string& commandStatus = "'" + response["request.methodLine"] + "' "
                                                                              "#" +
                                       SToStr(requestCount) + " "

--- a/libstuff/SPerformanceTimer.cpp
+++ b/libstuff/SPerformanceTimer.cpp
@@ -73,6 +73,7 @@ void SPerformanceTimer::log() {
     char buffer[7];
     snprintf(buffer, 7, "%.2f", percentage);
     // Log both raw numbers and our friendly percentage.
+    // Note: be mindful of external stats aggregation scripts/services that parse these messages
 
     SINFO("[performance] " << (_timeLogged + _timeNotLogged) << "us elapsed, " << _timeLogged << "us in "
                            << _description << ", " << _timeNotLogged << "us " << adj << ". " << buffer << "% "


### PR DESCRIPTION
Just adding some notes.  We log a lot of useful performance data which can be used by external programs for processing.  In most cases, changing the format of this data requires retooling of programs that grab this data, so let's make sure people are aware of that if they want to make changes 😉 .