### PR TITLE
[HOLD] Add timeout to Jobs

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -818,19 +818,18 @@ string BedrockPlugin_Jobs::_constructNextRunDATETIME(const string& lastScheduled
     }
 
     // Validate the sqlite date modifiers
-    // See: https://www.sqlite.org/lang_datefunc.html
+    if (!_isValidSQLiteDateModifier(SComposeList(parts))){
+        SWARN("Syntax error, failed parsing repeat");
+        return "";
+    }
+
     for (const string& part : parts) {
-        // Simple regexp validation
         if (SREMatch("^(\\+|-)\\d{1,3} (YEAR|MONTH|DAY|HOUR|MINUTE|SECOND)S?$", part)) {
             safeParts.push_back(SQ(part));
         } else if (SREMatch("^START OF (DAY|MONTH|YEAR)$", part)) {
             safeParts.push_back(SQ(part));
         } else if (SREMatch("^WEEKDAY [0-6]$", part)) {
             safeParts.push_back(SQ(part));
-        } else {
-            // Malformed part
-            SWARN("Syntax error, failed parsing repeat '" << repeat << "' on part '" << part << "'");
-            return "";
         }
     }
 
@@ -854,3 +853,25 @@ bool BedrockPlugin_Jobs::_hasPendingChildJobs(SQLite& db, int64_t jobID) {
     return !result.empty();
 }
 
+bool BedrockPlugin_Jobs::_isValidSQLiteDateModifier(const string& modifier) {
+    list<string> parts = SParseList(SToUpper(modifier));
+    for (const string& part : parts) {
+        // Simple regexp validation
+        if (SREMatch("^(\\+|-)\\d{1,3} (YEAR|MONTH|DAY|HOUR|MINUTE|SECOND)S?$", part)) {
+            continue;
+        }
+
+        if (SREMatch("^START OF (DAY|MONTH|YEAR)$", part)) {
+            continue;
+        }
+
+        if (SREMatch("^WEEKDAY [0-6]$", part)) {
+            continue;
+        }
+
+        SINFO("Syntax error, failed parsing date modifier '" << modifier << "' on part '" << part << "'");
+        return false;
+    }
+
+    return true;
+}

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -9,7 +9,7 @@
 void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
     // Create or verify the jobs table
     bool ignore;
-    SASSERT(db.verifyTable("jobs", "CREATE TABLE jobs ( "
+    bool originalTable = db.verifyTable("jobs", "CREATE TABLE jobs ( "
                                    "created  TIMESTAMP NOT NULL, "
                                    "jobID    INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, "
                                    "state    TEXT NOT NULL, "
@@ -19,8 +19,14 @@ void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
                                    "repeat   TEXT NOT NULL, "
                                    "data     TEXT NOT NULL, "
                                    "priority INTEGER NOT NULL DEFAULT " + SToStr(JOBS_DEFAULT_PRIORITY) + ", "
-                                   "parentJobID INTEGER NOT NULL DEFAULT 0 )",
-                           ignore));
+                                   "parentJobID INTEGER NOT NULL DEFAULT 0, "
+                                   "timeout  TEXT DEFAULT NULL)",
+                           ignore);
+
+
+    if (!originalTable) {
+        SASSERT(db.write("ALTER TABLE jobs ADD COLUMN timeout TEXT DEFAULT NULL;"));
+    }
 
     // These indexes are not used by the Bedrock::Jobs plugin, but provided for easy analysis
     // using the Bedrock::DB plugin.

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -263,8 +263,11 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         const string& safeData = request["data"].empty() ? SQ("{}") : SQ(request["data"]);
 
         // If no timeout was passed, set to NULL
-        // @todo validate timeout
-        const string& safeTimeout = request["timeout"].empty() ? "NULL" : SQ(request["timeout"]);
+        const string& timeout = request["timeout"].empty() ? "NULL" : request["timeout"];
+        if (timeout != "NULL" && !_isValidSQLiteDateModifier(timeout)) {
+            throw "402 Malformed timeout";
+        }
+        const string& safeTimeout = SQ(timeout);
 
         // If a repeat is provided, validate it
         if (request.isSet("repeat")) {

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -163,8 +163,8 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
         content["repeat"] = result[0][6];
         content["data"] = result[0][7];
         return true; // Successfully processed
-    } 
-    
+    }
+
     // ----------------------------------------------------------------------
     else if (SIEquals(request.methodLine, "CreateJob")) {
         // If unique flag was passed and the job exist in the DB, then we can
@@ -333,13 +333,13 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             // Create this new job
             if (!db.write("INSERT INTO jobs ( created, state, name, nextRun, repeat, data, priority, parentJobID, timeout ) "
                      "VALUES( " +
-                        SCURRENT_TIMESTAMP() + ", " + 
-                        SQ(initialState) + ", " + 
-                        SQ(request["name"]) + ", " + 
+                        SCURRENT_TIMESTAMP() + ", " +
+                        SQ(initialState) + ", " +
+                        SQ(request["name"]) + ", " +
                         safeFirstRun + ", " +
-                        SQ(SToUpper(request["repeat"])) + ", " + 
-                        safeData + ", " + 
-                        SQ(priority) + ", " + 
+                        SQ(SToUpper(request["repeat"])) + ", " +
+                        safeData + ", " +
+                        SQ(priority) + ", " +
                         SQ(parentJobID) + ", " +
                         safeTimeout +
                      " );"))
@@ -374,7 +374,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         // works!
         SQResult result;
         const string& name = request["name"];
-        string safeNumResults = SQ(max(request.calc("numResults"),1)); 
+        string safeNumResults = SQ(max(request.calc("numResults"),1));
         string selectQuery =
             "SELECT jobID, name, data, parentJobID FROM ( "
                 "SELECT * FROM ("
@@ -670,7 +670,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                     }
                 }
             } else {
-                // This is a standalone (not a child) job; delete it.  
+                // This is a standalone (not a child) job; delete it.
                 if (!db.write("DELETE FROM jobs WHERE jobID=" + SQ(jobID) + ";")) {
                     throw "502 Delete failed";
                 }
@@ -845,7 +845,7 @@ bool BedrockPlugin_Jobs::_hasPendingChildJobs(SQLite& db, int64_t jobID) {
     SQResult result;
     if (!db.read("SELECT 1 "
                  "FROM jobs "
-                 "WHERE parentJobID = " + SQ(jobID) + " " + 
+                 "WHERE parentJobID = " + SQ(jobID) + " " +
                  "  AND state IN ('QUEUED', 'RUNNING', 'PAUSED') "
                  "LIMIT 1;",
                  result)) {

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -15,4 +15,8 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     string _constructNextRunDATETIME(const string& lastScheduled, const string& lastRun, const string& repeat);
     bool _validateRepeat(const string& repeat) { return !_constructNextRunDATETIME("", "", repeat).empty(); }
     bool _hasPendingChildJobs(SQLite& db, int64_t jobID);
+
+    // Validates the sqlite date modifiers
+    // See: https://www.sqlite.org/lang_datefunc.html
+    bool _isValidSQLiteDateModifier(const string& modifier);
 };


### PR DESCRIPTION
@quinthar please review

# Notes
- Holding to benchmark the new queries
- GetJob can return RUNNING timed-out jobs before QUEUED jobs, but I don't know if the `ORDER BY`s in our queries are deterministic in this regard
- It's currently valid to call CreateJob with negative timeouts (eg, `timeout:-5 HOURS`). Opted not to handle that case now

# Tests

## Normal behavior
```
query:select * from jobs

200 OK
Content-Length: 1

CreateJob
name:test

200 OK
Content-Length: 14

{"jobID":2842}

GetJob
name:test

200 OK
Content-Length: 38

{"data":{},"jobID":2842,"name":"test"}

UpdateJob
data:{carlos:true}
jobID:2842

200 OK
Content-Length: 0

query:select * from jobs

200 OK
Content-Length: 226

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | timeout
2017-04-18 23:40:36 | 2842 | RUNNING | test | 2017-04-18 23:40:36 | 2017-04-18 23:40:44 |  | {carlos:true} | 500 | 0 | NULL

FinishJob
jobID:2842

200 OK
Content-Length: 0

query:select * from jobs

200 OK
Content-Length: 1
```

## Quick sample showing timeout
```
CreateJob
name:test2
timeout:+5 seconds

200 OK
Content-Length: 14

{"jobID":2847}
GetJob
name:test2

200 OK
Content-Length: 39

{"data":{},"jobID":2847,"name":"test2"}

GetJob
name:test2

404 No job found
Content-Length: 0


GetJob
name:test2

404 No job found
Content-Length: 0


GetJob
name:test2

200 OK
Content-Length: 39

{"data":{},"jobID":2847,"name":"test2"}
```

## Longer session showing timeouts

```
CreateJob
name:test
timeout:+10 seconds

200 OK
Content-Length: 14

{"jobID":2844}

CreateJob
name:test

200 OK
Content-Length: 14

{"jobID":2845}

CreateJob
name:test
timeout: +15 seconds

200 OK
Content-Length: 14

{"jobID":2846}

query:select * from jobs

200 OK
Content-Length: 395

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | timeout
2017-04-18 23:44:08 | 2844 | QUEUED | test | 2017-04-18 23:44:08 |  |  | {} | 500 | 0 | +10 seconds
2017-04-18 23:44:17 | 2845 | QUEUED | test | 2017-04-18 23:44:17 |  |  | {} | 500 | 0 | NULL
2017-04-18 23:44:30 | 2846 | QUEUED | test | 2017-04-18 23:44:30 |  |  | {} | 500 | 0 | +15 seconds

GetJob
name:test

200 OK
Content-Length: 38

{"data":{},"jobID":2844,"name":"test"}
query:select * from jobs

200 OK
Content-Length: 415

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | timeout
2017-04-18 23:44:08 | 2844 | RUNNING | test | 2017-04-18 23:44:08 | 2017-04-18 23:44:38 |  | {} | 500 | 0 | +10 seconds
2017-04-18 23:44:17 | 2845 | QUEUED | test | 2017-04-18 23:44:17 |  |  | {} | 500 | 0 | NULL
2017-04-18 23:44:30 | 2846 | QUEUED | test | 2017-04-18 23:44:30 |  |  | {} | 500 | 0 | +15 seconds


GetJob
name:test

200 OK
Content-Length: 38

{"data":{},"jobID":2845,"name":"test"}
query:select * from jobs

200 OK
Content-Length: 435

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | timeout
2017-04-18 23:44:08 | 2844 | RUNNING | test | 2017-04-18 23:44:08 | 2017-04-18 23:44:38 |  | {} | 500 | 0 | +10 seconds
2017-04-18 23:44:17 | 2845 | RUNNING | test | 2017-04-18 23:44:17 | 2017-04-18 23:44:47 |  | {} | 500 | 0 | NULL
2017-04-18 23:44:30 | 2846 | QUEUED | test | 2017-04-18 23:44:30 |  |  | {} | 500 | 0 | +15 seconds

GetJob
name:test

200 OK
Content-Length: 38

{"data":{},"jobID":2844,"name":"test"}

query:select * from jobs

200 OK
Content-Length: 435

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | timeout
2017-04-18 23:44:08 | 2844 | RUNNING | test | 2017-04-18 23:44:08 | 2017-04-18 23:44:57 |  | {} | 500 | 0 | +10 seconds
2017-04-18 23:44:17 | 2845 | RUNNING | test | 2017-04-18 23:44:17 | 2017-04-18 23:44:47 |  | {} | 500 | 0 | NULL
2017-04-18 23:44:30 | 2846 | QUEUED | test | 2017-04-18 23:44:30 |  |  | {} | 500 | 0 | +15 seconds

FinishJob
jobID:2845

200 OK
Content-Length: 0

query:select * from jobs

200 OK
Content-Length: 322

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | timeout
2017-04-18 23:44:08 | 2844 | RUNNING | test | 2017-04-18 23:44:08 | 2017-04-18 23:44:57 |  | {} | 500 | 0 | +10 seconds
2017-04-18 23:44:30 | 2846 | QUEUED | test | 2017-04-18 23:44:30 |  |  | {} | 500 | 0 | +15 seconds

GetJob
name:test

200 OK
Content-Length: 38

{"data":{},"jobID":2844,"name":"test"}

query:select * from jobs

200 OK
Content-Length: 322

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | timeout
2017-04-18 23:44:08 | 2844 | RUNNING | test | 2017-04-18 23:44:08 | 2017-04-18 23:45:23 |  | {} | 500 | 0 | +10 seconds
2017-04-18 23:44:30 | 2846 | QUEUED | test | 2017-04-18 23:44:30 |  |  | {} | 500 | 0 | +15 seconds

FinishJob
jobID: 2844

200 OK
Content-Length: 0

query:select * from jobs

200 OK
Content-Length: 202

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | timeout
2017-04-18 23:44:30 | 2846 | QUEUED | test | 2017-04-18 23:44:30 |  |  | {} | 500 | 0 | +15 seconds

GetJob
name:test

200 OK
Content-Length: 38

{"data":{},"jobID":2846,"name":"test"}

query:select * from jobs

200 OK
Content-Length: 222

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | timeout
2017-04-18 23:44:30 | 2846 | RUNNING | test | 2017-04-18 23:44:30 | 2017-04-18 23:45:40 |  | {} | 500 | 0 | +15 seconds

FinishJob
jobID:2846

200 OK
Content-Length: 0


query:select * from jobs

200 OK
Content-Length: 1
```

## Validation logic

```
CreateJob
name:test
timeout:bad

402 Malformed timeout
Content-Length: 0

CreateJob
name:test
timeout:scheduled, +1 minute

402 Malformed timeout
Content-Length: 0

CreateJob
name:test
timeout:finished, +2 days

402 Malformed timeout
Content-Length: 0

CreateJob
name:test
timeout:+1 minute

200 OK
Content-Length: 14

{"jobID":2848}

CreateJob
name:test
timeout:+5 hours

200 OK
Content-Length: 14

{"jobID":2849}

CreateJob
name:test
timeout:+2 days

200 OK
Content-Length: 14

{"jobID":2850}

CreateJob
name:test
repeat:bad

402 Malformed repeat
Content-Length: 0

CreateJob
name:test
repeat:+1 minute

402 Malformed repeat
Content-Length: 0

CreateJob
name:test
repeat:+2 days

402 Malformed repeat
Content-Length: 0

CreateJob
name:test
repeat:scheduled, +2 days

200 OK
Content-Length: 14

{"jobID":2852}

CreateJob
name:test
repeat:finished, +1 hour

200 OK
Content-Length: 14

{"jobID":2853}
```