### PR TITLE
Improve timing info

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -125,7 +125,7 @@ void BedrockCommand::stopTiming(TIMING_INFO type) {
     if (get<0>(_inProgressTiming) != type ||
         get<1>(_inProgressTiming) == 0
        ) {
-        SWARN("Stoping timing, but looks like it wasn't already running.");
+        SWARN("Stopping timing, but looks like it wasn't already running.");
     }
 
     // Add it to the list of timing info.
@@ -170,8 +170,8 @@ void BedrockCommand::finalizeTimingInfo() {
 
     // Log all this info.
     SINFO("command '" << request.methodLine << "' timing info (us): "
-          << peekTotal << "(" << peekCount << "), "
-          << processTotal << "(" << processCount << "), "
+          << peekTotal << " (" << peekCount << "), "
+          << processTotal << " (" << processCount << "), "
           << commitWorkerTotal << ", "
           << commitSyncTotal << ", "
           << queueWorkerTotal << ", "

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -6,7 +6,8 @@ BedrockCommand::BedrockCommand() :
     httpsRequest(nullptr),
     priority(PRIORITY_NORMAL),
     peekCount(0),
-    processCount(0)
+    processCount(0),
+    _inProgressTiming(INVALID, 0, 0)
 { }
 
 BedrockCommand::~BedrockCommand() {
@@ -21,7 +22,8 @@ BedrockCommand::BedrockCommand(SQLiteCommand&& from) :
     httpsRequest(nullptr),
     priority(PRIORITY_NORMAL),
     peekCount(0),
-    processCount(0)
+    processCount(0),
+    _inProgressTiming(INVALID, 0, 0)
 {
     _init();
 }
@@ -32,7 +34,8 @@ BedrockCommand::BedrockCommand(BedrockCommand&& from) :
     priority(from.priority),
     peekCount(from.peekCount),
     processCount(from.processCount),
-    timingInfo(from.timingInfo)
+    timingInfo(from.timingInfo),
+    _inProgressTiming(from._inProgressTiming)
 {
     // The move constructor (and likewise, the move assignment operator), don't simply copy this pointer value, but
     // they clear it from the old object, so that when its destructor is called, the HTTPS transaction isn't closed.
@@ -44,7 +47,8 @@ BedrockCommand::BedrockCommand(SData&& _request) :
     httpsRequest(nullptr),
     priority(PRIORITY_NORMAL),
     peekCount(0),
-    processCount(0)
+    processCount(0),
+    _inProgressTiming(INVALID, 0, 0)
 {
     _init();
 }
@@ -54,7 +58,8 @@ BedrockCommand::BedrockCommand(SData _request) :
     httpsRequest(nullptr),
     priority(PRIORITY_NORMAL),
     peekCount(0),
-    processCount(0)
+    processCount(0),
+    _inProgressTiming(INVALID, 0, 0)
 {
     _init();
 }
@@ -74,6 +79,7 @@ BedrockCommand& BedrockCommand::operator=(BedrockCommand&& from) {
         processCount = from.processCount;
         priority = from.priority;
         timingInfo = from.timingInfo;
+        _inProgressTiming = from._inProgressTiming;
 
         // And call the base class's move constructor as well.
         SQLiteCommand::operator=(move(from));
@@ -104,22 +110,81 @@ void BedrockCommand::_init() {
     }
 }
 
+void BedrockCommand::startTiming(TIMING_INFO type) {
+    if (get<0>(_inProgressTiming) != INVALID ||
+        get<1>(_inProgressTiming) != 0
+       ) {
+        SWARN("Starting timing, but looks like it was already running.");
+    }
+    get<0>(_inProgressTiming) = type;
+    get<1>(_inProgressTiming) = STimeNow();
+    get<2>(_inProgressTiming) = 0;
+}
+
+void BedrockCommand::stopTiming(TIMING_INFO type) {
+    if (get<0>(_inProgressTiming) != type ||
+        get<1>(_inProgressTiming) == 0
+       ) {
+        SWARN("Stoping timing, but looks like it wasn't already running.");
+    }
+
+    // Add it to the list of timing info.
+    get<2>(_inProgressTiming) = STimeNow();
+    timingInfo.push_back(_inProgressTiming);
+
+    // And reset it for next use.
+    get<0>(_inProgressTiming) = INVALID;
+    get<1>(_inProgressTiming) = 0;
+    get<2>(_inProgressTiming) = 0;
+}
+
 void BedrockCommand::finalizeTimingInfo() {
     uint64_t peekTotal = 0;
     uint64_t processTotal = 0;
+    uint64_t commitWorkerTotal = 0;
+    uint64_t commitSyncTotal = 0;
+    uint64_t queueWorkerTotal = 0;
+    uint64_t queueSyncTotal = 0;
     for (const auto& entry: timingInfo) {
         if (get<0>(entry) == PEEK) {
             peekTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == PROCESS) {
             processTotal += get<2>(entry) - get<1>(entry);
+        } else if (get<0>(entry) == COMMIT_WORKER) {
+            commitWorkerTotal += get<2>(entry) - get<1>(entry);
+        } else if (get<0>(entry) == COMMIT_SYNC) {
+            commitSyncTotal += get<2>(entry) - get<1>(entry);
+        } else if (get<0>(entry) == QUEUE_WORKER) {
+            queueWorkerTotal += get<2>(entry) - get<1>(entry);
+        } else if (get<0>(entry) == QUEUE_SYNC) {
+            queueSyncTotal += get<2>(entry) - get<1>(entry);
         }
     }
+
+    // The lifespan of the object up until now.
+    uint64_t totalTime = STimeNow() - creationTime;
+
+    // Time that wasn't accounted for in all the other metrics.
+    uint64_t unaccountedTime = totalTime - (peekTotal + processTotal + commitWorkerTotal + commitSyncTotal +
+                                            queueWorkerTotal + queueSyncTotal);
+
+    // Log all this info.
+    SINFO("command '" << request.methodLine << "' timing info (us): "
+          << peekTotal << "(" << peekCount << "), "
+          << processTotal << "(" << processCount << "), "
+          << commitWorkerTotal << ", "
+          << commitSyncTotal << ", "
+          << queueWorkerTotal << ", "
+          << queueSyncTotal << ", "
+          << totalTime << ", "
+          << unaccountedTime << "."
+    );
 
     // Build a map of the values we care about.
     map<string, uint64_t> valuePairs = {
         {"peekTime",       peekTotal},
         {"processTime",    processTotal},
-        {"totalTime",      STimeNow() - creationTime},
+        {"totalTime",      totalTime},
         {"escalationTime", escalationTimeUS},
     };
 
@@ -141,4 +206,29 @@ void BedrockCommand::finalizeTimingInfo() {
             response[p.first] = to_string(p.second);
         }
     }
+}
+
+// pop and push specializations for SSynchronizedQueue that record timing info.
+template<>
+BedrockCommand SSynchronizedQueue<BedrockCommand>::pop() {
+    SAUTOLOCK(_queueMutex);
+    if (!_queue.empty()) {
+        BedrockCommand item = move(_queue.front());
+        _queue.pop_front();
+        item.stopTiming(BedrockCommand::QUEUE_SYNC);
+        return item;
+    }
+    throw out_of_range("No commands");
+}
+
+template<>
+void SSynchronizedQueue<BedrockCommand>::push(BedrockCommand&& rhs) {
+    SAUTOLOCK(_queueMutex);
+    // Just add to the queue
+    _queue.push_back(move(rhs));
+    _queue.back().startTiming(BedrockCommand::QUEUE_SYNC);
+
+    // Write arbitrary buffer to the pipe so any subscribers will be awoken.
+    // **NOTE: 1 byte so write is atomic.
+    SASSERT(write(_pipeFD[1], "A", 1));
 }

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -12,8 +12,13 @@ class BedrockCommand : public SQLiteCommand {
     };
 
     enum TIMING_INFO {
+        INVALID,
         PEEK,
         PROCESS,
+        COMMIT_WORKER,
+        COMMIT_SYNC,
+        QUEUE_WORKER,
+        QUEUE_SYNC,
     };
 
     // Constructor to make an empty object.
@@ -37,6 +42,13 @@ class BedrockCommand : public SQLiteCommand {
     // Move assignment operator.
     BedrockCommand& operator=(BedrockCommand&& from);
 
+    // Start recording time for a given action type.
+    void startTiming(TIMING_INFO type);
+
+    // Finish recording time for a given action type. `type` must match what was passed to the most recent call to
+    // `startTiming`.
+    void stopTiming(TIMING_INFO type);
+
     // Add a summary of our timing info to our response object.
     void finalizeTimingInfo();
 
@@ -56,4 +68,7 @@ class BedrockCommand : public SQLiteCommand {
   private:
     // Set certain initial state on construction. Common functionality to several constructors.
     void _init();
+
+    // used as a temporary variable for startTiming and stopTiming.
+    tuple<TIMING_INFO, uint64_t, uint64_t> _inProgressTiming;
 };

--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -88,6 +88,7 @@ list<string> BedrockCommandQueue::getRequestMethodLines() {
 void BedrockCommandQueue::push(BedrockCommand&& item) {
     SAUTOLOCK(_queueMutex);
     auto& queue = _commandQueue[item.priority];
+    item.startTiming(BedrockCommand::QUEUE_WORKER);
     queue.emplace(item.request.calcU64("commandExecuteTime"), move(item));
     _queueCondition.notify_one();
 }
@@ -136,6 +137,7 @@ BedrockCommand BedrockCommandQueue::_dequeue() {
             }
 
             // Done!
+            command.stopTiming(BedrockCommand::QUEUE_WORKER);
             return command;
         }
     }

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -815,11 +815,11 @@ struct STestTimer {
 #include "STCPServer.h"
 #include "STCPNode.h"
 #include "SHTTPSManager.h"
-#include "SSynchronizedQueue.h"
 
 // Other libstuff headers.
 #include "SRandom.h"
 #include "SPerformanceTimer.h"
 #include "SLockTimer.h"
+#include "SSynchronizedQueue.h"
 
 #endif	// LIBSTUFF_H


### PR DESCRIPTION
@quinthar 

Addresses this issue: https://github.com/Expensify/Expensify/issues/56177

This produces log lines like this example: 
```
finalizeTimingInfo [sync] [info] command 'CreateTransaction' timing info (us): 6232(2), 6124(1), 0, 4565, 135, 96, 17694, 542.
```

Where the numbers are:
```
total peek time (peek count),
total process time(process count),
time spent committing in worker thread,
time spent committing in sync thread,
time spent in worker command queue,
time spent in sync thread command queue,
total lifespan of the object from creation until now,
unaccounted for time (total lifespan minus everything else)
```

This differs from the request in the issue in the following notable ways:

> recv - Time between when it was first deserialized (either from a slave, or from a client) and peeked on a worker thread

This is basically the time spent in the worker command queue, which we use instead.

> pass - Time spent "passing" between the worker and the sync thread (not sure the right term; 0 if never sent to sync thread)

This is essentially just the time required to call `syncNodeQueuedCommands.push`, which I doubt is a useful metric worth timing.

> wait - Time spent "waiting" for the commit lock (0 if a read only)

This is currently part of the `commit` time. It's not totally straightforward to separate out, though it could be done, but I feel like we can wait and see if that seems useful after we get timing for `commit`.

> send - Time spent waiting to send the response back to the client/slave

This is currently bundled in with `time spent in sync thread command queue` for commands that were originated by slaves, but processed on a worker thread. Otherwise, this number doesn't amount to much, as we send immediately upon finishing the command. In those cases, this is basically the time required to call `socket->send` which is probably not super-useful, and somewhat difficult to track with the current code where we compute timing info before sending so we can add it as headers to the response (we could compute it again for logging, but it's probably not worth it).