### PR TITLE
Always go through STANDINGDOWN when switching away from MASTERING

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -876,7 +876,6 @@ bool SQLiteNode::update() {
             // See if we're done
             // **FIXME: Add timeout?
             if (allUnsubscribed) {
-
                 // We can only switch to SEARCHING if the server has no outstanding write work to do.
                 if (!_server.canStandDown()) {
                     // Try again.


### PR DESCRIPTION
@quinthar @coleaeason @cead22 

So, this makes two changes. 

One is that if we switched out of MASTERING/STANDINGDOWN with a commit in progress, we wouldn't roll back that commit. I'm not sure this was actually possible to reach, but if so, it looks like it could have possibly caused the sort of problem we saw yesterday. It can only happen on a master, though, so I'm not sure it would have hit the whole cluster, unless it happened on each node as it stood up and then stood back down, though I'm not sure that happened.

The second change removes a case where we'd switch directly from MASTERING to SEARCHING without going through STANDINGDOWN. This used to be fairly safe (as long as you weren't mid-transaction) - the state of the DB was known. Now, with multi-write, this is less true, and we want to make sure that all threads have a chance to finish any transactions in progress, leaving the DB in a known-good state, then finish standing down.

Would this cause yesterday's issue? I'm not sure. It seems feasible that we could mess up the master by switching away from MASTERING to SEARCHING while transactions are in progress, and then as the machine came back up as a slave, it might have the highest commit count (as it may have finished those transactions mid-state-change), and cause problems by sending bad `SYNCHRONIZE_RESPONSE` messages to other peers.

This is a little speculative. When we try it, I'll plan on capturing start/end times for the deploy and any master node changes, so that we can hopefully be in a good place to sort through the correct logs and diagnose any other problems that we see happen at the time.