### PR TITLE
Only let the SQLiteNode switch out of standing down when the server is finished committing commands

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -876,6 +876,13 @@ bool SQLiteNode::update() {
             // See if we're done
             // **FIXME: Add timeout?
             if (allUnsubscribed) {
+
+                // We can only switch to SEARCHING if the server has no outstanding write work to do.
+                if (!_server.canStandDown()) {
+                    // Try again.
+                    SWARN("Can't switch from STANDINGDOWN to SEARCHING yet, server prevented state change.");
+                    return true;
+                }
                 // Standdown complete
                 SINFO("STANDDOWN complete, SEARCHING");
 

--- a/sqlitecluster/SQLiteServer.h
+++ b/sqlitecluster/SQLiteServer.h
@@ -14,4 +14,8 @@ class SQLiteServer : public STCPServer {
     // An SQLiteNode will call this to cancel a command that a peer has escalated but no longer wants a response to.
     // The command may or may not be canceled, depending on whether it's already been processed.
     virtual void cancelCommand(const string& commandID) = 0;
+
+    // This will return true if there's no outstanding writable activity that we're waiting on. It's called by an
+    // SQLiteNode in a STANDINGDOWN state to know that it can switch to searching.
+    virtual bool canStandDown() = 0;
 };

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -21,6 +21,7 @@ class TestServer : public SQLiteServer {
 
     virtual void acceptCommand(SQLiteCommand&& command) { };
     virtual void cancelCommand(const string& commandID) { };
+    virtual bool canStandDown() { return true; };
 };
 
 struct SQLiteNodeTest : tpunit::TestFixture {


### PR DESCRIPTION
@quinthar 

Adds a method that SQLiteNode can call to check if the server is ready to stand down.

Adds a counter to the server that keeps track of commands in progress that might try to write.

Only returns that the SQLiteNode can stand down when that counter is 0.

Only tests are the existing ones.