### PR TITLE
Remove Card-specific functionality from Bedrock

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -657,32 +657,6 @@ string SAESEncrypt(const string& buffer, const string& iv, const string& key);
 string SAESDecrypt(const string& buffer, const string& iv, const string& key);
 
 // --------------------------------------------------------------------------
-// Credit card stuff
-// --------------------------------------------------------------------------
-// Determine if some input is a PAN
-inline bool SIsPAN(const string& value) { return SREMatch("^\\d{13,19}$", value); }
-inline bool SIsMaskedPAN(const string& value) { return SREMatch("^\\d{0,6}[Xx]+\\d{4,7}$", value); }
-
-// --------------------------------------------------------------------------
-// Helper function to mask out the necessary digits in a card number to
-// comply with PCI 3.3.  Namely, replace all but the first six and last four
-// digits with X.
-inline string SMaskPAN(const string& pan) {
-    // First, make sure it's valid
-    const string& safePAN = SReplaceAllBut(pan, "0123456789", 'X');
-
-    if (safePAN.size() < 4) {
-        return string(safePAN.size(), 'X');
-    }
-    else if (safePAN.size() < 14) {
-        // Card numbers smaller than 14 digits can only reveal the last 4 digits
-        return string(safePAN.size() - 4, 'X') + safePAN.substr(safePAN.size() - 4);
-    }
-    // Can show last 4 and first 6.
-    return safePAN.substr(0, 6) + string(safePAN.size() - 10, 'X') + safePAN.substr(safePAN.size() - 4);
-}
-
-// --------------------------------------------------------------------------
 // SQLite Stuff
 // --------------------------------------------------------------------------
 #include "sqlite3.h"

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -3,7 +3,6 @@
 
 struct LibStuff : tpunit::TestFixture {
     LibStuff() : tpunit::TestFixture("LibStuff",
-                                    TEST(LibStuff::testMaskPAN),
                                     TEST(LibStuff::testEncryptDecrpyt),
                                     TEST(LibStuff::testSHMACSHA1),
                                     TEST(LibStuff::testJSONDecode),
@@ -25,20 +24,6 @@ struct LibStuff : tpunit::TestFixture {
                                     TEST(LibStuff::testRandom),
                                     TEST(LibStuff::testHexConversion))
     { }
-
-    void testMaskPAN() {
-        ASSERT_EQUAL(SMaskPAN(""), "");
-        ASSERT_EQUAL(SMaskPAN("123"), "XXX");
-        ASSERT_EQUAL(SMaskPAN("1234"), "1234");
-        ASSERT_EQUAL(SMaskPAN("12345"), "X2345");
-        ASSERT_EQUAL(SMaskPAN("1234567"), "XXX4567");
-        ASSERT_EQUAL(SMaskPAN("12345678"), "XXXX5678");
-        ASSERT_EQUAL(SMaskPAN("12345678a"), "XXXXX678X");
-        ASSERT_EQUAL(SMaskPAN("1234567890123"), "XXXXXXXXX0123");
-        ASSERT_EQUAL(SMaskPAN("12345678901234"), "123456XXXX1234");
-        ASSERT_EQUAL(SMaskPAN("12345678901234567"), "123456XXXXXXX4567");
-        ASSERT_EQUAL(SMaskPAN("123456789012345678901"), "123456XXXXXXXXXXX8901");
-    }
 
     void testEncryptDecrpyt() {
         string iv = "58fae8d18b6fe8ed";


### PR DESCRIPTION
@flodnv Remove card-specific functionality from Bedrock. Hold until the corresponding Auth changes are merged. Thanks!