### PR TITLE
Potential fix for missing loglines

### DIFF
--- a/libstuff/SLockTimer.h
+++ b/libstuff/SLockTimer.h
@@ -14,8 +14,8 @@ class SLockTimer : public SPerformanceTimer {
 
   private:
     atomic<int> _lockCount;
-    recursive_mutex _syncMutex;
     LOCKTYPE& _lock;
+    recursive_mutex _syncMutex;
 };
 
 template<typename LOCKTYPE>
@@ -30,11 +30,11 @@ SLockTimer<LOCKTYPE>::~SLockTimer() {
 template<typename LOCKTYPE>
 void SLockTimer<LOCKTYPE>::lock()
 {
-    SAUTOLOCK(_syncMutex);
     _lock.lock();
 
     // We atomically increment the counter, and only start the timer if we were the first to do so, in the case
     // multiple threads are competing for this.
+    SAUTOLOCK(_syncMutex);
     int count = _lockCount.fetch_add(1);
     if (!count) {
         start();
@@ -46,7 +46,7 @@ void SLockTimer<LOCKTYPE>::unlock()
 {
     SAUTOLOCK(_syncMutex);
     int count = _lockCount.fetch_sub(1);
-    
+
     // Count contains the value just before our decrement. If it was 1, that means we're now at a lock count of 0, and
     // can stop the timer.
     if (count == 1) {

--- a/libstuff/SPerformanceTimer.h
+++ b/libstuff/SPerformanceTimer.h
@@ -2,7 +2,7 @@
 
 class SPerformanceTimer {
   public:
-    SPerformanceTimer(string description, bool reverse = false, uint64_t logIntervalSeconds = 60);
+    SPerformanceTimer(string description, bool reverse = false, uint64_t logIntervalSeconds = 10);
     void start();
     void stop();
     void log();


### PR DESCRIPTION
We're supposed to log `[performance]` loglines for certain metrics (particularly, the amount of time spent in the main `commit` lock), however, we saw a case today where that didn't happen, and bedrock stopped logging these lines.

I'm speculating that we called either out-of-order, or simultaneously, and this may have caused our performance logger to end up in a broken state.

This adds an extra mutex and explicitly locks around starting and stopping the timer, so that these two operations must be serialized.

The previous code would correctly increment and decrement our counters, but once the counter values changed, there was no guarantee that `start` and `stop` ran in the same order. You could, potentially increment the counter intending to start the timer, be interrupted, then in a different thread, decrement the counter, call `stop()`, and then the first thread would resume and call `start()`. The counter ends up in a valid state, but we'd have called `stop` before `start`.