### PR TITLE
Truncate query in logline

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -434,7 +434,7 @@ void SQLite::rollback() {
     // Make sure we're actually inside a transaction
     if (_insideTransaction) {
         // Cancel this transaction
-        SINFO("Rolling back transaction: " << _uncommittedQuery);
+        SINFO("Rolling back transaction: " << _uncommittedQuery.substr(0, 100));
         uint64_t before = STimeNow();
         SASSERT(!SQuery(_db, "rolling back db transaction", "ROLLBACK"));
         _rollbackElapsed += STimeNow() - before;


### PR DESCRIPTION
@flodnv 

Fixes: https://github.com/Expensify/Expensify/issues/57907

No new tests, logline change only.