### PR TITLE
Handle assigning booleans correctly in STable

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -126,6 +126,12 @@ class SString : public string {
         string::operator=(from);
         return *this;
     }
+
+    // Booleans get converted to strings.
+    SString& operator=(const bool from) {
+        string::operator=(from ? "true" : "false");
+        return *this;
+    }
 };
 
 typedef map<string, SString, STableComp> STable;

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -374,6 +374,8 @@ struct LibStuff : tpunit::TestFixture {
         test["g"] = (unsigned char)'a';
         test["h"] = 'b';
         test["i"] = "string";
+        test["j"] = true;
+        test["k"] = false;
         ASSERT_EQUAL(test["a"], "1");
         ASSERT_EQUAL(test["b"], "-1");
         ASSERT_EQUAL(test["c"], "0");
@@ -383,6 +385,8 @@ struct LibStuff : tpunit::TestFixture {
         ASSERT_EQUAL(test["g"], "a");
         ASSERT_EQUAL(test["h"], "b");
         ASSERT_EQUAL(test["i"], "string");
+        ASSERT_EQUAL(test["j"], "true");
+        ASSERT_EQUAL(test["k"], "false");
     }
 
     void testFileIO() {


### PR DESCRIPTION
@mea36 

Up until now, we've never handled assigning booleans correctly in an STable. They do something useless like get converted to `char`s, and thus become useless strings representing the empty string and the ascii value of `1`.

A while back, we fixed this for integer types. This adds support for handling booleans correctly, too.

This lets you do:
```
STable table;
table["a"] = "string";
table["b"] = 1;
table["c"] = true;
```

And have the three values end up as `"string"`, `"1"` and `"true"` as expected.

## Tests

New unit test added.