### PR TITLE
Add setVersion status command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1285,7 +1285,11 @@ void BedrockServer::_status(BedrockCommand& command) {
         // If we set a version, override the version string and return both old and new values
         // If we forgot to send a version do nothing
         if (request.isSet("Version")) {
-          _version = request["Version"];
+          // We'll deconstruct the list given, sort it, then reconstruc it so the oeprator doesn't
+          // have to know the list needs to be sorted.
+          list<string> newVersionStrings = SParseList(request["Version"], ':');
+          newVersionStrings.sort();
+          _version = SComposeList(newVersionStrings, ":");
           content["newVersion"] = _version;
           response.methodLine = "200 OK";
           response.content = SComposeJSONObject(content);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1285,7 +1285,7 @@ void BedrockServer::_status(BedrockCommand& command) {
         // If we set a version, override the version string and return both old and new values
         // If we forgot to send a version do nothing
         if (request.isSet("Version")) {
-          // We'll deconstruct the list given, sort it, then reconstruc it so the oeprator doesn't
+          // We'll deconstruct the list given, sort it, then reconstruct it so the oeprator doesn't
           // have to know the list needs to be sorted.
           list<string> newVersionStrings = SParseList(request["Version"], ':');
           newVersionStrings.sort();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -679,12 +679,14 @@ void BedrockServer::worker(SData& args,
     }
 }
 
-BedrockServer::BedrockServer(const SData& args)
+BedrockServer::BedrockServer(const SData& args, const string& versionOverrideSet)
   : SQLiteServer(""), _args(args), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),
-    _syncNode(nullptr), _shutdownState(RUNNING), _backupOnShutdown(false), _controlPort(nullptr), _commandPort(nullptr)
+    _syncNode(nullptr), _shutdownState(RUNNING), _backupOnShutdown(false), _restartFromVersionChange(false),
+    _controlPort(nullptr), _commandPort(nullptr)
 {
-    _version = SVERSION;
+
+    _version = !versionOverrideSet.empty() ? versionOverrideSet : SVERSION;
 
     // Output the list of plugins.
     map<string, BedrockPlugin*> registeredPluginMap;
@@ -714,12 +716,15 @@ BedrockServer::BedrockServer(const SData& args)
         }
     }
     sort(versions.begin(), versions.end());
-    _version = SComposeList(versions, ":");
+    if (versionOverrideSet.empty()) {
+      _version = SComposeList(versions, ":");
+    }
 
-    // If `versionOverride` is set, we throw away what we just did and use the overridden value.
+    // If `versionOverride` is set and we didn't restart from a `SetVersion`,
+    // we throw away what we just did and use the overridden value.
     // We'll destruct, sort, and then reconstruct the version string passed in so we aren't relying
     // on the operator to know that they must be sorted.
-    if (args.isSet("-versionOverride")) {
+    if (args.isSet("-versionOverride") && versionOverrideSet.empty()) {
         list<string> versionStrings = SParseList(args["-versionOverride"], ':');
         versionStrings.sort();
         _version = SComposeList(versionStrings, ":");
@@ -1177,8 +1182,7 @@ bool BedrockServer::_isStatusCommand(BedrockCommand& command) {
         SIEquals(command.request.methodLine, STATUS_HANDLING_COMMANDS) ||
         SIEquals(command.request.methodLine, STATUS_PING)              ||
         SIEquals(command.request.methodLine, STATUS_STATUS)            ||
-        SIEquals(command.request.methodLine, STATUS_WHITELIST)         ||
-        SIEquals(command.request.methodLine, STATUS_VERSION)) {
+        SIEquals(command.request.methodLine, STATUS_WHITELIST)) {
         return true;
     }
     return false;
@@ -1303,33 +1307,13 @@ void BedrockServer::_status(BedrockCommand& command) {
         response.methodLine = "200 OK";
         response.content = SComposeJSONObject(content);
     }
-
-    else if (SIEquals(request.methodLine, STATUS_VERSION)) {
-        // Return the old version so we know what we changed from
-        STable content;
-        content["oldVersion"] = _version;
-
-        // If we set a version, override the version string and return both old and new values
-        // If we forgot to send a version do nothing
-        if (request.isSet("Version")) {
-          // We'll deconstruct the list given, sort it, then reconstruct it so the oeprator doesn't
-          // have to know the list needs to be sorted.
-          list<string> newVersionStrings = SParseList(request["Version"], ':');
-          newVersionStrings.sort();
-          _version = SComposeList(newVersionStrings, ":");
-          content["newVersion"] = _version;
-          response.methodLine = "200 OK";
-          response.content = SComposeJSONObject(content);
-        } else {
-          response.methodLine = "404 Must supply a version";
-        }
-    }
 }
 
 bool BedrockServer::_isControlCommand(BedrockCommand& command) {
     if (SIEquals(command.request.methodLine, "BeginBackup")         ||
         SIEquals(command.request.methodLine, "SuppressCommandPort") ||
-        SIEquals(command.request.methodLine, "ClearCommandPort")) {
+        SIEquals(command.request.methodLine, "ClearCommandPort")    ||
+        SIEquals(command.request.methodLine, "SetVersion")) {
         return true;
     }
     return false;
@@ -1345,6 +1329,32 @@ void BedrockServer::_control(BedrockCommand& command) {
         suppressCommandPort("SuppressCommandPort", true, true);
     } else if (SIEquals(command.request.methodLine, "ClearCommandPort")) {
         suppressCommandPort("ClearCommandPort", false, true);
+    } else if (SIEquals(command.request.methodLine, "SetVersion")) {
+        // Return the old version so we know what we changed from
+        STable content;
+        content["oldVersion"] = _version;
+
+        // If we set a version, override the version string and return both old and new values
+        // If we forgot to send a version do nothing
+        if (command.request.isSet("Version")) {
+          // We'll deconstruct the list given, sort it, then reconstruct it so the oeprator doesn't
+          // have to know the list needs to be sorted.
+          list<string> newVersionStrings = SParseList(command.request["Version"], ':');
+          newVersionStrings.sort();
+          _version = SComposeList(newVersionStrings, ":");
+          content["newVersion"] = _version;
+          response.methodLine = "200 OK";
+          response.content = SComposeJSONObject(content);
+
+          // If we're mastering, we need to restart the node so we can send our new version to all of our peers
+          SQLiteNode::State state = _replicationState.load();
+          if (state == SQLiteNode::MASTERING) {
+            newVersionOnStartup = _version;
+            _beginShutdown("SetVersion");
+          }
+        } else {
+          response.methodLine = "404 Must supply a version";
+        }
     }
 }
 
@@ -1396,4 +1406,8 @@ void BedrockServer::_beginShutdown(const string& reason) {
 
 bool BedrockServer::backupOnShutdown() {
     return _backupOnShutdown;
+}
+
+bool BedrockServer::restartFromVersionChange() {
+    return !newVersionOnStartup.empty();
 }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -170,6 +170,8 @@ class BedrockServer : public SQLiteServer {
     static constexpr auto STATUS_PING              = "Ping";
     static constexpr auto STATUS_STATUS            = "Status";
     static constexpr auto STATUS_WHITELIST         = "SetCommandWhitelist";
+    static constexpr auto STATUS_VERSION           = "SetVersion";
+
 
     // This *only* exists so that status commands can pull info from this node.
     SQLiteNode* _syncNode;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -44,7 +44,7 @@ class BedrockServer : public SQLiteServer {
     typedef SSynchronizedQueue<BedrockCommand> CommandQueue;
 
     // Our only constructor.
-    BedrockServer(const SData& args);
+    BedrockServer(const SData& args, const string& versionOverrideSet);
 
     // Destructor
     virtual ~BedrockServer();
@@ -81,6 +81,12 @@ class BedrockServer : public SQLiteServer {
 
     // Returns whether or not this server was configured to backup when it completed shutdown.
     bool backupOnShutdown();
+
+    // Returns whether or not this server was configured to restart from a version change.
+    bool restartFromVersionChange();
+
+    // The new version we should use on start up if we set it via SetVersion
+    string newVersionOnStartup;
 
   private:
     // The name of the sync thread.
@@ -173,7 +179,6 @@ class BedrockServer : public SQLiteServer {
     static constexpr auto STATUS_PING              = "Ping";
     static constexpr auto STATUS_STATUS            = "Status";
     static constexpr auto STATUS_WHITELIST         = "SetCommandWhitelist";
-    static constexpr auto STATUS_VERSION           = "SetVersion";
 
 
     // This *only* exists so that status commands can pull info from this node.
@@ -225,6 +230,9 @@ class BedrockServer : public SQLiteServer {
 
     // Set this to cause a backup to run when the server shuts down.
     bool _backupOnShutdown;
+
+    // Set this to cause the server to restart after a version change.
+    bool _restartFromVersionChange;
 
     // Pointer to the control port, so we know which port not to shut down when we close the command ports.
     Port* _controlPort;


### PR DESCRIPTION
@tylerkaraszewski Please review. Setting the versionOverride in the init script we run the servers with is fine for when we want to keep the versionOverride set between restarts, etc. but sometimes like when we're testing sqlite versions, we just want the version changed temporarily and then when we restart the node we want the node to come back up with it's actual version. Setting in the init script makes it _really_ easy for us to forget we did that (see recent deploy issues), but if restarting the node cleared the override, we wouldn't have to remember to change anything. This will also decrease the amount of times we need to bounce nodes, get keys, etc. and should be quite the time saver for us I think.

cc: @Expensify/infra @cead22 @flodnv 

## Tests
```
vagrant@vagrant-ubuntu-trusty-64:~$ nc localhost 4444
setversion

404 Must supply a version
nodeName: auth-on-bedrock
totalTime: 18
Content-Length: 0

setversion
version: XXXXX

200 OK
nodeName: auth-on-bedrock
totalTime: 44
Content-Length: 124

{"newVersion":"XXXXX","oldVersion":"16c2557a15c28de5753f7fb48d13f6b4d9e03ff7:Auth_1b76326e35e4a85d6e82da62bb66760368e78a61"}

status

200 OK
nodeName: auth-on-bedrock
totalTime: 92
Content-Length: 305

{"CommitCount":515,"escalatedCommandList":[],"host":"localhost:4445","isMaster":true,"multiWriteBlacklist":"","multiWriteWhiteList":[],"peerList":[],"plugins":[{"name":"Auth","version":"1b76326e35e4a85d6e82da62bb66760368e78a61"},{"name":"DB"}],"queuedCommandList":[],"state":"MASTERING","version":"XXXXX"}
```

Also tested the sorting by trying to set the new version to the opposite order:
```
vagrant@vagrant-ubuntu-trusty-64:~$ nc localhost 4444
status

200 OK
nodeName: auth-on-bedrock
totalTime: 118
Content-Length: 386

{"CommitCount":515,"escalatedCommandList":[],"host":"localhost:4445","isMaster":true,"multiWriteBlacklist":"","multiWriteWhiteList":[],"peerList":[],"plugins":[{"name":"Auth","version":"1b76326e35e4a85d6e82da62bb66760368e78a61"},{"name":"DB"}],"queuedCommandList":[],"state":"MASTERING","version":"057dc3f60c583981bde6cc11701d29382b53a6a5:Auth_1b76326e35e4a85d6e82da62bb66760368e78a61"}

setversion
version: Auth_1b76326e35e4a85d6e82da62bb66760368e78a61:057dc3f60c583981bde6cc11701d29382b53a6a5

200 OK
nodeName: auth-on-bedrock
totalTime: 51
Content-Length: 205

{"newVersion":"057dc3f60c583981bde6cc11701d29382b53a6a5:Auth_1b76326e35e4a85d6e82da62bb66760368e78a61","oldVersion":"057dc3f60c583981bde6cc11701d29382b53a6a5:Auth_1b76326e35e4a85d6e82da62bb66760368e78a61"}

status

200 OK
nodeName: auth-on-bedrock
totalTime: 96
Content-Length: 386

{"CommitCount":515,"escalatedCommandList":[],"host":"localhost:4445","isMaster":true,"multiWriteBlacklist":"","multiWriteWhiteList":[],"peerList":[],"plugins":[{"name":"Auth","version":"1b76326e35e4a85d6e82da62bb66760368e78a61"},{"name":"DB"}],"queuedCommandList":[],"state":"MASTERING","version":"057dc3f60c583981bde6cc11701d29382b53a6a5:Auth_1b76326e35e4a85d6e82da62bb66760368e78a61"}
```