### PR TITLE
Add escalation time logging.

### DIFF
--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -5,7 +5,8 @@ SQLiteCommand::SQLiteCommand(SData&& _request) :
     initiatingClientID(0),
     request(move(_request)),
     writeConsistency(SQLiteNode::ASYNC),
-    complete(false)
+    complete(false),
+    escalationTimeUS(0)
 {
     // Initialize the consistency, if supplied.
     if (request.isSet("writeConsistency")) {
@@ -35,5 +36,6 @@ SQLiteCommand::SQLiteCommand() :
     initiatingPeerID(0),
     initiatingClientID(0),
     writeConsistency(SQLiteNode::ASYNC),
-    complete(false)
+    complete(false),
+    escalationTimeUS(0)
 { }

--- a/sqlitecluster/SQLiteCommand.h
+++ b/sqlitecluster/SQLiteCommand.h
@@ -42,6 +42,12 @@ class SQLiteCommand {
     // Whether this command has been completed.
     bool complete;
 
+    // Performance metrics.
+    // This is the amount of time a command spent in escalation. A master node will record this from the time it first
+    // dequeues and parses the command, until the time it sends the response back to a slave. A slave node will record
+    // this from just before it sends the command to master until it gets the response back.
+    uint64_t escalationTimeUS;
+
     // Construct that takes a request object.
     SQLiteCommand(SData&& _request);
 


### PR DESCRIPTION
@quinthar 

This adds total time in escalation to the logs.

Master records the time from receiving an `ESCALATE` message to sending an `ESCALATE_RESPONSE` message.

Slaves record the time from sending an `ESCALATE` message to receiving an `ESCALATE_RESPONSE` message.

Slaves log both of these numbers upon receiving an `ESCALATE_RESPONSE` message. This gives us both total round-trip time including network time (the number recorded by slaves), and the actual time master took to peek/process the command (the number reported by master).