### PR TITLE
Set autocheckpoint to 0 in workers

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -430,7 +430,9 @@ void BedrockServer::worker(SData& args,
                            int threadCount)
 {
     SInitialize("worker" + to_string(threadId));
-    SQLite db(args["-db"], args.calc("-cacheSize"), 1024, args.calc("-maxJournalSize"), threadId, threadCount - 1);
+    // We pass `0` as the checkpoint size to disable checkpointing from workers. This can be a slow operation, and we
+    // don't want workers to be able to block the sync thread while it happens.
+    SQLite db(args["-db"], args.calc("-cacheSize"), 0, args.calc("-maxJournalSize"), threadId, threadCount - 1);
     BedrockCore core(db, server);
 
     // Command to work on. This default command is replaced when we find work to do.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -430,6 +430,7 @@ void BedrockServer::worker(SData& args,
                            int threadCount)
 {
     SInitialize("worker" + to_string(threadId));
+
     // We pass `0` as the checkpoint size to disable checkpointing from workers. This can be a slow operation, and we
     // don't want workers to be able to block the sync thread while it happens.
     SQLite db(args["-db"], args.calc("-cacheSize"), 0, args.calc("-maxJournalSize"), threadId, threadCount - 1);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -72,8 +72,9 @@ SQLite::SQLite(const string& filename, int cacheSize, int autoCheckpoint, int ma
     // These other pragmas only relate to read/write databases.
     SASSERT(!SQuery(_db, "disabling synchronous commits", "PRAGMA synchronous = OFF;"));
     SASSERT(!SQuery(_db, "disabling change counting", "PRAGMA count_changes = OFF;"));
-    DBINFO("Enabling automatic checkpointing every " << to_string(autoCheckpoint) << " pages.");
-    SASSERT(!SQuery(_db, "enabling auto-checkpointing", "PRAGMA wal_autocheckpoint = " + SQ(autoCheckpoint) + ";"));
+
+    DBINFO("Enabling automatic checkpointing every " << autoCheckpoint << " pages.");
+    sqlite3_wal_autocheckpoint(_db, autoCheckpoint);
 
     // Update the cache. -size means KB; +size means pages
     SINFO("Setting cache_size to " << cacheSize << "KB");

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -72,7 +72,6 @@ SQLite::SQLite(const string& filename, int cacheSize, int autoCheckpoint, int ma
     // These other pragmas only relate to read/write databases.
     SASSERT(!SQuery(_db, "disabling synchronous commits", "PRAGMA synchronous = OFF;"));
     SASSERT(!SQuery(_db, "disabling change counting", "PRAGMA count_changes = OFF;"));
-
     DBINFO("Enabling automatic checkpointing every " << autoCheckpoint << " pages.");
     sqlite3_wal_autocheckpoint(_db, autoCheckpoint);
 


### PR DESCRIPTION
@quinthar 

This turns off auto checkpointing in workers.

Also directly makes the call to `sqlite3_wal_autocheckpoint` as recommended by Dan at sqlite, rather than wrapping in a query (which [the documentation](https://sqlite.org/pragma.html#pragma_wal_autocheckpoint) says just calls this C function anyway),  which is simpler, and does the same thing.