### PR TITLE
Fix first round of bugs found in live testing.

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -256,8 +256,16 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         const string& safeData = request["data"].empty() ? SQ("{}") : SQ(request["data"]);
 
         // If a repeat is provided, validate it
-        if (request.isSet("repeat") && !_validateRepeat(request["repeat"]))
-            throw "402 Malformed repeat";
+        if (request.isSet("repeat")) {
+            if (request["repeat"].empty()) {
+                SWARN("Repeat is set in CreateJob, but is set to the empty string. Job Name: "
+                      << request["name"] << ", removing attribute.");
+                request.erase("repeat");
+            } else if (!_validateRepeat(request["repeat"])) {
+                throw "402 Malformed repeat";
+            }
+        }
+
 
         // If no priority set, set it
         int64_t priority = request.isSet("priority") ? request.calc("priority") : JOBS_DEFAULT_PRIORITY;
@@ -477,8 +485,15 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         verifyAttributeSize(request, "data", 1, MAX_SIZE_BLOB);
 
         // If a repeat is provided, validate it
-        if (request.isSet("repeat") && !_validateRepeat(request["repeat"]))
-            throw "402 Malformed repeat";
+        if (request.isSet("repeat")) {
+            if (request["repeat"].empty()) {
+                SWARN("Repeat is set in UpdateJob, but is set to the empty string. jobID: "
+                      << request["jobID"] << ", removing attribute.");
+                request.erase("repeat");
+            } else if (!_validateRepeat(request["repeat"])) {
+                throw "402 Malformed repeat";
+            }
+        }
 
         // Verify there is a job like this
         SQResult result;


### PR DESCRIPTION
@mcnamamj 

This fixes the first round of multi-write bugs we found in testing.

1. We don't assert on committing a change in the `STANDINGDOWN` state. This caused a crash at shutdown if we were mid-transaction and the node stopped `MASTERING`.
2. We use case-insensitive names for `Status` commands (including `Ping`). This showed up as `ping` being an unrecognized command, even though `Ping` worked.
3. We add logging around the `repeat` flag in `Jobs`,a s we were seeing warnings being thrown when it was blank.
4. We demote a warning for receiving outdated `APPROVE_TRANSACTION` messages, which can now have either an out-of-date transaction ID, or an out-of-date hash in the case of a conflict committing on master.