### PR TITLE
Fix quorum commit interval.

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -169,4 +169,8 @@ class BedrockServer : public SQLiteServer {
     // we catch up, and then move them back to the regular command queue.
     multimap<uint64_t, BedrockCommand> _futureCommitCommands;
     recursive_mutex _futureCommitCommandMutex;
+
+    // A set of command names that will always be run with QUORUM consistency level.
+    // Specified by the `-synchronousCommands` command-line switch.
+    set<string> _syncCommands;
 };

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -776,7 +776,7 @@ bool SQLiteNode::update() {
                     uint64_t totalElapsed = _db.getLastTransactionTiming(beginElapsed, readElapsed, writeElapsed,
                                                                          prepareElapsed, commitElapsed, rollbackElapsed);
                     SINFO("Committed master transaction for '"
-                          << _db.getCommitCount() + 1 << " (" << _db.getUncommittedHash() << "). "
+                          << _db.getCommitCount() << " (" << _db.getCommittedHash() << "). "
                           << _commitsSinceCheckpoint << " commits since quorum (consistencyRequired="
                           << consistencyLevelNames[consistencyRequired] << "), " << numFullApproved << " of "
                           << numFullPeers << " approved (" << peerList.size() << " total) in "
@@ -797,7 +797,7 @@ bool SQLiteNode::update() {
                     _lastSentTransactionID = _db.getCommitCount();
 
                     // If this was a quorum commit, we'll reset our counter, otherwise, we'll update it.
-                    if (consistencyRequired != QUORUM) {
+                    if (consistencyRequired == QUORUM) {
                         _commitsSinceCheckpoint = 0;
                     } else {
                         _commitsSinceCheckpoint++;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -147,16 +147,17 @@ string BedrockTester::getServerName() {
 list<string> BedrockTester::getServerArgs(map <string, string> args) {
 
     map <string, string> defaults = {
-        {"-db",             _dbFile.empty() ? DB_FILE : _dbFile},
-        {"-serverHost",     _serverAddr.empty() ? SERVER_ADDR : _serverAddr},
-        {"-nodeName",       "bedrock_test"},
-        {"-nodeHost",       "localhost:9889"},
-        {"-priority",       "200"},
-        {"-plugins",        "db,cache"},
-        {"-readThreads",    "8"},
-        {"-maxJournalSize", "100"},
-        {"-v",              ""},
-        {"-cache",          "10001"},
+        {"-db",               _dbFile.empty() ? DB_FILE : _dbFile},
+        {"-serverHost",       _serverAddr.empty() ? SERVER_ADDR : _serverAddr},
+        {"-nodeName",        "bedrock_test"},
+        {"-nodeHost",         "localhost:9889"},
+        {"-priority",         "200"},
+        {"-plugins",          "db,cache"},
+        {"-readThreads",      "8"},
+        {"-maxJournalSize",   "100"},
+        {"-v",                ""},
+        {"-quorumCheckpoint", "50"},
+        {"-cache",            "10001"},
     };
 
     for (auto row : defaults) {


### PR DESCRIPTION
@coleaeason @cead22

We should reset the `_commitsSinceCheckpoint` counter after a QUORUM commit, not after any other commit.

Also, fixes logline to have the just-committed `commitCount` and hash, instead of the uncommitted ones (nothing is uncommitted at this point).

Finally, sets the `-quorumCheckpoint` in the tests to `50` instead of unspecified (which is `0`).

## Tests:
Run the `clustertest` and watch the logs for `bedrock.*Committed master transaction`, you should see a lot of ASYNC commits, and a QUORUM commit on every 50th transaction.