### PR TITLE
Restore Bedrock Command Timing

### DIFF
--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -11,6 +11,12 @@ class BedrockCommand : public SQLiteCommand {
         PRIORITY_MAX = 1000
     };
 
+    enum TIMING_INFO {
+        PEEK,
+        PROCESS,
+        QUEUE,
+    };
+
     // Constructor to make an empty object.
     BedrockCommand();
 
@@ -32,6 +38,9 @@ class BedrockCommand : public SQLiteCommand {
     // Move assignment operator.
     BedrockCommand& operator=(BedrockCommand&& from);
 
+    // Add a summary of our timing info to our response object.
+    void finalizeTimingInfo();
+
     // If the `peek` portion of this command needs to make an HTTPS request, this is where we store it.
     SHTTPSManager::Transaction* httpsRequest;
 
@@ -41,6 +50,13 @@ class BedrockCommand : public SQLiteCommand {
     // We track how many times we `peek` and `process` each command.
     int peekCount;
     int processCount;
+
+    // Timestamp at which this command was created. This is specific to the current server - it's not persisted from
+    // slave to master.
+    uint64_t creationTime;
+
+    // A list of timing sets, With an info type, start, and end.
+    list<tuple<TIMING_INFO, uint64_t, uint64_t>> timingInfo;
 
   private:
     // Set certain initial state on construction. Common functionality to several constructors.

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -51,10 +51,6 @@ class BedrockCommand : public SQLiteCommand {
     int peekCount;
     int processCount;
 
-    // Timestamp at which this command was created. This is specific to the current server - it's not persisted from
-    // slave to master.
-    uint64_t creationTime;
-
     // A list of timing sets, With an info type, start, and end.
     list<tuple<TIMING_INFO, uint64_t, uint64_t>> timingInfo;
 

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -14,7 +14,6 @@ class BedrockCommand : public SQLiteCommand {
     enum TIMING_INFO {
         PEEK,
         PROCESS,
-        QUEUE,
     };
 
     // Constructor to make an empty object.
@@ -51,7 +50,7 @@ class BedrockCommand : public SQLiteCommand {
     int peekCount;
     int processCount;
 
-    // A list of timing sets, With an info type, start, and end.
+    // A list of timing sets, with an info type, start, and end.
     list<tuple<TIMING_INFO, uint64_t, uint64_t>> timingInfo;
 
   private:

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -8,6 +8,7 @@ _server(server)
 { }
 
 bool BedrockCore::peekCommand(BedrockCommand& command) {
+    AutoTimer timer(command, BedrockCommand::PEEK);
     // Convenience references to commonly used properties.
     SData& request = command.request;
     SData& response = command.response;
@@ -70,6 +71,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
 }
 
 bool BedrockCore::processCommand(BedrockCommand& command) {
+    AutoTimer timer(command, BedrockCommand::PROCESS);
     // Convenience references to commonly used properties.
     SData& request = command.request;
     SData& response = command.response;

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <sqlitecluster/SQLiteCore.h>
-class BedrockCommand;
+#include <BedrockCommand.h>
 class BedrockServer;
 
 class BedrockCore : public SQLiteCore {
@@ -29,6 +29,20 @@ class BedrockCore : public SQLiteCore {
     bool processCommand(BedrockCommand& command);
 
   private:
+
+    // Automatic timing class that records an entry corresponding to its lifespan.
+    class AutoTimer {
+      public:
+        AutoTimer(BedrockCommand& command, BedrockCommand::TIMING_INFO type) :
+        _command(command), _type(type), _start(STimeNow()) { }
+        ~AutoTimer() {
+            _command.timingInfo.emplace_back(make_tuple(_type, _start, STimeNow()));
+        }
+      private:
+        BedrockCommand& _command;
+        BedrockCommand::TIMING_INFO _type;
+        uint64_t _start;
+    };
     void _handleCommandException(BedrockCommand& command, const string& e, bool wasProcessing);
     const BedrockServer& _server;
 };

--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -6,7 +6,8 @@ SQLiteCommand::SQLiteCommand(SData&& _request) :
     request(move(_request)),
     writeConsistency(SQLiteNode::ASYNC),
     complete(false),
-    escalationTimeUS(0)
+    escalationTimeUS(0),
+    creationTime(STimeNow())
 {
     // Initialize the consistency, if supplied.
     if (request.isSet("writeConsistency")) {
@@ -37,5 +38,6 @@ SQLiteCommand::SQLiteCommand() :
     initiatingClientID(0),
     writeConsistency(SQLiteNode::ASYNC),
     complete(false),
-    escalationTimeUS(0)
+    escalationTimeUS(0),
+    creationTime(STimeNow())
 { }

--- a/sqlitecluster/SQLiteCommand.h
+++ b/sqlitecluster/SQLiteCommand.h
@@ -48,6 +48,10 @@ class SQLiteCommand {
     // this from just before it sends the command to master until it gets the response back.
     uint64_t escalationTimeUS;
 
+    // Timestamp at which this command was created. This is specific to the current server - it's not persisted from
+    // slave to master.
+    uint64_t creationTime;
+
     // Construct that takes a request object.
     SQLiteCommand(SData&& _request);
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -100,9 +100,6 @@ void SQLiteNode::sendResponse(const SQLiteCommand& command)
     SASSERT(peer);
     SData escalate("ESCALATE_RESPONSE");
     escalate["ID"] = command.id;
-    if (command.escalationTimeUS) {
-        escalate.set("escalationTimeUS", STimeNow() - command.escalationTimeUS);
-    }
     escalate.content = command.response.serialize();
     _sendToPeer(peer, escalate);
 }
@@ -1611,7 +1608,6 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             SQLiteCommand command(move(request));
             command.initiatingPeerID = peer->id;
             command.id = message["ID"];
-            command.escalationTimeUS = STimeNow();
             _server.acceptCommand(move(command));
         }
     } else if (SIEquals(message.methodLine, "ESCALATE_CANCEL")) {
@@ -1667,8 +1663,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             if (command.escalationTimeUS) {
                 command.escalationTimeUS = STimeNow() - command.escalationTimeUS;
                 SINFO("[performance] Total escalation time for command " << command.request.methodLine << " was "
-                      << command.escalationTimeUS << "us. Master processing time was: " << message["escalationTimeUS"]
-                      << "us.");
+                      << command.escalationTimeUS << "us.");
             }
             command.response = response;
             command.complete = true;

--- a/test/clustertest/tests/h_timingTest.cpp
+++ b/test/clustertest/tests/h_timingTest.cpp
@@ -1,0 +1,62 @@
+
+#include "../BedrockClusterTester.h"
+
+struct h_timingTest : tpunit::TestFixture {
+    h_timingTest()
+        : tpunit::TestFixture("h_timingTest",
+                              TEST(h_timingTest::test)) { }
+
+    BedrockClusterTester* tester;
+    void test()
+    {
+        BedrockClusterTester* tester = BedrockClusterTester::testers.front();
+        for (auto i : {0,1,2}) {
+            BedrockTester* brtester = tester->getBedrockTester(i);
+
+            // This just verifies that the dbupgrade table was created by TestPlugin.
+            SData query("idcollision");
+            query["writeConsistency"] = "ASYNC";
+            query["value"] = "default";
+            SData result = brtester->executeWaitData(query);
+            /* Uncomment for inspection.
+            for (const auto& row : result.nameValueMap) {
+                cout << row.first << ":" << row.second << endl;
+            }
+            cout << endl;
+            */
+
+            uint64_t peekTime = SToUInt64(result["peekTime"]);
+            uint64_t processTime = SToUInt64(result["processTime"]);
+            uint64_t totalTime = SToUInt64(result["totalTime"]);
+
+            // Only master is expected to have these set.
+            if (i == 0) {
+                ASSERT_GREATER_THAN(peekTime, 0);
+                ASSERT_GREATER_THAN(processTime, 0);
+            } else {
+                ASSERT_EQUAL(peekTime, 0);
+                ASSERT_EQUAL(processTime, 0);
+            }
+
+            ASSERT_LESS_THAN(peekTime + processTime, totalTime);
+
+            if (i != 0) {
+                // Extra data on slaves.
+                uint64_t escalationTime = SToUInt64(result["escalationTime"]);
+                uint64_t upstreamPeekTime = SToUInt64(result["upstreamPeekTime"]);
+                uint64_t upstreamProcessTime = SToUInt64(result["upstreamProcessTime"]);
+                uint64_t upstreamTotalTime = SToUInt64(result["upstreamTotalTime"]);
+
+                ASSERT_GREATER_THAN(escalationTime, 0);
+                ASSERT_GREATER_THAN(upstreamPeekTime, 0);
+                ASSERT_GREATER_THAN(upstreamProcessTime, 0);
+                ASSERT_GREATER_THAN(upstreamTotalTime, 0);
+
+                ASSERT_LESS_THAN(escalationTime, totalTime);
+                ASSERT_LESS_THAN(upstreamTotalTime, escalationTime);
+                ASSERT_LESS_THAN(upstreamPeekTime + upstreamProcessTime, upstreamTotalTime);
+            }
+        }
+    }
+} __h_timingTest;
+

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -370,7 +370,12 @@ string BedrockTester::getServerAddr() {
     return _serverAddr.empty() ? SERVER_ADDR : _serverAddr;
 }
 
-string BedrockTester::executeWait(const SData& request, const std::string& correctResponse) {
+string BedrockTester::executeWait(const SData& request, const string& correctResponse) {
+    SData response = executeWaitData(request, correctResponse);
+    return response.content;
+}
+
+SData BedrockTester::executeWaitData(const SData& request, const string& correctResponse) {
     // We create a socket, send the message, wait for the response, close the socket, and parse the message.
     int socket = S_socket(getServerAddr(), true, false, true);
 
@@ -401,5 +406,8 @@ string BedrockTester::executeWait(const SData& request, const std::string& corre
 
     close(socket);
 
-    return content;
+    SData response(methodLine);
+    response.nameValueMap = headers;
+    response.content = content;
+    return response;
 }

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -29,6 +29,9 @@ class BedrockTester {
     // Executes a command and waits for the response
     string executeWait(const SData& request, const std::string& correctResponse = "200");
 
+    // Same as above, but returns entire SData for the response
+    SData executeWaitData(const SData& request, const std::string& correctResponse = "200");
+
     // like executeWait, except it will execute multiple requests in parallel over several simultaneous connections.
     // returns a pair of strings for each request, with the response code and the response text, in that order.
     vector<pair<string,string>> executeWaitMultiple(vector<SData> requests, int connections = 10);


### PR DESCRIPTION
@flodnv @coleaeason 

## Issue:
https://github.com/Expensify/Expensify/issues/53793

This PR restores some timing metrics to bedrock commands.

The following data is recorded on master:

1. `peekTime` - the total time spent inside `peekCommand`
2. `processTime` - the total time spent inside `processCommand`
3. `totalTime` - the lifespan of the `BedrockCommand` object, from creation to sending a reply to the client or slave that sent the request.

On escalated commands, slaves will receive all of the above values from master, and rename them to `upstreamPeekTime`, `upstreamProcessTime`, and `upstreamTotalTime`, respectively.

Additionally, slaves add their *own*:

1. `peekTime` - same as above, but not recorded for commands that are escalated to master.
1. `totalTime` - same as above, including time spent waiting on master.
2. `escalationTime` - time from sending command to master to receiving a response. Only set on commands escalated to master.

### Not included:
We do not explicitly break out commit/queue time. This could be added in the future.

On a slave, network time waiting on master is roughly `escalationTime - upstreamTotalTime`. Similar derived metrics can be made from this data in other ways.

## Tests

Automated test added
