### PR TITLE
Improve exception error messages

### DIFF
--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -18,17 +18,6 @@ list<string> BedrockTester::locations = {
 #define __NOEXCEPT _GLIBCXX_USE_NOEXCEPT
 #endif
 
-class BedrockTestException : public std::exception {
-  private:
-    const string message;
-
-  public:
-    BedrockTestException(string message_) : message(message_) {}
-    virtual const char* what() const __NOEXCEPT {
-        return message.c_str();
-    }
-};
-
 string BedrockTester::getTempFileName(string prefix) {
     string templateStr = "/tmp/" + prefix + "bedrocktest_XXXXXX.db";
     char buffer[templateStr.size() + 1];

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -1,6 +1,9 @@
 #include "BedrockTester.h"
 #include <sys/wait.h>
 
+BedrockTestException::BedrockTestException(string message_) : message(message_) {}
+const char* BedrockTestException::what() const noexcept { return message.c_str(); }
+
 // Define static vars.
 string BedrockTester::defaultDBFile;
 string BedrockTester::defaultServerAddr;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -29,8 +29,6 @@ class BedrockTestException : public std::exception {
     }
 };
 
-
-
 string BedrockTester::getTempFileName(string prefix) {
     string templateStr = "/tmp/" + prefix + "bedrocktest_XXXXXX.db";
     char buffer[templateStr.size() + 1];

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -18,6 +18,19 @@ list<string> BedrockTester::locations = {
 #define __NOEXCEPT _GLIBCXX_USE_NOEXCEPT
 #endif
 
+class BedrockTestException : public std::exception {
+  private:
+    const string message;
+
+  public:
+    BedrockTestException(string message_) : message(message_) {}
+    virtual const char* what() const __NOEXCEPT {
+        return message.c_str();
+    }
+};
+
+
+
 string BedrockTester::getTempFileName(string prefix) {
     string templateStr = "/tmp/" + prefix + "bedrocktest_XXXXXX.db";
     char buffer[templateStr.size() + 1];
@@ -203,10 +216,10 @@ void BedrockTester::stopServer() {
 string BedrockTester::executeWaitVerifyContent(SData request, const string& expectedResult) {
     auto results = executeWaitMultipleData({request}, 1);
     if (results.size() == 0) {
-        throw "No result.";
+        throw BedrockTestException("No result.");
     }
     if (!SStartsWith(results[0].methodLine, expectedResult)) {
-        throw "Expected " + expectedResult + ", but got: " + results[0].methodLine;
+        throw BedrockTestException("Expected " + expectedResult + ", but got: " + results[0].methodLine);
     }
     return results[0].content;
 }

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -1,9 +1,6 @@
 #include "BedrockTester.h"
 #include <sys/wait.h>
 
-BedrockTestException::BedrockTestException(string message_) : message(message_) {}
-const char* BedrockTestException::what() const noexcept { return message.c_str(); }
-
 // Define static vars.
 string BedrockTester::defaultDBFile;
 string BedrockTester::defaultServerAddr;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -11,13 +11,6 @@ list<string> BedrockTester::locations = {
     "../../bedrock"
 };
 
-// Make llvm and gcc get along.
-#ifdef _NOEXCEPT
-#define __NOEXCEPT _NOEXCEPT
-#else
-#define __NOEXCEPT _GLIBCXX_USE_NOEXCEPT
-#endif
-
 string BedrockTester::getTempFileName(string prefix) {
     string templateStr = "/tmp/" + prefix + "bedrocktest_XXXXXX.db";
     char buffer[templateStr.size() + 1];

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -9,10 +9,8 @@ class BedrockTestException : public std::exception {
     const string message;
 
   public:
-    BedrockTestException(string message_) : message(message_) {}
-    virtual const char* what() noexcept {
-        return message.c_str();
-    }
+    BedrockTestException(string message_) : message(message_) {};
+    const char* what() const noexcept { return message.c_str(); };
 };
 
 class BedrockTester {

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -4,6 +4,17 @@
 #include <test/lib/TestHTTPS.h>
 #include <test/lib/tpunit++.hpp>
 
+class BedrockTestException : public std::exception {
+  private:
+    const string message;
+
+  public:
+    BedrockTestException(string message_) : message(message_) {}
+    virtual const char* what() const __NOEXCEPT {
+        return message.c_str();
+    }
+};
+
 class BedrockTester {
   public:
     // Generate a temporary filename for a test DB, with an optional prefix.

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -10,7 +10,7 @@ class BedrockTestException : public std::exception {
 
   public:
     BedrockTestException(string message_) : message(message_) {}
-    virtual const char* what() const __NOEXCEPT {
+    virtual const char* what() noexcept {
         return message.c_str();
     }
 };


### PR DESCRIPTION
@mea36 

Fixes exceptions thrown by BedrockTester to show print errors when caught by tpunit++.