### PR TITLE
Add more detailed logging to lock timer

### DIFF
--- a/libstuff/SLockTimer.h
+++ b/libstuff/SLockTimer.h
@@ -12,10 +12,15 @@ class SLockTimer : public SPerformanceTimer {
     void lock();
     void unlock();
 
+    // We override the base class log function.
+    virtual void log();
+
   private:
     atomic<int> _lockCount;
     LOCKTYPE& _lock;
-    recursive_mutex _syncMutex;
+
+    // Each thread keeps it's own counter of wait and lock time.
+    map<string, pair<int,int>> _perThreadTiming;
 };
 
 template<typename LOCKTYPE>
@@ -30,13 +35,26 @@ SLockTimer<LOCKTYPE>::~SLockTimer() {
 template<typename LOCKTYPE>
 void SLockTimer<LOCKTYPE>::lock()
 {
+    uint64_t waitStart = STimeNow();
     _lock.lock();
+    uint64_t waitEnd = STimeNow();
 
     // We atomically increment the counter, and only start the timer if we were the first to do so, in the case
-    // multiple threads are competing for this.
-    SAUTOLOCK(_syncMutex);
+    // we're calling this recursively.
     int count = _lockCount.fetch_add(1);
     if (!count) {
+
+        // We're locking, go ahead and update the per-thread map. This is already synchronized behind `_lock`, so no
+        // need to grab a second mutex.
+        auto it = _perThreadTiming.find(SThreadLogName);
+        if (it == _perThreadTiming.end()) {
+            // We didn't find an entry for this thread name, so we'll insert one with the calculated wait time, and a
+            // lock time of 0.
+            _perThreadTiming.emplace(make_pair(SThreadLogName, make_pair((waitEnd - waitStart), 0)));
+        } else {
+            // We already have an entry, add to the wait time.
+            it->second.first += (waitEnd - waitStart);
+        }
         start();
     }
 }
@@ -44,15 +62,69 @@ void SLockTimer<LOCKTYPE>::lock()
 template<typename LOCKTYPE>
 void SLockTimer<LOCKTYPE>::unlock()
 {
-    SAUTOLOCK(_syncMutex);
     int count = _lockCount.fetch_sub(1);
 
     // Count contains the value just before our decrement. If it was 1, that means we're now at a lock count of 0, and
     // can stop the timer.
     if (count == 1) {
         stop();
+
+        // We're still holding `_lock`, so no further synchronization is required for the per-thread map.
+        auto it = _perThreadTiming.find(SThreadLogName);
+        if (it != _perThreadTiming.end()) {
+            // We already have an entry, add to the lock time.
+            it->second.second += (_lastStop - _lastStart);
+        } else {
+            SWARN("Unlocking without ever locking.");
+        }
     }
     _lock.unlock();
+}
+
+template<typename LOCKTYPE>
+void SLockTimer<LOCKTYPE>::log() {
+
+    // When called inside `stop()`, as by the base class, this is thread safe as it's protected by `_lock`. When called
+    // from anywhere else, it's up to the caller to protect this!
+
+    for (auto& pair : _perThreadTiming) {
+        uint64_t waitTime = pair.second.first;
+        uint64_t lockTime = pair.second.second;
+        uint64_t freeTime = _timeLogged + _timeNotLogged - waitTime - lockTime;
+        string threadName = pair.first;
+
+        // Compute the percentage of time we've been busy since the last log period started, as a friendly floating point
+        // number with two decimal places.
+        double lockPercent = 0;
+        double waitPercent = 0;
+        double freePercent = 0;
+        if (_reverse) {
+            // we don't handle `reverse` for SLockTimer.
+            SWARN("`reverse` flag incorrectly specified for SLockTimer.");
+        } else {
+            lockPercent = 100.0 * ((double)lockTime / (_timeLogged + _timeNotLogged));
+            waitPercent = 100.0 * ((double)waitTime / (_timeLogged + _timeNotLogged));
+            freePercent = 100.0 * ((double)freeTime / (_timeLogged + _timeNotLogged));
+        }
+        char lockBuffer[7] = {0};
+        snprintf(lockBuffer, 7, "%.2f", lockPercent);
+        char waitBuffer[7] = {0};
+        snprintf(waitBuffer, 7, "%.2f", waitPercent);
+        char freeBuffer[7] = {0};
+        snprintf(freeBuffer, 7, "%.2f", freePercent);
+
+        // Log both raw numbers and our friendly lockPercent.
+        SINFO("[performance] " << _description << ", thread: " << threadName << ". Wait/Lock/Free " << waitTime << "/"
+              << lockTime << "/" << freeTime << "us, " << waitBuffer << "/" << lockBuffer << "/" << freeBuffer
+              << "%.");
+
+        // Reset the counters.
+        pair.second.first = 0;
+        pair.second.second = 0;
+    }
+
+    // Call the base class log function as well.
+    SPerformanceTimer::log();
 }
 
 template<typename TIMERTYPE> 

--- a/libstuff/SPerformanceTimer.h
+++ b/libstuff/SPerformanceTimer.h
@@ -5,7 +5,7 @@ class SPerformanceTimer {
     SPerformanceTimer(string description, bool reverse = false, uint64_t logIntervalSeconds = 10);
     void start();
     void stop();
-    void log();
+    virtual void log();
 
   protected:
     bool _reverse;


### PR DESCRIPTION
@cead22 @coleaeason 

This adds per-thread logging of lock time and wait time to SLockTimer to try and help diagnose why we slow down with high activity and multi-write enabled.

Example output:

```
[sync] [info] [performance] Commit Lock, thread: sync. Wait/Lock/Free 229707/1242104/8896260us, 2.22/11.98/85.80%.
[sync] [info] [performance] Commit Lock, thread: worker0. Wait/Lock/Free 130326/130877/10106868us, 1.26/1.26/97.48%.
[sync] [info] [performance] Commit Lock, thread: worker1. Wait/Lock/Free 179864/130653/10057554us, 1.73/1.26/97.01%.
[sync] [info] [performance] Commit Lock, thread: worker2. Wait/Lock/Free 151200/106599/10110272us, 1.46/1.03/97.51%.
[sync] [info] [performance] Commit Lock, thread: worker3. Wait/Lock/Free 38129/122179/10207763us, 0.37/1.18/98.45%.
[sync] [info] [performance] Commit Lock, thread: worker4. Wait/Lock/Free 88425/155340/10124306us, 0.85/1.50/97.65%.
[sync] [info] [performance] Commit Lock, thread: worker5. Wait/Lock/Free 51688/106420/10209963us, 0.50/1.03/98.48%.
[sync] [info] [performance] Commit Lock, thread: worker6. Wait/Lock/Free 130603/106425/10131043us, 1.26/1.03/97.71%.
[sync] [info] [performance] Commit Lock, thread: worker7. Wait/Lock/Free 16691/120039/10231341us, 0.16/1.16/98.68%.
[sync] [info] [performance] 10368071us elapsed, 2220637us in Commit Lock, 8147434us other. 21.42% usage.
```