### PR TITLE
More commit lock logging

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1125,6 +1125,10 @@ void BedrockServer::_status(BedrockCommand& command) {
                 _parallelCommands.insert(command);
             }
         }
+        // Enable extra logging in the commit lock timer.
+        decltype(SQLite::g_commitLock)::enableExtraLogging.store(!_parallelCommands.empty());
+
+        // PRepare the command to respond to the caller.
         response.methodLine = "200 OK";
         response.content = SComposeJSONObject(content);
     }

--- a/libstuff/SLockTimer.h
+++ b/libstuff/SLockTimer.h
@@ -5,6 +5,7 @@
 template<typename LOCKTYPE>
 class SLockTimer : public SPerformanceTimer {
   public:
+    static atomic<bool> enableExtraLogging;
     SLockTimer(string description, LOCKTYPE& lock, uint64_t logIntervalSeconds = 10);
     ~SLockTimer();
 
@@ -22,6 +23,9 @@ class SLockTimer : public SPerformanceTimer {
     // Each thread keeps it's own counter of wait and lock time.
     map<string, pair<int,int>> _perThreadTiming;
 };
+
+template<typename LOCKTYPE>
+atomic<bool> SLockTimer<LOCKTYPE>::enableExtraLogging(false);
 
 template<typename LOCKTYPE>
 SLockTimer<LOCKTYPE>::SLockTimer(string description, LOCKTYPE& lock, uint64_t logIntervalSeconds)
@@ -43,6 +47,7 @@ void SLockTimer<LOCKTYPE>::lock()
     // we're calling this recursively.
     int count = _lockCount.fetch_add(1);
     if (!count) {
+        uint64_t waitElapsed = waitEnd - waitStart;
 
         // We're locking, go ahead and update the per-thread map. This is already synchronized behind `_lock`, so no
         // need to grab a second mutex.
@@ -50,10 +55,14 @@ void SLockTimer<LOCKTYPE>::lock()
         if (it == _perThreadTiming.end()) {
             // We didn't find an entry for this thread name, so we'll insert one with the calculated wait time, and a
             // lock time of 0.
-            _perThreadTiming.emplace(make_pair(SThreadLogName, make_pair((waitEnd - waitStart), 0)));
+            _perThreadTiming.emplace(make_pair(SThreadLogName, make_pair((waitElapsed), 0)));
         } else {
             // We already have an entry, add to the wait time.
-            it->second.first += (waitEnd - waitStart);
+            it->second.first += (waitElapsed);
+        }
+        if (enableExtraLogging.load() && waitElapsed > 1000000) {
+            SWARN("[performance] Over 1s spent waiting for lock " << _description << ": " << waitElapsed << "us.");
+            SLogStackTrace();
         }
         start();
     }
@@ -68,14 +77,19 @@ void SLockTimer<LOCKTYPE>::unlock()
     // can stop the timer.
     if (count == 1) {
         stop();
+        uint64_t lockElapsed = _lastStop - _lastStart;
 
         // We're still holding `_lock`, so no further synchronization is required for the per-thread map.
         auto it = _perThreadTiming.find(SThreadLogName);
         if (it != _perThreadTiming.end()) {
             // We already have an entry, add to the lock time.
-            it->second.second += (_lastStop - _lastStart);
+            it->second.second += lockElapsed;
         } else {
             SWARN("Unlocking without ever locking.");
+        }
+        if (enableExtraLogging.load() && lockElapsed > 1000000) {
+            SWARN("[performance] Over 1s spent waiting in lock " << _description << ": " << lockElapsed << "us.");
+            SLogStackTrace();
         }
     }
     _lock.unlock();

--- a/libstuff/SLockTimer.h
+++ b/libstuff/SLockTimer.h
@@ -91,6 +91,12 @@ void SLockTimer<LOCKTYPE>::log() {
         uint64_t waitTime = pair.second.first;
         uint64_t lockTime = pair.second.second;
         uint64_t freeTime = _timeLogged + _timeNotLogged - waitTime - lockTime;
+
+        // Catch overflow.
+        if (_timeLogged + _timeNotLogged < waitTime + lockTime) {
+            freeTime = 0;
+        }
+
         string threadName = pair.first;
 
         // Compute the percentage of time we've been busy since the last log period started, as a friendly floating point

--- a/libstuff/SPerformanceTimer.cpp
+++ b/libstuff/SPerformanceTimer.cpp
@@ -41,9 +41,7 @@ void SPerformanceTimer::stop() {
     // If it's been longer than our log period, log our current statistics and start over on the next iteration.
     if (_lastLogStart + _logPeriod < timestamp) {
         log();
-        // Reset this to our period after our previous start time, not after the current time, to prevent slow skew as
-        // poll doesn't return precisely on these boundaries.
-        _lastLogStart += _logPeriod;
+        _lastLogStart = timestamp;
         _timeLogged = 0;
         _timeNotLogged = 0;
     }


### PR DESCRIPTION
@cead22 @coleaeason 

This adds yet-more-logging around our commit lock. Particularly, if we've sent a `SetCommandWhitelist` and set a non-empty list of parallel commands, if we ever see commit lock held for over 1 second, or a thread waiting for commit lock for over one second, we'll log that occurrence and also *log a stack trace*. Importantly, we log the stack trace without dying, but this should help give us a hint where we're waiting for locks, and where we're releasing long-held locks, which might narrow down this problem.

I also fixed two potential problems with the lock timer, in the case could overflow, and to prevent us from mis-counting time if we ever spent too much time in the lock.

To test this, I ran the `clustertest` suite, but modified `SQLite::commit()` to randomly (1/100th of the time) sleep for a second, and verified I saw the correct log output.

This change is intended to be temporary, but I can't replicate what we see in production in testing, and I hope to use this to gather more info about where we run into lock contention.