### PR TITLE
Simplify BedrockTester

### DIFF
--- a/test/clustertest/BedrockClusterTester.cpp
+++ b/test/clustertest/BedrockClusterTester.cpp
@@ -8,7 +8,6 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
     cout << "Starting " << size << " node bedrock cluster." << endl;
     // Make sure we won't re-allocate.
     _cluster.reserve(size);
-    _args.reserve(size);
 
     int nodePortBase = 9500;
     // We'll need a list of each node's addresses, and each will need to know the addresses of the others.
@@ -62,10 +61,16 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
             {"-plugins",     "db,cache," + string(cwd) + "/testplugin/testplugin.so"},
         };
 
-        // save this map for later.
-        _args.push_back(args);
-
         _cluster.emplace_back(db, serverHost, queries, args, false);
+    }
+    list<thread> threads;
+    for (size_t i = 0; i < _cluster.size(); i++) {
+        threads.emplace_back([i, this](){
+            _cluster[i].startServer();
+        });
+    }
+    for (auto& i : threads) {
+        i.join();
     }
 
     // Ok, now we should be able to wait for the cluster to come up. Let's wait until each server responds to 'status',
@@ -81,7 +86,7 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
             }
             try {
                 SData status("Status");
-                string response = _cluster[i].executeWait(status, "200");
+                string response = _cluster[i].executeWaitVerifyContent(status);
                 STable json = SParseJSONObject(response);
                 states[i] = json["state"];
                 break;
@@ -121,5 +126,5 @@ void BedrockClusterTester::stopNode(size_t nodeIndex)
 
 void BedrockClusterTester::startNode(size_t nodeIndex)
 {
-    _cluster[nodeIndex].startServer(_args[nodeIndex], true);
+    _cluster[nodeIndex].startServer();
 }

--- a/test/clustertest/BedrockClusterTester.cpp
+++ b/test/clustertest/BedrockClusterTester.cpp
@@ -60,8 +60,7 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
             {"-peerList",    peerString},
             {"-plugins",     "db,cache," + string(cwd) + "/testplugin/testplugin.so"},
         };
-
-        _cluster.emplace_back(db, serverHost, queries, args, false);
+        _cluster.emplace_back(args, queries, false);
     }
     list<thread> threads;
     for (size_t i = 0; i < _cluster.size(); i++) {

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -47,8 +47,4 @@ class BedrockClusterTester {
 
     // A list of all our testers that make up our cluster.
     vector<BedrockTester> _cluster;
-
-    // The arguments we start each server with. We store them so we can bring them down and back up with the same
-    // settings.
-    vector<map<string, string>> _args;
 };

--- a/test/clustertest/main.cpp
+++ b/test/clustertest/main.cpp
@@ -10,17 +10,9 @@
  * bits of functionality.
  */
 
-void cleanup() {
-    if (BedrockTester::serverPIDs.size()) {
-        while (BedrockTester::serverPIDs.size()) {
-            BedrockTester::stopServer(*(BedrockTester::serverPIDs.begin()));
-        }
-    }
-}
-
 void sigclean(int sig) {
     cout << "Got SIGINT, cleaning up." << endl;
-    cleanup();
+    BedrockTester::stopAll();
     cout << "Done." << endl;
     exit(1);
 }

--- a/test/clustertest/tests/a_MasteringTest.cpp
+++ b/test/clustertest/tests/a_MasteringTest.cpp
@@ -25,7 +25,7 @@ struct a_MasteringTest : tpunit::TestFixture {
                 BedrockTester* brtester = tester->getBedrockTester(i);
 
                 SData cmd("Status");
-                string response = brtester->executeWait(cmd);
+                string response = brtester->executeWaitVerifyContent(cmd);
                 STable json = SParseJSONObject(response);
                 results[i] = json["state"];
             }
@@ -51,7 +51,7 @@ struct a_MasteringTest : tpunit::TestFixture {
         bool success = false;
         while (count++ < 50) {
             SData cmd("Status");
-            string response = newMaster->executeWait(cmd);
+            string response = newMaster->executeWaitVerifyContent(cmd);
             STable json = SParseJSONObject(response);
             if (json["state"] == "MASTERING") {
                 success = true;
@@ -81,7 +81,7 @@ struct a_MasteringTest : tpunit::TestFixture {
                     SData status("Status");
                     status["writeConsistency"] = "ASYNC";
 
-                    auto result = brtester->executeWait(status);
+                    auto result = brtester->executeWaitVerifyContent(status);
                     lock_guard<decltype(m)> lock(m);
                     responses[i] = result;
                 });

--- a/test/clustertest/tests/b_ConflictSpamTest.cpp
+++ b/test/clustertest/tests/b_ConflictSpamTest.cpp
@@ -35,7 +35,7 @@ struct b_ConflictSpamTest : tpunit::TestFixture {
                 query["value"] = "sent-" + to_string(cmdNum);
 
                 // Ok, send.
-                string result = brtester->executeWait(query);
+                string result = brtester->executeWaitVerifyContent(query);
             }
         }
 
@@ -49,7 +49,7 @@ struct b_ConflictSpamTest : tpunit::TestFixture {
                 SData query("Query");
                 query["writeConsistency"] = "ASYNC";
                 query["query"] = "SELECT id, value FROM test ORDER BY id;";
-                string result = brtester->executeWait(query);
+                string result = brtester->executeWaitVerifyContent(query);
                 results[i] = result;
             }
 
@@ -89,13 +89,13 @@ struct b_ConflictSpamTest : tpunit::TestFixture {
                 }
 
                 // Ok, send them all!
-                auto results = brtester->executeWaitMultiple(requests);
+                auto results = brtester->executeWaitMultipleData(requests);
 
                 int failures = 0;
                 for (auto row : results) {
-                    if (SToInt(row.first) != 200) {
-                        cout << "Node " << i << " Expected 200, got: " << SToInt(row.first) << endl;
-                        cout << row.second << endl;
+                    if (SToInt(row.methodLine) != 200) {
+                        cout << "Node " << i << " Expected 200, got: " << SToInt(row.methodLine) << endl;
+                        cout << row.content << endl;
                         failures++;
                     }
                 }
@@ -119,7 +119,7 @@ struct b_ConflictSpamTest : tpunit::TestFixture {
                 query["query"] = "SELECT name FROM sqlite_master WHERE type='table';";
 
                 // Ok, send them all!
-                auto result = brtester->executeWait(query);
+                auto result = brtester->executeWaitVerifyContent(query);
 
                 SAUTOLOCK(m);
                 allResults[i] = result;
@@ -172,7 +172,7 @@ struct b_ConflictSpamTest : tpunit::TestFixture {
                     SData cmd("Query");
                     cmd["query"] = query;
                     // Ok, send them all!
-                    auto result = brtester->executeWait(cmd);
+                    auto result = brtester->executeWaitVerifyContent(cmd);
 
                     SAUTOLOCK(m);
                     allResults[i] = result;
@@ -213,12 +213,12 @@ struct b_ConflictSpamTest : tpunit::TestFixture {
 
 
             // Ok, send them all!
-            auto results = brtester->executeWaitMultiple(commands);
+            auto results = brtester->executeWaitMultipleData(commands);
 
             for (size_t i = 0; i < results.size(); i++) {
                 // Make sure they all succeeded.
-                ASSERT_TRUE(SToInt(results[i].first) == 200);
-                list<string> lines = SParseList(results[i].second, '\n');
+                ASSERT_TRUE(SToInt(results[i].methodLine) == 200);
+                list<string> lines = SParseList(results[i].content, '\n');
                 lines.pop_front();
             }
             // We can't verify the size of the journal, because we can insert any number of 'upgrade database' rows as
@@ -237,7 +237,7 @@ struct b_ConflictSpamTest : tpunit::TestFixture {
                 cmd["query"] = "SELECT * FROM test;";
 
                 // Ok, send them all!
-                auto result = brtester->executeWait(cmd);
+                auto result = brtester->executeWaitVerifyContent(cmd);
 
                 SAUTOLOCK(m);
                 allResults[i] = result;
@@ -268,7 +268,7 @@ struct b_ConflictSpamTest : tpunit::TestFixture {
                 cmd["query"] = "SELECT COUNT(id) FROM test;";
 
                 // Ok, send them all!
-                auto result = brtester->executeWait(cmd);
+                auto result = brtester->executeWaitVerifyContent(cmd);
 
                 SAUTOLOCK(m);
                 allResults[i] = result;

--- a/test/clustertest/tests/c_StatusTest.cpp
+++ b/test/clustertest/tests/c_StatusTest.cpp
@@ -24,7 +24,7 @@ struct c_StatusTest : tpunit::TestFixture {
                 status["writeConsistency"] = "ASYNC";
 
                 // Ok, send them all!
-                auto result = brtester->executeWait(status);
+                auto result = brtester->executeWaitVerifyContent(status);
                 lock_guard<decltype(m)> lock(m);
                 responses[i] = result;
             });

--- a/test/clustertest/tests/d_abandonedCommandTest.cpp
+++ b/test/clustertest/tests/d_abandonedCommandTest.cpp
@@ -59,7 +59,7 @@ struct d_abandonedCommandTest : tpunit::TestFixture {
                 SData query("Query");
                 query["Query"] = "SELECT value FROM test WHERE id >= 600;";
 
-                string result = brtester->executeWait(query);
+                string result = brtester->executeWaitVerifyContent(query);
                 SAUTOLOCK(m);
                 results[i] = result;
             });

--- a/test/clustertest/tests/e_futureExecutionTest.cpp
+++ b/test/clustertest/tests/e_futureExecutionTest.cpp
@@ -17,7 +17,7 @@ struct e_futureExecutionTest : tpunit::TestFixture {
         // Three seconds from now.
         query["commandExecuteTime"] = to_string(STimeNow() + 3000000);
         query["Query"] = "INSERT INTO test VALUES(" + SQ(50011) + ", " + SQ("sent_by_master") + ");";
-        string result = brtester->executeWait(query, "202"); 
+        string result = brtester->executeWaitVerifyContent(query, "202"); 
 
         // Ok, Now let's wait a second
         sleep(1);
@@ -26,14 +26,14 @@ struct e_futureExecutionTest : tpunit::TestFixture {
         query.clear();
         query.methodLine = "Query";
         query["Query"] = "SELECT * FROM test WHERE id = 50011;";
-        result = brtester->executeWait(query);
+        result = brtester->executeWaitVerifyContent(query);
         ASSERT_FALSE(SContains(result, "50011"));
 
         // Then sleep three more seconds, it *should* be there now.
         sleep(3);
 
         // And now it should be there.
-        result = brtester->executeWait(query);
+        result = brtester->executeWaitVerifyContent(query);
         ASSERT_TRUE(SContains(result, "50011"));
     }
 

--- a/test/clustertest/tests/g_upgradeDBTest.cpp
+++ b/test/clustertest/tests/g_upgradeDBTest.cpp
@@ -15,7 +15,7 @@ struct g_upgradeDBTest : tpunit::TestFixture {
             // This just verifies that the dbupgrade table was created by TestPlugin.
             SData query("Query");
             query["Query"] = "INSERT INTO dbupgrade VALUES(" + SQ(1 + i) + ", " + SQ("val") + ");";
-            string result = brtester->executeWait(query, "200");
+            string result = brtester->executeWaitVerifyContent(query, "200");
         }
     }
 } __g_upgradeDBTest;

--- a/test/clustertest/tests/h_timingTest.cpp
+++ b/test/clustertest/tests/h_timingTest.cpp
@@ -18,7 +18,8 @@ struct h_timingTest : tpunit::TestFixture {
             SData query("idcollision");
             query["writeConsistency"] = "ASYNC";
             query["value"] = "default";
-            SData result = brtester->executeWaitData(query);
+            auto results = brtester->executeWaitMultipleData({query});
+            auto result = results[0];
             /* Uncomment for inspection.
             for (const auto& row : result.nameValueMap) {
                 cout << row.first << ":" << row.second << endl;
@@ -66,7 +67,8 @@ struct h_timingTest : tpunit::TestFixture {
             // This just verifies that the dbupgrade table was created by TestPlugin.
             SData query("Query");
             query["query"] = "SELECT * FROM test;";
-            SData result = brtester->executeWaitData(query);
+            auto results = brtester->executeWaitMultipleData({query});
+            auto result = results[0];
             /* Uncomment for inspection.
             for (const auto& row : result.nameValueMap) {
                 cout << row.first << ":" << row.second << endl;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -110,6 +110,9 @@ BedrockTester::BedrockTester(const map<string, string>& args, const list<string>
 }
 
 BedrockTester::~BedrockTester() {
+    if (_db) {
+        delete _db;
+    }
     if (_serverPID) {
         stopServer();
     }
@@ -313,4 +316,22 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
 
     // All done!
     return results;
+}
+
+SQLite& BedrockTester::getSQLiteDB()
+{
+    if (!_db) {
+        _db = new SQLite(_dbName, 1000000, 0, 3000000, -1, 0);
+    }
+    return *_db;
+}
+
+string BedrockTester::readDB(const string& query)
+{
+    return getSQLiteDB().read(query);
+}
+
+bool BedrockTester::readDB(const string& query, SQResult& result)
+{
+    return getSQLiteDB().read(query, result);
 }

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -74,14 +74,6 @@ BedrockTester::BedrockTester(const string& filename, const string& serverAddress
 }
 
 BedrockTester::~BedrockTester() {
-    if (db) {
-        delete db;
-        db = 0;
-    }
-    if (writableDB) {
-        delete writableDB;
-        writableDB = 0;
-    }
     if (_serverPID) {
         stopServer();
     }
@@ -92,27 +84,6 @@ BedrockTester::~BedrockTester() {
     }
     _testers.erase(this);
 }
-
-SQLite& BedrockTester::getSQLiteDB() {
-    if (!db) {
-        db = new SQLite(_dbName, 1000000, 100, 3000000, -1, -1);
-    }
-    return *db;
-}
-
-SQLite& BedrockTester::getWritableSQLiteDB() {
-    if (!writableDB) {
-        writableDB = new SQLite(_dbName, 1000000, 100, 3000000, -1, -1);
-    }
-    return *writableDB;
-}
-
-// This is sort of convoluted because of the way it was originally built. We can probably just have this always
-// use the member variable db and never open it's own handle. This was added early ob for debugging and should be
-// obsolete.
-string BedrockTester::readDB(const string& query) { return getSQLiteDB().read(query); }
-
-bool BedrockTester::readDB(const string& query, SQResult& result) { return getSQLiteDB().read(query, result); }
 
 list<string> BedrockTester::getServerArgs() {
     // Use these defaults.

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -105,7 +105,13 @@ list<string> BedrockTester::getServerArgs() {
 
     // For anything in _args, add it to the defaults, replacing any existing value.
     for (auto row : _args) {
-        computedArgs[row.first] = row.second;
+        if (SStartsWith(row.second, "REPLACE_WITH_DB")) {
+            // This is a bit of a hack that lets callers ask for the DB file name, even though it may not have been set
+            // yet at construction, when this list is passed. Would be nice to fix.
+            computedArgs[row.first] = SReplace(row.second, "REPLACE_WITH_DB", _dbName);
+        } else {
+            computedArgs[row.first] = row.second;
+        }
     }
 
     // Convert to a list.

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -8,10 +8,7 @@ list<string> BedrockTester::locations = {
     "../bedrock",
     "../../bedrock"
 };
-set<string> BedrockTester::plugins = {
-    "db",
-    "cache"
-};
+SData* BedrockTester::globalArgs = nullptr;
 
 // Make llvm and gcc get along.
 #ifdef _NOEXCEPT
@@ -34,7 +31,8 @@ class BedrockTestException : public std::exception {
 
 // Create temporary file. Returns its name or the empty string on failure.
 string BedrockTester::getTempFileName(string prefix) {
-    string templateStr = "/tmp/" + prefix + "bedrocktest_XXXXXX.db";
+    string templateStr = "/var/lib/authdb/" + prefix + "bedrocktest_XXXXXX.db";
+    //string templateStr = "/tmp/" + prefix + "bedrocktest_XXXXXX.db";
     char buffer[templateStr.size() + 1];
     strcpy(buffer, templateStr.c_str());
     int filedes = mkstemps(buffer, 3);
@@ -90,7 +88,9 @@ BedrockTester::~BedrockTester() {
     }
     if (serverPID) {
         stopServer();
-        deleteFile(_dbFile);
+        if (deleteOnClose) {
+            deleteFile(_dbFile);
+        }
     }
 }
 
@@ -149,20 +149,18 @@ string BedrockTester::getServerName() {
 }
 
 list<string> BedrockTester::getServerArgs(map <string, string> args) {
-
     map <string, string> defaults = {
         {"-db",               _dbFile.empty() ? DB_FILE : _dbFile},
         {"-serverHost",       _serverAddr.empty() ? SERVER_ADDR : _serverAddr},
         {"-nodeName",        "bedrock_test"},
         {"-nodeHost",         "localhost:9889"},
         {"-priority",         "200"},
-        {"-plugins",          SComposeList(plugins)},
         {"-readThreads",      "8"},
         {"-maxJournalSize",   "100"},
         {"-v",                ""},
         {"-quorumCheckpoint", "50"},
         {"-parallelCommands", "Query,idcollision"},
-        {"-cache",            "10001"},
+        {"-cacheSize",        "1000"},
     };
 
     for (auto row : defaults) {
@@ -254,12 +252,21 @@ void BedrockTester::stopServer() {
 }
 
 vector<pair<string,string>> BedrockTester::executeWaitMultiple(vector<SData> requests, int connections) {
+    auto results = executeWaitMultipleData(requests, connections);
+    vector<pair<string,string>> response;
+    for (auto p : results) {
+        response.push_back(make_pair(p.first, p.second.content));
+    }
+    return response;
+}
+
+vector<pair<string,SData>> BedrockTester::executeWaitMultipleData(vector<SData> requests, int connections) {
 
     // Synchronize dequeuing requessts, and saving results.
     recursive_mutex listLock;
 
     // Our results go here.
-    vector<pair<string,string>> results;
+    vector<pair<string,SData>> results;
     results.resize(requests.size());
 
     // This is the next index of `requests` that needs processing.
@@ -334,7 +341,7 @@ vector<pair<string,string>> BedrockTester::executeWaitMultiple(vector<SData> req
                             //SAUTOLOCK(listLock);
                             //cout << "Timeout (" << timeouts << ") waiting on socket, will try again." << endl;
                         }
-                        if (timeouts == 60) {
+                        if (timeouts == 600) {
                             SAUTOLOCK(listLock);
                             cout << "Thread " << i << ". Too many timeouts! Giving up on: " << myRequest["Query"] << endl;
                             break;
@@ -348,10 +355,14 @@ vector<pair<string,string>> BedrockTester::executeWaitMultiple(vector<SData> req
                     SAUTOLOCK(listLock);
                     if (timeouts == 60) {
                         // cout << "this failed: " << myRequest.serialize() << endl;
-                        results[myIndex] = make_pair("000 Timeout", myRequest.serialize());
+                        results[myIndex] = make_pair("000 Timeout", myRequest);
                     } else {
                         // Ok, done, let's lock again and insert this in the results.
-                        results[myIndex] = make_pair(methodLine, content);
+                        SData responseData;
+                        responseData.nameValueMap = headers;
+                        responseData.methodLine = methodLine;
+                        responseData.content = content;
+                        results[myIndex] = make_pair(methodLine, responseData);
                     }
                 }
             }
@@ -368,6 +379,93 @@ vector<pair<string,string>> BedrockTester::executeWaitMultiple(vector<SData> req
 
     // All done!
     return results;
+}
+
+// Returns no results, does less work.
+void BedrockTester::executeWaitMultipleFast(const vector<SData>& requests, int connections) {
+
+    // Synchronize dequeuing requessts, and saving results.
+    recursive_mutex listLock;
+
+    // This is the next index of `requests` that needs processing.
+    int currentIndex = 0;
+
+    // This is the list of threads that we'll use for each connection.
+    list <thread> threads;
+
+    // Spawn a thread for each connection.
+    for (int i = 0; i < connections; i++) {
+        threads.emplace_back([&, i](){
+            // Create a socket.
+            int socket = S_socket(_serverAddr.empty() ? SERVER_ADDR : _serverAddr, true, false, true);
+            while (true) {
+                size_t myIndex = 0;
+                SData myRequest;
+                {
+                    SAUTOLOCK(listLock);
+                    myIndex = currentIndex;
+                    currentIndex++;
+                    if (myIndex >= requests.size()) {
+                        // No more requests to process.
+                        break;
+                    } else {
+                        myRequest = requests[myIndex];
+                    }
+                }
+
+                // We've released our lock so other threads can dequeue stuff now.
+                // Send some stuff on our socket.
+                string sendBuffer = myRequest.serialize();
+                // Send our data.
+                while (sendBuffer.size()) {
+                    bool result = S_sendconsume(socket, sendBuffer);
+                    if (!result) {
+                        break;
+                    }
+                }
+
+                // Receive some stuff on our socket.
+                string recvBuffer = "";
+                string methodLine, content;
+                STable headers;
+                int timeouts = 0;
+                while (!SParseHTTP(recvBuffer.c_str(), recvBuffer.size(), methodLine, headers, content)) {
+                    // Poll the socket, so we get a timeout.
+                    pollfd readSock;
+                    readSock.fd = socket;
+                    readSock.events = POLLIN;
+                    readSock.revents = 0;
+
+                    // wait for a second...
+                    poll(&readSock, 1, 1000);
+                    if (readSock.revents & POLLIN) {
+                        bool result = S_recvappend(socket, recvBuffer);
+                        if (!result) {
+                            break;
+                        }
+                    } else {
+                        timeouts++;
+                        if (timeouts > 5) {
+                            //SAUTOLOCK(listLock);
+                            //cout << "Timeout (" << timeouts << ") waiting on socket, will try again." << endl;
+                        }
+                        if (timeouts == 300) {
+                            SAUTOLOCK(listLock);
+                            cout << "Thread " << i << ". Too many timeouts! Giving up on: " << myRequest["Query"] << endl;
+                            break;
+                        }
+                    }
+
+                }
+            }
+            close(socket);
+        });
+    }
+
+    // Wait for our threads to finish.
+    for (thread& t : threads) {
+        t.join();
+    }
 }
 
 string BedrockTester::getServerAddr() {

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -286,7 +286,7 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
                 // Lock to avoid log lines writing over each other.
                 {
                     SAUTOLOCK(listLock);
-                    if (timeouts == 60) {
+                    if (timeouts == 600) {
                         SData responseData = myRequest;
                         responseData.nameValueMap = headers;
                         responseData.methodLine = "000 Timeout";

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -8,6 +8,10 @@ list<string> BedrockTester::locations = {
     "../bedrock",
     "../../bedrock"
 };
+set<string> BedrockTester::plugins = {
+    "db",
+    "cache"
+};
 SData* BedrockTester::globalArgs = nullptr;
 
 // Make llvm and gcc get along.
@@ -31,8 +35,7 @@ class BedrockTestException : public std::exception {
 
 // Create temporary file. Returns its name or the empty string on failure.
 string BedrockTester::getTempFileName(string prefix) {
-    string templateStr = "/var/lib/authdb/" + prefix + "bedrocktest_XXXXXX.db";
-    //string templateStr = "/tmp/" + prefix + "bedrocktest_XXXXXX.db";
+    string templateStr = "/tmp/" + prefix + "bedrocktest_XXXXXX.db";
     char buffer[templateStr.size() + 1];
     strcpy(buffer, templateStr.c_str());
     int filedes = mkstemps(buffer, 3);
@@ -155,6 +158,7 @@ list<string> BedrockTester::getServerArgs(map <string, string> args) {
         {"-nodeName",        "bedrock_test"},
         {"-nodeHost",         "localhost:9889"},
         {"-priority",         "200"},
+        {"-plugins",          SComposeList(plugins)},
         {"-readThreads",      "8"},
         {"-maxJournalSize",   "100"},
         {"-v",                ""},

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -27,10 +27,7 @@ class BedrockTester {
     // Shuts down all bedrock servers associated with any testers.
     static void stopAll();
 
-    SQLite* db = nullptr;
-    SQLite* writableDB = nullptr;
-
-
+    // Returns the address of this server.
     string getServerAddr() { return _serverAddr; };
 
     // Constructor/destructor
@@ -54,12 +51,7 @@ class BedrockTester {
     // If the response method line doesn't begin with the expected result, throws.
     string executeWaitVerifyContent(SData request, const string& expectedResult = "200");
 
-    string readDB(const string& query);
-    bool readDB(const string& query, SQResult& result);
-    SQLite& getSQLiteDB();
-    SQLite& getWritableSQLiteDB();
-
-  private:
+  protected:
     // returns a list of arguments with which to start the server.
     list<string> getServerArgs();
 

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -15,7 +15,7 @@ class BedrockTester {
     static bool deleteFile(string name);
     static bool startServers;
     static list<string> locations;
-
+    static set<string> plugins;
     static SData* globalArgs;
 
     uint64_t nextActivity;

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -49,6 +49,11 @@ class BedrockTester {
     // If the response method line doesn't begin with the expected result, throws.
     string executeWaitVerifyContent(SData request, const string& expectedResult = "200");
 
+    // Read from the DB file. Interface is the same as SQLiteNode's 'read' for backwards compatibility.
+    string readDB(const string& query); 
+    bool readDB(const string& query, SQResult& result);
+    SQLite& getSQLiteDB();
+
   protected:
     // Args passed on creation, which will be used to start the server if the `start` flag is set, or if `startServer`
     // is called later on with an empty args list.
@@ -66,4 +71,7 @@ class BedrockTester {
 
     // Flag indicating whether the DB should be kept when the tester is destroyed.
     bool _keepFilesWhenFinished;
+
+    // A version of the DB that can be queries without going through bedrock.
+    SQLite* _db = 0;
 };

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -40,8 +40,8 @@ class BedrockTester {
     ~BedrockTester();
 
     // Start and stop the bedrock server.
-    void stopServer();
     void startServer();
+    void stopServer();
 
     // Takes a list of requests, and returns a corresponding list of responses.
     // Uses `connections` parallel connections to the server to send the requests.

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -15,12 +15,15 @@ class BedrockTester {
     static bool deleteFile(string name);
     static bool startServers;
     static list<string> locations;
-    static set<string> plugins;
+
+    static SData* globalArgs;
 
     uint64_t nextActivity;
     int serverPID = 0;
     SQLite* db = nullptr;
     SQLite* writableDB = nullptr;
+
+    bool deleteOnClose = true;
 
     string getServerAddr();
 
@@ -37,6 +40,12 @@ class BedrockTester {
     // like executeWait, except it will execute multiple requests in parallel over several simultaneous connections.
     // returns a pair of strings for each request, with the response code and the response text, in that order.
     vector<pair<string,string>> executeWaitMultiple(vector<SData> requests, int connections = 10);
+
+    // Same as above, but returns entire SData for the response
+    vector<pair<string, SData>> executeWaitMultipleData(vector<SData> requests, int connections = 10);
+
+    // Same as above, but returns entire SData for the response
+    void executeWaitMultipleFast(const vector<SData>& requests, int connections = 10);
 
     string readDB(const string& query);
     bool readDB(const string& query, SQResult& result);

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -18,8 +18,8 @@ class BedrockTester {
     // Default values for the location of the DB file and the server to talk to.
     // These can be over-ridden when instantiating a tester.
     // Typically, these values will be set in main().
-    static string dbFile;
-    static string serverAddr;
+    static string defaultDBFile;
+    static string defaultServerAddr;
 
     // This is expected to be set by main, built from argv, to expose command-line options to tests.
     static SData globalArgs;
@@ -31,11 +31,9 @@ class BedrockTester {
     string getServerAddr() { return _serverAddr; };
 
     // Constructor/destructor
-    BedrockTester(const string& filename = "",
-                  const string& serverAddress = "",
-                  const list<string>& queries = {},
-                  const map<string, string>& args = {},
-                  bool start = true,
+    BedrockTester(const map<string, string>& args = {},
+                  const list<string>& queries = {}, 
+                  bool startImmediately = true,
                   bool keepFilesWhenFinished = false);
     ~BedrockTester();
 
@@ -52,12 +50,9 @@ class BedrockTester {
     string executeWaitVerifyContent(SData request, const string& expectedResult = "200");
 
   protected:
-    // returns a list of arguments with which to start the server.
-    list<string> getServerArgs();
-
     // Args passed on creation, which will be used to start the server if the `start` flag is set, or if `startServer`
     // is called later on with an empty args list.
-    const map<string, string> _args;
+    map<string, string> _args;
 
     // If these are set, they'll be used instead of the global defaults.
     string _serverAddr;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -68,9 +68,9 @@ int main(int argc, char* argv[]) {
     }
 
     // Set the defaults for the servers that each BedrockTester will start.
-    BedrockTester::dbFile = BedrockTester::getTempFileName();
-    cout << "Temp file for this run: " << BedrockTester::dbFile << endl;
-    BedrockTester::serverAddr = "127.0.0.1:8989";
+    BedrockTester::defaultDBFile = BedrockTester::getTempFileName();
+    cout << "Temp file for this run: " << BedrockTester::defaultDBFile << endl;
+    BedrockTester::defaultServerAddr = "127.0.0.1:8989";
 
     if (args.isSet("-wait")) {
         cout << "Waiting... (type anything to continue)." << endl;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -9,28 +9,16 @@
  * -wait            : Waits before running tests, in case you want to connect with the debugger.
  */
 
-void cleanup() {
-    if (BedrockTester::serverPIDs.size()) {
-        cout << BedrockTester::serverPIDs.size() << " servers to stop." << endl;
-        while (BedrockTester::serverPIDs.size()) {
-            BedrockTester::stopServer(*(BedrockTester::serverPIDs.begin()));
-        }
-    }
-
-    // Delete temp file.
-    BedrockTester::deleteFile(BedrockTester::DB_FILE);
-}
-
 void sigclean(int sig) {
     cout << "Got SIGINT, cleaning up." << endl;
-    cleanup();
+    BedrockTester::stopAll();
     cout << "Done." << endl;
     exit(1);
 }
 
 int main(int argc, char* argv[]) {
     SData args = SParseCommandLine(argc, argv);
-    BedrockTester::globalArgs = &args;
+    BedrockTester::globalArgs = args;
 
     // Catch sigint.
     signal(SIGINT, sigclean);
@@ -80,17 +68,9 @@ int main(int argc, char* argv[]) {
     }
 
     // Set the defaults for the servers that each BedrockTester will start.
-    BedrockTester::DB_FILE = BedrockTester::getTempFileName();
-    cout << "Temp file for this run: " << BedrockTester::DB_FILE << endl;
-    BedrockTester::SERVER_ADDR = "127.0.0.1:8989";
-
-    if (args.isSet("-dontStartServer")) {
-        BedrockTester::startServers = false;
-        cout << "Not starting server, would have run:" << endl;
-        //cout << BedrockTester::getCommandLine() << endl;
-        cout << "TYLER BROKE THIS. FIX EVENTUALLY." << endl;
-        exit(1);
-    }
+    BedrockTester::dbFile = BedrockTester::getTempFileName();
+    cout << "Temp file for this run: " << BedrockTester::dbFile << endl;
+    BedrockTester::serverAddr = "127.0.0.1:8989";
 
     if (args.isSet("-wait")) {
         cout << "Waiting... (type anything to continue)." << endl;
@@ -105,8 +85,6 @@ int main(int argc, char* argv[]) {
         cout << "Unhandled exception running tests!" << endl;
         retval = 1;
     }
-
-    cleanup();
 
     return retval;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -30,6 +30,7 @@ void sigclean(int sig) {
 
 int main(int argc, char* argv[]) {
     SData args = SParseCommandLine(argc, argv);
+    BedrockTester::globalArgs = &args;
 
     // Catch sigint.
     signal(SIGINT, sigclean);
@@ -67,6 +68,15 @@ int main(int argc, char* argv[]) {
     }
     if (args.isSet("-threads")) {
         threads = SToInt(args["-threads"]);
+    }
+
+    // Perf is excluded unless specified explicitly.
+    if (args.isSet("-perf")) {
+        include.insert("Perf");
+        exclude.erase("Perf");
+    } else {
+        include.erase("Perf");
+        exclude.insert("Perf");
     }
 
     // Set the defaults for the servers that each BedrockTester will start.

--- a/test/tests/ReadTest.cpp
+++ b/test/tests/ReadTest.cpp
@@ -18,7 +18,7 @@ struct ReadTest : tpunit::TestFixture {
     void simpleRead() {
         SData status("Query");
         status["query"] = "SELECT 1;";
-        string response = tester->executeWait(status);
+        string response = tester->executeWaitVerifyContent(status);
         int val = SToInt(response);
         ASSERT_EQUAL(val, 1);
     }
@@ -26,7 +26,7 @@ struct ReadTest : tpunit::TestFixture {
     void simpleReadWithHttp() {
         SData status("Query / HTTP/1.1");
         status["query"] = "SELECT 1;";
-        string response = tester->executeWait(status);
+        string response = tester->executeWaitVerifyContent(status);
         int val = SToInt(response);
         ASSERT_EQUAL(val, 1);
     }
@@ -34,7 +34,7 @@ struct ReadTest : tpunit::TestFixture {
     void readNoSemicolon() {
         SData status("Query");
         status["query"] = "SELECT 1";
-        tester->executeWait(status, "502 Query aborted");
+        tester->executeWaitVerifyContent(status, "502");
     }
 
 } __ReadTest;

--- a/test/tests/StatusTest.cpp
+++ b/test/tests/StatusTest.cpp
@@ -15,7 +15,7 @@ struct StatusTest : tpunit::TestFixture {
 
     void test() {
         SData status("Status");
-        string response = tester->executeWait(status);
+        string response = tester->executeWaitMultipleData({status})[0].content;
         ASSERT_TRUE(SContains(response, "plugins"));
         ASSERT_TRUE(SContains(response, "multiWriteWhiteList"));
     }

--- a/test/tests/WriteTest.cpp
+++ b/test/tests/WriteTest.cpp
@@ -39,12 +39,12 @@ struct WriteTest : tpunit::TestFixture {
             SData status("Query");
             status["writeConsistency"] = "ASYNC";
             status["query"] = "INSERT INTO foo VALUES ( RANDOM() );";
-            tester->executeWait(status);
+            tester->executeWaitVerifyContent(status);
         }
 
         SData status("Query");
         status["query"] = "SELECT COUNT(*) FROM foo;";
-        string response = tester->executeWait(status);
+        string response = tester->executeWaitVerifyContent(status);
         // Skip the header line.
         string secondLine = response.substr(response.find('\n') + 1);
         int val = SToInt(secondLine);
@@ -62,13 +62,13 @@ struct WriteTest : tpunit::TestFixture {
             query["query"] = "INSERT INTO stuff VALUES ( NULL, " + SQ(i) + " );";
             requests.push_back(query);
         }
-        auto results = tester->executeWaitMultiple(requests);
+        auto results = tester->executeWaitMultipleData(requests);
 
         int success = 0;
         int failure = 0;
 
         for (auto& row : results) {
-            if (SToInt(row.first) == 200) {
+            if (SToInt(row.methodLine) == 200) {
                 success++;
             } else {
                 failure++;
@@ -80,7 +80,7 @@ struct WriteTest : tpunit::TestFixture {
         // Verify there's actually data there.
         SData status("Query");
         status["query"] = "SELECT COUNT(*) FROM stuff;";
-        string response = tester->executeWait(status);
+        string response = tester->executeWaitVerifyContent(status);
         // Skip the header line.
         string secondLine = response.substr(response.find('\n') + 1);
         int val = SToInt(secondLine);
@@ -91,14 +91,14 @@ struct WriteTest : tpunit::TestFixture {
         SData status("Query");
         status["writeConsistency"] = "ASYNC";
         status["query"] = "INSERT INTO foo VALUES ( RANDOM() )";
-        tester->executeWait(status, "502 Query aborted");
+        tester->executeWaitVerifyContent(status, "502 Query aborted");
     }
 
     void failedDeleteNoWhere() {
         SData status("Query");
         status["writeConsistency"] = "ASYNC";
         status["query"] = "DELETE FROM foo;";
-        tester->executeWait(status, "502 Query aborted");
+        tester->executeWaitVerifyContent(status, "502 Query aborted");
     }
 
     void deleteNoWhereFalse() {
@@ -106,7 +106,7 @@ struct WriteTest : tpunit::TestFixture {
         status["writeConsistency"] = "ASYNC";
         status["query"] = "DELETE FROM foo;";
         status["nowhere"] = "false";
-        tester->executeWait(status, "502 Query aborted");
+        tester->executeWaitVerifyContent(status, "502 Query aborted");
     }
 
     void deleteNoWhereTrue() {
@@ -114,34 +114,34 @@ struct WriteTest : tpunit::TestFixture {
         status["writeConsistency"] = "ASYNC";
         status["query"] = "DELETE FROM foo;";
         status["nowhere"] = "true";
-        tester->executeWait(status);
+        tester->executeWaitVerifyContent(status);
     }
 
     void deleteWithWhere() {
         SData status("Query");
         status["writeConsistency"] = "ASYNC";
         status["query"] = "INSERT INTO foo VALUES ( 666 );";
-        tester->executeWait(status);
+        tester->executeWaitVerifyContent(status);
 
         status["query"] = "DELETE FROM foo WHERE bar = 666;";
-        tester->executeWait(status);
+        tester->executeWaitVerifyContent(status);
     }
 
     void update() {
         SData status("Query");
         status["writeConsistency"] = "ASYNC";
         status["query"] = "INSERT INTO foo VALUES ( 666 );";
-        tester->executeWait(status);
+        tester->executeWaitVerifyContent(status);
 
         status["query"] = "UPDATE foo SET bar = 777 WHERE bar = 666;";
-        tester->executeWait(status);
+        tester->executeWaitVerifyContent(status);
     }
 
     void failedUpdateNoWhere() {
         SData status("Query");
         status["writeConsistency"] = "ASYNC";
         status["query"] = "UPDATE foo SET bar = 0;";
-        tester->executeWait(status, "502 Query aborted");
+        tester->executeWaitVerifyContent(status, "502 Query aborted");
     }
 
     void failedUpdateNoWhereFalse() {
@@ -149,7 +149,7 @@ struct WriteTest : tpunit::TestFixture {
         status["writeConsistency"] = "ASYNC";
         status["query"] = "UPDATE foo SET bar = 0;";
         status["nowhere"] = "false";
-        tester->executeWait(status, "502 Query aborted");
+        tester->executeWaitVerifyContent(status, "502 Query aborted");
     }
 
     void failedUpdateNoWhereTrue() {
@@ -157,17 +157,17 @@ struct WriteTest : tpunit::TestFixture {
         status["writeConsistency"] = "ASYNC";
         status["query"] = "UPDATE foo SET bar = 0;";
         status["nowhere"] = "true";
-        tester->executeWait(status);
+        tester->executeWaitVerifyContent(status);
     }
 
     void updateAndInsertWithHttp() {
         SData status("Query / HTTP/1.1");
         status["writeConsistency"] = "ASYNC";
         status["query"] = "INSERT INTO foo VALUES ( 666 );";
-        tester->executeWait(status);
+        tester->executeWaitVerifyContent(status);
 
         status["query"] = "UPDATE foo SET bar = 777 WHERE bar = 666;";
-        tester->executeWait(status);
+        tester->executeWaitVerifyContent(status);
     }
 
 } __WriteTest;

--- a/test/tests/WriteTest.cpp
+++ b/test/tests/WriteTest.cpp
@@ -20,14 +20,11 @@ struct WriteTest : tpunit::TestFixture {
 
     BedrockTester* tester;
 
-
-    list<string> queries = {
-        "CREATE TABLE foo (bar INTEGER);",
-        "CREATE TABLE stuff (id INTEGER PRIMARY KEY, value INTEGER);",
-    };
-
     void setup() {
-        tester = new BedrockTester("", "", queries);
+        tester = new BedrockTester({}, {
+            "CREATE TABLE foo (bar INTEGER);",
+            "CREATE TABLE stuff (id INTEGER PRIMARY KEY, value INTEGER);",
+        });
     }
 
     void tearDown() {


### PR DESCRIPTION
While doing a lot of testing, dealing with similar but disparate Tester classes in Auth and Bedrock, and dealing with redundant code in both of them, I decide to clean them both up, and make AuthTester a subclass of BedrockTester, such that improvements to BedrockTester don't need to be replicated in AuthTester.

This is the bedrock portion of the change. A separate PR will be made in Server-Expensify for the auth change.