### PR TITLE
Lock mutex in getRequestMethodLines

### DIFF
--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -76,6 +76,7 @@ BedrockCommand BedrockCommandQueue::get(uint64_t timeoutUS) {
 
 list<string> BedrockCommandQueue::getRequestMethodLines() {
     list<string> returnVal;
+    SAUTOLOCK(_queueMutex);
     for (auto& queue : _commandQueue) {
         for (auto& entry : queue.second) {
             returnVal.push_back(entry.second.request.methodLine);


### PR DESCRIPTION
@coleaeason 

Somehow I omitted locking the queue's mutex inside `getRequestMethodLines`, which made it possible to modify the queue while `getRequestMethodLines` was executing, for example, to delete an item that we were going to inspect.

This change adds `SAUTOLOCK(_queueMutex);` to the function, just like every other function in this class.

## Tests

Automated tests still pass.