### PR TITLE
Un-revert Jobs plugin schema change.

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -9,18 +9,22 @@
 void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
     // Create or verify the jobs table
     bool ignore;
-    SASSERT(db.verifyTable("jobs", "CREATE TABLE jobs ( "
-                                   "created  TIMESTAMP NOT NULL, "
-                                   "jobID    INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, "
-                                   "state    TEXT NOT NULL, "
-                                   "name     TEXT NOT NULL, "
-                                   "nextRun  TIMESTAMP NOT NULL, "
-                                   "lastRun  TIMESTAMP, "
-                                   "repeat   TEXT NOT NULL, "
-                                   "data     TEXT NOT NULL, "
-                                   "priority INTEGER NOT NULL DEFAULT " + SToStr(JOBS_DEFAULT_PRIORITY) + ", "
-                                   "parentJobID INTEGER NOT NULL DEFAULT 0 )",
-                           ignore));
+    if (!db.verifyTable("jobs", "CREATE TABLE jobs ( "
+                                   "created     TIMESTAMP NOT NULL, "
+                                   "jobID       INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, "
+                                   "state       TEXT NOT NULL, "
+                                   "name        TEXT NOT NULL, "
+                                   "nextRun     TIMESTAMP NOT NULL, "
+                                   "lastRun     TIMESTAMP, "
+                                   "repeat      TEXT NOT NULL, "
+                                   "data        TEXT NOT NULL, "
+                                   "priority    INTEGER NOT NULL DEFAULT " + SToStr(JOBS_DEFAULT_PRIORITY) + ", "
+                                   "parentJobID INTEGER NOT NULL DEFAULT 0, "
+                                   "retryAfter  TEXT NOT NULL DEFAULT \"\" )",
+                        ignore))
+    {
+        SASSERT(db.write("ALTER TABLE jobs ADD COLUMN retryAfter TEXT NOT NULL DEFAULT \"\";"));
+    }
 
     // These indexes are not used by the Bedrock::Jobs plugin, but provided for easy analysis
     // using the Bedrock::DB plugin.


### PR DESCRIPTION
@coleaeason 

This un-reverts *only* the schema change portion of this change: https://github.com/Expensify/Bedrock/pull/194/files

The intention is to split the offending change in half, and see if we see the same problems when deploying only the schema change. If so, we know there's some problem with this new schema causing performance issues. If not, there's some problem with the remainder of the code that causes the issues, which would be diagnosed next.