### PR TITLE
Improve Multi-Write Performance

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -95,10 +95,10 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
     // Keep track of whether we've modified the database and need to perform a `commit`.
     bool needsCommit = false;
     try {
-        // If a transaction was already begun in `peek`, then this is a no-op. We cal it here to support the case where
+        // If a transaction was already begun in `peek`, then this is a no-op. We call it here to support the case where
         // peek created a httpsRequest and closed it's first transaction until the httpsRequest was complete, in which
         // case we need to open a new transaction.
-        if (!_db.beginConcurrentTransaction()) {
+        if (!_db.insideTransaction() && !_db.beginConcurrentTransaction()) {
             throw "501 Failed to begin concurrent transaction";
         }
 

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -81,11 +81,6 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
 bool BedrockCore::processCommand(BedrockCommand& command, bool beginTransaction) {
     AutoTimer timer(command, BedrockCommand::PROCESS);
 
-    if (beginTransaction) {
-        if (!_db.beginConcurrentTransaction()) {
-            throw "501 Failed to begin concurrent transaction";
-        }
-    }
     // Convenience references to commonly used properties.
     SData& request = command.request;
     SData& response = command.response;
@@ -96,6 +91,12 @@ bool BedrockCore::processCommand(BedrockCommand& command, bool beginTransaction)
     // Keep track of whether we've modified the database and need to perform a `commit`.
     bool needsCommit = false;
     try {
+        if (beginTransaction) {
+            if (!_db.beginConcurrentTransaction()) {
+                throw "501 Failed to begin concurrent transaction";
+            }
+        }
+
         // Loop across the plugins to see which wants to take this.
         bool pluginProcessed = false;
         for (auto plugin : _server.plugins) {

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -18,9 +18,13 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
 
     // We catch any exception and handle in `_handleCommandException`.
     try {
+        // We start a transaction in `peekCommand` because we want to support having atomic transactions from peek
+        // through process. This allows for consistency through this two-phase process. I.e., anything checked in
+        // peek is guaranteed to still be valid in process, because they're done together as one transaction.
         if (!_db.beginConcurrentTransaction()) {
             throw "501 Failed to begin concurrent transaction";
         }
+
         // Try each plugin, and go with the first one that says it succeeded.
         bool pluginPeeked = false;
         for (auto plugin : _server.plugins) {

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -40,10 +40,7 @@ class BedrockCore : public SQLiteCore {
     // replicate the transaction to slave nodes. Upon being returned `true`, the caller will attempt to perform a
     // `COMMIT` and replicate the transaction to slave nodes. It's allowable for this `COMMIT` to fail, in which case
     // this command *will be passed to process again in the future to retry*.
-    // The `beginTransaction` flag allows the caller to force this function to begin a transaction if it knows one has
-    // already been started. This is used to allow handling commands with httpsRequests without re-peeking them, which
-    // would potentially duplicate the httpsRequest.
-    bool processCommand(BedrockCommand& command, bool beginTransaction = false);
+    bool processCommand(BedrockCommand& command);
 
   private:
     void _handleCommandException(BedrockCommand& command, const string& e, bool wasProcessing);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -591,8 +591,6 @@ void BedrockServer::worker(SData& args,
                                       << " during worker commit. Rolling back transaction!");
                                 core.rollback();
                             } else {
-                                bool commitSuccess;
-
                                 // Before we commit, we need to grab the sync thread lock. Because the sync thread grabs
                                 // an exclusive lock on this wrapping any transactions that it performs, we'll get this
                                 // lock while the sync thread isn't in the process of handling a transaction, thus
@@ -601,6 +599,7 @@ void BedrockServer::worker(SData& args,
                                 // after we called `processCommand` and before we call `commit`, or we could conflict
                                 // with another worker thread, but the sync thread will never see a conflict as long
                                 // as we don't commit while it's performing a transaction.
+                                bool commitSuccess;
                                 shared_lock<decltype(server._syncThreadCommitMutex)> lock(server._syncThreadCommitMutex);
                                 {
                                     // Scoped for auto-timer.

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -177,7 +177,9 @@ SQLite::~SQLite() {
 }
 
 bool SQLite::beginTransaction() {
-    SASSERT(!_insideTransaction);
+    if (_insideTransaction) {
+        return true;
+    }
     SASSERT(_uncommittedHash.empty());
     SASSERT(_uncommittedQuery.empty());
     SDEBUG("Beginning transaction");
@@ -193,7 +195,9 @@ bool SQLite::beginTransaction() {
 }
 
 bool SQLite::beginConcurrentTransaction() {
-    SASSERT(!_insideTransaction);
+    if (_insideTransaction) {
+        return true;
+    }
     SASSERT(_uncommittedHash.empty());
     SASSERT(_uncommittedQuery.empty());
     SDEBUG("[concurrent] Beginning transaction");

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -177,9 +177,7 @@ SQLite::~SQLite() {
 }
 
 bool SQLite::beginTransaction() {
-    if (_insideTransaction) {
-        return true;
-    }
+    SASSERT(!_insideTransaction);
     SASSERT(_uncommittedHash.empty());
     SASSERT(_uncommittedQuery.empty());
     SDEBUG("Beginning transaction");
@@ -195,9 +193,7 @@ bool SQLite::beginTransaction() {
 }
 
 bool SQLite::beginConcurrentTransaction() {
-    if (_insideTransaction) {
-        return true;
-    }
+    SASSERT(!_insideTransaction);
     SASSERT(_uncommittedHash.empty());
     SASSERT(_uncommittedQuery.empty());
     SDEBUG("[concurrent] Beginning transaction");


### PR DESCRIPTION
There are two changes in this PR (you can look at them individual in each commit).

Change 1 is a correctness issue. It makes us include `peekCommand` in a transaction so that it's done atomically with `processCommand`. This involved a couple differences. We need to `rollback` after `peekCommand` now, because we've begun a transaction. And there is special handling for commands with `httpsRequests`, which won't get re-peeked, and thus are exempted from this single-transaction-per-command behavior.

Change 2 is a performance change, and while simpler, is the more exciting part of this PR. It does two things: First it moves the lock of `_syncThreadCommitMutex` to after `processCommand` in worker threads. Second, it logs the amount of time it takes the sync thread to acquire the same lock.

I did some analysis of the logs from our last test. I couldn't pinpoint exactly how much time we spent acquiring the lock in the sync thread, because we didn't have that info, but I timed the difference from when we dequeued a command until we started to commit a command, which includes waiting for this lock. Notably, this also includes `processCommand`, but that shouldn't affect the overall results.

Here's what I found in my sample data:

Before turning on multi-write:
19,862 commits totaling 50.01 seconds. Average 2.52ms per command.

While multi-write was enabled:
21048 commits totaling 419.20 seconds. Average 19.91ms per command.

After turning off multi-write:
15982 commits totaling 117.80 seconds. Average 7.37ms per command.

So, there's some pretty high variability there - before and after have average times that vary by a factor of 3x. But with multi-write enabled, the times are 2.5-10x slower than with it off. `processCommand` should take a significant amount of time, but it shouldn't change with the state of multi-write -- it runs in parallel on all threads.

So, the difference could be down to waiting for the lock, at an average of an extra 12-17ms per command. Is this a feasible time to wait? Well, if we have to wait for one worker thread to run `processCommand`, that seems to take 2.5-7ms. If we wait for two or three, this seems feasible. Even more so when you consider that retries due to conflicts will also fall into this category.

Note that the increase isn't uniform across commands. Most remain fast, but a few get markedly slower. A small number of commands can take over a second to process. If a worker runs one of these slow commands, before this change, the sync thread will block until the worker finishes before even starting, thus drastically increasing it's total time.

The actual time we see when we look at the entire lifetime of commands is mostly taken up waiting around in the sync thread queue, but that makes sense when the sync thread is just slow enough to fall behind. Each command takes longer to process, so the queue backs up, so new commands sit in it longer.

Please review carefully, all this code is fairly nuanced.