### PR TITLE
Don't dereference null terminator in DNS lookup result

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1467,7 +1467,7 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking) {
             if (elapsed > 100 * STIME_US_PER_MS) {
                 SWARN("Slow DNS lookup. " << elapsed / STIME_US_PER_MS << "ms for '" << domain << "'.");
             }
-            if (!hostent || hostent->h_length != 4 || !hostent->h_addr_list || !*(uint32_t*)hostent->h_addr_list[0]) {
+            if (!hostent || hostent->h_length != 4 || !hostent->h_addr_list || !*hostent->h_addr_list[0]) {
                 throw "can't resolve host";
             }
             in_addr* addr = (in_addr*)hostent->h_addr_list[0];

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1464,10 +1464,12 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking) {
             uint64_t start = STimeNow();
             hostent* hostent = gethostbyname(domain.c_str());
             uint64_t elapsed = STimeNow() - start;
-            if (elapsed > 100 * STIME_US_PER_MS)
+            if (elapsed > 100 * STIME_US_PER_MS) {
                 SWARN("Slow DNS lookup. " << elapsed / STIME_US_PER_MS << "ms for '" << domain << "'.");
-            if (!hostent || hostent->h_length != 4 || !hostent->h_addr_list)
+            }
+            if (!hostent || hostent->h_length != 4 || !hostent->h_addr_list || !*(uint32_t*)hostent->h_addr_list[0]) {
                 throw "can't resolve host";
+            }
             in_addr* addr = (in_addr*)hostent->h_addr_list[0];
             ip = addr->s_addr;
         }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1467,7 +1467,7 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking) {
             if (elapsed > 100 * STIME_US_PER_MS) {
                 SWARN("Slow DNS lookup. " << elapsed / STIME_US_PER_MS << "ms for '" << domain << "'.");
             }
-            if (!hostent || hostent->h_length != 4 || !hostent->h_addr_list || !*hostent->h_addr_list[0]) {
+            if (!hostent || hostent->h_length != 4 || !hostent->h_addr_list || !hostent->h_addr_list[0]) {
                 throw "can't resolve host";
             }
             in_addr* addr = (in_addr*)hostent->h_addr_list[0];


### PR DESCRIPTION
@quinthar @cead22 @righdforsa @coleaeason 

This change fixes the way we check that we successfully looked up a DNS entry.

The `hostent` struct contains a field `char** h_addr_list`.

This is described in the `gethostbyname` man page as:

> h_addr_list
> An array of pointers to network addresses for the host (in network byte order), terminated by a NULL pointer.

Which implies to me that this list is always of `length >= 1`, and the last entry in the list is always `0x00` (it's verified four-bytes long, because we already check `hostent->h_length != 4`).

So, while we previously (and continue to) checked that `h_addr_list` itself wasn't null (with `!hostent->h_addr_list`), this check probably never failed, because even if there were no addresses, this pointer itself wouldn't be null, but the first entry would be the null terminator.

So, we've added another check to make sure that the first entry in the list isn't null before we dereference it.

Also, we added parentheses.