### PR TITLE
Prevent creating grandchildren from RUNNING jobs.

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -441,7 +441,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             int64_t parentJobID = SContains(job, "parentJobID") ? SToInt(job["parentJobID"]) : 0;
             if (parentJobID) {
                 SQResult result;
-                if (!db.read("SELECT state FROM jobs WHERE jobID=" + SQ(parentJobID) + ";", result)) {
+                if (!db.read("SELECT state, parentJobID FROM jobs WHERE jobID=" + SQ(parentJobID) + ";", result)) {
                     throw "502 Select failed";
                 }
                 if (result.empty()) {
@@ -452,13 +452,10 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                     throw "405 Can only create child job when parent is RUNNING or PAUSED";
                 }
               
-                // Prevent jobs from creating grandchildren when children are still PAUSED.
-                // If we don't do this, we can create jobs that will be QUEUED and therefore can end up being run
-                // at the same time as their parents.
-                auto children = db.read("SELECT * FROM jobs WHERE parentJobID=" + SQ(parentJobID) + ";");
-                if (SIEquals(result[0][0], "PAUSED") && children.empty()) {
-                    SWARN("Trying to create grandchild job with parent jobID#" << parentJobID << ", but job is still not QUEUED because its parent is running itself");
-                    throw "405 Cannot create grandchildren while grandfather is RUNNING and parent is PAUSED";
+                // Prevent jobs from creating grandchildren
+                if (!SIEquals(result[0][1], "0")) {
+                    SWARN("Trying to create grandchild job with parent jobID#" << parentJobID);
+                    throw "405 Cannot create grandchildren";
                 }
             }
 

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -456,7 +456,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 // If we don't do this, we can create jobs that will be QUEUED and therefore can end up being run
                 // at the same time as their parents.
                 auto children = db.read("SELECT * FROM jobs WHERE parentJobID=" + SQ(parentJobID) + ";");
-                if (SIEquals(parentState, "PAUSED") && children.empty()) {
+                if (SIEquals(result[0][0], "PAUSED") && children.empty()) {
                     SWARN("Trying to create grandchild job with parent jobID#" << parentJobID << ", but job is still not QUEUED because its parent is running itself");
                     throw "405 Cannot create grandchildren while grandfather is RUNNING and parent is PAUSED";
                 }

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -290,7 +290,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             // Prevent jobs from creating grandchildren when children are still PAUSED.
             // If we don't do this, we can create jobs that will be QUEUED and therefore can end up being run
             // at the same time as their parents.
-            auto children = db.read("SELECT COUNT(*) FROM jobs WHERE jobID=" + SQ(parentJobID) + ";");
+            auto children = db.read("SELECT COUNT(*) FROM jobs WHERE parentJobID=" + SQ(parentJobID) + ";");
             if (SIEquals(parentState, "PAUSED") && children.empty()) {
                 SWARN("Trying to create grandchild job with parent jobID#" << parentJobID << ", but job is still not QUEUED because its parent is running itself");
                 throw "405 Cannot create grandchildren while grandfather is RUNNING and parent is PAUSED";

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -290,7 +290,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             // Prevent jobs from creating grandchildren when children are still PAUSED.
             // If we don't do this, we can create jobs that will be QUEUED and therefore can end up being run
             // at the same time as their parents.
-            auto children = db.read("SELECT COUNT(*) FROM jobs WHERE parentJobID=" + SQ(parentJobID) + ";");
+            auto children = db.read("SELECT * FROM jobs WHERE parentJobID=" + SQ(parentJobID) + ";");
             if (SIEquals(parentState, "PAUSED") && children.empty()) {
                 SWARN("Trying to create grandchild job with parent jobID#" << parentJobID << ", but job is still not QUEUED because its parent is running itself");
                 throw "405 Cannot create grandchildren while grandfather is RUNNING and parent is PAUSED";

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -287,7 +287,9 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 throw "405 Can only create child job when parent is RUNNING or PAUSED";
             }
             
-            // Prevent jobs from creating grandchildren when children are still PAUSED
+            // Prevent jobs from creating grandchildren when children are still PAUSED.
+            // If we don't do this, we can create jobs that will be QUEUED and therefore can end up being run
+            // at the same time as their parents.
             auto children = db.read("SELECT COUNT(*) FROM jobs WHERE jobID=" + SQ(parentJobID) + ";");
             if (SIEquals(parentState, "PAUSED") && children.empty()) {
                 SWARN("Trying to create grandchild job with parent jobID#" << parentJobID << ", but job is still not QUEUED because its parent is running itself");


### PR DESCRIPTION
@cead22 

I am leaving this on HOLD because it may create some conflicts with https://github.com/Expensify/Bedrock/pull/195

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/56724

### Tests

```
createJob
name:job

200 OK
commitCount: 16145
peekTime: 2063
processTime: 2782
totalTime: 15457
Content-Length: 12

{"jobID":98}

query:select * from jobs where jobID>97; 

200 OK
commitCount: 16146
peekTime: 7113
totalTime: 7459
Content-Length: 191

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-07-07 21:37:41 | 98 | QUEUED | job | 2017-07-07 21:37:41 |  |  | {} | 500 | 0 | 

getJob
name:job

200 OK
commitCount: 16146
peekTime: 4880
processTime: 2483
totalTime: 18713
Content-Length: 35

{"data":{},"jobID":98,"name":"job"}

query:select * from jobs where jobID>97; 

200 OK
commitCount: 16147
peekTime: 6326
totalTime: 6418
Content-Length: 211

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-07-07 21:37:41 | 98 | RUNNING | job | 2017-07-07 21:37:41 | 2017-07-07 21:37:58 |  | {} | 500 | 0 | 

createJob
name:job
parentJobID:98

200 OK
commitCount: 16147
peekTime: 3476
processTime: 3457
totalTime: 13410
Content-Length: 12

{"jobID":99}

query:select * from jobs where jobID>97;

200 OK
commitCount: 16148
peekTime: 7641
totalTime: 8382
Content-Length: 298

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-07-07 21:37:41 | 98 | RUNNING | job | 2017-07-07 21:37:41 | 2017-07-07 21:37:58 |  | {} | 500 | 0 | 
2017-07-07 21:38:24 | 99 | PAUSED | job | 2017-07-07 21:38:24 |  |  | {} | 500 | 98 | 

createJob
name:job
parentJobID:99

405 Cannot create grandchildren
commitCount: 16152
peekTime: 2981
processTime: 819
totalTime: 4670
Content-Length: 0
```