### PR TITLE
Add Bedrock::Job::CancelJob

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -751,14 +751,6 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             int64_t cancellingJobID = nonVisited.top();
             nonVisited.pop();
 
-            // Cancel children if they are not running
-            if (!db.write("UPDATE jobs "
-                          "SET state='CANCELLED' "
-                          "WHERE parentJobID=" + SQ(cancellingJobID) + " "
-                            "AND (state = 'QUEUED' OR state = 'PAUSED');")) {
-                throw "502 Failed to update job data";
-            }
-
             // Retrieve PAUSED children (potential parents)
             SQResult result;
             if (!db.read("SELECT j.jobID "
@@ -772,6 +764,14 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             for (const auto& row : result.rows) {
                 // If paused, child may have more children, cancel them as well.
                 nonVisited.push(SToInt64(row[0]));
+            }
+
+            // Cancel children if they are not running
+            if (!db.write("UPDATE jobs "
+                          "SET state='CANCELLED' "
+                          "WHERE parentJobID=" + SQ(cancellingJobID) + " "
+                            "AND (state = 'QUEUED' OR state = 'PAUSED');")) {
+                throw "502 Failed to update job data";
             }
         }
 


### PR DESCRIPTION
@cead22 

I rewrote the command taking [Carlos's comment](https://github.com/Expensify/Bedrock/pull/191#issuecomment-304101067) into account.

## Tests

```
createJob
name:testCancel

200 OK
commitCount: 15970
Content-Length: 12

{"jobID":34}

query:select * from jobs where jobid=34

200 OK
commitCount: 15971
Content-Length: 198

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:32:16 | 34 | QUEUED | testCancel | 2017-06-06 23:32:16 |  |  | {} | 500 | 0 | 

createJob
name:testCancel
parentJobID:34

405 Can only create child job when parent is RUNNING or PAUSED
commitCount: 15971
Content-Length: 0

getJob
name:testCancel

200 OK
commitCount: 15971
Content-Length: 42

{"data":{},"jobID":34,"name":"testCancel"}

query:select * from jobs where jobid=34

200 OK
commitCount: 15972
Content-Length: 218

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:32:16 | 34 | RUNNING | testCancel | 2017-06-06 23:32:16 | 2017-06-06 23:34:14 |  | {} | 500 | 0 | 

createJob
name:testCancel
parentJobID:34

200 OK
commitCount: 15972
Content-Length: 12

{"jobID":35}

createJob
name:testCancel
parentJobID:34

200 OK
commitCount: 15973
Content-Length: 12

{"jobID":36}

createJob
name:testCancel
parentJobID:34

200 OK
commitCount: 15974
Content-Length: 12

{"jobID":37}

query:select * from jobs where jobid IN (35,36,37) 

200 OK
commitCount: 15975
Content-Length: 387

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:34:29 | 35 | PAUSED | testCancel | 2017-06-06 23:34:29 |  |  | {} | 500 | 34 | 
2017-06-06 23:34:32 | 36 | PAUSED | testCancel | 2017-06-06 23:34:32 |  |  | {} | 500 | 34 | 
2017-06-06 23:39:22 | 37 | PAUSED | testCancel | 2017-06-06 23:39:22 |  |  | {} | 500 | 34 | 

cancelJob
jobID:35

200 OK
commitCount: 15975
Content-Length: 0

query:select * from jobs where jobid IN (35,36,37) 

200 OK
commitCount: 15975
Content-Length: 387

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:34:29 | 35 | PAUSED | testCancel | 2017-06-06 23:34:29 |  |  | {} | 500 | 34 | 
2017-06-06 23:34:32 | 36 | PAUSED | testCancel | 2017-06-06 23:34:32 |  |  | {} | 500 | 34 | 
2017-06-06 23:39:22 | 37 | PAUSED | testCancel | 2017-06-06 23:39:22 |  |  | {} | 500 | 34 | 

finishJob
jobID:34       

200 OK
commitCount: 15976
Content-Length: 0

getJob
name:testCancel

200 OK
commitCount: 15977
Content-Length: 75

{"data":{},"jobID":35,"name":"testCancel","parentData":{},"parentJobID":34}

query:select * from jobs where jobid IN (35,36,37)

200 OK
commitCount: 15978
Content-Length: 501

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:34:29 | 35 | RUNNING | testCancel | 2017-06-06 23:34:29 | 2017-06-06 23:45:55 |  | {} | 500 | 34 | 
2017-06-06 23:34:32 | 36 | QUEUED | testCancel | 2017-06-06 23:34:32 |  |  | {} | 500 | 34 | 
2017-06-06 23:39:22 | 37 | QUEUED | testCancel | 2017-06-06 23:39:22 |  |  | {} | 500 | 34 | 

createJob
name:testCancel
parentJobID:35

200 OK
commitCount: 15975
Content-Length: 12

{"jobID":38}

query:select * from jobs where jobid IN (35,36,37,38)

200 OK
commitCount: 15978
Content-Length: 501

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:34:29 | 35 | RUNNING | testCancel | 2017-06-06 23:34:29 | 2017-06-06 23:45:55 |  | {} | 500 | 34 | 
2017-06-06 23:34:32 | 36 | QUEUED | testCancel | 2017-06-06 23:34:32 |  |  | {} | 500 | 34 | 
2017-06-06 23:39:22 | 37 | QUEUED | testCancel | 2017-06-06 23:39:22 |  |  | {} | 500 | 34 | 
2017-06-06 23:43:29 | 38 | PAUSED | testCancel | 2017-06-06 23:43:29 |  |  | {} | 500 | 35 | 

cancelJob
jobID:37

200 OK
commitCount: 15978
Content-Length: 0

query:select * from jobs where jobid IN (35,36,37,38)    

200 OK
commitCount: 15979
Content-Length: 504

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:34:29 | 35 | RUNNING | testCancel | 2017-06-06 23:34:29 | 2017-06-06 23:45:55 |  | {} | 500 | 34 | 
2017-06-06 23:34:32 | 36 | QUEUED | testCancel | 2017-06-06 23:34:32 |  |  | {} | 500 | 34 | 
2017-06-06 23:39:22 | 37 | CANCELLED | testCancel | 2017-06-06 23:39:22 |  |  | {} | 500 | 34 | 
2017-06-06 23:43:29 | 38 | PAUSED | testCancel | 2017-06-06 23:43:29 |  |  | {} | 500 | 35 | 

cancelJob
jobID:35

404 Invalid jobID - Cannot cancel a job with children
commitCount: 15984
Content-Length: 0

getJob
name:testCancel

200 OK
commitCount: 15984
Content-Length: 75

{"data":{},"jobID":36,"name":"testCancel","parentData":{},"parentJobID":34}

finishJob
jobID:35

200 OK
commitCount: 16125
peekTime: 38
processTime: 2746
totalTime: 10236
Content-Length: 0

getJob
name:testCancel

200 OK
commitCount: 15984
Content-Length: 75

{"data":{},"jobID":38,"name":"testCancel","parentData":{},"parentJobID":35}

query:select * from jobs where jobid IN (35,36,37,38)    

200 OK
commitCount: 15985
Content-Length: 543

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:34:29 | 35 | PAUSED | testCancel | 2017-06-06 23:34:29 | 2017-06-06 23:45:55 |  | {} | 500 | 34 | 
2017-06-06 23:34:32 | 36 | RUNNING | testCancel | 2017-06-06 23:34:32 | 2017-06-06 23:55:20 |  | {} | 500 | 34 | 
2017-06-06 23:39:22 | 37 | CANCELLED | testCancel | 2017-06-06 23:39:22 |  |  | {} | 500 | 34 | 
2017-06-06 23:43:29 | 38 | RUNNING | testCancel | 2017-06-06 23:43:29 | 2017-06-07 00:03:12 |  | {} | 500 | 35 | 

cancelJob                                                      
jobID:38

200 OK
commitCount: 15985
Content-Length: 0

query:select * from jobs where jobid=38

200 OK
commitCount: 15985
Content-Length: 219

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:43:29 | 38 | RUNNING | testCancel | 2017-06-06 23:43:29 | 2017-06-07 00:03:12 |  | {} | 500 | 35 | 

finishJob
jobID:36

200 OK
commitCount: 15985
Content-Length: 0

query:select * from jobs where jobid IN (35,36,37,38) 

200 OK
commitCount: 15986
Content-Length: 544

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:34:29 | 35 | PAUSED | testCancel | 2017-06-06 23:34:29 | 2017-06-06 23:45:55 |  | {} | 500 | 34 | 
2017-06-06 23:34:32 | 36 | FINISHED | testCancel | 2017-06-06 23:34:32 | 2017-06-06 23:55:20 |  | {} | 500 | 34 | 
2017-06-06 23:39:22 | 37 | CANCELLED | testCancel | 2017-06-06 23:39:22 |  |  | {} | 500 | 34 | 
2017-06-06 23:43:29 | 38 | RUNNING | testCancel | 2017-06-06 23:43:29 | 2017-06-07 00:03:12 |  | {} | 500 | 35 | 

finishJob
jobID:38

200 OK
commitCount: 15986
Content-Length: 0

query:select * from jobs where jobid IN (35,36,37,38,34)

200 OK
commitCount: 15987
Content-Length: 657

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:32:16 | 34 | PAUSED | testCancel | 2017-06-06 23:32:16 | 2017-06-06 23:34:14 |  | {} | 500 | 0 | 
2017-06-06 23:34:29 | 35 | QUEUED | testCancel | 2017-06-06 23:34:29 | 2017-06-06 23:45:55 |  | {} | 500 | 34 | 
2017-06-06 23:34:32 | 36 | FINISHED | testCancel | 2017-06-06 23:34:32 | 2017-06-06 23:55:20 |  | {} | 500 | 34 | 
2017-06-06 23:39:22 | 37 | CANCELLED | testCancel | 2017-06-06 23:39:22 |  |  | {} | 500 | 34 | 
2017-06-06 23:43:29 | 38 | FINISHED | testCancel | 2017-06-06 23:43:29 | 2017-06-07 00:03:12 |  | {} | 500 | 35 | 

getJob
name:testCancel

200 OK
commitCount: 15987
Content-Length: 120

{"data":{},"finishedChildJobs":[{"data":{},"jobID":38}],"jobID":35,"name":"testCancel","parentData":{},"parentJobID":34}

query:select * from jobs where jobid IN (35,36,37,38,34)

200 OK
commitCount: 15988
Content-Length: 658

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:32:16 | 34 | PAUSED | testCancel | 2017-06-06 23:32:16 | 2017-06-06 23:34:14 |  | {} | 500 | 0 | 
2017-06-06 23:34:29 | 35 | RUNNING | testCancel | 2017-06-06 23:34:29 | 2017-06-07 00:53:13 |  | {} | 500 | 34 | 
2017-06-06 23:34:32 | 36 | FINISHED | testCancel | 2017-06-06 23:34:32 | 2017-06-06 23:55:20 |  | {} | 500 | 34 | 
2017-06-06 23:39:22 | 37 | CANCELLED | testCancel | 2017-06-06 23:39:22 |  |  | {} | 500 | 34 | 
2017-06-06 23:43:29 | 38 | FINISHED | testCancel | 2017-06-06 23:43:29 | 2017-06-07 00:03:12 |  | {} | 500 | 35 | 

finishJob 
jobID:35

200 OK
commitCount: 15988
Content-Length: 0


query:select * from jobs where jobid IN (35,36,37,38,34)

200 OK
commitCount: 15989
Content-Length: 544

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-06-06 23:32:16 | 34 | QUEUED | testCancel | 2017-06-06 23:32:16 | 2017-06-06 23:34:14 |  | {} | 500 | 0 | 
2017-06-06 23:34:29 | 35 | FINISHED | testCancel | 2017-06-06 23:34:29 | 2017-06-07 00:53:13 |  | {} | 500 | 34 | 
2017-06-06 23:34:32 | 36 | FINISHED | testCancel | 2017-06-06 23:34:32 | 2017-06-06 23:55:20 |  | {} | 500 | 34 | 
2017-06-06 23:39:22 | 37 | CANCELLED | testCancel | 2017-06-06 23:39:22 |  |  | {} | 500 | 34 | 

cancelJob
jobID:34

404 Invalid jobID - Cannot cancel a job with children
commitCount: 15989
Content-Length: 0

getJob
name:testCancel

200 OK
commitCount: 15989
Content-Length: 110

{"data":{},"finishedChildJobs":[{"data":{},"jobID":35},{"data":{},"jobID":36}],"jobID":34,"name":"testCancel"}

finishJob
jobID:34

200 OK
commitCount: 15990
Content-Length: 0

query:select * from jobs where jobid IN (35,36,37,38,34)

200 OK
commitCount: 15991
Content-Length: 202

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter

```