### PR TITLE
Disable warning, only treat warnings as errors for cpp files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# # Set the compiler, if it's not set by the environment.
+# Set the compiler, if it's not set by the environment.
 ifndef GXX
 	GXX = g++-6
 endif
@@ -14,9 +14,9 @@ PROJECT = $(shell pwd)
 VERSION = $(shell git log -1 | head -n 1 | cut -d ' ' -f 2)
 
 # Turn on C++14.
-CFLAGS =-g -DSVERSION="\"$(VERSION)\"" -Wall -Werror
+CFLAGS =-g -DSVERSION="\"$(VERSION)\"" -Wall
 CXXFLAGS =-std=gnu++14
-CXXFLAGS +=-I$(PROJECT) -I$(PROJECT)/mbedtls/include
+CXXFLAGS +=-I$(PROJECT) -I$(PROJECT)/mbedtls/include -Werror -Wno-unused-result
 
 # This works because 'PRODUCTION' is passed as a command-line param, and so is ignored here when set that way.
 PRODUCTION=false

--- a/test/clustertest/testplugin/Makefile
+++ b/test/clustertest/testplugin/Makefile
@@ -14,7 +14,7 @@ PROJECT = $(shell pwd)/../../..
 VERSION = $(shell git log -1 | head -n 1 | cut -d ' ' -f 2)
 
 # Turn on C++14.
-CXXFLAGS =-g -std=gnu++14 -fpic -DSVERSION="\"$(VERSION)\"" -Wall -Werror
+CXXFLAGS =-g -std=gnu++14 -fpic -DSVERSION="\"$(VERSION)\"" -Wall -Werror -Wno-unused-result
 CXXFLAGS +=-I$(PROJECT) -I../../../mbedtls/include
 
 # This works because 'PRODUCTION' is passed as a command-line param, and so is ignored here when set that way.


### PR DESCRIPTION
@coleaeason 

Turn off -Werror for `c` files (i.e., `sqlite3.c`) entirely.

Turn off warnings for `-Wno-unused-result` in cpp files as well.