### PR TITLE
Clear transaction list after commit on slaves.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1538,6 +1538,12 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         }
 
         _db.commit();
+
+        // Clear the list of committed transactions. We're slaving, so we don't need to send these.
+        _db.getCommittedTransactions();
+
+        // Log timing info.
+        // TODO: This is obsolete and replaced by timing info in BedrockCommand. This should be removed.
         uint64_t beginElapsed, readElapsed, writeElapsed, prepareElapsed, commitElapsed, rollbackElapsed;
         uint64_t totalElapsed = _db.getLastTransactionTiming(beginElapsed, readElapsed, writeElapsed, prepareElapsed,
                                                              commitElapsed, rollbackElapsed);


### PR DESCRIPTION
@cead22 

This fixes a memory leak (depending on your definition of memory leak).

Beginning with multi-write, the `SQLite` object keeps a list of transactions that it's recently committed. This exists so that when `SQLiteNode` on master needs to replicate out recent transactions to slaves, it can ask `SQLite` for those recent transactions, which clears them from the list in `SQLite`. It sends them to slaves, and `SQLite` starts from scratch on it's list of transactions.

However, `SQLite` builds this list of recent transactions regardless of whether it's mastering or slaving. While slaving, it will only commit transactions in response to a `COMMIT_TRANSACTION` command from master, but nonetheless, it records that transaction in it's `_inFlightTransactions` list. But, since it's a slave, it never looked up the list to send and cleared it.

This change just clears the list after each call to `commit` when handling `COMMIT_TRANSACTION`.