### PR TITLE
Filter escalated command log messages for commands marked high latency

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -613,7 +613,10 @@ void SQLiteNode::_finishCommand(Command* command) {
         // This should never get called if the initiating slave was lost; on
         // slave drop we clean out any pending commands.
         uint64_t elapsed = STimeNow() - command->creationTimestamp;
-        if (elapsed < STIME_US_PER_S * 4 || !command->request["HeldBy"].empty()) {
+        if (elapsed < STIME_US_PER_S * 4 ||
+            !command->request["HeldBy"].empty() ||
+            SIEquals(command->response["latency"], "high"))
+        {
             SINFO("Responding to escalation for transaction '" << command->request.methodLine << "' (" << command->id
                                                                << ") after " << elapsed / STIME_US_PER_MS << " ms");
         } else {


### PR DESCRIPTION
@flodnv 

## Fixes:
https://github.com/Expensify/Expensify/issues/49569
https://github.com/Expensify/Expensify/issues/48562

So, we added the `latency: high` flag to allow a given command to mark it's response as high latency to avoid certain warnings. In particular, we don't warn `Slow command (high latency)` with these commands.

However, when commands are escalated to master, we still warn with `Responding to escalation for transaction` for these commands.

This change adds the same filtering to these warnings, so they're logged as `info` if `latency: high` is set in the response.

## Tests:

Unfortunately, there isn't an easy way to test this. The log line only appears when commands are escalated by a slave to master, and none of our testing infrastructure runs a multi-node bedrock cluster (this is changing with multi-write, which adds cluster tests).

However, it's super-low risk, so I think we can safely deploy it and test in the real world. The worst case scenario is we get warns that should be infos or vice-versa.

This may need to be re-addressed in multi-write, as the architecture has changed so much.