### PR TITLE
Replace multi-write whitelist with blacklist

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1285,7 +1285,7 @@ void BedrockServer::_status(BedrockCommand& command) {
             _multiWriteEnabled.store((request["Enable"] == "true"));
             response.methodLine = "200 OK";
         } else {
-            response.methodLine = "500 Must Specify 'Enabled'";
+            response.methodLine = "500 Must Specify 'Enable'";
         }
     }
 }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -5,8 +5,8 @@
 #include "BedrockConflictMetrics.h"
 #include "BedrockCore.h"
 
-set<string>BedrockServer::_parallelCommands;
-recursive_mutex BedrockServer::_parallelCommandMutex;
+set<string>BedrockServer::_blacklistedParallelCommands;
+recursive_mutex BedrockServer::_blacklistedParallelCommandMutex;
 
 void BedrockServer::acceptCommand(SQLiteCommand&& command) {
     _commandQueue.push(BedrockCommand(move(command)));
@@ -550,13 +550,18 @@ void BedrockServer::worker(SData& args,
                     // it, or if we should send it off to the sync node.
                     bool canWriteParallel = false;
                     { 
-                        SAUTOLOCK(_parallelCommandMutex);
-                        canWriteParallel =
-                            (_parallelCommands.find(command.request.methodLine) != _parallelCommands.end());
+                        // Multi-write needs to be enabled.
+                        canWriteParallel = server._multiWriteEnabled.load();
+                        if (canWriteParallel) {
+                            // If multi-write is enabled, then we need to make sure the command isn't blacklisted.
+                            SAUTOLOCK(_blacklistedParallelCommandMutex);
+                            canWriteParallel =
+                                (_blacklistedParallelCommands.find(command.request.methodLine) == _blacklistedParallelCommands.end());
+                        }
                     }
 
-                    // For now, commands need to be in `_parallelCommands` *and* `multiWriteOK`. When we're
-                    // confident in BedrockConflictMetrics, we can remove `_parallelCommands`.
+                    // We need to have multi-write enabled, the command needs to not be explicitly blacklisted, and it
+                    // needs to not be automatically blacklisted.
                     canWriteParallel = canWriteParallel && BedrockConflictMetrics::multiWriteOK(command.request.methodLine);
                     if (!canWriteParallel               ||
                         state != SQLiteNode::MASTERING  ||
@@ -682,7 +687,7 @@ void BedrockServer::worker(SData& args,
 BedrockServer::BedrockServer(const SData& args)
   : SQLiteServer(""), _args(args), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),
-    _syncNode(nullptr), _shutdownState(RUNNING)
+    _syncNode(nullptr), _shutdownState(RUNNING), _multiWriteEnabled(false)
 {
     _version = SVERSION;
 
@@ -730,13 +735,13 @@ BedrockServer::BedrockServer(const SData& args)
         }
     }
 
-    // Check for commands that can be written by workers.
-    if (args.isSet("-parallelCommands")) {
-        SAUTOLOCK(_parallelCommandMutex);
+    // Check for commands that can't be written by workers.
+    if (args.isSet("-blacklistedParallelCommands")) {
+        SAUTOLOCK(_blacklistedParallelCommandMutex);
         list<string> parallelCommands;
-        SParseList(args["-parallelCommands"], parallelCommands);
+        SParseList(args["-blacklistedParallelCommands"], parallelCommands);
         for (auto& command : parallelCommands) {
-            _parallelCommands.insert(command);
+            _blacklistedParallelCommands.insert(command);
         }
     }
 
@@ -1150,7 +1155,8 @@ bool BedrockServer::_isStatusCommand(BedrockCommand& command) {
         SIEquals(command.request.methodLine, STATUS_HANDLING_COMMANDS) ||
         SIEquals(command.request.methodLine, STATUS_PING)              ||
         SIEquals(command.request.methodLine, STATUS_STATUS)            ||
-        SIEquals(command.request.methodLine, STATUS_WHITELIST)) {
+        SIEquals(command.request.methodLine, STATUS_BLACKLIST)         ||
+        SIEquals(command.request.methodLine, STATUS_MULTIWRITE)) {
         return true;
     }
     return false;
@@ -1208,10 +1214,10 @@ void BedrockServer::_status(BedrockCommand& command) {
         content["version"]  = _version;
         content["host"]     = _args["-nodeHost"];
 
-        // On master, return the current multi-write blacklist.
+        // On master, return the current multi-write blacklists.
         if (state == SQLiteNode::MASTERING) {
-            content["multiWriteBlacklist"] = BedrockConflictMetrics::getMultiWriteDeniedCommands();
-            content["multiWriteWhiteList"] = SComposeJSONArray(_parallelCommands);
+            content["multiWriteAutoBlacklist"] = BedrockConflictMetrics::getMultiWriteDeniedCommands();
+            content["multiWriteManualBlacklist"] = SComposeJSONArray(_blacklistedParallelCommands);
         }
 
         // We read from syncNode internal state here, so we lock to make sure that this doesn't conflict with the sync
@@ -1248,20 +1254,20 @@ void BedrockServer::_status(BedrockCommand& command) {
         response.content = SComposeJSONObject(content);
     }
 
-    else if (SIEquals(request.methodLine, STATUS_WHITELIST)) {
-        SAUTOLOCK(_parallelCommandMutex);
+    else if (SIEquals(request.methodLine, STATUS_BLACKLIST)) {
+        SAUTOLOCK(_blacklistedParallelCommandMutex);
 
         // Return the old list. We can check the list by not passing the "Commands" param.
         STable content;
-        content["oldCommandWhitelist"] = SComposeList(_parallelCommands);
+        content["oldCommandBlacklist"] = SComposeList(_blacklistedParallelCommands);
 
         // If the Comamnds param is set, parse it and update our value.
         if (request.isSet("Commands")) {
-            _parallelCommands.clear();
+            _blacklistedParallelCommands.clear();
             list<string> parallelCommands;
             SParseList(request["Commands"], parallelCommands);
             for (auto& command : parallelCommands) {
-                _parallelCommands.insert(command);
+                _blacklistedParallelCommands.insert(command);
             }
         }
         if (request.isSet("autoBlacklistConflictFraction")) {
@@ -1269,11 +1275,18 @@ void BedrockServer::_status(BedrockCommand& command) {
         }
 
         // Enable extra logging in the commit lock timer.
-        decltype(SQLite::g_commitLock)::enableExtraLogging.store(!_parallelCommands.empty());
+        decltype(SQLite::g_commitLock)::enableExtraLogging.store(!_blacklistedParallelCommands.empty());
 
-        // PRepare the command to respond to the caller.
+        // Prepare the command to respond to the caller.
         response.methodLine = "200 OK";
         response.content = SComposeJSONObject(content);
+    } else if (SIEquals(request.methodLine, STATUS_MULTIWRITE)) {
+        if (request.isSet("Enable")) {
+            _multiWriteEnabled.store((request["Enable"] == "true"));
+            response.methodLine = "200 OK";
+        } else {
+            response.methodLine = "500 Must Specify 'Enabled'";
+        }
     }
 }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -557,9 +557,7 @@ void BedrockServer::worker(SData& args,
                     }
                     // Peek wasn't enough to handle this command. Now we need to decide if we should try and process
                     // it, or if we should send it off to the sync node.
-                    bool canWriteParallel = false;
-                    // Multi-write needs to be enabled.
-                    canWriteParallel = server._multiWriteEnabled.load();
+                    bool canWriteParallel = server._multiWriteEnabled.load();
                     if (canWriteParallel) {
                         // If multi-write is enabled, then we need to make sure the command isn't blacklisted.
                         SAUTOLOCK(_blacklistedParallelCommandMutex);
@@ -1308,15 +1306,12 @@ void BedrockServer::_status(BedrockCommand& command) {
             BedrockConflictMetrics::setFraction(SToFloat(request["autoBlacklistConflictFraction"]));
         }
 
-        // Enable extra logging in the commit lock timer.
-        decltype(SQLite::g_commitLock)::enableExtraLogging.store(!_blacklistedParallelCommands.empty());
-
         // Prepare the command to respond to the caller.
         response.methodLine = "200 OK";
         response.content = SComposeJSONObject(content);
     } else if (SIEquals(request.methodLine, STATUS_MULTIWRITE)) {
         if (request.isSet("Enable")) {
-            _multiWriteEnabled.store((request["Enable"] == "true"));
+            _multiWriteEnabled.store(request.test("Enable"));
             response.methodLine = "200 OK";
         } else {
             response.methodLine = "500 Must Specify 'Enable'";

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -694,7 +694,7 @@ void BedrockServer::worker(SData& args,
 BedrockServer::BedrockServer(const SData& args)
   : SQLiteServer(""), _args(args), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),
-    _syncNode(nullptr), _shutdownState(RUNNING), _multiWriteEnabled(false), _backupOnShutdown(false), _controlPort(nullptr), _commandPort(nullptr)
+    _syncNode(nullptr), _shutdownState(RUNNING), _multiWriteEnabled(true), _backupOnShutdown(false), _controlPort(nullptr), _commandPort(nullptr)
 {
     _version = SVERSION;
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -172,7 +172,7 @@ class BedrockServer : public SQLiteServer {
     static constexpr auto STATUS_HANDLING_COMMANDS = "GET /status/handlingCommands HTTP/1.1";
     static constexpr auto STATUS_PING              = "Ping";
     static constexpr auto STATUS_STATUS            = "Status";
-    static constexpr auto STATUS_BLACKLIST         = "SetCommandBlacklist";
+    static constexpr auto STATUS_BLACKLIST         = "SetParallelCommandBlacklist";
     static constexpr auto STATUS_MULTIWRITE        = "EnableMultiWrite";
 
     // This *only* exists so that status commands can pull info from this node.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -169,7 +169,8 @@ class BedrockServer : public SQLiteServer {
     static constexpr auto STATUS_HANDLING_COMMANDS = "GET /status/handlingCommands HTTP/1.1";
     static constexpr auto STATUS_PING              = "Ping";
     static constexpr auto STATUS_STATUS            = "Status";
-    static constexpr auto STATUS_WHITELIST         = "SetCommandWhitelist";
+    static constexpr auto STATUS_BLACKLIST         = "SetCommandBlacklist";
+    static constexpr auto STATUS_MULTIWRITE        = "EnableMultiWrite";
 
     // This *only* exists so that status commands can pull info from this node.
     SQLiteNode* _syncNode;
@@ -204,12 +205,15 @@ class BedrockServer : public SQLiteServer {
     set<string> _syncCommands;
 
     // This is a list of command names than can be processed and committed in worker threads.
-    static set<string> _parallelCommands;
-    static recursive_mutex  _parallelCommandMutex;
+    static set<string> _blacklistedParallelCommands;
+    static recursive_mutex  _blacklistedParallelCommandMutex;
 
     // Stopwatch to track if we're going to give up on gracefully shutting down and force it.
     SStopwatch _gracefulShutdownTimeout;
 
     // The current state of shutdown. Starts as RUNNING.
     atomic<SHUTDOWN_STATE> _shutdownState;
+
+    // Flag indicating whether multi-write is enabled.
+    atomic<bool> _multiWriteEnabled;
 };

--- a/test/clustertest/tests/b_ConflictSpamTest.cpp
+++ b/test/clustertest/tests/b_ConflictSpamTest.cpp
@@ -71,6 +71,11 @@ struct b_ConflictSpamTest : tpunit::TestFixture {
         recursive_mutex m;
         atomic<int> totalRequestFailures(0);
 
+        BedrockTester* brtester = tester->getBedrockTester(0);
+        SData enable("EnableMultiWrite");
+        enable["Enable"] = "true";
+        brtester->executeWait(enable);
+
         // Let's spin up three threads, each spamming commands at one of our nodes.
         list<thread> threads;
         for (int i : {0, 1, 2}) {

--- a/test/clustertest/tests/b_ConflictSpamTest.cpp
+++ b/test/clustertest/tests/b_ConflictSpamTest.cpp
@@ -71,11 +71,6 @@ struct b_ConflictSpamTest : tpunit::TestFixture {
         recursive_mutex m;
         atomic<int> totalRequestFailures(0);
 
-        BedrockTester* brtester = tester->getBedrockTester(0);
-        SData enable("EnableMultiWrite");
-        enable["Enable"] = "true";
-        brtester->executeWaitVerifyContent(enable);
-
         // Let's spin up three threads, each spamming commands at one of our nodes.
         list<thread> threads;
         for (int i : {0, 1, 2}) {

--- a/test/tests/StatusTest.cpp
+++ b/test/tests/StatusTest.cpp
@@ -17,7 +17,8 @@ struct StatusTest : tpunit::TestFixture {
         SData status("Status");
         string response = tester->executeWait(status);
         ASSERT_TRUE(SContains(response, "plugins"));
-        ASSERT_TRUE(SContains(response, "multiWriteWhiteList"));
+        ASSERT_TRUE(SContains(response, "multiWriteManualBlacklist"));
+        ASSERT_TRUE(SContains(response, "multiWriteAutoBlacklist"));
     }
 
 } __StatusTest;


### PR DESCRIPTION
We started out with a whitelist to enable just a few commands for multi-write, thinking this would be the lowest impact way to test. As multi-write evolved, we changed its behavior so that it's now designed to work most efficiently with nearly every command being processed by workers, and we added auto-blacklisting for commands that reliably cause conflicts.

This change removes the whitelist, replacing it with a blacklist. We already added the ability for specific auth commands to be marked as non-multi-write, and for commands that are known not to work well with multi-write, this will be our SOP. We retain a blacklist for emergencies, if we discover a specific command is unexpectedly causing problems.

We also add a new `enableMultiWrite` command, so that we can simply switch the whole feature on and off without worrying about long lists of commands. For now, this defaults to off.

## Testing
`clustertest` has been updated to send the new command and verified to run in multi-write mode only after it's been sent.