### PR TITLE
Adds setter functions to SData

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -119,6 +119,22 @@ struct SData {
     string& operator[](const string& name);
     string operator[](const string& name) const;
 
+    // Two templated versions of `set` are provided. One for arithmetic types, and one for other types (which must be
+    // convertible to 'string'). These allow you to do the following:
+    // SData.set("count", 7);
+    // SData.set("name", "Tyler");
+    // for all string and integer types.
+    template <typename T>
+    typename enable_if<is_arithmetic<T>::value, void>::type set(const string& key, const T item)
+    {
+        nameValueMap[key] = to_string(item);
+    }
+    template <typename T>
+    typename enable_if<!is_arithmetic<T>::value, void>::type set(const string& key, const T item)
+    {
+        nameValueMap[key] = item;
+    }
+
     // Mutators
     void clear();
     void erase(const string& name);

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -359,6 +359,23 @@ struct LibStuff : tpunit::TestFixture {
         ASSERT_EQUAL(b.methodLine, "methodline");
         ASSERT_EQUAL(a.getVerb(), "this");
         ASSERT_EQUAL(b.getVerb(), "methodline");
+
+        SData c("Test");
+        c.set("a", 1);
+        c.set("b", 2.5);
+        c.set("c", 3ll);
+        c.set("d", 4ull);
+        c.set("e", "char*");
+        c.set("f", string("string"));
+        c.set("g", 'a'); // char, get's converted to number, not string!
+
+        ASSERT_EQUAL(c["a"], "1");
+        ASSERT_EQUAL(SToFloat(c["b"]), 2.5);
+        ASSERT_EQUAL(c["c"], "3");
+        ASSERT_EQUAL(c["d"], "4");
+        ASSERT_EQUAL(c["e"], "char*");
+        ASSERT_EQUAL(c["f"], "string");
+        ASSERT_EQUAL(SToInt(c["g"]), 97);
     }
 
     void testFileIO() {


### PR DESCRIPTION
@flodnv 

This just adds a setter function for SData.

I was tired of this:
```
SData cmd("Command");
cmd["accountID"] = to_string(65);
```

Because:

1. having to add the `to_string` is annoying.
2. If you forget to add `to_string`, what you get is this:

```
cmd["accountID"] = 65;
cout << cmd["accountID"] << endl;

// prints "A".
```
Because what happens is that the integer gets cast to a char and converted to a string, which is never what you expect.

So I added `set`, which lets you do:

```
cmd.set("accountID", 65);
cout << cmd["accountID"] << endl;

// prints "65".
```

It's templated to work on all arithmetic types (integral and floating point types) by calling `to_string` on them, and to work on regular string types by normal casting.

Tests have been added. This isn't used anywhere yet, but I think it's both more convenient and safer for integer types anywhere we use `SData`.