### PR TITLE
Fix Broken Journal Query

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -351,7 +351,7 @@ int SQLite::commit() {
         // Delete the oldest entry
         truncating = true;
         uint64_t before = STimeNow();
-        string query = "DELETE FROM" + _journalName + " WHERE id = MIN(id);";
+        string query = "DELETE FROM " + _journalName + " WHERE id = (SELECT MIN(id) FROM " + _journalName + ")";
         SASSERT(!SQuery(_db, "Deleting oldest row", query));
         _writeElapsed += STimeNow() - before;
     }

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -100,14 +100,15 @@ string BedrockTester::getServerName() { return "../bedrock"; }
 
 list<string> BedrockTester::getServerArgs() {
     list<string> args = {
-        "-db",         BedrockTester::DB_FILE,
-        "-serverHost", SERVER_ADDR,
-        "-nodeName",   "bedrock_test",
-        "-nodeHost",   "localhost:9889",
-        "-priority",   "200",
-        "-plugins",    "status,db,cache",
-        "-v",          "-cache",
-        "10001",
+        "-db",             BedrockTester::DB_FILE,
+        "-serverHost",     SERVER_ADDR,
+        "-nodeName",       "bedrock_test",
+        "-nodeHost",       "localhost:9889",
+        "-priority",       "200",
+        "-maxJournalSize", "10",
+        "-plugins",        "status,db,cache",
+        "-cache",          "10001",
+        "-v",
     };
 
     return args;


### PR DESCRIPTION
@cead22 @flodnv 

@mea36 noticed that the query to truncate the journal when it got too long was broken:

```
Mar 29 08:04:56 vagrant-ubuntu-trusty-64 bedrock: FbB8C8 (libstuff.cpp:2232) SQuery [write0] [dbug] DELETE FROM journal0014 WHERE id = MIN(id);
Mar 29 08:04:56 vagrant-ubuntu-trusty-64 bedrock: FbB8C8 (SQLite.cpp:129) _sqliteLogCallback [write0] [info] {SQLITE} Code: 1, Message: misuse of aggregate function MIN()
Mar 29 08:04:56 vagrant-ubuntu-trusty-64 bedrock: FbB8C8 (libstuff.cpp:2265) SQuery [write0] [warn] 'Deleting oldest row', query failed with error #1 (misuse of aggregate function MIN()): DELETE FROM   journal0014 WHERE id = MIN(id);
Mar 29 08:04:56 vagrant-ubuntu-trusty-64 bedrock: FbB8C8 (SQLite.cpp:355) commit [write0] [eror] Assertion failed: (!SQuery(_db, "Deleting oldest row", query)) != true
```

Unfortunately this isn't tested in any of our tests, because we always keep millions of rows in the journal. This fixes the query and makes the tests exercise this code.