### PR TITLE
Don't send to disconnected peers

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1760,6 +1760,12 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
 void SQLiteNode::_sendToPeer(Peer* peer, const SData& message) {
     SASSERT(peer);
     SASSERT(!message.empty());
+
+    // If a peer is currently disconnected, we can't send it a message.
+    if (!peer->s) {
+        PWARN("Can't send message to peer, no socket. Message '" << message.methodLine << "' will be discarded.");
+        return;
+    }
     // Piggyback on whatever we're sending to add the CommitCount/Hash
     SData messageCopy = message;
     messageCopy["CommitCount"] = to_string(_db.getCommitCount());


### PR DESCRIPTION
@righdforsa @cead22 @coleaeason 

If master loses a connection to a peer while it's processing commands, we'll delete the `Socket` object in `postPoll`, but then we can still try to send the `ESCALATE_RESPONSE` to that peer, even though we have no connection. This causes a crash.

This change detects when a peer has no socket, warns, and drops the message without crashing. Peers already detect disconnection from master, clear out their escalated commands, and return `500 Aborted` to clients.