### PR TITLE
Fix shutdown when commands are queued

### DIFF
--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -2,6 +2,11 @@
 #include "BedrockCommand.h"
 #include "BedrockCommandQueue.h"
 
+void BedrockCommandQueue::clear()  {
+    SAUTOLOCK(_queueMutex);
+    return _commandQueue.clear();
+}
+
 bool BedrockCommandQueue::empty()  {
     SAUTOLOCK(_queueMutex);
     return _commandQueue.empty();

--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -7,6 +7,11 @@ bool BedrockCommandQueue::empty()  {
     return _commandQueue.empty();
 }
 
+size_t BedrockCommandQueue::size()  {
+    SAUTOLOCK(_queueMutex);
+    return _commandQueue.size();
+}
+
 BedrockCommand BedrockCommandQueue::get(uint64_t timeoutUS) {
     unique_lock<mutex> queueLock(_queueMutex);
 

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -6,6 +6,9 @@ class BedrockCommandQueue {
     // Returns true if there are no queued commands.
     bool empty();
 
+    // Returns the size of the queue.
+    size_t size();
+
     // Get an item from the queue. Optionally, a timeout can be specified.
     // If timeout is non-zero, an exception will be thrown after timeoutUS microseconds, if no work was available.
     BedrockCommand get(uint64_t timeoutUS = 0);

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -3,6 +3,9 @@ class BedrockCommand;
 
 class BedrockCommandQueue {
   public:
+    // Remove all items from the queue.
+    void clear();
+
     // Returns true if there are no queued commands.
     bool empty();
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -366,6 +366,13 @@ void BedrockServer::sync(SData& args,
         threadId++;
         workerThread.join();
     }
+
+    // If there's anything left in the command queue here, we'll discard it, because we have no way of processing it.
+    if (server._commandQueue.size()) {
+        SWARN("Sync thread shut down with " << server._commandQueue.size() << " queued commands. Commands were: "
+              << SComposeList(server._commandQueue.getRequestMethodLines()) << ". Clearing.");
+        server._commandQueue.clear();
+    }
 }
 
 void BedrockServer::worker(SData& args,
@@ -570,7 +577,7 @@ void BedrockServer::worker(SData& args,
         }
 
         // Ok, we're done with this loop, see if we should exit.
-        if (nodeGracefulShutdown.load() && server._commandQueue.empty()) {
+        if (nodeGracefulShutdown.load()) {
             SINFO("Shutdown flag set and nothing left in queue. worker" << to_string(threadId) << " exiting.");
             break;
         }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -178,4 +178,7 @@ class BedrockServer : public SQLiteServer {
     // This is a list of command names than can be processed and committed in worker threads.
     static set<string> _parallelCommands;
     static recursive_mutex  _parallelCommandMutex;
+
+    // Stopwatch to track if we're going to give up on gracefully shutting down and force it.
+    SStopwatch _gracefulShutdownTimeout;
 };


### PR DESCRIPTION
@cead22 @coleaeason 

This adds a timeout like in `SQLiteNode` that will force shutdown after 30 seconds, even if something should block shutdown. If it fires, it does some elaborate logging of exactly what was in the queue at shutdown.

It makes worker threads stop waiting until the command queue is empty to exit, and makes the sync thread clear the queue when it exits.

This, effectively drops the queue after finishing whatever commands were currently processing when we were instructed to exit, rather than running through the entire queue. This should be OK, it's much less ambiguous than what happens during a cash, and it can't get blocked by a single command waiting on a slow HTTP request, or a command with a scheduled execution time minutes in the future.