### PR TITLE
Add Temporary 'extraLogging' crash to diagnose crash on commit.

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -6,7 +6,8 @@ BedrockCommand::BedrockCommand() :
     httpsRequest(nullptr),
     priority(PRIORITY_NORMAL),
     peekCount(0),
-    processCount(0)
+    processCount(0),
+    extraLogging(false)
 { }
 
 BedrockCommand::~BedrockCommand() {
@@ -21,7 +22,8 @@ BedrockCommand::BedrockCommand(SQLiteCommand&& from) :
     httpsRequest(nullptr),
     priority(PRIORITY_NORMAL),
     peekCount(0),
-    processCount(0)
+    processCount(0),
+    extraLogging(false)
 {
     _init();
 }
@@ -31,7 +33,8 @@ BedrockCommand::BedrockCommand(BedrockCommand&& from) :
     httpsRequest(from.httpsRequest),
     priority(from.priority),
     peekCount(from.peekCount),
-    processCount(from.processCount)
+    processCount(from.processCount),
+    extraLogging(from.extraLogging)
 {
     // The move constructor (and likewise, the move assignment operator), don't simply copy this pointer value, but
     // they clear it from the old object, so that when its destructor is called, the HTTPS transaction isn't closed.
@@ -43,7 +46,8 @@ BedrockCommand::BedrockCommand(SData&& _request) :
     httpsRequest(nullptr),
     priority(PRIORITY_NORMAL),
     peekCount(0),
-    processCount(0)
+    processCount(0),
+    extraLogging(false)
 {
     _init();
 }
@@ -53,7 +57,8 @@ BedrockCommand::BedrockCommand(SData _request) :
     httpsRequest(nullptr),
     priority(PRIORITY_NORMAL),
     peekCount(0),
-    processCount(0)
+    processCount(0),
+    extraLogging(false)
 {
     _init();
 }
@@ -72,6 +77,7 @@ BedrockCommand& BedrockCommand::operator=(BedrockCommand&& from) {
         peekCount = from.peekCount;
         processCount = from.processCount;
         priority = from.priority;
+        extraLogging = from.extraLogging;
 
         // And call the base class's move constructor as well.
         SQLiteCommand::operator=(move(from));

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -42,6 +42,8 @@ class BedrockCommand : public SQLiteCommand {
     int peekCount;
     int processCount;
 
+    bool extraLogging;
+
   private:
     // Set certain initial state on construction. Common functionality to several constructors.
     void _init();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -531,7 +531,7 @@ void BedrockServer::worker(SData& args,
                                       << " during worker commit. Rolling back transaction!");
                                 core.rollback();
                             } else {
-                                if (core.commit()) {
+                                if (core.commit(command.extraLogging)) {
                                     SINFO("Successfully committed " << command.request.methodLine << " on worker thread.");
                                     // So we must still be mastering, and at this point our commit has succeeded, let's
                                     // mark it as complete!

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -312,7 +312,7 @@ void BedrockServer::sync(SData& args,
                     // The processor says we need to commit this, so let's start that process.
                     committingCommand = true;
                     server._writableCommandsInProgress++;
-                    syncNode.startCommit(command.writeConsistency);
+                    syncNode.startCommit(command.writeConsistency, command.extraLogging);
 
                     // And we'll start the next main loop.
                     // NOTE: This will cause us to read from the network again. This, in theory, is fine, but we saw

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -347,7 +347,7 @@ bool SQLite::prepare() {
     return true;
 }
 
-int SQLite::commit() {
+int SQLite::commit(bool extraLogging) {
     SASSERT(_insideTransaction);
     SASSERT(!_uncommittedHash.empty()); // Must prepare first
     int result = 0;
@@ -377,7 +377,21 @@ int SQLite::commit() {
     // Make sure one is ready to commit
     SDEBUG("Committing transaction");
     uint64_t before = STimeNow();
+
+    if (extraLogging) {
+        SWARN("Extra logging enabled for commit. Pre-commit query is: " << _uncommittedQuery);
+    }
     result = SQuery(_db, "committing db transaction", "COMMIT");
+
+    if (extraLogging) {
+        if (result == SQLITE_OK) {
+            SWARN("Commit completed with SQLITE_OK. Pre-commit query was:" << _uncommittedQuery);
+        } else if (result == SQLITE_BUSY_SNAPSHOT) {
+            SWARN("Commit completed with SQLITE_BUSY_SNAPSHOT. Pre-commit query was:" << _uncommittedQuery);
+        } else {
+            SWARN("Commit completed with unexpected result code: " << result << ". Pre-commit query was:" << _uncommittedQuery);
+        }
+    }
 
     // If there were conflicting commits, will return SQLITE_BUSY_SNAPSHOT
     SASSERT(result == SQLITE_OK || result == SQLITE_BUSY_SNAPSHOT);

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -59,7 +59,7 @@ class SQLite {
     bool prepare();
 
     // Commits the current transaction to disk. Returns an sqlite3 result code.
-    int commit();
+    int commit(bool extraLogging = false);
 
     // Cancels the current transaction and rolls it back
     void rollback();

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -5,7 +5,7 @@
 SQLiteCore::SQLiteCore(SQLite& db) : _db(db)
 { }
 
-bool SQLiteCore::commit() {
+bool SQLiteCore::commit(bool extraLogging) {
     // Grab the global SQLite lock.
     SQLITE_COMMIT_AUTOLOCK;
 
@@ -19,7 +19,7 @@ bool SQLiteCore::commit() {
     }
 
     // Perform the actual commit, rollback if it fails.
-    int errorCode = _db.commit();
+    int errorCode = _db.commit(extraLogging);
     if (errorCode == SQLITE_BUSY_SNAPSHOT) {
         SINFO("Commit conflict, rolling back.");
         _db.rollback();

--- a/sqlitecluster/SQLiteCore.h
+++ b/sqlitecluster/SQLiteCore.h
@@ -8,7 +8,7 @@ class SQLiteCore {
 
     // Commit the outstanding transaction on the DB.
     // Returns true on successful commit, false on conflict.
-    bool commit();
+    bool commit(bool extraLogging = false);
 
     // Roll back a transaction if we've decided not to commit it.
     void rollback();

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -82,7 +82,7 @@ class SQLiteNode : public STCPNode {
 
     // Begins the process of committing a transaction on this SQLiteNode's database. When this returns,
     // commitInProgress() will return true until the commit completes.
-    void startCommit(ConsistencyLevel consistency);
+    void startCommit(ConsistencyLevel consistency, bool extraLogging = false);
 
     // If we have a command that can't be handled on a slave, we can escalate it to the master node. The SQLiteNode
     // takes ownership of the command until it receives a response from the slave. When the command completes, it will
@@ -146,6 +146,9 @@ class SQLiteNode : public STCPNode {
 
     // The write consistency requested for the current in-progress commit.
     ConsistencyLevel _commitConsistency;
+
+    // Whether or not we pass the extraLogging flag to the SQLite object on commit.
+    bool _commitExtraLogging;
 
     // Stopwatch to track if we're going to give up on gracefully shutting down and force it.
     SStopwatch _gracefulShutdownTimeout;


### PR DESCRIPTION
@cead22 @coleaeason @quinthar 

This change adds extra logging to diagnose a crash happening on commit. If a command has specified the `extraLogging` flag, it will log the transaction that's about to crash just before callnig `COMMIT`, so that we can diagnose where this comes from.

This is a temporary change and will be reverted once diagnosis is complete.