### PR TITLE
Revert jobs to pervious deployed version

### DIFF
--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -15,5 +15,4 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     string _constructNextRunDATETIME(const string& lastScheduled, const string& lastRun, const string& repeat);
     bool _validateRepeat(const string& repeat) { return !_constructNextRunDATETIME("", "", repeat).empty(); }
     bool _hasPendingChildJobs(SQLite& db, int64_t jobID);
-    bool _isValidSQLiteDateModifier(const string& modifier);
 };


### PR DESCRIPTION
@coleaeason @righdforsa 

This is the known working version of the jobs plugin, because the current one at `head` is mysteriously broken. We're reverting for the time being to allow deploys while this change is fixed.

Tests:
Jobs doesn't have tests.