### PR TITLE
Return commits in correct order

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -472,9 +472,10 @@ string SQLite::getCommittedHash() {
 bool SQLite::getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result) {
     // Look up all the queries within that range
     SASSERTWARN(SWITHIN(1, fromIndex, toIndex));
-    string query = _getJournalQuery({"SELECT hash, query FROM", "WHERE id >= " + SQ(fromIndex) +
+    string query = _getJournalQuery({"SELECT id, hash, query FROM", "WHERE id >= " + SQ(fromIndex) +
                                     (toIndex ? " AND id <= " + SQ(toIndex) : "")});
     SDEBUG("Getting commits #" << fromIndex << "-" << toIndex);
+    query = "SELECT hash, query FROM (" + query  + ") ORDER BY id";
     return !SQuery(_db, "getting commits", query, result);
 }
 


### PR DESCRIPTION
@righdforsa @cead22 

SQLiteNode, the consumer of `getCommits` expects it to return commits in order, which it previously did (see here: https://github.com/Expensify/Bedrock/blob/4cd5f84bf58bc8743d4277b2fd652296478a28c7/sqlitecluster/SQLite.cpp#L373 )

In updating the query to use multiple journals, we dropped the `order by` clause, and the commits are returned in arbitrary order, causing `SYNCHRONIZE` messages to receive incorrect responses.
