### PR TITLE
Add a queue for commands dependent on a future commit.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -384,12 +384,12 @@ void BedrockServer::worker(SData& args,
             uint64_t commandCommitCount = command.request.calcU64("commitCount");
             if (commandCommitCount > commitCount) {
                 SAUTOLOCK(server._futureCommitCommandMutex);
-                server._futureCommitCommands.insert(make_pair(commandCommitCount, move(command)));
-                auto queueSize = server._futureCommitCommands.size();
+                auto newQueueSize = server._futureCommitCommands.size() + 1;
                 SINFO("Command (" << command.request.methodLine << ") depends on future commit(" << commandCommitCount
-                      << "), Currently at: " << commitCount << ", storing for later. Queue size: " << queueSize);
-                if (queueSize > 100) {
-                    SHMMM("server._futureCommitCommands.size() == " << queueSize);
+                      << "), Currently at: " << commitCount << ", storing for later. Queue size: " << newQueueSize);
+                server._futureCommitCommands.insert(make_pair(commandCommitCount, move(command)));
+                if (newQueueSize > 100) {
+                    SHMMM("server._futureCommitCommands.size() == " << newQueueSize);
                 }
                 continue;
             }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -162,4 +162,10 @@ class BedrockServer : public SQLiteServer {
     // won't start any of these unless we're mastering, and we won't allow SQLiteNode to drop out of STANDINGDOWN until
     // it's 0.
     atomic<int> _writableCommandsInProgress;
+
+    // This is a mp of commit counts in the future to commands that depend on them. We can receive a command that
+    // depends on a future commit if we're a slave that's behind master, and a client makes two requests, one to a node
+    // more current than ourselves, and a following request to us.
+    multimap<uint64_t, BedrockCommand> _futureCommitCommands;
+    recursive_mutex _futureCommitCommandMutex;
 };

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -163,9 +163,10 @@ class BedrockServer : public SQLiteServer {
     // it's 0.
     atomic<int> _writableCommandsInProgress;
 
-    // This is a mp of commit counts in the future to commands that depend on them. We can receive a command that
+    // This is a map of commit counts in the future to commands that depend on them. We can receive a command that
     // depends on a future commit if we're a slave that's behind master, and a client makes two requests, one to a node
-    // more current than ourselves, and a following request to us.
+    // more current than ourselves, and a following request to us. We'll move these commands to this special map until
+    // we catch up, and then move them back to the regular command queue.
     multimap<uint64_t, BedrockCommand> _futureCommitCommands;
     recursive_mutex _futureCommitCommandMutex;
 };


### PR DESCRIPTION
@cead22 @quinthar 

The main gist of this change can be summed up in this comment: https://github.com/Expensify/Bedrock/compare/tyler-future-queue?expand=1#diff-754f778bc15d5dcbe7abaeb4f079bdb2R166

If we're a slave, and slightly behind master's commit count, it's feasible for us to receive a command that depends on a commit we don't yet have. This change stores these commands in a special map until we update our commit count and can move them back to the main command queue.

No new tests for this, it's a bit of a strange scenario and @cole @righdforsa have discussed testing it live.