### PR TITLE
Add missing semicolon when converting to DB queries

### DIFF
--- a/plugins/MySQL.cpp
+++ b/plugins/MySQL.cpp
@@ -237,6 +237,10 @@ void BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
         case 3: { // COM_QUERY
             // Decode the query
             string query = packet.payload.substr(1, packet.payload.size() - 1);
+            if (!SEndsWith(query, ";")) {
+                // We translate our query to one we can pass to `DB`, for which this is mandatory.
+                query += ";";
+            }
             SINFO("Processing query '" << query << "'");
 
             // See if it's asking for a global variable


### PR DESCRIPTION
As of here:
https://github.com/Expensify/Bedrock/pull/215/files#diff-b2359e8d2bf83fec3253f345ed32a30bR55

We now require all queries passed to `DB` to end in a semi-colon.

`MySQL` works by translating mysql queries into `DB` queries. It does so without adding a semi-colon at the end.

This change adds the trailing semi-colon.