### PR TITLE
Fix SCollapse to work as advertised.

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -194,10 +194,10 @@ string SCollapse(const string& lhs) {
         if (isspace(*c)) {
             // Only add if not already whitespace
             if (!inWhite)
-                out += *c;
+                out += ' ';
             inWhite = true;
         } else {
-            // Not whitespace,a dd
+            // Not whitespace, add
             out += *c;
             inWhite = false;
         }

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -156,7 +156,7 @@ struct LibStuff : tpunit::TestFixture {
     void testCollapse() {
         ASSERT_EQUAL("", SCollapse(""));
         ASSERT_EQUAL(" ", SCollapse("   "));
-        ASSERT_EQUAL("\t", SCollapse("\t  "));
+        ASSERT_EQUAL(" ", SCollapse("\t  "));
         ASSERT_EQUAL("Lorem ipsum", SCollapse("Lorem ipsum"));
         ASSERT_EQUAL("Lorem ipsum", SCollapse("Lorem \r\t\nipsum"));
         ASSERT_EQUAL(" Lorem ipsum ", SCollapse("  Lorem \r\t\nipsum \r\n"));


### PR DESCRIPTION
@quinthar @mea36 

SCollapse *says* it collapses all whitespace to a single space, but it actually collapses it to a single character of whatever was first in a series of whitespace chars.

This fixes it to work as advertised, such that strings like:

```
a\n b
```
and
```
a \nb
```

collapse to the same result.