### PR TITLE
Remove re-initialization of test name to null.

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -69,7 +69,6 @@ tpunit::TestFixture::TestFixture(method* m0,  method* m1,  method* m2,  method* 
        }
     }
     _threadID = 0;
-    _name     = 0;
     _mutex    = 0;
 }
 


### PR DESCRIPTION
@mea36 

We initialize the test name from the argument, but then we re-initialize it to `0` in the constructor body, which clears it, so we can't find the names of tests to use with the `-only` or `-exclude` flags.

This fixes that re-initialization to 0.