### PR TITLE
Only check for uniqueness when creating a single job

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -239,7 +239,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
                 }
 
                 // If there's no job or the existing job doesn't match the data we've been passed, escalate to master.
-                if (!result.empty() && result[0][1] == job["data"]) {
+                if (!result.empty() && result[0][1] == (job["data"].empty() ? SToStr("{}") : job["data"])) {
                     // Return early, no need to pass to master, there are no more jobs to create.
                     SINFO("Job already existed and unique flag was passed, reusing existing job " << result[0][0]);
                     content["jobID"] = result[0][0];
@@ -386,7 +386,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 }
 
                 // If we got a result, and it's data is the same as passed, we won't change anything.
-                if (!result.empty() && result[0][1] == job["data"]) {
+                if (!result.empty() && result[0][1] == (job["data"].empty() ? SToStr("{}") : job["data"])) {
                     SINFO("Job already existed with matching data, and unique flag was passed, reusing existing job "
                           << result[0][0]);
 

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -239,7 +239,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
                 }
 
                 // If there's no job or the existing job doesn't match the data we've been passed, escalate to master.
-                if (!result.empty() && result[0][1] == (job["data"].empty() ? SToStr("{}") : job["data"])) {
+                if (!result.empty() && ((job["data"].empty() && result[0][1] == "{}") || (!job["data"].empty() && result[0][1] == job["data"]))) {
                     // Return early, no need to pass to master, there are no more jobs to create.
                     SINFO("Job already existed and unique flag was passed, reusing existing job " << result[0][0]);
                     content["jobID"] = result[0][0];
@@ -386,7 +386,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 }
 
                 // If we got a result, and it's data is the same as passed, we won't change anything.
-                if (!result.empty() && result[0][1] == (job["data"].empty() ? SToStr("{}") : job["data"])) {
+                if (!result.empty() && ((job["data"].empty() && result[0][1] == "{}") || (!job["data"].empty() && result[0][1] == job["data"]))) {
                     SINFO("Job already existed with matching data, and unique flag was passed, reusing existing job "
                           << result[0][0]);
 


### PR DESCRIPTION
@pecanoro, will you please review this?

Coming from https://github.com/Expensify/Bedrock/pull/195/files#r126695588 and https://github.com/Expensify/Bedrock/pull/195/files#r126695946

### Tests

1. Make sure passing `unique: true` with `CreateJobs` still checks for an already existing job inside the peeking process:
```
CreateJob           
name: www-prod/IntercomCloseConversation?id=123
unique: true

200 OK
commitCount: 3467
peekTime: 7615
totalTime: 7760
Content-Length: 13

{"jobID":595}







CreateJob           
name: www-prod/IntercomCloseConversation?id=123
unique: true

200 OK
commitCount: 3467
peekTime: 2826
totalTime: 2903
Content-Length: 13

{"jobID":595}
```
```
Jul 14 19:45:57 vagrant-ubuntu-trusty-64 bedrock: xxxxx (Jobs.cpp:233) peekCommand [worker0] [info] {Jobs} Unique flag was passed, checking existing job with name www-prod/IntercomCloseConversation?id=123
Jul 14 19:45:57 vagrant-ubuntu-trusty-64 bedrock: xxxxx (libstuff.cpp:2150) SQuery [worker0] [dbug] SELECT jobID, data FROM jobs WHERE name='www-prod/IntercomCloseConversation?id=123';
Jul 14 19:45:57 vagrant-ubuntu-trusty-64 bedrock: xxxxx (Jobs.cpp:244) peekCommand [worker0] [info] {Jobs} Job already existed and unique flag was passed, reusing existing job 595
```

2. Make sure that `CreateJobs` still creates unique jobs just fine, but without checking for existing jobs (aka make sure the `checking existing job with name...` log line does not show up when creating multiple jobs using `CreateJobs`)