### PR TITLE
Fix journal truncation to delete the right amount of rows.

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -354,7 +354,7 @@ int SQLite::commit() {
 
     // Do we need to truncate as we go?
     uint64_t newJournalSize = _journalSize + 1;
-    if (_journalSize + 1 > _maxJournalSize) {
+    if (newJournalSize > _maxJournalSize) {
         // Delete the oldest entry
         uint64_t before = STimeNow();
         string query = "DELETE FROM " + _journalName + " WHERE id < (SELECT MAX(id) FROM " + SQ(_journalName) + ") - " + SQ(_maxJournalSize);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -353,7 +353,7 @@ int SQLite::commit() {
     int result = 0;
 
     // Do we need to truncate as we go?
-    uint64_t newJournalSize = 0;
+    uint64_t newJournalSize = _journalSize + 1;
     if (_journalSize + 1 > _maxJournalSize) {
         // Delete the oldest entry
         uint64_t before = STimeNow();


### PR DESCRIPTION
@cead22 @coleaeason 

In "new" (multi-journal and later) SQLite, we keep track of journal size as the range of values between `max`, and `max - _maxJournalSize`. Since the journal is split across multiple tables, each journal has a sparsely-populated where the newest value is approximately the newest value committed (journals that did not do the most recent commit will be slightly behind), and the oldest value will be roughly `_maxJournalSize` behind that.

The size that we store in `_journalSize` is not a count of rows in the journal, but rather, the difference between its min and max values.

Our `DELETE FROM` query has been modified to delete entries farther back than `_maxJournalSize` entries ago, rather than entries before `_journalSize` entries ago. The previous behavior meant that we'd never really shrink the journal, because we were comparing against a larger number of entries than intended. Now, if you set `_maxJournalSize` to (for example), `1,000,000`, then older entries than that will be removed when we truncate from it, even if the existing table is `2,000,000` entries long.

We then re-calculate the journal size based on the new min and max, rather than just adding 1 or not, which was incorrect.