### PR TITLE
Disable SQLITE_CONFIG_MEMSTATUS

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -46,6 +46,10 @@ SQLite::SQLite(const string& filename, int cacheSize, int autoCheckpoint, int ma
     // We need to initialize sqlite. Only the first thread to get here will do this.
     if (initializer) {
         sqlite3_config(SQLITE_CONFIG_LOG, _sqliteLogCallback, 0);
+
+        // Disable a mutex around `malloc`, which is *EXTREMELY IMPORTANT* for multi-threaded performance. Without this
+        // setting, all reads are essentially single-threaded as they'll all fight with each other for this mutex.
+        sqlite3_config(SQLITE_CONFIG_MEMSTATUS, 0);
         sqlite3_initialize();
         SASSERT(sqlite3_threadsafe());
 


### PR DESCRIPTION
As per the recent email discussion with sqlite,  disabling this configuration option improves multi-threaded read performance. As is not evident from the recent email discussion, it improves it *MASSIVELY*.

Here are improvements run with the current perf test on our demo server, with 1-16 threads.

```
Speedups per thread:
 1 thread:   1.14x
 2 threads:  3.55x
 4 threads:  5.44x
 8 threads: 11.47x
16 threads: 19.36x
```

As clarification, after this change, bedrock is 14% faster with one thread, and *1900%* faster with 16 threads, with no other changes except disabling this setting.