### PR TITLE
Return whitelisted commands in the status command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1181,6 +1181,7 @@ void BedrockServer::_status(BedrockCommand& command) {
         // On master, return the current multi-write blacklist.
         if (state == SQLiteNode::MASTERING) {
             content["multiWriteBlacklist"] = BedrockConflictMetrics::getMultiWriteDeniedCommands();
+            content["multiWriteWhiteList"] = SComposeJSONArray(_parallelCommands);
         }
 
         // We read from syncNode internal state here, so we lock to make sure that this doesn't conflict with the sync

--- a/test/tests/StatusTest.cpp
+++ b/test/tests/StatusTest.cpp
@@ -17,6 +17,7 @@ struct StatusTest : tpunit::TestFixture {
         SData status("Status");
         string response = tester->executeWait(status);
         ASSERT_TRUE(SContains(response, "plugins"));
+        ASSERT_TRUE(SContains(response, "multiWriteWhiteList"));
     }
 
 } __StatusTest;


### PR DESCRIPTION
Adds the list of white listed multi write commands to the status command.

# Tests
- Run status, check the output:
```
>>> $status = Auth::call('Status', [])
=> [
     "CommitCount" => 14276,
     "escalatedCommandList" => [],
     "host" => "localhost:4445",
     "isMaster" => true,
     "multiWriteBlacklist" => "",
     "multiWriteWhiteList" => [
       "CreateReport",
       "SetNameValuePair",
     ],
     "peerList" => [],
     "plugins" => [
       [
         "name" => "Auth",
         "version" => "ce069334f00b9c3d95b07c13ec5643dee5684c15",
       ],
       [
         "name" => "DB",
       ],
     ],
     "queuedCommandList" => [],
     "state" => "MASTERING",
     "version" => "1758e8ac4d3860dc3f13a9aef29c8fbd2f1d77fe:Auth_ce069334f00b9c3d95b07c13ec5643dee5684c15",
     "httpCode" => 200,
     "jsonCode" => 200,
   ]
```