### PR TITLE
Add Control Port to Bedrock

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -682,7 +682,7 @@ void BedrockServer::worker(SData& args,
 BedrockServer::BedrockServer(const SData& args)
   : SQLiteServer(""), _args(args), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),
-    _syncNode(nullptr), _shutdownState(RUNNING)
+    _syncNode(nullptr), _shutdownState(RUNNING), _backupOnShutdown(false), _controlPort(nullptr), _commandPort(nullptr)
 {
     _version = SVERSION;
 
@@ -869,29 +869,44 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     if (!_suppressCommandPort && state == SQLiteNode::SLAVING && (masterVersion != _version)) {
         SINFO("Node " << _args["-nodeName"] << " slaving on version " << _version << ", master is version: "
               << masterVersion << ", not opening command port.");
-        suppressCommandPort(true);
+        suppressCommandPort("wrong master version", true);
     } else if (_suppressCommandPort && (state == SQLiteNode::MASTERING || (masterVersion == _version))) {
         // If we become master, or if master's version resumes matching ours, open the command port again.
         if (!_suppressCommandPortManualOverride) {
             // Only generate this logline if we haven't manually blocked this.
             SINFO("Node " << _args["-nodeName"] << " disabling previously suppressed command port after version check.");
         }
-        suppressCommandPort(false);
+        suppressCommandPort("master version valid", false);
     }
-    if (!_suppressCommandPort && portList.empty() && (state == SQLiteNode::MASTERING || state == SQLiteNode::SLAVING) &&
+    if (!_suppressCommandPort && (state == SQLiteNode::MASTERING || state == SQLiteNode::SLAVING) &&
         _shutdownState.load() == RUNNING) {
         // Open the port
-        SINFO("Ready to process commands, opening command port on '" << _args["-serverHost"] << "'");
-        openPort(_args["-serverHost"]);
+        if (!_commandPort) {
+            SINFO("Ready to process commands, opening command port on '" << _args["-serverHost"] << "'");
+            _commandPort = openPort(_args["-serverHost"]);
+        }
+        if (!_controlPort) {
+            _controlPort = openPort(_args["-controlPort"]);
+        }
 
         // Open any plugin ports on enabled plugins
         for (auto plugin : plugins) {
             string portHost = plugin->getPort();
             if (!portHost.empty()) {
+                bool alreadyOpened = false;
+                for (auto pluginPorts : _portPluginMap) {
+                    if (pluginPorts.second == plugin) {
+                        // We've already got this one.
+                        alreadyOpened = true;
+                        break;
+                    }
+                }
                 // Open the port and associate it with the plugin
-                SINFO("Opening port '" << portHost << "' for plugin '" << plugin->getName() << "'");
-                Port* port = openPort(portHost);
-                _portPluginMap[port] = plugin;
+                if (!alreadyOpened) {
+                    SINFO("Opening port '" << portHost << "' for plugin '" << plugin->getName() << "'");
+                    Port* port = openPort(portHost);
+                    _portPluginMap[port] = plugin;
+                }
             }
         }
     }
@@ -908,27 +923,14 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
         if (SGetSignal(SIGTTIN)) {
             // Suppress command port, but only if we haven't already cleared it
             if (!SCheckSignal(SIGTTOU)) {
-                SHMMM("Suppressing command port due to SIGTTIN");
-                suppressCommandPort(true, true);
+                suppressCommandPort("SIGTTIN", true, true);
             }
         } else if (SGetSignal(SIGTTOU)) {
             // Clear command port suppression
-            SHMMM("Clearing command port supression due to SIGTTOU");
-            suppressCommandPort(false, true);
+            suppressCommandPort("SIGTTOU", false, true);
         } else {
-            // For anything else, just shutdown -- but only if we're not already shutting down
-            if (_shutdownState.load() == RUNNING) {
-                // Begin a graceful shutdown; close our port
-                SINFO("Beginning graceful shutdown due to '" << SGetSignalDescription()
-                      << "', closing command port on '" << _args["-serverHost"] << "'");
-                _gracefulShutdownTimeout.alarmDuration = STIME_US_PER_S * 30; // 30s timeout before we give up
-                _gracefulShutdownTimeout.start();
-
-                // Close our listening ports, we won't accept any new connections on them.
-                closePorts();
-                _shutdownState.store(START_SHUTDOWN);
-                SINFO("START_SHUTDOWN. Ports shutdown, will perform final socket read.");
-            }
+            // For any other signal, just shutdown.
+            _beginShutdown(SGetSignalDescription());
         }
     }
 
@@ -1035,10 +1037,26 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                     // And we and keep track of the client that initiated this command, so we can respond later.
                     command.initiatingClientID = s->id;
 
-                    // Status requests are handled specially.
+                    // Status and control requests are handled specially.
                     if (_isStatusCommand(command)) {
                         _status(command);
                         _reply(command);
+                    } else if (_isControlCommand(command)) {
+                        // Verify this came from localhost.
+                        unsigned long ip = ntohl(s->addr.sin_addr.s_addr);
+
+                        // This number is the unsigned long representation of 127.0.0.1.
+                        if (2130706433 == ip) {
+                            _control(command);
+                            _reply(command);
+                        } else {
+                            char str[INET_ADDRSTRLEN];
+                            inet_ntop(AF_INET, &(s->addr.sin_addr), str, INET_ADDRSTRLEN);
+                            SWARN("Got control command " << command.request.methodLine
+                                  << " on non-localhost socket (" << str << "). Ignoring.");
+                            command.response.methodLine = "401 Unauthorized";
+                            _reply(command);
+                        }
                     } else {
                         // Otherwise we queue it for later processing.
                         _commandQueue.push(move(command));
@@ -1122,7 +1140,8 @@ void BedrockServer::_reply(BedrockCommand& command) {
     }
 }
 
-void BedrockServer::suppressCommandPort(bool suppress, bool manualOverride) {
+void BedrockServer::suppressCommandPort(const string& reason, bool suppress, bool manualOverride) {
+    SINFO((suppress ? "Suppressing" : "Clearing") << " command port due to: " << reason);
     // If we've set the manual override flag, then we'll only actually make this change if we've specified it again.
     if (_suppressCommandPortManualOverride && !manualOverride) {
         return;
@@ -1137,8 +1156,11 @@ void BedrockServer::suppressCommandPort(bool suppress, bool manualOverride) {
     if (suppress) {
         // Close the command port, and all plugin's ports. Won't reopen.
         SHMMM("Suppressing command port");
-        if (!portList.empty())
-            closePorts();
+        if (!portList.empty()) {
+            closePorts({_controlPort});
+            _portPluginMap.clear();
+            _commandPort = nullptr;
+        }
     } else {
         // Clearing past suppression, but don't reopen (It's always safe to close, but not always safe to open).
         SHMMM("Clearing command port suppression");
@@ -1255,7 +1277,7 @@ void BedrockServer::_status(BedrockCommand& command) {
         STable content;
         content["oldCommandWhitelist"] = SComposeList(_parallelCommands);
 
-        // If the Comamnds param is set, parse it and update our value.
+        // If the Commands param is set, parse it and update our value.
         if (request.isSet("Commands")) {
             _parallelCommands.clear();
             list<string> parallelCommands;
@@ -1274,6 +1296,28 @@ void BedrockServer::_status(BedrockCommand& command) {
         // PRepare the command to respond to the caller.
         response.methodLine = "200 OK";
         response.content = SComposeJSONObject(content);
+    }
+}
+
+bool BedrockServer::_isControlCommand(BedrockCommand& command) {
+    if (SIEquals(command.request.methodLine, "BeginBackup")         ||
+        SIEquals(command.request.methodLine, "SuppressCommandPort") ||
+        SIEquals(command.request.methodLine, "ClearCommandPort")) {
+        return true;
+    }
+    return false;
+}
+
+void BedrockServer::_control(BedrockCommand& command) {
+    SData& response = command.response;
+    response.methodLine = "200 OK";
+    if (SIEquals(command.request.methodLine, "BeginBackup")) {
+        _backupOnShutdown = true;
+        _beginShutdown("BeginBackup");
+    } else if (SIEquals(command.request.methodLine, "SuppressCommandPort")) {
+        suppressCommandPort("SuppressCommandPort", true, true);
+    } else if (SIEquals(command.request.methodLine, "ClearCommandPort")) {
+        suppressCommandPort("ClearCommandPort", false, true);
     }
 }
 
@@ -1303,4 +1347,26 @@ void BedrockServer::_postPollPlugins(fd_map& fdm, uint64_t nextActivity) {
             manager->postPoll(fdm, nextActivity);
         }
     }
+}
+
+void BedrockServer::_beginShutdown(const string& reason) {
+if (_shutdownState.load() == RUNNING) {
+    // Begin a graceful shutdown; close our port
+    SINFO("Beginning graceful shutdown due to '" << reason
+          << "', closing command port on '" << _args["-serverHost"] << "'");
+    _gracefulShutdownTimeout.alarmDuration = STIME_US_PER_S * 30; // 30s timeout before we give up
+    _gracefulShutdownTimeout.start();
+
+    // Close our listening ports, we won't accept any new connections on them.
+    closePorts();
+    _portPluginMap.clear();
+    _commandPort = nullptr;
+    _controlPort = nullptr;
+    _shutdownState.store(START_SHUTDOWN);
+    SINFO("START_SHUTDOWN. Ports shutdown, will perform final socket read.");
+}
+}
+
+bool BedrockServer::backupOnShutdown() {
+    return _backupOnShutdown;
 }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -14,7 +14,7 @@ class BedrockServer : public SQLiteServer {
         // This is the state until we begin shutting down.
         RUNNING,
 
-        // In postPoll, this will be set if we received a SIGTERM or SIGINT since gthe last poll iteration. This will
+        // In postPoll, this will be set if we received a SIGTERM or SIGINT since the last poll iteration. This will
         // happen as soon as we've begun the shutdown process.
         START_SHUTDOWN,
 
@@ -73,11 +73,14 @@ class BedrockServer : public SQLiteServer {
 
     // Control the command port. The server will toggle this as necessary, unless manualOverride is set,
     // in which case the `suppress` setting will be forced.
-    void suppressCommandPort(bool suppress, bool manualOverride = false);
+    void suppressCommandPort(const string& reason, bool suppress, bool manualOverride = false);
 
     // This will return true if there's no outstanding writable activity that we're waiting on. It's called by an
     // SQLiteNode in a STANDINGDOWN state to know that it can switch to searching.
     virtual bool canStandDown();
+
+    // Returns whether or not this server was configured to backup when it completed shutdown.
+    bool backupOnShutdown();
 
   private:
     // The name of the sync thread.
@@ -177,9 +180,14 @@ class BedrockServer : public SQLiteServer {
     // Because status will access internal sync node data, we lock in both places that will access the pointer above.
     mutex _syncMutex;
 
-    // Functions for checking for and responding to status commands.
+    // Functions for checking for and responding to status and control commands.
     bool _isStatusCommand(BedrockCommand& command);
     void _status(BedrockCommand& command);
+    bool _isControlCommand(BedrockCommand& command);
+    void _control(BedrockCommand& command);
+
+    // This stars the server shutting down.
+    void _beginShutdown(const string& reason);
 
     // This counts the number of commands that are being processed that might be able to write to the database. We
     // won't start any of these unless we're mastering, and we won't allow SQLiteNode to drop out of STANDINGDOWN until
@@ -212,4 +220,11 @@ class BedrockServer : public SQLiteServer {
 
     // The current state of shutdown. Starts as RUNNING.
     atomic<SHUTDOWN_STATE> _shutdownState;
+
+    // Set this to cause a backup to run when the server shuts down.
+    bool _backupOnShutdown;
+
+    // Pointer to the control port, so we know which port not to shut down when we close the command ports.
+    Port* _controlPort;
+    Port* _commandPort;
 };

--- a/libstuff/STCPServer.cpp
+++ b/libstuff/STCPServer.cpp
@@ -24,9 +24,6 @@ STCPServer::Port* STCPServer::openPort(const string& host) {
 }
 
 void STCPServer::closePorts(list<Port*> except) {
-    for (auto p : except) {
-        SINFO("close ports will skip: " << p->host);
-    }
     // Are there any ports to close?
     if (!portList.empty()) {
         // Loop across and close all ports not excepted.

--- a/libstuff/STCPServer.cpp
+++ b/libstuff/STCPServer.cpp
@@ -23,15 +23,25 @@ STCPServer::Port* STCPServer::openPort(const string& host) {
     return &*portIt;
 }
 
-void STCPServer::closePorts() {
+void STCPServer::closePorts(list<Port*> except) {
+    for (auto p : except) {
+        SINFO("close ports will skip: " << p->host);
+    }
     // Are there any ports to close?
     if (!portList.empty()) {
-        // Loop across and close all ports
-        for (Port& port : portList) {
-            // Close this port
-            ::close(port.s);
+        // Loop across and close all ports not excepted.
+        auto it = portList.begin();
+        while (it != portList.end()) {
+            if  (find(except.begin(), except.end(), &(*it)) == except.end()) {
+                // Close this port
+                ::close(it->s);
+                SINFO("Close ports closing " << it->host << ".");
+                it = portList.erase(it);
+            } else {
+                SINFO("Close ports skipping " << it->host << ": in except list.");
+                it++;
+            }
         }
-        portList.clear();
     } else {
         SHMMM("Ports already closed.");
     }

--- a/libstuff/STCPServer.h
+++ b/libstuff/STCPServer.h
@@ -19,8 +19,8 @@ struct STCPServer : public STCPManager {
     // Begins listening on a new port
     Port* openPort(const string& host);
 
-    // Closes all open ports
-    void closePorts();
+    // Closes all open ports, allowing for exceptions.
+    void closePorts(list<Port*> except = {});
 
     // Tries to accept a new incoming socket
     Socket* acceptSocket(Port*& port);

--- a/main.cpp
+++ b/main.cpp
@@ -262,6 +262,7 @@ int main(int argc, char* argv[]) {
     SETDEFAULT("-db", "bedrock.db");
     SETDEFAULT("-serverHost", "localhost:8888");
     SETDEFAULT("-nodeHost", "localhost:8889");
+    SETDEFAULT("-controlPort", "localhost:9999");
     SETDEFAULT("-nodeName", SGetHostName());
     SETDEFAULT("-cacheSize", SToStr(1024 * 1024)); // 1024 * 1024KB = 1GB.
     SETDEFAULT("-plugins", "db,jobs,cache");
@@ -306,6 +307,10 @@ int main(int argc, char* argv[]) {
                 server.postPoll(fdm, nextActivity);
             }
             SINFO("Graceful bedrock shutdown complete");
+
+            if (server.backupOnShutdown()) {
+                BackupDB(args["-db"]);
+            }
         }
 
         // Backup the main database on HUP signal.

--- a/main.cpp
+++ b/main.cpp
@@ -307,7 +307,6 @@ int main(int argc, char* argv[]) {
                 server.postPoll(fdm, nextActivity);
             }
             SINFO("Graceful bedrock shutdown complete");
-
             if (server.backupOnShutdown()) {
                 BackupDB(args["-db"]);
             }

--- a/test/clustertest/BedrockClusterTester.cpp
+++ b/test/clustertest/BedrockClusterTester.cpp
@@ -28,13 +28,15 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
         // on the same machine, they can't share a port.
         int serverPort = 9000 + i;
         int nodePort = nodePortBase + i;
+        int controlPort = 19999 + i;
 
         // Construct all the arguments for each server.
-        string serverHost = "127.0.0.1:" + to_string(serverPort);
-        string nodeHost   = "127.0.0.1:" + to_string(nodePort);
-        string db         = BedrockTester::getTempFileName("cluster_node_" + to_string(i) + "_");
-        string priority   = to_string(100 - (i * 10));
-        string nodeName   = nodeNamePrefix + to_string(i);
+        string serverHost  = "127.0.0.1:" + to_string(serverPort);
+        string nodeHost    = "127.0.0.1:" + to_string(nodePort);
+        string controlHost = "127.0.0.1:" + to_string(controlPort);
+        string db          = BedrockTester::getTempFileName("cluster_node_" + to_string(i) + "_");
+        string priority    = to_string(100 - (i * 10));
+        string nodeName    = nodeNamePrefix + to_string(i);
 
         // Construct our list of peers.
         list<string> peerList;
@@ -50,13 +52,14 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
 
         // Ok, build a legit map out of these.
         map <string, string> args = {
-            {"-serverHost", serverHost},
-            {"-nodeHost",   nodeHost},
-            {"-db",         db},
-            {"-priority",   priority},
-            {"-nodeName",   nodeName},
-            {"-peerList",   peerString},
-            {"-plugins",    "db,cache," + string(cwd) + "/testplugin/testplugin.so"},
+            {"-serverHost",  serverHost},
+            {"-nodeHost",    nodeHost},
+            {"-controlPort", controlHost},
+            {"-db",          db},
+            {"-priority",    priority},
+            {"-nodeName",    nodeName},
+            {"-peerList",    peerString},
+            {"-plugins",     "db,cache," + string(cwd) + "/testplugin/testplugin.so"},
         };
 
         // save this map for later.

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -153,8 +153,9 @@ list<string> BedrockTester::getServerArgs(map <string, string> args) {
     map <string, string> defaults = {
         {"-db",               _dbFile.empty() ? DB_FILE : _dbFile},
         {"-serverHost",       _serverAddr.empty() ? SERVER_ADDR : _serverAddr},
-        {"-nodeName",        "bedrock_test"},
+        {"-nodeName",         "bedrock_test"},
         {"-nodeHost",         "localhost:9889"},
+        {"-controlPort",      "localhost:19999"},
         {"-priority",         "200"},
         {"-plugins",          SComposeList(plugins)},
         {"-readThreads",      "8"},


### PR DESCRIPTION
@cead22 @coleaeason @righdforsa 

[HOLD] for https://github.com/Expensify/Server-Expensify/pull/2137 to make auth tests compatible with this.

This adds the long-discussed but never implemented control port to Bedrock. Essentially, it adds a second command port, and a set of commands called "control commands". There are currently three control commands:
```
BeginBackup
SuppressCommandPort
ClearCommandPort
```

These are in addition to the existing signal-based handling for these actions, though the intention is to eventually remove signals as a mechanism for controlling bedrock and use the control port instead.

### What's better about using a control port than signals?

1. We can send more than a few commands, with names that make sense. Currently, to run a backup, we send `SIGHUP`. To close the command port, we send `SIGTTIN`. Nobody knows what `SIGTTIN` even exists for. Then we're almost out of useable signals unless we just start sending random numbers.
2. Control commands can have parameters. What if we want to send a timeout for how long to close the command port for? Easy with a control command, impossible with a signal.
3. Control commands can return results. Want to know if the command port actually opened or closed, or query some internal state? Easy with a control command, impossible with a signal.
4. Signals are messy, and we can avoiding dealing with [signal safety](http://man7.org/linux/man-pages/man7/signal-safety.7.html).

### Extra Bonus: Send Commands When the Command Port is Closed

Ever wanted to send a `Status` command to a bedrock node, but couldn't, because the command port was closed? Now you can. The control port is just an extra command port that always stays open, and only listens on localhost. You can send it any command you like. If the command port is closed though, you probably don't want to send regular auth commands.

### Notes

1. The command port defaults to port 9999, which was chosen pretty arbitrary.
2. Control commands can be sent to the regular command port as well, but will only be processed if they originated from a localhost address.

### Testing

Using `nc`, send the new control commands to bedrock and observe the results. They should mirror the existing behavior for signals.