### PR TITLE
Different logic for card numbers smaller than 4 digits

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -666,8 +666,11 @@ inline string SMaskPAN(const string& pan) {
     // First, make sure it's valid
     const string& safePAN = SReplaceAllBut(pan, "0123456789", 'X');
 
-    // Can show last 4.
-    if (safePAN.size() < 14) {
+    if (safePAN.size() < 4) {
+        return string(safePAN.size(), 'X');
+    }
+    else if (safePAN.size() < 14) {
+        // Card numbers smaller than 14 digits can only reveal the last 4 digits
         return string(safePAN.size() - 4, 'X') + safePAN.substr(safePAN.size() - 4);
     }
     // Can show last 4 and first 6.

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -29,6 +29,9 @@ struct LibStuff : tpunit::TestFixture {
     }
 
     void testMaskPAN() {
+        ASSERT_EQUAL(SMaskPAN(""), "");
+        ASSERT_EQUAL(SMaskPAN("123"), "XXX");
+        ASSERT_EQUAL(SMaskPAN("1234"), "1234");
         ASSERT_EQUAL(SMaskPAN("12345"), "X2345");
         ASSERT_EQUAL(SMaskPAN("1234567"), "XXX4567");
         ASSERT_EQUAL(SMaskPAN("12345678"), "XXXX5678");


### PR DESCRIPTION
@tylerkaraszewski Thanks for discovering the bug introduced following these changes: https://github.com/Expensify/Bedrock/pull/113

Card numbers smaller than 4 digits do not work well with the other masking flows. I've added additional test cases for those conditions.