### PR TITLE
Mark commands as un-peeked on standup to master

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -61,12 +61,19 @@ BedrockCommand::BedrockCommand(SData _request) :
 BedrockCommand& BedrockCommand::operator=(BedrockCommand&& from) {
     if (this != &from) {
         // The current incarnation of this object is going away, if it had an httpsRequest, we'll need to destroy it,
-        // or it will leak nad never get cleaned up.
+        // or it will leak and never get cleaned up.
         if (httpsRequest) {
             httpsRequest->owner.closeTransaction(httpsRequest);
         }
         httpsRequest = from.httpsRequest;
         from.httpsRequest = nullptr;
+
+        // Update our other properties.
+        peekCount = from.peekCount;
+        processCount = from.processCount;
+        priority = from.priority;
+
+        // And call the base class's move constructor as well.
         SQLiteCommand::operator=(move(from));
     }
 

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -13,6 +13,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
     SData& response = command.response;
     STable& content = command.jsonContent;
     SDEBUG("Peeking at '" << request.methodLine << "'");
+    command.peekCount++;
 
     // We catch any exception and handle in `_handleCommandException`.
     try {
@@ -23,7 +24,6 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
             if (plugin->peekCommand(_db, command)) {
                 SINFO("Plugin '" << plugin->getName() << "' peeked command '" << request.methodLine << "'");
                 pluginPeeked = true;
-                command.peekCount++;
                 break;
             }
         }
@@ -75,6 +75,7 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
     SData& response = command.response;
     STable& content = command.jsonContent;
     SDEBUG("Processing '" << request.methodLine << "'");
+    command.processCount++;
 
     // Keep track of whether we've modified the database and need to perform a `commit`.
     bool needsCommit = false;
@@ -90,7 +91,6 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
             if (plugin->processCommand(_db, command)) {
                 SINFO("Plugin '" << plugin->getName() << "' processed command '" << request.methodLine << "'");
                 pluginProcessed = true;
-                command.processCount++;
                 break;
             }
         }

--- a/libstuff/SSynchronizedQueue.h
+++ b/libstuff/SSynchronizedQueue.h
@@ -31,6 +31,9 @@ class SSynchronizedQueue {
     // Returns the queue's size.
     size_t size() const;
 
+    // Apply a lambda to each item in the queue.
+    void each(const function<void (T&)>& f);
+
   protected:
     list<T> _queue;
     mutable recursive_mutex _queueMutex;
@@ -114,4 +117,10 @@ template<typename T>
 size_t SSynchronizedQueue<T>::size() const {
     SAUTOLOCK(_queueMutex);
     return _queue.size();
+}
+
+template<typename T>
+void SSynchronizedQueue<T>::each(const function<void (T&)>& f) {
+    SAUTOLOCK(_queueMutex);
+    for_each(_queue.begin(), _queue.end(), f);
 }


### PR DESCRIPTION
@cead22 @coleaeason 

This fixes a subtle bug where we could `process` a command without `peeking` it, which was fatal for certain commands that made `httpsRequest`s, as we'd try to dereference the `httpsRequest` object in `process`, but it was never created.

In the normal case, commands are `peeked` by a worker thread, and if that isn't adequate to complete the command, the already-peeked command is sent to the sync thread for processing.

For certain commands, such as commands that make `httpsRequest` requests, they specifically *won't* create that object unless they're on the MASTER node, expecting that they will get escalated to master, and then re-peeked, where they can create that object.

However, there's a race condition - if the command is peeked on a slave, and then queued for escalation, and then the slave is promoted to master before the command is de-queued, the now-MASTER node will dequeue a command that was never peeked, but won't be escalated.

This is where we'd try and dereference the null `httpsRequest` and crash.

The fix is to reset the `peekCount` of all commands that are in the sync thread queue when we stand up to master, and make the sync thread `peek` any commands with a `peekCount` of `0`.

This change also fixes two bugs with `peekCount`, which previously had no effect, as the counter was only used for testing purposes.
1. It resets the count appropriately in the assignment operator.
2. It increments it whenever bedrock calls `peekCommand`, rather than when a plugin responds `true` to that call.

We also add a general-purpose `each` method to `SSynchronizedQueue` to allow a caller to pass an arbitrary function to run on each item in the queue in a synchronized fashion. I know not everyone likes lambdas as they can be confusing, but with a general-purpose templated container class like this, this allows callers to easily implement their own arbitrary operations (like reset all of the `peekCount`s in the queue) without having to subclass `SSynchronizedQueue` for each new type it contains.

