### PR TITLE
Update BedrockTester to be compatible with plugins not in this repo

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -121,7 +121,7 @@ set<string> loadPlugins(SData& args) {
         // Open the library.
         void* lib = dlopen(pluginName.c_str(), RTLD_NOW);
         if(!lib) {
-            cout << dlerror() << endl;
+            cout << "Error loading bedrock plugin " << pluginName << ": " << dlerror() << endl;
         } else {
             void* sym = dlsym(lib, symbolName.c_str());
             if (!sym) {

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -4,17 +4,14 @@ string BedrockTester::DB_FILE = "";
 string BedrockTester::SERVER_ADDR = "";
 bool BedrockTester::startServers = true;
 set<int> BedrockTester::serverPIDs;
-list<string> BedrockTester_locations = {
+list<string> BedrockTester::locations = {
     "../bedrock",
     "../../bedrock"
 };
-string BedrockTester::plugins = "db,cache";
-/*
 set<string> BedrockTester::plugins = {
     "db",
     "cache"
 };
-*/
 
 // Make llvm and gcc get along.
 #ifdef _NOEXCEPT
@@ -143,7 +140,7 @@ bool BedrockTester::createFile(string name) {
 }
 
 string BedrockTester::getServerName() {
-    for (auto location : BedrockTester_locations) {
+    for (auto location : locations) {
         if (SFileExists(location)) {
             return location;
         }
@@ -159,8 +156,7 @@ list<string> BedrockTester::getServerArgs(map <string, string> args) {
         {"-nodeName",        "bedrock_test"},
         {"-nodeHost",         "localhost:9889"},
         {"-priority",         "200"},
-        //{"-plugins",          SComposeList(plugins)},
-        {"-plugins",          plugins},
+        {"-plugins",          SComposeList(plugins)},
         {"-readThreads",      "8"},
         {"-maxJournalSize",   "100"},
         {"-v",                ""},

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -4,6 +4,17 @@ string BedrockTester::DB_FILE = "";
 string BedrockTester::SERVER_ADDR = "";
 bool BedrockTester::startServers = true;
 set<int> BedrockTester::serverPIDs;
+list<string> BedrockTester::locations = {
+    "../bedrock",
+    "../../bedrock"
+};
+string BedrockTester::plugins = "db,cache";
+/*
+set<string> BedrockTester::plugins = {
+    "db",
+    "cache"
+};
+*/
 
 // Make llvm and gcc get along.
 #ifdef _NOEXCEPT
@@ -132,10 +143,6 @@ bool BedrockTester::createFile(string name) {
 }
 
 string BedrockTester::getServerName() {
-    list<string> locations = {
-        "../bedrock",
-        "../../bedrock",
-    };
     for (auto location : locations) {
         if (SFileExists(location)) {
             return location;
@@ -152,7 +159,8 @@ list<string> BedrockTester::getServerArgs(map <string, string> args) {
         {"-nodeName",        "bedrock_test"},
         {"-nodeHost",         "localhost:9889"},
         {"-priority",         "200"},
-        {"-plugins",          "db,cache"},
+        //{"-plugins",          SComposeList(plugins)},
+        {"-plugins",          plugins},
         {"-readThreads",      "8"},
         {"-maxJournalSize",   "100"},
         {"-v",                ""},

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -4,7 +4,7 @@ string BedrockTester::DB_FILE = "";
 string BedrockTester::SERVER_ADDR = "";
 bool BedrockTester::startServers = true;
 set<int> BedrockTester::serverPIDs;
-list<string> BedrockTester::locations = {
+list<string> BedrockTester_locations = {
     "../bedrock",
     "../../bedrock"
 };
@@ -143,7 +143,7 @@ bool BedrockTester::createFile(string name) {
 }
 
 string BedrockTester::getServerName() {
-    for (auto location : locations) {
+    for (auto location : BedrockTester_locations) {
         if (SFileExists(location)) {
             return location;
         }

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -14,6 +14,9 @@ class BedrockTester {
     static void stopServer(int pid);
     static bool deleteFile(string name);
     static bool startServers;
+    static list<string> locations;
+    //static set<string> plugins;
+    static string plugins;
 
     uint64_t nextActivity;
     int serverPID = 0;

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -4,9 +4,6 @@
 #include <test/lib/TestHTTPS.h>
 #include <test/lib/tpunit++.hpp>
 
-// Instead of being a static member of BedrockTester, this is declared as a global to make the linker work reasonably
-// when a shared library wants to access it.
-
 class BedrockTester {
   public:
     // The location of the database. This is static so we can re-use it for the life of the test app.

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -6,7 +6,6 @@
 
 // Instead of being a static member of BedrockTester, this is declared as a global to make the linker work reasonably
 // when a shared library wants to access it.
-extern list<string> BedrockTester_locations;
 
 class BedrockTester {
   public:
@@ -18,8 +17,8 @@ class BedrockTester {
     static void stopServer(int pid);
     static bool deleteFile(string name);
     static bool startServers;
-    //static set<string> plugins;
-    static string plugins;
+    static list<string> locations;
+    static set<string> plugins;
 
     uint64_t nextActivity;
     int serverPID = 0;

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -4,6 +4,10 @@
 #include <test/lib/TestHTTPS.h>
 #include <test/lib/tpunit++.hpp>
 
+// Instead of being a static member of BedrockTester, this is declared as a global to make the linker work reasonably
+// when a shared library wants to access it.
+extern list<string> BedrockTester_locations;
+
 class BedrockTester {
   public:
     // The location of the database. This is static so we can re-use it for the life of the test app.
@@ -14,7 +18,6 @@ class BedrockTester {
     static void stopServer(int pid);
     static bool deleteFile(string name);
     static bool startServers;
-    static list<string> locations;
     //static set<string> plugins;
     static string plugins;
 


### PR DESCRIPTION
This updates `locations` and `plugins` in BedrockTester to be globals so other plugins can use BedrockTester and customize these values