### PR TITLE
Add flag to commands so they're only processed on the sync thread.

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -7,6 +7,7 @@ BedrockCommand::BedrockCommand() :
     priority(PRIORITY_NORMAL),
     peekCount(0),
     processCount(0),
+    onlyProcessOnSyncThread(false),
     _inProgressTiming(INVALID, 0, 0)
 { }
 
@@ -23,6 +24,7 @@ BedrockCommand::BedrockCommand(SQLiteCommand&& from) :
     priority(PRIORITY_NORMAL),
     peekCount(0),
     processCount(0),
+    onlyProcessOnSyncThread(false),
     _inProgressTiming(INVALID, 0, 0)
 {
     _init();
@@ -35,6 +37,7 @@ BedrockCommand::BedrockCommand(BedrockCommand&& from) :
     peekCount(from.peekCount),
     processCount(from.processCount),
     timingInfo(from.timingInfo),
+    onlyProcessOnSyncThread(from.onlyProcessOnSyncThread),
     _inProgressTiming(from._inProgressTiming)
 {
     // The move constructor (and likewise, the move assignment operator), don't simply copy this pointer value, but
@@ -48,6 +51,7 @@ BedrockCommand::BedrockCommand(SData&& _request) :
     priority(PRIORITY_NORMAL),
     peekCount(0),
     processCount(0),
+    onlyProcessOnSyncThread(false),
     _inProgressTiming(INVALID, 0, 0)
 {
     _init();
@@ -59,6 +63,7 @@ BedrockCommand::BedrockCommand(SData _request) :
     priority(PRIORITY_NORMAL),
     peekCount(0),
     processCount(0),
+    onlyProcessOnSyncThread(false),
     _inProgressTiming(INVALID, 0, 0)
 {
     _init();
@@ -79,6 +84,7 @@ BedrockCommand& BedrockCommand::operator=(BedrockCommand&& from) {
         processCount = from.processCount;
         priority = from.priority;
         timingInfo = from.timingInfo;
+        onlyProcessOnSyncThread = from.onlyProcessOnSyncThread;
         _inProgressTiming = from._inProgressTiming;
 
         // And call the base class's move constructor as well.

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -65,6 +65,10 @@ class BedrockCommand : public SQLiteCommand {
     // A list of timing sets, with an info type, start, and end.
     list<tuple<TIMING_INFO, uint64_t, uint64_t>> timingInfo;
 
+    // This defaults to false, but a specific plugin can set it to 'true' in peek() to force this command to be passed
+    // to the sync thread for processing, thus guaranteeing that process() will not result in a conflict.
+    bool onlyProcessOnSyncThread;
+
   private:
     // Set certain initial state on construction. Common functionality to several constructors.
     void _init();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -558,9 +558,10 @@ void BedrockServer::worker(SData& args,
                     // For now, commands need to be in `_parallelCommands` *and* `multiWriteOK`. When we're
                     // confident in BedrockConflictMetrics, we can remove `_parallelCommands`.
                     canWriteParallel = canWriteParallel && BedrockConflictMetrics::multiWriteOK(command.request.methodLine);
-                    if (!canWriteParallel              ||
-                        state != SQLiteNode::MASTERING ||
-                        command.httpsRequest           ||
+                    if (!canWriteParallel               ||
+                        state != SQLiteNode::MASTERING  ||
+                        command.httpsRequest            ||
+                        command.onlyProcessOnSyncThread ||
                         command.writeConsistency != SQLiteNode::ASYNC)
                     {
                         // Roll back the transaction, it'll get re-run in the sync thread.


### PR DESCRIPTION
@flodnv 

Adds a flag such that specific commands can be forced to be processed on the sync thread.

Server-Expensify change coming as well with changes to commands that need this.