### PR TITLE
Disable multi-write. Demote warning.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -399,7 +399,8 @@ void BedrockServer::worker(SData& args,
                     }
                     // Peek wasn't enough to handle this command. Now we need to decide if we should try and process
                     // it, or if we should send it off to the sync node.
-                    if (state != SQLiteNode::MASTERING ||
+                    if (true || /* DISABLE MULTI-WRITE*/
+                        state != SQLiteNode::MASTERING ||
                         command.httpsRequest           ||
                         command.writeConsistency != SQLiteNode::ASYNC)
                     {
@@ -409,7 +410,7 @@ void BedrockServer::worker(SData& args,
                         // look for another command to work on. We're also not handling a writable command anymore.
                         server._writableCommandsInProgress--;
                         break;
-                    }  else {
+                    } else {
                         // In this case, there's nothing blocking us from processing this in a worker, so let's try it.
                         if (core.processCommand(command)) {
                             // If processCommand returned true, then we need to do a commit. Otherwise, the command is

--- a/main.cpp
+++ b/main.cpp
@@ -182,7 +182,7 @@ int main(int argc, char* argv[]) {
         cout << "-nodeHost       <host:port> Listen on this host:port for connections from other nodes" << endl;
         cout << "-peerList       <list>      See below" << endl;
         cout << "-priority       <value>     See '-peerList Details' below (defaults to 100)" << endl;
-        cout << "-plugins        <list>      Enable these plugins (defaults to 'status,db,jobs,cache')" << endl;
+        cout << "-plugins        <list>      Enable these plugins (defaults to 'db,jobs,cache')" << endl;
         cout << "-cacheSize      <kb>        number of KB to allocate for a page cache (defaults to 1GB)" << endl;
         cout << "-workerThreads  <#>         Number of worker threads to start (min 1, defaults to # of cores)" << endl;
         cout << "-queryLog       <filename>  Set the query log filename (default 'queryLog.csv', SIGUSR2/SIGQUIT to "

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1540,7 +1540,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         if (_db.getUncommittedHash().empty()) {
             throw "no outstanding transaction";
         }
-        SWARN("ROLLBACK received on slave for: " << message["ID"]);
+        SINFO("ROLLBACK received on slave for: " << message["ID"]);
         _db.rollback();
 
         // Look through our escalated commands and see if it's one being processed


### PR DESCRIPTION
@coleaeason

Always hand commands to the sync node after peeking.