### PR TITLE
Fix double unlock bug that caused loss of performance logs.

### DIFF
--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -206,6 +206,10 @@ class SQLite {
     uint64_t _commitElapsed;
     uint64_t _rollbackElapsed;
 
+    // We keep track of whether we've locked the global mutex so that we know whether or not we need to unlock it when
+    // we call `rollback`.
+    bool _mutexLocked;
+
     // Like getCommitCount(), but only callable internally, when we know for certain that we're not in the middle of
     // any transactions. Instead of reading from an atomic var, reads directly from the database.
     uint64_t _getCommitCount();


### PR DESCRIPTION
@cead22 @righdforsa @coleaeason 

### Issue fixed:
Nodes stop reporting performance info.

### Tests:
Run the `clustertest` test, grepping logs for `performance` and you should see one for each node every 10 seconds.

Ok, the code change here is really small, but let me try and explain what's going on.

The way the performance metrics for the global commit lock work are like this: we keep a count of locks held on the commit lock. Whenever that changes from 0->1, we start counting locked time. When it changes from 1->0, we stop counting locked time. This breaks down such that "usage" time, is time where the lock count > 0.

Ok, so what's the problem? The problem is that we unlock our mutex in places we shouldn't. This works ok for the mutex, because our C++ library allows:

```
mutex.lock();
mutex.unlock();
mutex.unlock();
```

And the second `unlock` call just has no effect. However, for our counter, what this would do is:

```
mutex.lock(); // lockCount = 1. Start timing.
mutex.unlock(); // lockCount = 0. Stop timing.
mutex.unlock(); // lockCount = -1. Oops.
```

This happened because of the way SQLite locked and unlocked it's mutex. When you call `prepare()`, the mutex is locked. Then the mutex is unlocked when you call either `commit()` or `rollback()`. Generally, this was what happened, except that you're allowed to call `rollback()` without calling `prepare()`. We would do this when master tried to upgrade its DB, if we found there were no changes to the DB. So every time master started up, it'd `unlock` without `lock`ing, and that'd put our `lockCount` at -1, and then we wouldn't log correctly anymore.

There was also a spot where we would call `rollback` and then `unlock`, which was redundant and would cause the same issue. The extra `unlock` call there has been removed.

To fix the main problem, we add a `bool` that keeps track of whether we've called `lock` and in `rollback`, only unlocks if we've previously called `lock`.

It seems like instead, we could have just refused to decrement our lock count below zero. I think this would have worked fine as well, but the C++ standard says calling `unlock` on a mutex that isn't locked is undefined behavior, and this being an open-source project, I felt like we should do the technically correct thing, and not `unlock` unless we'd `lock`ed.

I hope that's enough explanation for a 15 line change.
