### PR TITLE
Make SContains support finding char* in list<string>

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -433,6 +433,7 @@ template <class A> inline bool SContains(const set<A>& valueList, const A& value
     return ::find(valueList.begin(), valueList.end(), value) != valueList.end();
 }
 
+inline bool SContains(const list<string>& valueList, const char* value) { return ::find(valueList.begin(), valueList.end(), string(value)) != valueList.end(); }
 inline bool SContains(const string& haystack, const string& needle) { return haystack.find(needle) != string::npos; }
 inline bool SContains(const string& haystack, char needle) { return haystack.find(needle) != string::npos; }
 inline bool SContains(const STable& nameValueMap, const string& name) {

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -23,7 +23,8 @@ struct LibStuff : tpunit::TestFixture {
                                     TEST(LibStuff::testCurrentTimestamp),
                                     TEST(LibStuff::testSQList),
                                     TEST(LibStuff::testRandom),
-                                    TEST(LibStuff::testHexConversion))
+                                    TEST(LibStuff::testHexConversion),
+                                    TEST(LibStuff::testContains))
     { }
 
     void testEncryptDecrpyt() {
@@ -590,5 +591,15 @@ struct LibStuff : tpunit::TestFixture {
 
         string start = "I wish I was an Oscar Meyer Weiner";
         ASSERT_EQUAL(SStrFromHex(SToHex(start)), start);
+    }
+
+    void testContains() {
+        list<string> stringList = list<string>();
+        stringList.push_back("asdf");
+        ASSERT_TRUE(SContains(stringList, "asdf"));
+        ASSERT_FALSE(SContains(stringList, "fdsa"));
+
+        ASSERT_TRUE(SContains(string("asdf"), "a"));
+        ASSERT_TRUE(SContains(string("asdf"), string("asd")));
     }
 } __LibStuff;


### PR DESCRIPTION
Currently `SContains` will only work with char* if you cast it to a string first, so this adds the shortcut.