### PR TITLE
Update the way we handle journal size.

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -27,7 +27,7 @@ SQLite::SQLite(const string& filename, int cacheSize, int autoCheckpoint, int ma
     SASSERT(maxJournalSize > 0);
     _filename = filename;
     _insideTransaction = false;
-    _maxJournalSize = maxJournalSize / (maxRequiredJournalTableID + 2);
+    _maxJournalSize = maxJournalSize;
     _beginElapsed = 0;
     _readElapsed = 0;
     _writeElapsed = 0;
@@ -103,9 +103,23 @@ SQLite::SQLite(const string& filename, int cacheSize, int autoCheckpoint, int ma
 
     // We keep track of the number of rows in the journal, so that we can delete old entries when we're over our size
     // limit.
+    // We want the min of all journal tables.
+    string minQuery = _getJournalQuery({"SELECT MIN(id) AS id FROM"}, true);
+    minQuery = "SELECT MIN(id) AS id FROM (" + minQuery + ")";
+
+    // And the max.
+    string maxQuery = _getJournalQuery({"SELECT MAX(id) AS id FROM"}, true);
+    maxQuery = "SELECT MAX(id) AS id FROM (" + maxQuery + ")";
+
+    // Look up the min and max values in the database.
     SQResult result;
-    SASSERT(!SQuery(_db, "getting commit count", "SELECT COUNT(*) FROM " + _journalName + ";", result));
-    _journalSize = SToUInt64(result[0][0]);
+    SASSERT(!SQuery(_db, "getting commit min", minQuery, result));
+    uint64_t min = SToUInt64(result[0][0]);
+    SASSERT(!SQuery(_db, "getting commit max", maxQuery, result));
+    uint64_t max = SToUInt64(result[0][0]);
+
+    // And save the difference as the size of the journal.
+    _journalSize = max - min;
 
     // Now that the DB's all up and running, we can load our global data from it, if we're the initializer thread.
     if (initializer) {
@@ -351,7 +365,7 @@ int SQLite::commit() {
         // Delete the oldest entry
         truncating = true;
         uint64_t before = STimeNow();
-        string query = "DELETE FROM " + _journalName + " WHERE id = (SELECT MIN(id) FROM " + _journalName + ")";
+        string query = "DELETE FROM " + _journalName + " WHERE id < (SELECT MAX(id) FROM " + SQ(_journalName) + ") - " + SQ(_journalSize);
         SASSERT(!SQuery(_db, "Deleting oldest row", query));
         _writeElapsed += STimeNow() - before;
     }


### PR DESCRIPTION
@cead22 @coleaeason 

We discovered two issues yesterday while testing multi-journal on Bedrock. This change addresses both of them.

1. Because the journal is now split, we can't assume that the number of rows in any given journal table is the difference between the max and min of IDs in that table. Before this change, we had used `COUNT(*)` to get the count of rows in each table, but this was prohibitively slow. This change goes back to using the difference between MIN and MAX, across the union of all tables. We now truncate each journal table by deleting any rows older than the max in a given table, minus the max size of the journal.

2. We'd added a hack to write to random journal tables in this branch, as there's still only one write thread, and thus we wouldn't have used multiple journals for anything without writing some data to them. Unfortunately, a bug with this caused us to truncate entries in the journal tables if the main `journal` table had enough entries to need truncation, resulting in new entries in the journal being truncated. This is also fixed by the above change to truncation.