### PR TITLE
Restore commit count header, don't process commands with future commit count.

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -41,6 +41,9 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
             response.methodLine = "200 OK";
         }
 
+        // Add the commitCount header to the response.
+        response["commitCount"] = _db.getCommitCount();
+
         // Success. If a command has set "content", encode it in the response.
         SINFO("Responding '" << response.methodLine << "' to read-only '" << request.methodLine << "'.");
         if (!content.empty()) {
@@ -109,6 +112,9 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         if (response.methodLine == "") {
             response.methodLine = "200 OK";
         }
+
+        // Add the commitCount header to the response.
+        response["commitCount"] = _db.getCommitCount();
 
         // Success, this command will be committed.
         SINFO("Processed '" << response.methodLine << "' for '" << request.methodLine << "'.");

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -42,7 +42,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
         }
 
         // Add the commitCount header to the response.
-        response["commitCount"] = _db.getCommitCount();
+        response["commitCount"] = to_string(_db.getCommitCount());
 
         // Success. If a command has set "content", encode it in the response.
         SINFO("Responding '" << response.methodLine << "' to read-only '" << request.methodLine << "'.");
@@ -114,7 +114,7 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         }
 
         // Add the commitCount header to the response.
-        response["commitCount"] = _db.getCommitCount();
+        response["commitCount"] = to_string(_db.getCommitCount());
 
         // Success, this command will be committed.
         SINFO("Processed '" << response.methodLine << "' for '" << request.methodLine << "'.");
@@ -167,4 +167,7 @@ void BedrockCore::_handleCommandException(BedrockCommand& command, const string&
     if (command.response.methodLine.empty()) {
         command.response.methodLine = e;
     }
+
+    // Add the commitCount header to the response.
+    command.response["commitCount"] = to_string(_db.getCommitCount());
 }

--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -6,7 +6,8 @@ SQLiteCommand::SQLiteCommand(SData&& _request) :
     request(move(_request)),
     writeConsistency(SQLiteNode::ASYNC),
     complete(false),
-    executeTimestamp(SToUInt64(request["commandExecuteTime"]) ?: STimeNow())
+    executeTimestamp(SToUInt64(request["commandExecuteTime"]) ?: STimeNow()),
+    commitCount(SToUInt64(request["commitCount"]) ?: 0)
 {
     // Initialize the consistency, if supplied.
     if (request.isSet("writeConsistency")) {

--- a/sqlitecluster/SQLiteCommand.h
+++ b/sqlitecluster/SQLiteCommand.h
@@ -41,6 +41,9 @@ class SQLiteCommand {
     // Specified in microseconds.
     uint64_t executeTimestamp;
 
+    // If set, a commit count upon which this request depends, presumably a result from a previous request.
+    uint64_t commitCount;
+
     // Construct that takes a request object.
     SQLiteCommand(SData&& _request);
 


### PR DESCRIPTION
@quinthar 

Addresses the issue discussed here: https://github.com/Expensify/Expensify/issues/47980#issuecomment-296814483

There are no new tests for this case, it has been tested with a modified version of `authtest` that spits out the `commitCount` on every response it gets from bedrock.

The change itself is fairly straightforward.