### PR TITLE
Add retryAfter column if it's not there already

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -9,20 +9,8 @@
 void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
     // Create or verify the jobs table
     bool ignore;
-    bool oldSchema = db.verifyTable("jobs", "CREATE TABLE jobs ( "
-                                            "created  TIMESTAMP NOT NULL, "
-                                            "jobID    INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, "
-                                            "state    TEXT NOT NULL, "
-                                            "name     TEXT NOT NULL, "
-                                            "nextRun  TIMESTAMP NOT NULL, "
-                                            "lastRun  TIMESTAMP, "
-                                            "repeat   TEXT NOT NULL, "
-                                            "data     TEXT NOT NULL, "
-                                            "priority INTEGER NOT NULL DEFAULT " + SToStr(JOBS_DEFAULT_PRIORITY) + ", "
-                                            "parentJobID INTEGER NOT NULL DEFAULT 0 )",
-                     ignore);
 
-    bool newSchema = db.verifyTable("jobs", "CREATE TABLE jobs ( "
+    if (!db.verifyTable("jobs", "CREATE TABLE jobs ( "
                                             "created  TIMESTAMP NOT NULL, "
                                             "jobID    INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, "
                                             "state    TEXT NOT NULL, "
@@ -34,10 +22,9 @@ void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
                                             "priority INTEGER NOT NULL DEFAULT " + SToStr(JOBS_DEFAULT_PRIORITY) + ", "
                                             "parentJobID INTEGER NOT NULL DEFAULT 0, "
                                             "retryAfter TEXT NOT NULL DEFAULT \"\" )",
-                     ignore);
-
-    // @todo remove when we migrate to the new schema
-    SASSERT(oldSchema || newSchema);
+                     ignore)) {
+        SASSERT(db.write("ALTER TABLE jobs ADD COLUMN retryAfter TEXT NOT NULL DEFAULT \"\";"));
+    }
 
     // These indexes are not used by the Bedrock::Jobs plugin, but provided for easy analysis
     // using the Bedrock::DB plugin.


### PR DESCRIPTION
@coleaeason please review
cc @mea36 @tylerkaraszewski 

# Tests
- Dropped the retryAfter column, recompiled, restarted bedrock and verified the column was added
- Restarted bedrock with the column already present, didn't crash
- Queued a job successfully
```
createjob
name:test

200 OK
commitCount: 2
Content-Length: 11

{"jobID":1}

getjob
name:test

200 OK
commitCount: 3
Content-Length: 35

{"data":{},"jobID":1,"name":"test"}

updatejob
jobID:1
data:{"carlos":"true"}

200 OK
commitCount: 4
Content-Length: 0

query:select * from jobs;

200 OK
commitCount: 5
Content-Length: 226

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-05-16 00:45:31 | 1 | RUNNING | test | 2017-05-16 00:45:31 | 2017-05-16 00:45:35 |  | {"carlos":"true"} | 500 | 0 |

finishjob
jobid:1

200 OK
commitCount: 5
Content-Length: 0

query:select * from jobs;

200 OK
commitCount: 6
Content-Length: 1
```