### PR TITLE
Use Upgraded tpunit framework from auth.

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -133,6 +133,11 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
         }
     }
 
+    // And exclude our `after` tests so they don't get run in the main loop.
+    for (auto name : after) {
+        _exclude.insert(name);
+    }
+
     list<TestFixture*> afterTests;
 
     for (int threadID = 0; threadID < threads; threadID++) {
@@ -171,6 +176,7 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
                     // Try the next test.
                     if (!should_run) {
                         // Put in the after list, in case we want to run it there.
+                        lock_guard<recursive_mutex> lock(m);
                         afterTests.push_back(f);
                         continue;
                     }

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -1,0 +1,329 @@
+#include "tpunit++.hpp"
+#include <string.h>
+using namespace tpunit;
+
+bool tpunit::TestFixture::exitFlag = false;
+
+tpunit::TestFixture::method::method(TestFixture* obj, void (TestFixture::*addr)(), const char* name, unsigned char type)
+    : _this(obj)
+    , _addr(addr)
+    , _type(type)
+    , _next(0) {
+        char* dest = _name;
+        while(name && *name != 0) {
+          *dest++ = *name++;
+        }
+        *dest = 0;
+}
+
+tpunit::TestFixture::method::~method() {
+    delete _next;
+}
+
+tpunit::TestFixture::stats::stats()
+    : _failures(0)
+    , _passes(0)
+    {}
+
+tpunit::TestFixture::perFixtureStats::perFixtureStats()
+    : _assertions(0)
+    , _exceptions(0)
+    , _traces(0)
+    {}
+
+tpunit::TestFixture::TestFixture(method* m0,  method* m1,  method* m2,  method* m3,  method* m4, 
+                         method* m5,  method* m6,  method* m7,  method* m8,  method* m9, 
+                         method* m10, method* m11, method* m12, method* m13, method* m14,
+                         method* m15, method* m16, method* m17, method* m18, method* m19,
+                         method* m20, method* m21, method* m22, method* m23, method* m24,
+                         method* m25, method* m26, method* m27, method* m28, method* m29,
+                         method* m30, method* m31, method* m32, method* m33, method* m34,
+                         method* m35, method* m36, method* m37, method* m38, method* m39,
+                         method* m40, method* m41, method* m42, method* m43, method* m44,
+                         method* m45, method* m46, method* m47, method* m48, method* m49,
+                         const char* name)
+  : _name(name)
+{
+    tpunit_detail_fixture_list()->push_back(this);
+
+    method* methods[50] = { m0,  m1,  m2,  m3,  m4,  m5,  m6,  m7,  m8,  m9,
+                            m10, m11, m12, m13, m14, m15, m16, m17, m18, m19,
+                            m20, m21, m22, m23, m24, m25, m26, m27, m28, m29,
+                            m30, m31, m32, m33, m34, m35, m36, m37, m38, m39,
+                            m40, m41, m42, m43, m44, m45, m46, m47, m48, m49 };
+
+    for(int i = 0; i < 50; i++) {
+       if(methods[i]) {
+          method** m = 0;
+          switch(methods[i]->_type) {
+             case method::AFTER_METHOD:        m = &_afters;         break;
+             case method::AFTER_CLASS_METHOD:  m = &_after_classes;  break;
+             case method::BEFORE_METHOD:       m = &_befores;        break;
+             case method::BEFORE_CLASS_METHOD: m = &_before_classes; break;
+             case method::TEST_METHOD:         m = &_tests;          break;
+          }
+          while(*m && (*m)->_next) {
+             m = &(*m)->_next;
+          }
+          (*m) ? (*m)->_next = methods[i] : *m = methods[i];
+       }
+    }
+    _threadID = 0;
+    _name     = 0;
+    _mutex    = 0;
+}
+
+tpunit::TestFixture::~TestFixture() {
+    delete _afters;
+    delete _after_classes;
+    delete _befores;
+    delete _before_classes;
+    delete _tests;
+}
+
+int tpunit::TestFixture::tpunit_detail_do_run(int threads) {
+    const std::set<std::string> include, exclude;
+    return tpunit_detail_do_run(include, exclude, threads);
+}
+
+int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const set<string>& exclude, int threads) {
+    /*
+    * Run specific tests by name. If 'include' is empty, then every test is
+    * run unless it's in 'exclude'. If 'include' has at least one entry,
+    * then only tests in 'include' are run, and 'exclude' is ignored.
+    */
+    std::list<TestFixture*> testFixtureList = *tpunit_detail_fixture_list();
+    testFixtureList.sort([&](TestFixture* a, TestFixture* b) {
+        if (a->_name && b->_name) {
+            return strcmp(a->_name, b->_name) < 0;
+        }
+        return false;
+    });
+
+    // Create a list of threads, and have them each pull tests of the queue.
+    list<thread> threadList;
+    recursive_mutex m;
+
+    for (int threadID = 0; threadID < threads; threadID++) {
+        // Capture everything by reference except threadID, because we don't want it to be incremented for the
+        // next thread in the loop.
+        thread t = thread([&, threadID]{
+            try {
+                // Do test.
+                while (1) {
+                    TestFixture* f = 0;
+                    {
+                        lock_guard<recursive_mutex> lock(m);
+                        if (testFixtureList.empty()) {
+                            // Done looping.
+                            break;
+                        }
+                        f = testFixtureList.front();
+                        testFixtureList.pop_front();
+                    }
+
+                    f->_threadID = threadID;
+                    f->_mutex = &m;
+                    f->_multiThreaded = threads > 1;
+
+                    // Determine if this test even should run.
+                    bool should_run = true;
+                    if (include.size()) {
+                       if (!f->_name || (include.find(std::string(f->_name)) == include.end())) {
+                          should_run = false;
+                       }
+                    }
+                    else if (f->_name && (exclude.find(std::string(f->_name)) != exclude.end())) {
+                       should_run = false;
+                    }
+
+                    // Try the next test.
+                    if (!should_run) {
+                        continue;
+                    }
+
+                   // At this point, we know this test should run.
+                   if (!f->_multiThreaded) {
+                       printf("[--------------]\n");
+                   }
+                   tpunit_detail_do_methods(f->_before_classes);
+                   tpunit_detail_do_tests(f);
+                   tpunit_detail_do_methods(f->_after_classes);
+                   if (!f->_multiThreaded) {
+                       printf("[--------------]\n\n");
+                   }
+                }
+            } catch (ShutdownException se) {
+                // This will have broken us out of our main loop, so we'll just exit. We also set the exit flag to let
+                // other threads know we're trying to exit.
+                lock_guard<recursive_mutex> lock(m);
+                exitFlag = true;
+                printf("Thread %d caught shutdown exception, exiting.\n", threadID);
+            }
+        });
+        threadList.push_back(move(t));
+    }
+
+    // Wait for them all to finish.
+    for (thread& currentThread : threadList) {
+        currentThread.join();
+    }
+    threadList.clear();
+     if (!exitFlag) {
+         printf("[==============]\n");
+         printf("[ TEST RESULTS ] Passed: %i, Failed: %i\n", tpunit_detail_stats()._passes, tpunit_detail_stats()._failures);
+         printf("[==============]\n");
+         return tpunit_detail_stats()._failures;
+     }
+     return 1;
+}
+
+bool tpunit::TestFixture::tpunit_detail_fp_equal(float lhs, float rhs, unsigned char ulps) {
+    union {
+       float f;
+       char  c[4];
+    } lhs_u, rhs_u;
+    lhs_u.f = lhs;
+    rhs_u.f = rhs;
+
+    bool lil_endian = ((unsigned char) 0x00FF) == 0xFF;
+    int msb = lil_endian ? 3 : 0;
+    int lsb = lil_endian ? 0 : 3;
+    if(lhs_u.c[msb] < 0) {
+       lhs_u.c[0 ^ lsb] = 0x00 - lhs_u.c[0 ^ lsb];
+       lhs_u.c[1 ^ lsb] = (((unsigned char) lhs_u.c[0 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[1 ^ lsb];
+       lhs_u.c[2 ^ lsb] = (((unsigned char) lhs_u.c[1 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[2 ^ lsb];
+       lhs_u.c[3 ^ lsb] = (((unsigned char) lhs_u.c[2 ^ lsb] > 0x00) ? 0x7F : 0x80) - lhs_u.c[3 ^ lsb];
+    }
+    if(rhs_u.c[msb] < 0) {
+       rhs_u.c[0 ^ lsb] = 0x00 - rhs_u.c[0 ^ lsb];
+       rhs_u.c[1 ^ lsb] = (((unsigned char) rhs_u.c[0 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[1 ^ lsb];
+       rhs_u.c[2 ^ lsb] = (((unsigned char) rhs_u.c[1 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[2 ^ lsb];
+       rhs_u.c[3 ^ lsb] = (((unsigned char) rhs_u.c[2 ^ lsb] > 0x00) ? 0x7F : 0x80) - rhs_u.c[3 ^ lsb];
+    }
+    return (lhs_u.c[1] == rhs_u.c[1] && lhs_u.c[2] == rhs_u.c[2] && lhs_u.c[msb] == rhs_u.c[msb]) &&
+           ((lhs_u.c[lsb] > rhs_u.c[lsb]) ? lhs_u.c[lsb] - rhs_u.c[lsb] : rhs_u.c[lsb] - lhs_u.c[lsb]) <= ulps;
+}
+
+bool tpunit::TestFixture::tpunit_detail_fp_equal(double lhs, double rhs, unsigned char ulps) {
+    union {
+       double d;
+       char   c[8];
+    } lhs_u, rhs_u;
+    lhs_u.d = lhs;
+    rhs_u.d = rhs;
+
+    bool lil_endian = ((unsigned char) 0x00FF) == 0xFF;
+    int msb = lil_endian ? 7 : 0;
+    int lsb = lil_endian ? 0 : 7;
+    if(lhs_u.c[msb] < 0) {
+       lhs_u.c[0 ^ lsb] = 0x00 - lhs_u.c[0 ^ lsb];
+       lhs_u.c[1 ^ lsb] = (((unsigned char) lhs_u.c[0 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[1 ^ lsb];
+       lhs_u.c[2 ^ lsb] = (((unsigned char) lhs_u.c[1 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[2 ^ lsb];
+       lhs_u.c[3 ^ lsb] = (((unsigned char) lhs_u.c[2 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[3 ^ lsb];
+       lhs_u.c[4 ^ lsb] = (((unsigned char) lhs_u.c[3 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[4 ^ lsb];
+       lhs_u.c[5 ^ lsb] = (((unsigned char) lhs_u.c[4 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[5 ^ lsb];
+       lhs_u.c[6 ^ lsb] = (((unsigned char) lhs_u.c[5 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[6 ^ lsb];
+       lhs_u.c[7 ^ lsb] = (((unsigned char) lhs_u.c[6 ^ lsb] > 0x00) ? 0x7F : 0x80) - lhs_u.c[7 ^ lsb];
+    }
+    if(rhs_u.c[msb] < 0) {
+       rhs_u.c[0 ^ lsb] = 0x00 - rhs_u.c[0 ^ lsb];
+       rhs_u.c[1 ^ lsb] = (((unsigned char) rhs_u.c[0 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[1 ^ lsb];
+       rhs_u.c[2 ^ lsb] = (((unsigned char) rhs_u.c[1 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[2 ^ lsb];
+       rhs_u.c[3 ^ lsb] = (((unsigned char) rhs_u.c[2 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[3 ^ lsb];
+       rhs_u.c[4 ^ lsb] = (((unsigned char) rhs_u.c[3 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[4 ^ lsb];
+       rhs_u.c[5 ^ lsb] = (((unsigned char) rhs_u.c[4 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[5 ^ lsb];
+       rhs_u.c[6 ^ lsb] = (((unsigned char) rhs_u.c[5 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[6 ^ lsb];
+       rhs_u.c[7 ^ lsb] = (((unsigned char) rhs_u.c[6 ^ lsb] > 0x00) ? 0x7F : 0x80) - rhs_u.c[7 ^ lsb];
+    }
+    return (lhs_u.c[1] == rhs_u.c[1] && lhs_u.c[2] == rhs_u.c[2] &&
+            lhs_u.c[3] == rhs_u.c[3] && lhs_u.c[4] == rhs_u.c[4] &&
+            lhs_u.c[5] == rhs_u.c[5] && lhs_u.c[6] == rhs_u.c[6] &&
+            lhs_u.c[msb] == rhs_u.c[msb]) &&
+           ((lhs_u.c[lsb] > rhs_u.c[lsb]) ? lhs_u.c[lsb] - rhs_u.c[lsb] : rhs_u.c[lsb] - lhs_u.c[lsb]) <= ulps;
+}
+
+// TODO: These three functions need to be updated to act on the current TestFixture.
+void tpunit::TestFixture::tpunit_detail_assert(TestFixture* f, const char* _file, int _line) {
+    lock_guard<recursive_mutex> lock(*(f->_mutex));
+    printf("[              ]    assertion #%i at %s:%i\n", ++f->_stats._assertions, _file, _line);
+}
+
+void tpunit::TestFixture::tpunit_detail_exception(TestFixture* f, method* _method, const char* _message) {
+    lock_guard<recursive_mutex> lock(*(f->_mutex));
+    printf("[              ]    exception #%i from %s with cause: %s\n", ++f->_stats._exceptions, _method->_name, _message);
+}
+
+void tpunit::TestFixture::tpunit_detail_trace(TestFixture* f, const char* _file, int _line, const char* _message) {
+    lock_guard<recursive_mutex> lock(*(f->_mutex));
+    printf("[              ]    trace #%i at %s:%i: %s\n", ++f->_stats._traces, _file, _line, _message);
+}
+
+void tpunit::TestFixture::tpunit_detail_do_method(tpunit::TestFixture::method* m) {
+    try {
+       // If we're exiting, then don't try and run any more tests.
+       if (exitFlag) {
+            throw ShutdownException();
+       }
+       (*m->_this.*m->_addr)();
+    } catch(const std::exception& e) {
+       lock_guard<recursive_mutex> lock(*(m->_this->_mutex));
+       tpunit_detail_exception(m->_this, m, e.what());
+    } catch(ShutdownException se) {
+       // Just re-throw, this exception is special and indicates that a test wants its thread to quit.
+       throw;
+    } catch(...) {
+       lock_guard<recursive_mutex> lock(*(m->_this->_mutex));
+       tpunit_detail_exception(m->_this, m, "caught unknown exception type");
+    }
+}
+
+void tpunit::TestFixture::tpunit_detail_do_methods(tpunit::TestFixture::method* m) {
+    while (m) {
+       tpunit_detail_do_method(m);
+       m = m->_next;
+    }
+}
+
+void tpunit::TestFixture::tpunit_detail_do_tests(TestFixture* f) {
+    method* t = f->_tests;
+    recursive_mutex& m = *(f->_mutex);
+    while(t) {
+       int _prev_assertions = f->_stats._assertions;
+       int _prev_exceptions = f->_stats._exceptions;
+       if (!f->_multiThreaded) {
+           printf("[ RUN          ] %s\n", t->_name);
+       }
+       tpunit_detail_do_methods(f->_befores);
+       tpunit_detail_do_method(t);
+       tpunit_detail_do_methods(f->_afters);
+       if(_prev_assertions == f->_stats._assertions && _prev_exceptions == f->_stats._exceptions) {
+          lock_guard<recursive_mutex> lock(m);
+          printf("[       PASSED ] %s\n", t->_name);
+          tpunit_detail_stats()._passes++;
+       } else {
+          lock_guard<recursive_mutex> lock(m);
+          printf("[       FAILED ] %s\n", t->_name);
+          tpunit_detail_stats()._failures++;
+       }
+       t = t->_next;
+    }
+}
+
+tpunit::TestFixture::stats& tpunit::TestFixture::tpunit_detail_stats() {
+    static stats _stats;
+    return _stats;
+}
+
+list<tpunit::TestFixture*>* tpunit::TestFixture::tpunit_detail_fixture_list() {
+    static list<TestFixture*>* _fixtureList = new list<TestFixture*>;
+    return _fixtureList;
+}
+
+int tpunit::Tests::run(int threads) {
+    return TestFixture::tpunit_detail_do_run(threads);
+}
+
+int tpunit::Tests::run(const set<string>& include, const set<string>& exclude, int threads) {
+    return TestFixture::tpunit_detail_do_run(include, exclude, threads);
+}

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -299,7 +299,8 @@ namespace tpunit {
 
          static int tpunit_detail_do_run(int threads = 1);
 
-         static int tpunit_detail_do_run(const std::set<std::string>& include, const std::set<std::string>& exclude, int threads);
+         static int tpunit_detail_do_run(const std::set<std::string>& include, const std::set<std::string>& exclude,
+                                         const std::list<std::string>& before, const std::list<std::string>& after, int threads);
 
       protected:
 
@@ -367,6 +368,7 @@ namespace tpunit {
        *
        * @return Number of failed assertions or zero if all tests pass.
        */
-      static int run(const std::set<std::string>& include, const std::set<std::string>& exclude, int threads = 1);
+      static int run(const std::set<std::string>& include, const std::set<std::string>& exclude,
+                     const std::list<std::string>& before, const std::list<std::string>& after, int threads = 1);
    };
 }

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -19,14 +19,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef __TPUNITPP_HPP__
-#define __TPUNITPP_HPP__
+#pragma once
 
 #include <cstdio>
 #include <set>
 #include <string>
+#include <list>
+#include <thread>
+#include <mutex>
+#include <algorithm>
+using namespace std;
 
 /**
+ * This version string has been updated to MAJOR_VERSION 2 by Expensify, as this library has been forked and
+ * significantly diverged from the original library. This is basically our own code at that point.
+ * In the future, we may even rename this library to avoid confusion.
+ *
  * TPUNITPP_VERSION macro contains an integer represented by
  * the value (M*1000000 + N*1000 + P) where M is the major
  * version, N is the minor version, and P is the patch version.
@@ -35,8 +43,8 @@
  * TPUNITPP_VERSION_MINOR is an integer of the minor version.
  * TPUNITPP_VERSION_PATCH is an integer of the patch version.
  */
-#define TPUNITPP_VERSION 1002001
-#define TPUNITPP_VERSION_MAJOR 1
+#define TPUNITPP_VERSION 2002001
+#define TPUNITPP_VERSION_MAJOR 2
 #define TPUNITPP_VERSION_MINOR 2
 #define TPUNITPP_VERSION_PATCH 1
 
@@ -50,10 +58,10 @@
  * TRACE(message); adds a trace to the test output with a user
  * specified string message.
  */
-#define ABORT() tpunit_detail_assert(__FILE__, __LINE__); return;
-#define FAIL()  tpunit_detail_assert(__FILE__, __LINE__);
+#define ABORT() tpunit_detail_assert(this, __FILE__, __LINE__); return;
+#define FAIL()  tpunit_detail_assert(this, __FILE__, __LINE__);
 #define PASS()  /* do nothing */
-#define TRACE(message) tpunit_detail_trace(__FILE__, __LINE__, message);
+#define TRACE(message) tpunit_detail_trace(this, __FILE__, __LINE__, message);
 
 /**
  * The set of core macros for basic predicate testing of boolean
@@ -177,33 +185,41 @@
 #endif
 
 namespace tpunit {
+
+    // Doesn't do anything except allow us to detect when the program wants to shutdown.
+    class ShutdownException{};
+
    /**
     * The primary class that provides the integration point for creating user
     * defined test cases. To get started one only needs to derive from TestFixture,
     * define a few test methods and register them with the base constructor.
     */
    class TestFixture {
+      public:
+
+         static bool exitFlag;
+
+         struct perFixtureStats {
+            perFixtureStats();
+
+            int _assertions;
+            int _exceptions;
+            int _traces;
+         };
+
+         perFixtureStats  _stats;
+         recursive_mutex* _mutex;
+         int _threadID;
+
       protected:
 
          /**
           * Internal class encapsulating a registered test method.
           */
          struct method {
-            method(TestFixture* obj, void (TestFixture::*addr)(), const char* name, unsigned char type)
-               : _this(obj)
-               , _addr(addr)
-               , _type(type)
-               , _next(0) {
-               char* dest = _name;
-               while(name && *name != 0) {
-                  *dest++ = *name++;
-               }
-               *dest = 0;
-            }
+            method(TestFixture* obj, void (TestFixture::*addr)(), const char* name, unsigned char type);
 
-            ~method() {
-               delete _next;
-            }
+            ~method();
 
             TestFixture* _this;
             void (TestFixture::*_addr)();
@@ -223,19 +239,10 @@ namespace tpunit {
           * Internal class encapsulating test statistics.
           */
          struct stats {
-            stats()
-               : _assertions(0)
-               , _exceptions(0)
-               , _failures(0)
-               , _passes(0)
-               , _traces(0)
-               {}
+            stats();
 
-            int _assertions;
-            int _exceptions;
             int _failures;
             int _passes;
-            int _traces;
          };
 
       public:
@@ -254,12 +261,11 @@ namespace tpunit {
                      method* m35 = 0, method* m36 = 0, method* m37 = 0, method* m38 = 0, method* m39 = 0,
                      method* m40 = 0, method* m41 = 0, method* m42 = 0, method* m43 = 0, method* m44 = 0,
                      method* m45 = 0, method* m46 = 0, method* m47 = 0, method* m48 = 0, method* m49 = 0)
-                    : TestFixture( m0,  m1,  m2,  m3,  m4,  m5,  m6,  m7,  m8,  m9,
+                     : TestFixture( m0,  m1,  m2,  m3,  m4,  m5,  m6,  m7,  m8,  m9,
                                   m10, m11, m12, m13, m14, m15, m16, m17, m18, m19,
                                   m20, m21, m22, m23, m24, m25, m26, m27, m28, m29,
                                   m30, m31, m32, m33, m34, m35, m36, m37, m38, m39,
                                   m40, m41, m42, m43, m44, m45, m46, m47, m48, m49, name) { }
-
          /**
           * Base constructor to register methods with the test fixture. A test
           * fixture can register up to 50 methods.
@@ -276,67 +282,9 @@ namespace tpunit {
                      method* m35 = 0, method* m36 = 0, method* m37 = 0, method* m38 = 0, method* m39 = 0,
                      method* m40 = 0, method* m41 = 0, method* m42 = 0, method* m43 = 0, method* m44 = 0,
                      method* m45 = 0, method* m46 = 0, method* m47 = 0, method* m48 = 0, method* m49 = 0,
-                     const char* name = 0) : _name(name) {
-            TestFixture** f = tpunit_detail_fixtures();
+                     const char* name = 0);
 
-            if (!(*f)) {
-               tpunit_detail_fixtures(this);
-            } else {
-               TestFixture* current = *f;
-               TestFixture* last = 0;
-               bool inserted = false;
-               while(current) {
-                  if (current->_name && _name && strcmp(current->_name, _name) > 0) {
-                     if (last) {
-                        last->_next = this;
-                     } else {
-                        tpunit_detail_fixtures(this);
-                     }
-                     this->_next = current;
-
-                     inserted = true;
-                     break;
-                  }
-                  last = current;
-                  current = current->_next;
-               }
-
-               if (!inserted) {
-                  last->_next = this;
-               }
-            }
-
-            method* methods[50] = { m0,  m1,  m2,  m3,  m4,  m5,  m6,  m7,  m8,  m9,
-                                    m10, m11, m12, m13, m14, m15, m16, m17, m18, m19,
-                                    m20, m21, m22, m23, m24, m25, m26, m27, m28, m29,
-                                    m30, m31, m32, m33, m34, m35, m36, m37, m38, m39,
-                                    m40, m41, m42, m43, m44, m45, m46, m47, m48, m49 };
-
-            for(int i = 0; i < 50; i++) {
-               if(methods[i]) {
-                  method** m = 0;
-                  switch(methods[i]->_type) {
-                     case method::AFTER_METHOD:        m = &_afters;         break;
-                     case method::AFTER_CLASS_METHOD:  m = &_after_classes;  break;
-                     case method::BEFORE_METHOD:       m = &_befores;        break;
-                     case method::BEFORE_CLASS_METHOD: m = &_before_classes; break;
-                     case method::TEST_METHOD:         m = &_tests;          break;
-                  }
-                  while(*m && (*m)->_next) {
-                     m = &(*m)->_next;
-                  }
-                  (*m) ? (*m)->_next = methods[i] : *m = methods[i];
-               }
-            }
-         }
-
-         ~TestFixture() {
-            delete _afters;
-            delete _after_classes;
-            delete _befores;
-            delete _before_classes;
-            delete _tests;
-         }
+         ~TestFixture();
 
          /**
           * Create a new method to register with the test fixture.
@@ -349,42 +297,9 @@ namespace tpunit {
             return new method(this, static_cast<void (TestFixture::*)()>(_method), _name, _type);
          }
 
-         static int tpunit_detail_do_run() {
-            const std::set<std::string> include, exclude;
-            return tpunit_detail_do_run(include, exclude);
-         }
+         static int tpunit_detail_do_run(int threads = 1);
 
-         static int tpunit_detail_do_run(const std::set<std::string>& include, const std::set<std::string>& exclude) {
-            TestFixture* f = *tpunit_detail_fixtures();
-            /*
-            * Run specific tests by name. If 'include' is empty, then every test is
-            * run unless it's in 'exclude'. If 'include' has at least one entry,
-            * then only tests in 'include' are run, and 'exclude' is ignored.
-            */
-             while (f) {
-                bool should_run = true;
-                if (include.size()) {
-                   if (!f->_name || (include.find(std::string(f->_name)) == include.end())) {
-                      should_run = false;
-                   }
-                }
-                else if (f->_name && (exclude.find(std::string(f->_name)) != exclude.end())) {
-                   should_run = false;
-                }
-                if (should_run) {
-                   printf("[--------------]\n");
-                   tpunit_detail_do_methods(f->_before_classes);
-                   tpunit_detail_do_tests(f);
-                   tpunit_detail_do_methods(f->_after_classes);
-                   printf("[--------------]\n\n");
-                }
-                f = f->_next;
-             }
-             printf("[==============]\n");
-             printf("[ TEST RESULTS ] Passed: %i, Failed: %i\n", tpunit_detail_stats()._passes, tpunit_detail_stats()._failures);
-             printf("[==============]\n");
-             return tpunit_detail_stats()._failures;
-         }
+         static int tpunit_detail_do_run(const std::set<std::string>& include, const std::set<std::string>& exclude, int threads);
 
       protected:
 
@@ -394,32 +309,7 @@ namespace tpunit {
           *
           * http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm 
           */
-         static bool tpunit_detail_fp_equal(float lhs, float rhs, unsigned char ulps) {
-            union {
-               float f;
-               char  c[4];
-            } lhs_u, rhs_u;
-            lhs_u.f = lhs;
-            rhs_u.f = rhs;
-
-            bool lil_endian = ((unsigned char) 0x00FF) == 0xFF;
-            int msb = lil_endian ? 3 : 0;
-            int lsb = lil_endian ? 0 : 3;
-            if(lhs_u.c[msb] < 0) {
-               lhs_u.c[0 ^ lsb] = 0x00 - lhs_u.c[0 ^ lsb];
-               lhs_u.c[1 ^ lsb] = (((unsigned char) lhs_u.c[0 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[1 ^ lsb];
-               lhs_u.c[2 ^ lsb] = (((unsigned char) lhs_u.c[1 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[2 ^ lsb];
-               lhs_u.c[3 ^ lsb] = (((unsigned char) lhs_u.c[2 ^ lsb] > 0x00) ? 0x7F : 0x80) - lhs_u.c[3 ^ lsb];
-            }
-            if(rhs_u.c[msb] < 0) {
-               rhs_u.c[0 ^ lsb] = 0x00 - rhs_u.c[0 ^ lsb];
-               rhs_u.c[1 ^ lsb] = (((unsigned char) rhs_u.c[0 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[1 ^ lsb];
-               rhs_u.c[2 ^ lsb] = (((unsigned char) rhs_u.c[1 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[2 ^ lsb];
-               rhs_u.c[3 ^ lsb] = (((unsigned char) rhs_u.c[2 ^ lsb] > 0x00) ? 0x7F : 0x80) - rhs_u.c[3 ^ lsb];
-            }
-            return (lhs_u.c[1] == rhs_u.c[1] && lhs_u.c[2] == rhs_u.c[2] && lhs_u.c[msb] == rhs_u.c[msb]) &&
-                   ((lhs_u.c[lsb] > rhs_u.c[lsb]) ? lhs_u.c[lsb] - rhs_u.c[lsb] : rhs_u.c[lsb] - lhs_u.c[lsb]) <= ulps;
-         }
+         static bool tpunit_detail_fp_equal(float lhs, float rhs, unsigned char ulps);
 
          /**
           * Determine if two binary64 double precision IEEE 754 floating-point
@@ -427,123 +317,36 @@ namespace tpunit {
           *
           * http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm 
           */
-         static bool tpunit_detail_fp_equal(double lhs, double rhs, unsigned char ulps) {
-            union {
-               double d;
-               char   c[8];
-            } lhs_u, rhs_u;
-            lhs_u.d = lhs;
-            rhs_u.d = rhs;
+         static bool tpunit_detail_fp_equal(double lhs, double rhs, unsigned char ulps);
 
-            bool lil_endian = ((unsigned char) 0x00FF) == 0xFF;
-            int msb = lil_endian ? 7 : 0;
-            int lsb = lil_endian ? 0 : 7;
-            if(lhs_u.c[msb] < 0) {
-               lhs_u.c[0 ^ lsb] = 0x00 - lhs_u.c[0 ^ lsb];
-               lhs_u.c[1 ^ lsb] = (((unsigned char) lhs_u.c[0 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[1 ^ lsb];
-               lhs_u.c[2 ^ lsb] = (((unsigned char) lhs_u.c[1 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[2 ^ lsb];
-               lhs_u.c[3 ^ lsb] = (((unsigned char) lhs_u.c[2 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[3 ^ lsb];
-               lhs_u.c[4 ^ lsb] = (((unsigned char) lhs_u.c[3 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[4 ^ lsb];
-               lhs_u.c[5 ^ lsb] = (((unsigned char) lhs_u.c[4 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[5 ^ lsb];
-               lhs_u.c[6 ^ lsb] = (((unsigned char) lhs_u.c[5 ^ lsb] > 0x00) ? 0xFF : 0x00) - lhs_u.c[6 ^ lsb];
-               lhs_u.c[7 ^ lsb] = (((unsigned char) lhs_u.c[6 ^ lsb] > 0x00) ? 0x7F : 0x80) - lhs_u.c[7 ^ lsb];
-            }
-            if(rhs_u.c[msb] < 0) {
-               rhs_u.c[0 ^ lsb] = 0x00 - rhs_u.c[0 ^ lsb];
-               rhs_u.c[1 ^ lsb] = (((unsigned char) rhs_u.c[0 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[1 ^ lsb];
-               rhs_u.c[2 ^ lsb] = (((unsigned char) rhs_u.c[1 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[2 ^ lsb];
-               rhs_u.c[3 ^ lsb] = (((unsigned char) rhs_u.c[2 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[3 ^ lsb];
-               rhs_u.c[4 ^ lsb] = (((unsigned char) rhs_u.c[3 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[4 ^ lsb];
-               rhs_u.c[5 ^ lsb] = (((unsigned char) rhs_u.c[4 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[5 ^ lsb];
-               rhs_u.c[6 ^ lsb] = (((unsigned char) rhs_u.c[5 ^ lsb] > 0x00) ? 0xFF : 0x00) - rhs_u.c[6 ^ lsb];
-               rhs_u.c[7 ^ lsb] = (((unsigned char) rhs_u.c[6 ^ lsb] > 0x00) ? 0x7F : 0x80) - rhs_u.c[7 ^ lsb];
-            }
-            return (lhs_u.c[1] == rhs_u.c[1] && lhs_u.c[2] == rhs_u.c[2] &&
-                    lhs_u.c[3] == rhs_u.c[3] && lhs_u.c[4] == rhs_u.c[4] &&
-                    lhs_u.c[5] == rhs_u.c[5] && lhs_u.c[6] == rhs_u.c[6] &&
-                    lhs_u.c[msb] == rhs_u.c[msb]) &&
-                   ((lhs_u.c[lsb] > rhs_u.c[lsb]) ? lhs_u.c[lsb] - rhs_u.c[lsb] : rhs_u.c[lsb] - lhs_u.c[lsb]) <= ulps;
-         }
+         static void tpunit_detail_assert(TestFixture* f, const char* _file, int _line);
 
-         static void tpunit_detail_assert(const char* _file, int _line) {
-            printf("[              ]    assertion #%i at %s:%i\n", ++tpunit_detail_stats()._assertions, _file, _line);
-         }
+         static void tpunit_detail_exception(TestFixture* f, method* _method, const char* _message);
 
-         static void tpunit_detail_exception(method* _method, const char* _message) {
-            printf("[              ]    exception #%i from %s with cause: %s\n", ++tpunit_detail_stats()._exceptions, _method->_name, _message);
-         }
-
-         static void tpunit_detail_trace(const char* _file, int _line, const char* _message) {
-            printf("[              ]    trace #%i at %s:%i: %s\n", ++tpunit_detail_stats()._traces, _file, _line, _message);
-         }
+         static void tpunit_detail_trace(TestFixture* f, const char* _file, int _line, const char* _message);
 
          const char* _name;
 
       private:
 
-         static void tpunit_detail_do_method(method* m) {
-            #ifdef TPUNITPP_HAS_EXCEPTIONS
-            try {
-            #endif
-               (*m->_this.*m->_addr)();
-            #ifdef TPUNITPP_HAS_EXCEPTIONS
-            } catch(const std::exception& e) {
-               tpunit_detail_exception(m, e.what());
-            } catch(...) {
-               tpunit_detail_exception(m, "caught unknown exception type");
-            }
-            #endif
-         }
+         static void tpunit_detail_do_method(method* m);
 
-         static void tpunit_detail_do_methods(method* m) {
-            while(m) {
-               tpunit_detail_do_method(m);
-               m = m->_next;
-            }
-         }
+         static void tpunit_detail_do_methods(method* m);
 
-         static void tpunit_detail_do_tests(TestFixture* f) {
-            method* t = f->_tests;
-            while(t) {
-               int _prev_assertions = tpunit_detail_stats()._assertions;
-               int _prev_exceptions = tpunit_detail_stats()._exceptions;
-               printf("[ RUN          ] %s\n", t->_name);
-               tpunit_detail_do_methods(f->_befores);
-               tpunit_detail_do_method(t);
-               tpunit_detail_do_methods(f->_afters);
-               if(_prev_assertions == tpunit_detail_stats()._assertions &&
-                  _prev_exceptions == tpunit_detail_stats()._exceptions) {
-                  printf("[       PASSED ] %s\n", t->_name);
-                  tpunit_detail_stats()._passes++;
-               } else {
-                  printf("[       FAILED ] %s\n", t->_name);
-                  tpunit_detail_stats()._failures++;
-               }
-               t = t->_next;
-            }
-         }
+         static void tpunit_detail_do_tests(TestFixture* f);
 
-         static stats& tpunit_detail_stats() {
-            static stats _stats;
-            return _stats;
-         }
+         static stats& tpunit_detail_stats();
 
-         // We can reset the head of the list by passing it in here.
-         static TestFixture** tpunit_detail_fixtures(TestFixture* newFixture = 0) {
-            static TestFixture* _fixtures = 0;
-            if (newFixture) {
-                _fixtures = newFixture;
-            }
-            return &_fixtures;
-         }
-
-         TestFixture* _next;
+          static std::list<TestFixture*>* tpunit_detail_fixture_list();
 
          method* _afters;
          method* _after_classes;
          method* _befores;
          method* _before_classes;
          method* _tests;
+
+         // True if running multithreaded.
+         bool _multiThreaded;
    };
 
    /**
@@ -555,9 +358,7 @@ namespace tpunit {
        *
        * @return Number of failed assertions or zero if all tests pass.
        */
-      static int run() {
-         return TestFixture::tpunit_detail_do_run();
-      }
+      static int run(int threads = 1);
 
       /**
        * Run specific tests by name. If 'include' is empty, then every test is
@@ -566,10 +367,6 @@ namespace tpunit {
        *
        * @return Number of failed assertions or zero if all tests pass.
        */
-      static int run(const std::set<std::string>& include, const std::set<std::string>& exclude) {
-         return TestFixture::tpunit_detail_do_run(include, exclude);
-      }
-
+      static int run(const std::set<std::string>& include, const std::set<std::string>& exclude, int threads = 1);
    };
-} // namespace tpunit
-#endif //__TPUNITPP_HPP__
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -37,6 +37,8 @@ int main(int argc, char* argv[]) {
     // Tests to run (or skip);
     set<string> include;
     set<string> exclude;
+    list<string> before;
+    list<string> after;
     int threads = 1;
 
     if (args.isSet("-only")) {
@@ -49,6 +51,18 @@ int main(int argc, char* argv[]) {
         list<string> excludeList = SParseList(args["-except"]);
         for (string name : excludeList) {
             exclude.insert(name);
+        }
+    }
+    if (args.isSet("-before")) {
+        list<string> beforeList = SParseList(args["-before"]);
+        for (string name : beforeList) {
+            before.push_back(name);
+        }
+    }
+    if (args.isSet("-after")) {
+        list<string> afterList = SParseList(args["-after"]);
+        for (string name : afterList) {
+            after.push_back(name);
         }
     }
     if (args.isSet("-threads")) {
@@ -76,7 +90,7 @@ int main(int argc, char* argv[]) {
 
     int retval = 0;
     try {
-        retval = tpunit::Tests::run(include, exclude, threads);
+        retval = tpunit::Tests::run(include, exclude, before, after, threads);
     } catch (...) {
         cout << "Unhandled exception running tests!" << endl;
         retval = 1;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -37,6 +37,7 @@ int main(int argc, char* argv[]) {
     // Tests to run (or skip);
     set<string> include;
     set<string> exclude;
+    int threads = 1;
 
     if (args.isSet("-only")) {
         list<string> includeList = SParseList(args["-only"]);
@@ -49,6 +50,9 @@ int main(int argc, char* argv[]) {
         for (string name : excludeList) {
             exclude.insert(name);
         }
+    }
+    if (args.isSet("-threads")) {
+        threads = SToInt(args["-threads"]);
     }
 
     // Set the defaults for the servers that each BedrockTester will start.
@@ -72,7 +76,7 @@ int main(int argc, char* argv[]) {
 
     int retval = 0;
     try {
-        retval = tpunit::Tests::run(include, exclude);
+        retval = tpunit::Tests::run(include, exclude, threads);
     } catch (...) {
         cout << "Unhandled exception running tests!" << endl;
         retval = 1;


### PR DESCRIPTION
@flodnv 

For some time now, we've had two different versions of tpunit in use, both modified from the standard public version, in different ways. One was in bedrock, and one was in auth.

This moves the version from auth to bedrock, making a few changes to keep it compatible with both projects.

## Added Functionality:
This also adds support for `before` and `after` test lists. These are tests that are run before and after the main body of the tests, one at a time, in the specified order.

This allows you to do `./authtest -threads 8 -after zEncryption` which will run all of the auth tests in 8 simultaneous threads, except `zEncryption`, which will be run after all other tests complete, by itself. You can also pass a list to `-before` or `-after`, i.e., `-after TestA,TestB,TestC` and it will run each test, in the specified order, one at a time.

## Note:
There will be another change to auth to remove that project's tpunit so that we use the same version everywhere.