### PR TITLE
Enable -Werror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PROJECT = $(shell pwd)
 VERSION = $(shell git log -1 | head -n 1 | cut -d ' ' -f 2)
 
 # Turn on C++11.
-CFLAGS =-g -DSVERSION="\"$(VERSION)\"" -Wall
+CFLAGS =-g -DSVERSION="\"$(VERSION)\"" -Wall -Werror
 CXXFLAGS =-std=gnu++11
 CXXFLAGS +=-I$(PROJECT) -I$(PROJECT)/mbedtls/include
 

--- a/test/clustertest/testplugin/Makefile
+++ b/test/clustertest/testplugin/Makefile
@@ -14,7 +14,7 @@ PROJECT = $(shell pwd)/../../..
 VERSION = $(shell git log -1 | head -n 1 | cut -d ' ' -f 2)
 
 # Turn on C++11.
-CXXFLAGS =-g -std=gnu++11 -fpic -DSVERSION="\"$(VERSION)\"" -Wall
+CXXFLAGS =-g -std=gnu++11 -fpic -DSVERSION="\"$(VERSION)\"" -Wall -Werror
 CXXFLAGS +=-I$(PROJECT) -I../../../mbedtls/include
 
 # This works because 'PRODUCTION' is passed as a command-line param, and so is ignored here when set that way.


### PR DESCRIPTION
Turns on -Werror to treat warnings as errors.

No new tests, just that it still compiles.