### PR TITLE
Add performance metric for synchronization time.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -393,6 +393,7 @@ bool SQLiteNode::update() {
         SASSERTWARN(!_syncPeer);
         _updateSyncPeer();
         if (_syncPeer) {
+            _synchronizeStart = STimeNow();
             _sendToPeer(_syncPeer, SData("SYNCHRONIZE"));
         } else {
             SWARN("Updated to NULL _syncPeer when about to send SYNCHRONIZE. Going to WAITING.");
@@ -1309,6 +1310,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                       << peerCommitCount - _db.getCommitCount() << " to go.");
                 _updateSyncPeer();
                 if (_syncPeer) {
+                    _synchronizeStart = STimeNow();
                     _sendToPeer(_syncPeer, SData("SYNCHRONIZE"));
                 } else {
                     SWARN("No usable _syncPeer but syncing not finished. Going to SEARCHING.");
@@ -1930,7 +1932,7 @@ void SQLiteNode::_queueSynchronize(Peer* peer, SData& response, bool sendAll) {
         uint64_t fromIndex = peerCommitCount + 1;
         uint64_t toIndex = _db.getCommitCount();
         if (!sendAll)
-            toIndex = min(toIndex, fromIndex + 100); // 100 transactions at a time
+            toIndex = min(toIndex, fromIndex + SYNCHRONIZE_COMMIT_COUNT);
         if (!_db.getCommits(fromIndex, toIndex, result))
             throw "error getting commits";
         if ((uint64_t)result.size() != toIndex - fromIndex + 1)
@@ -2005,6 +2007,8 @@ void SQLiteNode::_recvSynchronize(Peer* peer, const SData& message) {
     // Did we get all our commits?
     if (commitsRemaining)
         throw "commits remaining at end";
+
+    SINFO("Synchronized " << message["NumCommits"] << " transactions in " << (STimeNow() - _synchronizeStart) << "us.");
 }
 
 void SQLiteNode::_updateSyncPeer()

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -47,6 +47,9 @@ class SQLiteNode : public STCPNode {
         FAILED
     };
 
+    // The number of commits to send at once in response to a `SYNCHRONIZE` request.
+    static constexpr int SYNCHRONIZE_COMMIT_COUNT = 100;
+
     // Constructor/Destructor
     SQLiteNode(SQLiteServer& server, SQLite& db, const string& name, const string& host, const string& peerList,
                int priority, uint64_t firstTimeout, const string& version, int quorumCheckpoint = 0);
@@ -162,6 +165,9 @@ class SQLiteNode : public STCPNode {
 
     // The number of commits we've actually done since the last quorum command.
     int _commitsSinceCheckpoint;
+
+    // Timestamp for the last time we sent a `SYNCHRONIZE` message, for performance metrics.
+    uint64_t _synchronizeStart;
 
     // Helper methods
     void _sendToPeer(Peer* peer, const SData& message);


### PR DESCRIPTION
@quinthar 

This addresses this issue: https://github.com/Expensify/Expensify/issues/55556 without actually changing current behavior. It adds a metric that we can use to see if we actually gain any performance. If we change `SYNCHRONIZE_COMMIT_COUNT` to `1000`, our new logline needs to show less than 10x the current time to indicate a performance increase. In it's current state, this gives us a baseline to compare against.

Also, I know you hate constants @quinthar but this seems like the perfect case for using one.