### PR TITLE
Don't have abort() handler call exit()

### DIFF
--- a/libstuff/SSignal.cpp
+++ b/libstuff/SSignal.cpp
@@ -54,14 +54,15 @@ void SSendSignal(int signum) {
     //         inside a non-reentrant system call.
     _SSignal_sentBitmask |= (1 << signum);
 
-    // We *do* do logging for SIGABRT, because we have no way to recover from
-    // this, the process will be terminated as soon as we return from this handler.
+    // If we get SIGABRT or SIGSEGV, we want to exit abnormally. That is to say, either explicitly call abort() or let
+    // it continue naturally. 
+    // We don't call `SERROR` because that calls `exit(1)`, which can interrupt our signal handling process and never
+    // return. Instead, we explictly let this function return, so that abort() can complete, and we can generate core
+    // files.
     if (signum == SIGABRT) {
-        SERROR("Got SIGABRT, logging stack trace.");
+        SWARN("Got SIGABRT, logging stack trace.");
+        SLogStackTrace();
     } else if (signum == SIGSEGV) {
-        // If we catch a segfault, let's log that, and then manually log a stack trace and call abort(), instead of
-        // calling SERROR. The reasoning behind that is because `SERROR` will just call `exit(1)`, which keeps us from
-        // being able to generate core files, which are sometimes useful.
         SWARN("Got SIGSEGV, logging stack trace.");
         SLogStackTrace();
         abort();


### PR DESCRIPTION
@coleaeason 

try to keep `abort()` from exiting early.

`abort()` is supposed to work and exit abnormally as long as the signal handler it call returns. Exit never returns, so we can't call `exit()` from within our signal handler and have `abort()` work correctly. Since `SERROR` calls exit, we can't use it here.