### PR TITLE
fixes for `no matching function for call to 'max'`

### DIFF
--- a/docs/osx.md
+++ b/docs/osx.md
@@ -1,0 +1,21 @@
+---
+layout: default
+---
+
+# Building on OSX
+
+Please make sure you have Xcode / build tools installed.
+
+
+```
+# fetches mbedtls repo
+$ git submodule init
+$ git submodule update
+
+# overrides the compilers for OSX
+$ GXX='g++' CC='gcc' make all
+
+
+# view help for bedrock
+$ ./bedrock -h
+```

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -1,4 +1,5 @@
 #include "libstuff.h"
+#include <algorithm>
 
 #undef SLOGPREFIX
 #define SLOGPREFIX "{" << name << "} "
@@ -164,7 +165,7 @@ void STCPNode::postSelect(fd_map& fdm, uint64_t& nextActivity) {
                             // We set a lower bound on this at 1, because even though it should be pretty impossible
                             // for this to be 0 (it's in us), we rely on it being non-zero in order to connect to
                             // peers.
-                            peer->latency = max(STimeNow() - message.calc64("Timestamp"), 1ul);
+                            peer->latency = std::max(STimeNow() - message.calc64("Timestamp"), UINT64_C(0x1));
                             SINFO("Received PONG from peer '" << peer->name << "' (" << peer->latency << "us latency)");
                         } else {
                             // Not a PING or PONG; pass to the child class


### PR DESCRIPTION
problem: 
- build on OSX currently fails, as reported here
- https://github.com/Expensify/Bedrock/issues/120

solution: 
- use std::max with some adjustments
- also include docs/osx.md with instructions