### PR TITLE
Add SString, with auto-stringification

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -632,7 +632,7 @@ int SParseHTTP(const char* buffer, size_t length, string& methodLine, STable& na
                     int headerLength = (int)(parseEnd - buffer);
 
                     // If there is no content-length, just return the length of the headers
-                    int contentLength = (SContains<string, string>(nameValueMap, "Content-Length")
+                    int contentLength = (SContains(nameValueMap, "Content-Length")
                                              ? atoi(nameValueMap["Content-Length"].c_str())
                                              : 0);
                     if (!contentLength)

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -95,7 +95,39 @@ class STableComp : binary_function<string, string, bool> {
         bool operator()(const unsigned char& c1, const unsigned char& c2) const { return tolower(c1) < tolower(c2); }
     };
 };
-typedef map<string, string, STableComp> STable;
+
+// An SString is just a string with special assignment operators so that we get automatic conversion from arithmetic
+// types.
+class SString : public string {
+  public:
+    // Templated assignment operator for arithmetic types.
+    template <typename T>
+    typename enable_if<is_arithmetic<T>::value, SString&>::type operator=(const T& from) {
+        string::operator=(to_string(from));
+        return *this;
+    }
+
+    // Templated assignment operator for non-arithmetic types.
+    template <typename T>
+    typename enable_if<!is_arithmetic<T>::value, SString&>::type operator=(const T& from) {
+        string::operator=(from);
+        return *this;
+    }
+
+    // Chars are special, we don't treat them as integral types, even though they'd normally count.
+    SString& operator=(const char& from) {
+        string::operator=(from);
+        return *this;
+    }
+
+    // The above is also true for unsigned chars.
+    SString& operator=(const unsigned char& from) {
+        string::operator=(from);
+        return *this;
+    }
+};
+
+typedef map<string, SString, STableComp> STable;
 
 // --------------------------------------------------------------------------
 // A very simple HTTP-like structure consisting of a method line, a table,

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -18,6 +18,7 @@ struct LibStuff : tpunit::TestFixture {
                                     TEST(LibStuff::testConstantTimeEquals),
                                     TEST(LibStuff::testParseIntegerList),
                                     TEST(LibStuff::testSData),
+                                    TEST(LibStuff::testSTable),
                                     TEST(LibStuff::testFileIO),
                                     TEST(LibStuff::testSTimeNow),
                                     TEST(LibStuff::testCurrentTimestamp),
@@ -374,6 +375,29 @@ struct LibStuff : tpunit::TestFixture {
         ASSERT_EQUAL(c["e"], "char*");
         ASSERT_EQUAL(c["f"], "string");
         ASSERT_EQUAL(SToInt(c["g"]), 97);
+    }
+
+    void testSTable() {
+        // Verify that auto-stringification works.
+        STable test;
+        test["a"] = 1;
+        test["b"] = -1;
+        test["c"] = 0;
+        test["d"] = 5000000001;
+        test["e"] = -5000000001;
+        test["f"] = 1.2;
+        test["g"] = (unsigned char)'a';
+        test["h"] = 'b';
+        test["i"] = "string";
+        ASSERT_EQUAL(test["a"], "1");
+        ASSERT_EQUAL(test["b"], "-1");
+        ASSERT_EQUAL(test["c"], "0");
+        ASSERT_EQUAL(test["d"], "5000000001");
+        ASSERT_EQUAL(test["e"], "-5000000001");
+        ASSERT_EQUAL(test["f"], "1.200000"); // default precision.
+        ASSERT_EQUAL(test["g"], "a");
+        ASSERT_EQUAL(test["h"], "b");
+        ASSERT_EQUAL(test["i"], "string");
     }
 
     void testFileIO() {


### PR DESCRIPTION
@quinthar @flodnv 

So, this was a bit of an experiment, but it turned out to be a lot more straightforward than I thought it might be, and seems to work just great.

It adds a new type, `SString`, which is just a subclass of `string` that adds new assignment operators.

For any arithmetic type, (except `char` and `unsigned char`), we'll call `to_string` in the assignment operator. Otherwise, we just use the base class assignment operator.

And we change `STable` to be a map of `string`s to `SString`s. What this does, is when we use the `[]` operator to return a reference to an item in an `STable`, and perform an assignment on that object, we get to use our new assignment operators, which fixes probably the single-most-common error we make around `STable`s, which is doing this;

```
int someInt = 65;

STable request;
request["ID"] = someInt;
```

and then expecting that: `request["ID"] == "65"` but actually seeing `request["ID"] == "A"` because the int got cast to a char so that we could assign it to a string.

Now, this works, and will result in `request["ID"] == "65"`.