### PR TITLE
Use new method signatures so inheritance works.

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1,12 +1,12 @@
 #include "Jobs.h"
 
 #undef SLOGPREFIX
-#define SLOGPREFIX "{" << node->name << ":" << getName() << "} "
+#define SLOGPREFIX "{" << getName() << "} "
 
 #define JOBS_DEFAULT_PRIORITY 500
 
 // ==========================================================================
-void BedrockPlugin_Jobs::upgradeDatabase(SQLiteNode* node, SQLite& db) {
+void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
     // Create or verify the jobs table
     bool ignore;
     SASSERT(db.verifyTable("jobs", "CREATE TABLE jobs ( "
@@ -37,11 +37,11 @@ void BedrockPlugin_Jobs::upgradeDatabase(SQLiteNode* node, SQLite& db) {
 }
 
 // ==========================================================================
-bool BedrockPlugin_Jobs::peekCommand(SQLiteNode* node, SQLite& db, BedrockCommand* command) {
+bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
     // Pull out some helpful variables
-    SData& request = command->request;
-    SData& response = command->response;
-    STable& content = command->jsonContent;
+    SData& request = command.request;
+    SData& response = command.response;
+    STable& content = command.jsonContent;
 
     // ----------------------------------------------------------------------
     if (SIEquals(request.methodLine, "GetJob") || SIEquals(request.methodLine, "GetJobs")) {
@@ -194,11 +194,11 @@ bool BedrockPlugin_Jobs::peekCommand(SQLiteNode* node, SQLite& db, BedrockComman
 }
 
 // ==========================================================================
-bool BedrockPlugin_Jobs::processCommand(SQLiteNode* node, SQLite& db, BedrockCommand* command) {
+bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
     // Pull out some helpful variables
-    SData& request = command->request;
-    SData& response = command->response;
-    STable& content = command->jsonContent;
+    SData& request = command.request;
+    SData& response = command.response;
+    STable& content = command.jsonContent;
 
     // ----------------------------------------------------------------------
     if (SIEquals(request.methodLine, "CreateJob")) {

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -6,9 +6,9 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
   public:
     // Implement base class interface
     virtual string getName() { return "Jobs"; }
-    virtual void upgradeDatabase(SQLiteNode* node, SQLite& db);
-    virtual bool peekCommand(SQLiteNode* node, SQLite& db, BedrockCommand* command);
-    virtual bool processCommand(SQLiteNode* node, SQLite& db, BedrockCommand* command);
+    virtual void upgradeDatabase(SQLite& db);
+    virtual bool peekCommand(SQLite& db, BedrockCommand& command);
+    virtual bool processCommand(SQLite& db, BedrockCommand& command);
 
   private:
     // Helper functions


### PR DESCRIPTION
@flodnv 

We changed the method signatures for plugins. Unortunately, we missed updating them in `Jobs`. This causes the default implementations (which do nothing) to get called for `peekCommand`, `processCommand` and `upgradeDatabase`.

This change updates the signatures so that these methods override the base class versions, and thus get called correctly.

Tests:
Use the bedrock jobs plugin.