### PR TITLE
Fix command queue size counting

### DIFF
--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -14,7 +14,11 @@ bool BedrockCommandQueue::empty()  {
 
 size_t BedrockCommandQueue::size()  {
     SAUTOLOCK(_queueMutex);
-    return _commandQueue.size();
+    size_t size = 0;
+    for (const auto& queue : _commandQueue) {
+        size += queue.second.size();
+    }
+    return size;
 }
 
 BedrockCommand BedrockCommandQueue::get(uint64_t timeoutUS) {


### PR DESCRIPTION
@cead22

We need to count the total size of all the priority queues, not the number of priority queues.

I think this wasn't used anywhere except logging.

Tests
No new tests