### PR TITLE
Adds to properties to Status command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1077,6 +1077,7 @@ void BedrockServer::_status(BedrockCommand& command) {
         content["plugins"]  = SComposeJSONArray(pluginList);
         content["state"]    = SQLiteNode::stateNames[state];
         content["version"]  = _version;
+        content["host"]     = _args["-nodeHost"];
 
         // We read from syncNode internal state here, so we lock to make sure that this doesn't conflict with the sync
         // thread.
@@ -1084,6 +1085,9 @@ void BedrockServer::_status(BedrockCommand& command) {
         list<string> escalated;
         {
             SAUTOLOCK(_syncMutex);
+
+            // Set some information about this node.
+            content["CommitCount"] = to_string(_syncNode->getCommitCount());
 
             // Retrieve information about our peers.
             for (SQLiteNode::Peer* peer : _syncNode->peerList) {

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -57,6 +57,7 @@ class SQLiteNode : public STCPNode {
     int           getPriority()      { return _priority; }
     const string& getMasterVersion() { return _masterVersion; }
     const string& getVersion()       { return _version; }
+    uint64_t      getCommitCount()   { return _db.getCommitCount(); }
 
     // Returns whether we're in the process of gracefully shutting down.
     bool gracefulShutdown() { return (_gracefulShutdownTimeout.alarmDuration != 0); }


### PR DESCRIPTION
@cead22 @righdforsa @mcnamamj 

Fixes:
$ https://github.com/Expensify/Expensify/issues/53542

Adds two new properties to be reported about the current node via a status command.

Adds an accessor to `SQLiteNode` to expose this info.