### PR TITLE
Improve handling of BR child jobs

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -545,6 +545,8 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
             if (!db.write("DELETE FROM jobs WHERE jobID=" + SQ(request.calc64("jobID")) + ";")) {
                 throw "502 Delete failed";
             }
+
+            // Resume the parent if this is the last pending child
             if (parentJobID > 0 && !_hasPendingChildJobs(db, parentJobID)) {
                 SINFO("Job has parentJobID: " + SToStr(parentJobID) +
                       " and no other pending children, resuming parent job");

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -265,7 +265,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         // Validate that the parentJobID exists and is in the right state if one was passed.
         int64_t parentJobID = request.calc64("parentJobID");
         if (parentJobID) {
-            auto parentState = db.read("SELECT state FROM jobs WHERE jobID=" +SQ(parentJobID) + ";");
+            auto parentState = db.read("SELECT state FROM jobs WHERE jobID=" + SQ(parentJobID) + ";");
             if (parentState.empty()) {
                 throw "404 parentJobID does not exist";
             } else if (!SIEquals(parentState, "RUNNING") && !SIEquals(parentState, "PAUSED")) {
@@ -304,7 +304,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
             // in the QUEUED state.
             auto initialState = "QUEUED";
             if (parentJobID) {
-                auto parentState = db.read("SELECT state FROM jobs WHERE jobID=" +SQ(parentJobID) + ";");
+                auto parentState = db.read("SELECT state FROM jobs WHERE jobID=" + SQ(parentJobID) + ";");
                 if (SIEquals(parentState, "RUNNING")) {
                     initialState = "PAUSED";
                 }
@@ -428,7 +428,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
             if (parentJobID) {
                 // Has a parent job, add the parent data
                 job["parentJobID"] = SToStr(parentJobID);;
-                job["parentData"] = db.read("SELECT data FROM jobs WHERE jobID=" +SQ(parentJobID)+ ";");
+                job["parentData"] = db.read("SELECT data FROM jobs WHERE jobID=" + SQ(parentJobID) + ";");
             }
             if (!finishedChildJobs.empty()) {
                 // Add an associative array of all children
@@ -557,7 +557,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         // double-check that child jobs aren't somehow running in parallel to
         // the parent.
         if (parentJobID) {
-            auto parentState = db.read("SELECT state FROM jobs WHERE jobID=" +SQ(parentJobID) + ";");
+            auto parentState = db.read("SELECT state FROM jobs WHERE jobID=" + SQ(parentJobID) + ";");
             if (!SIEquals(parentState, "PAUSED")) {
                 SWARN("Trying to finish job#" << jobID << ", but parent isn't PAUSED (" << parentState << ")");
                 throw "405 Can only retry/finish child job when parent is PAUSED";
@@ -573,7 +573,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
         // If we've been asked to update the data, let's do that
         auto data = request["data"];
         if (!data.empty()) {
-            if (!db.write("UPDATE jobs SET data=" +SQ(data)+ " WHERE jobID=" +SQ(jobID)+ ";")) {
+            if (!db.write("UPDATE jobs SET data=" + SQ(data) + " WHERE jobID=" + SQ(jobID) + ";")) {
                 throw "502 Failed to update job data";
             }
         }
@@ -628,7 +628,7 @@ bool BedrockPlugin_Jobs::processCommand(BedrockNode* node, SQLite& db, BedrockNo
             SASSERT(!SIEquals(request.methodLine, "RetryJob"));
             if (parentJobID) {
                 // This is a child job.  Mark it as finished.
-                if (!db.write("UPDATE jobs SET state='FINISHED' WHERE jobID=" +SQ(jobID)+ ";")) {
+                if (!db.write("UPDATE jobs SET state='FINISHED' WHERE jobID=" + SQ(jobID) + ";")) {
                     throw "502 Failed to mark job as FINISHED";
                 }
 

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -16,5 +16,4 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     string _constructNextRunDATETIME(const string& lastScheduled, const string& lastRun, const string& repeat);
     bool _validateRepeat(const string& repeat) { return !_constructNextRunDATETIME("", "", repeat).empty(); }
     bool _hasPendingChildJobs(SQLite& db, int64_t jobID);
-    void _deleteFinishedJob(SQLite& db, const string& safeJobID);
 };

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -16,4 +16,5 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     string _constructNextRunDATETIME(const string& lastScheduled, const string& lastRun, const string& repeat);
     bool _validateRepeat(const string& repeat) { return !_constructNextRunDATETIME("", "", repeat).empty(); }
     bool _hasPendingChildJobs(SQLite& db, int64_t jobID);
+    void _deleteFinishedJob(SQLite& db, const string& safeJobID);
 };


### PR DESCRIPTION
Fixes https://github.com/Expensify/Bedrock/issues/109

Here are tests for each of the changes:

> Verify that the parent is PAUSED when any child (not just the last) calls FinishJob, and return 405 Parent must be PAUSED when children are running. By making this check early and often, we help shorten the window between whatever problem happened and we discover it.

```
CreateJob
name: parent

200 OK
commitCount: 1
nodeName: vagrant-ubuntu-trusty-64
processingTime: 8
totalTime: 12
waitTime: 4
Content-Length: 11

{"jobID":1}

GetJob
name: *

200 OK
commitCount: 2
nodeName: vagrant-ubuntu-trusty-64
processingTime: 12
totalTime: 17
waitTime: 5
Content-Length: 37

{"data":{},"jobID":1,"name":"parent"}

CreateJob
name: child
parentJobID: 1

200 OK
commitCount: 3
nodeName: vagrant-ubuntu-trusty-64
processingTime: 3
totalTime: 5
waitTime: 2
Content-Length: 11

{"jobID":2}

FinishJob
jobID: 1

200 OK
commitCount: 4
nodeName: vagrant-ubuntu-trusty-64
processingTime: 2
totalTime: 4
waitTime: 2
Content-Length: 0

GetJob
name: *

200 OK
commitCount: 5
nodeName: vagrant-ubuntu-trusty-64
processingTime: 8
totalTime: 10
waitTime: 2
Content-Length: 68

{"data":{},"jobID":2,"name":"child","parentData":{},"parentJobID":1}

query: select * from jobs;

200 OK
commitCount: 6
nodeName: vagrant-ubuntu-trusty-64
processingTime: 0
totalTime: 1
waitTime: 1
Content-Length: 296

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID
2017-03-31 17:59:08 | 1 | PAUSED | parent | 2017-03-31 17:59:08 | 2017-03-31 17:59:11 |  | {} | 0 | 0
2017-03-31 17:59:20 | 2 | RUNNING | child | 2017-03-31 17:59:20 | 2017-03-31 17:59:32 |  | {} | 0 | 1


query: update jobs set state='RUNNING' where jobID=1;

200 OK
commitCount: 6
nodeName: vagrant-ubuntu-trusty-64
processingTime: 3
totalTime: 4
waitTime: 1
Content-Length: 0

FinishJob
jobID: 2

405 Can only retry/finish child job when parent is PAUSED
commitCount: 7
nodeName: vagrant-ubuntu-trusty-64
processingTime: 5
totalTime: 7
waitTime: 2
Content-Length: 0
```

> Create children in the PAUSED state, and then mark them as QUEUED when the parent is paused. However, if the parent is PAUSED (indicating a child is creating a sibling job) then set the new child to QUEUED.

```
CreateJob
name: parent

200 OK
commitCount: 2
nodeName: vagrant-ubuntu-trusty-64
processingTime: 2
totalTime: 5
waitTime: 3
Content-Length: 11

{"jobID":1}

GetJob
name: *

200 OK
commitCount: 2
nodeName: vagrant-ubuntu-trusty-64
processingTime: 10
totalTime: 12
waitTime: 1
Content-Length: 37

{"data":{},"jobID":1,"name":"parent"}

CreateJob
name: child 
parentJobID: 1

200 OK
commitCount: 3
nodeName: vagrant-ubuntu-trusty-64
processingTime: 2
totalTime: 3
waitTime: 0
Content-Length: 11

{"jobID":2}

query: select * from jobs;

200 OK
commitCount: 4
nodeName: vagrant-ubuntu-trusty-64
processingTime: 0
totalTime: 1
waitTime: 1
Content-Length: 277

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID
2017-03-31 18:01:01 | 1 | RUNNING | parent | 2017-03-31 18:01:01 | 2017-03-31 18:01:07 |  | {} | 0 | 0
2017-03-31 18:01:22 | 2 | PAUSED | child | 2017-03-31 18:01:22 |  |  | {} | 0 | 1


FinishJob
jobID: 1

200 OK
commitCount: 4
nodeName: vagrant-ubuntu-trusty-64
processingTime: 2
totalTime: 3
waitTime: 1
Content-Length: 0

query: select * from jobs;

200 OK
commitCount: 5
nodeName: vagrant-ubuntu-trusty-64
processingTime: 0
totalTime: 1
waitTime: 1
Content-Length: 276

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID
2017-03-31 18:01:01 | 1 | PAUSED | parent | 2017-03-31 18:01:01 | 2017-03-31 18:01:07 |  | {} | 0 | 0
2017-03-31 18:01:22 | 2 | QUEUED | child | 2017-03-31 18:01:22 |  |  | {} | 0 | 1

GetJob
name: *

200 OK
commitCount: 5
nodeName: vagrant-ubuntu-trusty-64
processingTime: 5
totalTime: 8
waitTime: 2
Content-Length: 68

{"data":{},"jobID":2,"name":"child","parentData":{},"parentJobID":1}

query: select * from jobs;

200 OK
commitCount: 6
nodeName: vagrant-ubuntu-trusty-64
processingTime: 0
totalTime: 1
waitTime: 1
Content-Length: 296

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID
2017-03-31 18:01:01 | 1 | PAUSED | parent | 2017-03-31 18:01:01 | 2017-03-31 18:01:07 |  | {} | 0 | 0
2017-03-31 18:01:22 | 2 | RUNNING | child | 2017-03-31 18:01:22 | 2017-03-31 18:01:48 |  | {} | 0 | 1


CreateJob
name: sibling
parentJobID: 1

200 OK
commitCount: 6
nodeName: vagrant-ubuntu-trusty-64
processingTime: 5
totalTime: 8
waitTime: 3
Content-Length: 11

{"jobID":3}

query: select * from jobs;

200 OK
commitCount: 7
nodeName: vagrant-ubuntu-trusty-64
processingTime: 0
totalTime: 2
waitTime: 1
Content-Length: 380

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID
2017-03-31 18:01:01 | 1 | PAUSED | parent | 2017-03-31 18:01:01 | 2017-03-31 18:01:07 |  | {} | 0 | 0
2017-03-31 18:01:22 | 2 | RUNNING | child | 2017-03-31 18:01:22 | 2017-03-31 18:01:48 |  | {} | 0 | 1
2017-03-31 18:02:07 | 3 | QUEUED | sibling | 2017-03-31 18:02:07 |  |  | {} | 0 | 1
```

> Verify that the parent is RUNNING or PAUSED when any attempt is made to create a child job, and return 405 Only parents can create their own children otherwise.

```
CreateJob
name: parent

200 OK
commitCount: 1
nodeName: vagrant-ubuntu-trusty-64
processingTime: 6
totalTime: 11
waitTime: 4
Content-Length: 11

{"jobID":1}

CreateJob
name: child
parentJobID: 1

405 Can only create child job when parent is RUNNING or PAUSED
commitCount: 2
nodeName: vagrant-ubuntu-trusty-64
processingTime: 4
totalTime: 7
waitTime: 2
Content-Length: 0
```

> When finishing a child job, mark it as FINISHED rather than deleting it immediately. Also, when resuming a parent job, return a JSON object (eg, associative array) of the data objects for all FINISHED child jobs, with the jobID as the key, and an object consisting of data and state. This clearly signals to the worker "You are being resumed after finishing a bunch of child jobs", as well as alleviates the need for the worker to manually query the results of the children. This is backwards compatible with the current method, but obviates it over time.
>
> When finishing a parent job, delete any FINISHED child jobs even if there are other PAUSED child jobs outstanding (as is done by step (2) above). This way the next time the parent is resumed, the child jobs returned (via step (4) above) will only be for the latest round.

```
CreateJob
name: parent

200 OK
commitCount: 1
nodeName: vagrant-ubuntu-trusty-64
processingTime: 6
totalTime: 9
waitTime: 3
Content-Length: 11

{"jobID":1}

GetJob
name: *

200 OK
commitCount: 2
nodeName: vagrant-ubuntu-trusty-64
processingTime: 13
totalTime: 18
waitTime: 4
Content-Length: 37

{"data":{},"jobID":1,"name":"parent"}

CreateJob
name: child
parentJobID: 1

200 OK
commitCount: 3
nodeName: vagrant-ubuntu-trusty-64
processingTime: 3
totalTime: 4
waitTime: 1
Content-Length: 11

{"jobID":2}

FinishJob
jobID: 1

200 OK
commitCount: 4
nodeName: vagrant-ubuntu-trusty-64
processingTime: 9
totalTime: 13
waitTime: 4
Content-Length: 0

GetJob
name: *

200 OK
commitCount: 5
nodeName: vagrant-ubuntu-trusty-64
processingTime: 11
totalTime: 16
waitTime: 4
Content-Length: 68

{"data":{},"jobID":2,"name":"child","parentData":{},"parentJobID":1}

FinishJob
jobID: 2
data: {"foo":"bar"}

200 OK
commitCount: 6
nodeName: vagrant-ubuntu-trusty-64
processingTime: 10
totalTime: 13
waitTime: 3
Content-Length: 0

GetJob
name: *

200 OK
commitCount: 7
nodeName: vagrant-ubuntu-trusty-64
processingTime: 6
totalTime: 11
waitTime: 5
Content-Length: 92

{"data":{},"finishedChildJobs":[{"data":{"foo":"bar"},"jobID":2}],"jobID":1,"name":"parent"}

FinishJob
jobID: 1

200 OK
commitCount: 8
nodeName: vagrant-ubuntu-trusty-64
processingTime: 1
totalTime: 3
waitTime: 1
Content-Length: 0

query: select * from jobs;

200 OK
commitCount: 9
nodeName: vagrant-ubuntu-trusty-64
processingTime: 0
totalTime: 1
waitTime: 1
Content-Length: 1
```
