### PR TITLE
Use now, rather than 0, as default timetamp

### DIFF
--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -24,6 +24,11 @@ SQLiteCommand::SQLiteCommand(SData&& _request) :
                 break;
         }
     }
+
+    // If the request doesn't specify an execution time, default to right now.
+    if (!request.isSet("commandExecuteTime")) {
+        request["commandExecuteTime"] = to_string(STimeNow());
+    }
 }
 
 SQLiteCommand::SQLiteCommand() :


### PR DESCRIPTION
@quinthar 

Fixes a bug introduced here:
https://github.com/Expensify/Bedrock/pull/155/files#diff-c3f18a7d36357de294f26aed031d81bdL9

By removing the initializer here, the default for "no value" became 0, rather than `STimeNow()`. This specifically sets the value to `STimeNow()` if it wasn't specified.

In most cases, this has no effect, but there are a couple auth commands that throw exceptions if they're over 30 seconds old. These commands would fail with an execution time of `0`.

Tests: no new tests. Auth tests handle this case.