### PR TITLE
Fix initializing the version string

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -461,8 +461,9 @@ BedrockServer::BedrockServer(const SData& args)
         registeredPluginMap[pluginName] = plugin;
     }
 
-    // Enable the requested plugins
+    // Enable the requested plugins, and update our version string if required.
     list<string> pluginNameList = SParseList(args["-plugins"]);
+    vector<string> versions = {_version};
     for (string& pluginName : pluginNameList) {
         BedrockPlugin* plugin = registeredPluginMap[SToLower(pluginName)];
         if (!plugin) {
@@ -470,19 +471,12 @@ BedrockServer::BedrockServer(const SData& args)
         }
         plugin->initialize(args, *this);
         plugins.push_back(plugin);
-    }
 
-    // Initialize our version string.
-    vector<string> versions = {_version};
-    for (const string& pluginName : pluginNameList) {
-        BedrockPlugin* plugin = BedrockPlugin::getPluginByName(pluginName);
-        if (plugin) {
-            plugin->initialize(args, *this);
-            auto info = plugin->getInfo();
-            auto iterator = info.find("version");
-            if (iterator != info.end()) {
-                versions.push_back(plugin->getName() + "_" + iterator->second);
-            }
+        // If the plugin has version info, add it to the list.
+        auto info = plugin->getInfo();
+        auto iterator = info.find("version");
+        if (iterator != info.end()) {
+            versions.push_back(plugin->getName() + "_" + iterator->second);
         }
     }
     sort(versions.begin(), versions.end());


### PR DESCRIPTION
@cead22 

Fixes how we initialize the version string, which was removed from `main.cpp`, but never got added to `BedrockServer.cpp`, where it's been added.

## Tests:

Build Bedrock and Auth. Start them. Send them a `Status` command. Verify they both return a version, and for auth, it contains the auth version.