### PR TITLE
Prevent conflicts in sync thread

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -490,7 +490,7 @@ void BedrockServer::worker(SData& args,
                     // able to cause a conflict on the sync thread. We only grab this after calling `peekCommand`, as
                     // we want to allow read-only commands to continue as usual even if the sync thread is busy
                     // writing. This lock is released when it goes out of scope.
-                    shared_lock<decltype(server._syncThreadCommitMutex)>(server._syncThreadCommitMutex);
+                    shared_lock<decltype(server._syncThreadCommitMutex)> lock(server._syncThreadCommitMutex);
 
                     // We've just unsuccessfully peeked a command, which means we're in a state where we might want to
                     // write it. We'll flag that here, to keep the node from falling out of MASTERING/STANDINGDOWN

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -190,21 +190,10 @@ void BedrockServer::sync(SData& args,
         // If we've just switched to the mastering state, we want to upgrade the DB. We'll set a global flag to let
         // worker threads know that a DB upgrade is in progress, and start the upgrade process, which works basically
         // like a regular distributed commit.
-        // We also want to mark anything in our command queue as 'unpeeked'. It's possible that plugins skipped the
-        // peek for various commands, because they'd intended to escalate them to master. We'll reset the peek count to
-        // 0 for everything currently in our queue, and they'll be peeked by the sync thread, as they've been
-        // effectively "escalated" to master without being sent to another server.
         if (preUpdateState != SQLiteNode::MASTERING && nodeState == SQLiteNode::MASTERING) {
-            auto queueSize = syncNodeQueuedCommands.size();
-            if (queueSize) {
-                SWARN("State changed to MASTERING with " << queueSize << " queued commands, resetting peek count.");
-
-                // Pass `each` a lambda function that resets the peek count.
-                syncNodeQueuedCommands.each([](BedrockCommand& c) { c.peekCount = 0; });
-            }
-
             if (server._upgradeDB(db)) {
                 upgradeInProgress.store(true);
+                server._syncThreadCommitMutex.lock();
                 committingCommand = true;
                 server._writableCommandsInProgress++;
                 syncNode.startCommit(SQLiteNode::QUORUM);
@@ -220,7 +209,8 @@ void BedrockServer::sync(SData& args,
             // It should be impossible to get here if we're not mastering or standing down.
             SASSERT(nodeState == SQLiteNode::MASTERING || nodeState == SQLiteNode::STANDINGDOWN);
 
-            // We're done with the commit, we decrement our counter.
+            // We're done with the commit, we unlock our mutex and decrement our counter.
+            server._syncThreadCommitMutex.unlock();
             committingCommand = false;
             server._writableCommandsInProgress--;
             if (syncNode.commitSucceeded()) {
@@ -288,18 +278,18 @@ void BedrockServer::sync(SData& args,
             // We got a command to work on! Set our log prefix to the request ID.
             SAUTOPREFIX(command.request["requestID"]);
 
-            // If a command hasn't been peeked yet (which should be unusual and only happen for commands that were
-            // already queued as we were promoted to MASTERING), we'll peek it now.
-            if (!command.peekCount) {
-                if (!command.httpsRequest) {
-                    if (core.peekCommand(command)) {
-                        // This command completed in peek, stick it back in the queue for a worker to respond to.
-                        SASSERT(command.complete);
-                        server._commandQueue.push(move(command));
-                        continue;
-                    }
-                } else {
-                    SWARN("Command " << command.request.methodLine << " has peekCount of 0 but httpsRequest.");
+            // We peek commands here in the sync thread to be able to run peek and process as part of the same
+            // transaction. This guarantees that any checks made in peek are still valid in process, as the DB can't
+            // have changed in the meantime.
+            // IMPORTANT: This check is omitted for commands with an HTTPS request object, because we don't want to
+            // risk duplicating that request. If your command creates an HTTPS request, it needs to explicitly
+            // re-verify that any checks made in peek are still valid in process.
+            if (!command.httpsRequest) {
+                if (core.peekCommand(command)) {
+                    // This command completed in peek, stick it back in the queue for a worker to respond to.
+                    SASSERT(command.complete);
+                    server._commandQueue.push(move(command));
+                    continue;
                 }
             }
 
@@ -313,9 +303,9 @@ void BedrockServer::sync(SData& args,
 
             // And now we'll decide how to handle it.
             if (nodeState == SQLiteNode::MASTERING) {
-                // If we're getting it on the sync thread, that means it's already been `peeked` unsuccessfully, and it
-                // needed to be processed. If it were `peeked` successfully, then the worker thread wouldn't have given
-                // it back to us.
+                // Now that we've peeked without finishing the command, we grab the commit mutex exclusively, so that none
+                // of our worker threads can attempt to write to the database until we're finished.
+                server._syncThreadCommitMutex.lock();
                 if (core.processCommand(command)) {
                     // The processor says we need to commit this, so let's start that process.
                     committingCommand = true;
@@ -334,6 +324,7 @@ void BedrockServer::sync(SData& args,
                 } else {
                     // Otherwise, the command doesn't need a commit (maybe it was an error, or it didn't have any work
                     // to do. We'll just respond.
+                    server._syncThreadCommitMutex.unlock();
                     if (command.initiatingPeerID) {
                         command.finalizeTimingInfo();
                         syncNode.sendResponse(command);
@@ -493,6 +484,14 @@ void BedrockServer::worker(SData& args,
                 // Try peeking the command. If this succeeds, then it's finished, and all we need to do is respond to
                 // the command at the bottom.
                 if (!core.peekCommand(command)) {
+                    // Now that we've unsuccessfully peeked this command, we want to grab a shared lock of our sync
+                    // thread's commit mutex. This will block if the sync thread is mid-transaction, keeping us from
+                    // writing anything while the sync thread is also doing so, and thus guaranteeing that we won't be
+                    // able to cause a conflict on the sync thread. We only grab this after calling `peekCommand`, as
+                    // we want to allow read-only commands to continue as usual even if the sync thread is busy
+                    // writing. This lock is released when it goes out of scope.
+                    shared_lock<decltype(server._syncThreadCommitMutex)>(server._syncThreadCommitMutex);
+
                     // We've just unsuccessfully peeked a command, which means we're in a state where we might want to
                     // write it. We'll flag that here, to keep the node from falling out of MASTERING/STANDINGDOWN
                     // until we're finished with this command.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -171,6 +171,12 @@ class BedrockServer : public SQLiteServer {
     multimap<uint64_t, BedrockCommand> _futureCommitCommands;
     recursive_mutex _futureCommitCommandMutex;
 
+    // This is a shared mutex. It can be locked by many readers at once, but if the writer (the sync thread) locks it,
+    // no other thread can access it. It's locked by the sync thread immediately before starting a transaction, and
+    // unlocked afterward. Workers do the same, so that they won't try to start a new transaction while the sync thread
+    // is committing. This mutex is *not* recursive.
+    shared_timed_mutex _syncThreadCommitMutex;
+
     // A set of command names that will always be run with QUORUM consistency level.
     // Specified by the `-synchronousCommands` command-line switch.
     set<string> _syncCommands;

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ PROJECT = $(shell pwd)
 # Extract our version information from git.
 VERSION = $(shell git log -1 | head -n 1 | cut -d ' ' -f 2)
 
-# Turn on C++11.
+# Turn on C++14.
 CFLAGS =-g -DSVERSION="\"$(VERSION)\"" -Wall
-CXXFLAGS =-std=gnu++11
+CXXFLAGS =-std=gnu++14
 CXXFLAGS +=-I$(PROJECT) -I$(PROJECT)/mbedtls/include
 
 # This works because 'PRODUCTION' is passed as a command-line param, and so is ignored here when set that way.

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <random>
 #include <set>
+#include <shared_mutex>
 #include <sstream>
 #include <string>
 #include <thread>

--- a/test/clustertest/testplugin/Makefile
+++ b/test/clustertest/testplugin/Makefile
@@ -13,8 +13,8 @@ PROJECT = $(shell pwd)/../../..
 # Extract our version information from git.
 VERSION = $(shell git log -1 | head -n 1 | cut -d ' ' -f 2)
 
-# Turn on C++11.
-CXXFLAGS =-g -std=gnu++11 -fpic -DSVERSION="\"$(VERSION)\"" -Wall
+# Turn on C++14.
+CXXFLAGS =-g -std=gnu++14 -fpic -DSVERSION="\"$(VERSION)\"" -Wall
 CXXFLAGS +=-I$(PROJECT) -I../../../mbedtls/include
 
 # This works because 'PRODUCTION' is passed as a command-line param, and so is ignored here when set that way.


### PR DESCRIPTION
@quinthar 

~HOLD for: https://github.com/Expensify/Server-Expensify/pull/2000~

This change adds a lock around writing from the sync thread. I've upgraded our C++ standard to C++14 for this (which is actually the default for our current compiler, we've been downgrading it specifically with C++11) so that we can use `<shared_mutex>`.

This locks around the `process` and `commit` portions of each command, with a shared lock in worker threads, but an exclusive lock in the sync thread. This means many workers can process commands simultaneously, but once the sync thread acquires this lock exclusively, worker threads will have to wait until the sync thread releases it before they can call `process`, thus avoiding ever conflicting with the sync thread.

So, essentially, workers can write simultaneously with one another, while the sync thread always writes by itself, forcing workers to wait. This is the change discussed in [this document](https://gist.github.com/tylerkaraszewski/da89a1660b5108b861c671c880dfe3fa). To really see a performance improvement here, we need to offload nearly all command processing from the sync thread, so that the worker threads are rarely blocked there, this should be doable by setting most commands as parallel.

I have a feeling that when you see this line:
```
shared_lock<decltype(server._syncThreadCommitMutex)> lock(server._syncThreadCommitMutex);
```
You'll think "WTF does that do?" so I'll explain it here. `decltype(server._syncThreadCommitMutex)` is sort of like `auto`, but for templates. It just resolves to the declared type of `server._syncThreadCommitMutex`, which, in this case is equivalent to:
`shared_lock<shared_timed_mutex> lock(server._syncThreadCommitMutex)`, except if you ever change the type of mutex we're using, the template argument automatically picks that up.

## Tests

Existing automated tests.