### PR TITLE
Delete existing transaction on assignment

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -60,6 +60,11 @@ BedrockCommand::BedrockCommand(SData _request) :
 
 BedrockCommand& BedrockCommand::operator=(BedrockCommand&& from) {
     if (this != &from) {
+        // The current incarnation of this object is going away, if it had an httpsRequest, we'll need to destroy it,
+        // or it will leak nad never get cleaned up.
+        if (httpsRequest) {
+            httpsRequest->owner.closeTransaction(httpsRequest);
+        }
         httpsRequest = from.httpsRequest;
         from.httpsRequest = nullptr;
         SQLiteCommand::operator=(move(from));


### PR DESCRIPTION
@cead22 @coleaeason @righdforsa 

### Fixes the bug where we fail to connect to scrapers.

This bug was caused by leaking `HTTPSTransaction` object, each of which had a socket open. We'd close the sockets when we deleted them, but they didn't get deleted. Eventually, we'd run out of available sockets and fail to be able to connect to scrapers (or anything else).

The main loop in `BedrockServer` essentially does this:

```
BedrockCommand command;
while(1) {
    processCommand();
    if (command.complete) {
        command = getNewCommand();
    }
}
```

Which is fine, except for:
```
command = getNewCommand();
```

We've set up a command so that *when it's deleted* it will clean up after it's HTTPS request, if it has one. However, assigning a new value to the command doesn't delete it - it just overwrites the existing HTTPS request with a new one, leaking the old one. We'd never delete any of them, because on each assignment, we'd lose the old one.

This change alters the assignment operator to delete any existing HTTPS request on the old object before assigning the new one, the same as the destructor does.