### PR TITLE
Add tests for CreateJob(s), RetryJob, and FinishJob

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -452,7 +452,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                     SWARN("Trying to create child job with parent jobID#" << parentJobID << ", but parent isn't RUNNING or PAUSED (" << result[0][0] << ")");
                     throw "405 Can only create child job when parent is RUNNING or PAUSED";
                 }
-              
+
                 // Prevent jobs from creating grandchildren
                 if (!SIEquals(result[0][1], "0")) {
                     SWARN("Trying to create grandchild job with parent jobID#" << parentJobID);
@@ -463,7 +463,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             // Are we creating a new job, or updating an existing job?
             if (updateJobID) {
                 // Update the existing job.
-                if(!db.write("UPDATE JOBS SET "
+                if(!db.write("UPDATE jobs SET "
                                "repeat   = " + SQ(SToUpper(job["repeat"])) + ", " +
                                "data     = JSON_PATCH(data, " + safeData + "), " +
                                "priority = " + SQ(priority) + " " +
@@ -548,7 +548,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         // works!
         SQResult result;
         const string& name = request["name"];
-        string safeNumResults = SQ(max(request.calc("numResults"),1)); 
+        string safeNumResults = SQ(max(request.calc("numResults"),1));
         string selectQuery =
             "SELECT jobID, name, data, parentJobID FROM ( "
                 "SELECT * FROM ("

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -270,7 +270,8 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
         if (!db.read("SELECT j.state, GROUP_CONCAT(jj.jobID) "
                      "FROM jobs j "
                      "LEFT JOIN jobs jj ON jj.parentJobID = j.jobID "
-                     "WHERE j.jobID=" + SQ(jobID) + ";",
+                     "WHERE j.jobID=" + SQ(jobID) + " "
+                     "GROUP BY j.jobID;",
                      result)) {
             throw "502 Select failed";
         }

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -211,6 +211,11 @@ string BedrockTester::executeWaitVerifyContent(SData request, const string& expe
     return results[0].content;
 }
 
+STable BedrockTester::executeWaitVerifyContentTable(SData request, const string& expectedResult) {
+    string result = executeWaitVerifyContent(request, expectedResult);
+    return SParseJSONObject(result);
+}
+
 vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int connections) {
     // Synchronize dequeuing requests, and saving results.
     recursive_mutex listLock;

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -49,8 +49,12 @@ class BedrockTester {
     // If the response method line doesn't begin with the expected result, throws.
     string executeWaitVerifyContent(SData request, const string& expectedResult = "200");
 
+    // Sends a single request, returning the response content as a STable.
+    // If the response method line doesn't begin with the expected result, throws.
+    STable executeWaitVerifyContentTable(SData request, const string& expectedResult = "200");
+
     // Read from the DB file. Interface is the same as SQLiteNode's 'read' for backwards compatibility.
-    string readDB(const string& query); 
+    string readDB(const string& query);
     bool readDB(const string& query, SQResult& result);
     SQLite& getSQLiteDB();
 

--- a/test/tests/jobs/CancelJobTest.cpp
+++ b/test/tests/jobs/CancelJobTest.cpp
@@ -16,7 +16,7 @@ struct CancelJobTest : tpunit::TestFixture {
 
     BedrockTester* tester;
 
-    void setupClass() { tester = new BedrockTester({{"-plugins", "Jobs,DB"}}, {}, true, true);}
+    void setupClass() { tester = new BedrockTester({{"-plugins", "Jobs,DB"}}, {});}
 
     // Reset the jobs table
     void tearDown() {

--- a/test/tests/jobs/CancelJobTest.cpp
+++ b/test/tests/jobs/CancelJobTest.cpp
@@ -1,0 +1,268 @@
+#include <test/lib/BedrockTester.h>
+
+struct CancelJobTest : tpunit::TestFixture {
+    CancelJobTest()
+        : tpunit::TestFixture("CancelJob",
+                              BEFORE_CLASS(CancelJobTest::setupClass),
+                              TEST(CancelJobTest::cancelNonExistentJob),
+                              TEST(CancelJobTest::cancelJobWithChild),
+                              TEST(CancelJobTest::cancelRunningJob),
+                              TEST(CancelJobTest::cancelFinishedJob),
+                              TEST(CancelJobTest::cancelPausedJob),
+                              TEST(CancelJobTest::cancelJob),
+                              TEST(CancelJobTest::cancelChildJob),
+                              AFTER(CancelJobTest::tearDown),
+                              AFTER_CLASS(CancelJobTest::tearDownClass)) { }
+
+    BedrockTester* tester;
+
+    void setupClass() { tester = new BedrockTester({{"-plugins", "Jobs,DB"}}, {}, true, true);}
+
+    // Reset the jobs table
+    void tearDown() {
+        SData command("Query");
+        command["query"] = "DELETE FROM jobs WHERE jobID > 0;";
+        tester->executeWaitVerifyContent(command);
+    }
+
+    void tearDownClass() { delete tester; }
+
+    // Cannot cancel a job that doesn't exist
+    void cancelNonExistentJob() {
+        SData command("CancelJob");
+        command["jobID"] = "1";
+        tester->executeWaitVerifyContent(command, "404 No job with this jobID");
+    }
+
+    // Cannot cancel a job with children
+    void cancelJobWithChild() {
+        // Create a parent job
+        SData command("CreateJob");
+        command["name"] = "parent";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string parentID = response["jobID"];
+
+        // Get the parent
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "parent";
+        tester->executeWaitVerifyContent(command);
+
+        // Create the child
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string childID = response["jobID"];
+
+        // Finish the parent
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = parentID;
+        tester->executeWaitVerifyContent(command);
+
+        // Get the child and finish it to put the parent in the QUEUED state
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "child";
+        tester->executeWaitVerifyContent(command);
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = childID;
+        tester->executeWaitVerifyContent(command);
+
+        // Assert parent is in QUEUED state
+        SQResult result;
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + parentID + ";", result);
+        ASSERT_EQUAL(result[0][0], "QUEUED");
+
+        // Cannot finish a job with a child
+        command.clear();
+        command.methodLine = "CancelJob";
+        command["jobID"] = parentID;
+        tester->executeWaitVerifyContent(command, "404 Invalid jobID - Cannot cancel a job with children");
+    }
+
+    // Ignore canceljob for RUNNING jobs
+    void cancelRunningJob() {
+        // Create a job
+        SData command("CreateJob");
+        command["name"] = "job";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Assert job is in RUNNING state
+        SQResult result;
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + jobID + ";", result);
+        ASSERT_EQUAL(result[0][0], "RUNNING");
+
+        // Cannot finish a job in RUNNING state
+        command.clear();
+        command.methodLine = "CancelJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // Assert job state is unchanged
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + jobID + ";", result);
+        ASSERT_EQUAL(result[0][0], "RUNNING");
+    }
+
+    // Ignore canceljob for FINISHED jobs
+    void cancelFinishedJob() {
+        // Create a parent job
+        SData command("CreateJob");
+        command["name"] = "parent";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string parentID = response["jobID"];
+
+        // Get the parent
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "parent";
+        tester->executeWaitVerifyContent(command);
+
+        // Create the child
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string childID = response["jobID"];
+
+        // Finish the parent
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = parentID;
+        tester->executeWaitVerifyContent(command);
+
+        // Get the child and finish it to put the child in the FINISHED state
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "child";
+        tester->executeWaitVerifyContent(command);
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = childID;
+        tester->executeWaitVerifyContent(command);
+
+        // Assert job is in FINISHED state
+        SQResult result;
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + childID + ";", result);
+        ASSERT_EQUAL(result[0][0], "FINISHED");
+
+        // Cannot finish a job in FINISHED state
+        command.clear();
+        command.methodLine = "CancelJob";
+        command["jobID"] = childID;
+        tester->executeWaitVerifyContent(command);
+
+        // Assert job state is unchanged
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + childID + ";", result);
+        ASSERT_EQUAL(result[0][0], "FINISHED");
+    }
+
+    // Ignore canceljob for PAUSED jobs
+    void cancelPausedJob() {
+        // Create a parent job
+        SData command("CreateJob");
+        command["name"] = "parent";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string parentID = response["jobID"];
+
+        // Get the parent
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "parent";
+        tester->executeWaitVerifyContent(command);
+
+        // Create the child
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string childID = response["jobID"];
+
+        // Assert job is in PAUSED state
+        SQResult result;
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + childID + ";", result);
+        ASSERT_EQUAL(result[0][0], "PAUSED");
+
+        // Cannot finish a job in PAUSED state
+        command.clear();
+        command.methodLine = "CancelJob";
+        command["jobID"] = childID;
+        tester->executeWaitVerifyContent(command);
+
+        // Assert job state is unchanged
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + childID + ";", result);
+        ASSERT_EQUAL(result[0][0], "PAUSED");
+    }
+
+    // Cancel a job
+    void cancelJob() {
+        // Create a job
+        SData command("CreateJob");
+        command["name"] = "job";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Cancel it
+        command.clear();
+        command.methodLine = "CancelJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // Assert job state is cancelled
+        SQResult result;
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + jobID + ";", result);
+        ASSERT_EQUAL(result[0][0], "CANCELLED");
+    }
+
+    // Cancel a child job
+    void cancelChildJob() {
+        // Create a parent job
+        SData command("CreateJob");
+        command["name"] = "parent";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string parentID = response["jobID"];
+
+        // Get the parent
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "parent";
+        tester->executeWaitVerifyContent(command);
+
+        // Create the child
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string childID = response["jobID"];
+
+        // Finish the parent to put the child in the QUEUED state
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = parentID;
+        tester->executeWaitVerifyContent(command);
+
+        // Cancel the child
+        command.clear();
+        command.methodLine = "CancelJob";
+        command["jobID"] = childID;
+        tester->executeWaitVerifyContent(command);
+
+        // Assert job state is cancelled
+        SQResult result;
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + childID + ";", result);
+        ASSERT_EQUAL(result[0][0], "CANCELLED");
+    }
+} __CancelJobTest;

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -1,0 +1,237 @@
+#include <test/lib/BedrockTester.h>
+
+struct CreateJobTest : tpunit::TestFixture {
+    CreateJobTest()
+        : tpunit::TestFixture("CreateJob",
+                              BEFORE_CLASS(CreateJobTest::setupClass),
+                              TEST(CreateJobTest::create),
+                              TEST(CreateJobTest::createWithPriority),
+                              TEST(CreateJobTest::createWithData),
+                              TEST(CreateJobTest::createWithRepeat),
+                              TEST(CreateJobTest::uniqueJob),
+                              TEST(CreateJobTest::createWithBadData),
+                              TEST(CreateJobTest::createWithBadRepeat),
+                              TEST(CreateJobTest::createChildWithQueuedParent),
+                              TEST(CreateJobTest::createChildWithRunningGrandparent),
+                              AFTER(CreateJobTest::tearDown),
+                              AFTER_CLASS(CreateJobTest::tearDownClass)) { }
+
+    BedrockTester* tester;
+
+    void setupClass() { tester = new BedrockTester({{"-plugins", "Jobs,DB"}}, {});}
+
+    // Reset the jobs table
+    void tearDown() {
+        SData command("Query");
+        command["query"] = "DELETE FROM jobs WHERE jobID > 0;";
+        tester->executeWaitVerifyContent(command);
+    }
+
+    void tearDownClass() { delete tester; }
+
+    void create() {
+        SData command("CreateJob");
+        string jobName = "testCreate";
+        command["name"] = jobName;
+        STable response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_GREATER_THAN(SToInt(response["jobID"]), 0);
+
+        SQResult originalJob;
+        tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", originalJob);
+        ASSERT_EQUAL(originalJob.size(), 1);
+        // Assert the values are what we expect
+        ASSERT_EQUAL(originalJob[0][1], response["jobID"]);
+        ASSERT_EQUAL(originalJob[0][2], "QUEUED");
+        ASSERT_EQUAL(originalJob[0][3], jobName);
+        // nextRun should equal created
+        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
+        ASSERT_EQUAL(originalJob[0][5], "");
+        ASSERT_EQUAL(originalJob[0][6], "");
+        ASSERT_EQUAL(originalJob[0][7], "{}");
+        ASSERT_EQUAL(SToInt(originalJob[0][8]), 500);
+        ASSERT_EQUAL(SToInt(originalJob[0][9]), 0);
+    }
+
+    void createWithPriority() {
+        SData command("CreateJob");
+        string jobName = "testCreate";
+        string priority = "1000";
+        command["name"] = jobName;
+        command["priority"] = priority;
+        STable response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_GREATER_THAN(SToInt(response["jobID"]), 0);
+
+        SQResult originalJob;
+        tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", originalJob);
+        ASSERT_EQUAL(originalJob.size(), 1);
+        // Assert the values are what we expect
+        ASSERT_EQUAL(originalJob[0][1], response["jobID"]);
+        ASSERT_EQUAL(originalJob[0][2], "QUEUED");
+        ASSERT_EQUAL(originalJob[0][3], jobName);
+        // nextRun should equal created
+        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
+        ASSERT_EQUAL(originalJob[0][5], "");
+        ASSERT_EQUAL(originalJob[0][6], "");
+        ASSERT_EQUAL(originalJob[0][7], "{}");
+        ASSERT_EQUAL(originalJob[0][8], priority);
+        ASSERT_EQUAL(SToInt(originalJob[0][9]), 0);
+    }
+
+    void createWithData() {
+        SData command("CreateJob");
+        string jobName = "testCreate";
+        string data = "{\"blabla\":\"blabla\"}";
+        command["name"] = jobName;
+        command["data"] = data;
+        STable response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_GREATER_THAN(SToInt(response["jobID"]), 0);
+
+        SQResult originalJob;
+        tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", originalJob);
+        ASSERT_EQUAL(originalJob.size(), 1);
+        // Assert the values are what we expect
+        ASSERT_EQUAL(originalJob[0][1], response["jobID"]);
+        ASSERT_EQUAL(originalJob[0][2], "QUEUED");
+        ASSERT_EQUAL(originalJob[0][3], jobName);
+        // nextRun should equal created
+        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
+        ASSERT_EQUAL(originalJob[0][5], "");
+        ASSERT_EQUAL(originalJob[0][6], "");
+        ASSERT_EQUAL(originalJob[0][7], data);
+        ASSERT_EQUAL(SToInt(originalJob[0][8]), 500);
+        ASSERT_EQUAL(SToInt(originalJob[0][9]), 0);
+    }
+
+    void createWithRepeat() {
+        SData command("CreateJob");
+        string jobName = "testCreate";
+        string repeat = "SCHEDULED, +1 HOUR";
+        command["name"] = jobName;
+        command["repeat"] = repeat;
+        STable response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_GREATER_THAN(SToInt(response["jobID"]), 0);
+
+        SQResult originalJob;
+        tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", originalJob);
+        ASSERT_EQUAL(originalJob.size(), 1);
+        // Assert the values are what we expect
+        ASSERT_EQUAL(originalJob[0][1], response["jobID"]);
+        ASSERT_EQUAL(originalJob[0][2], "QUEUED");
+        ASSERT_EQUAL(originalJob[0][3], jobName);
+        // nextRun should equal created
+        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
+        ASSERT_EQUAL(originalJob[0][5], "");
+        ASSERT_EQUAL(originalJob[0][6], repeat);
+        ASSERT_EQUAL(originalJob[0][7], "{}");
+        ASSERT_EQUAL(SToInt(originalJob[0][8]), 500);
+        ASSERT_EQUAL(SToInt(originalJob[0][9]), 0);
+    }
+
+    // Create a unique job
+    // Then try to recreate the job with the some data
+    // Make sure the new data is saved
+    void uniqueJob() {
+        // Create a unique job
+        SData command("CreateJob");
+        string jobName = "blabla";
+        command["name"] = jobName;
+        command["unique"] = "true";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        int jobID = SToInt(response["jobID"]);
+        ASSERT_GREATER_THAN(jobID, 0);
+
+        SQResult originalJob;
+        tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", originalJob);
+
+        // Try to recreate the job with new data
+        string data = "{\"blabla\":\"test\"}";
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = jobName;
+        command["unique"] = "true";
+        command["data"] = data;
+        response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_EQUAL(SToInt(response["jobID"]), jobID);
+
+        SQResult updatedJob;
+        tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", updatedJob);
+        ASSERT_EQUAL(updatedJob.size(), 1);
+        // Assert the values are what we expect
+        ASSERT_EQUAL(updatedJob[0][0], originalJob[0][0]);
+        ASSERT_EQUAL(updatedJob[0][1], originalJob[0][1]);
+        ASSERT_EQUAL(updatedJob[0][2], originalJob[0][2]);
+        ASSERT_EQUAL(updatedJob[0][3], originalJob[0][3]);
+        ASSERT_EQUAL(updatedJob[0][4], originalJob[0][4]);
+        ASSERT_EQUAL(updatedJob[0][5], originalJob[0][5]);
+        ASSERT_EQUAL(updatedJob[0][6], originalJob[0][6]);
+        ASSERT_EQUAL(updatedJob[0][7], data);
+        ASSERT_EQUAL(updatedJob[0][8], originalJob[0][8]);
+        ASSERT_EQUAL(updatedJob[0][9], originalJob[0][9]);
+    }
+
+    void createWithBadData() {
+        SData command("CreateJob");
+        command["name"] = "blabla";
+        command["data"] = "blabla";
+        tester->executeWaitVerifyContent(command, "402 Data is not a valid JSON Object");
+    }
+
+    void createWithBadRepeat() {
+        SData command("CreateJob");
+        command["name"] = "blabla";
+        command["repeat"] = "blabla";
+        tester->executeWaitVerifyContent(command, "402 Malformed repeat");
+    }
+
+    // Cannot create a child job when parent is QUEUED
+    void createChildWithQueuedParent() {
+        // Create a parent job
+        SData command("CreateJob");
+        command["name"] = "parent";
+
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string parentID = response["jobID"];
+
+        // Try to create the child
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child";
+        command["parentJobID"] = parentID;
+        tester->executeWaitVerifyContent(command, "405 Can only create child job when parent is RUNNING or PAUSED");
+    }
+
+    // Cannot create a job with a running grandparent
+    void createChildWithRunningGrandparent() {
+        // Create a parent job
+        SData command("CreateJob");
+        command["name"] = "parent";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string parentID = response["jobID"];
+
+        // Get the parent
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "parent";
+        tester->executeWaitVerifyContent(command);
+
+        // Create the child
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string childID = response["jobID"];
+
+        // Assert parent is still running
+        SQResult result;
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + parentID + ";", result);
+        ASSERT_EQUAL(result[0][0], "RUNNING");
+
+        // Try to create grandchild
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "grandchild";
+        command["parentJobID"] = childID;
+        tester->executeWaitVerifyContent(command, "405 Cannot create grandchildren");
+    }
+} __CreateJobTest;

--- a/test/tests/jobs/CreateJobsTest.cpp
+++ b/test/tests/jobs/CreateJobsTest.cpp
@@ -1,0 +1,60 @@
+#include <test/lib/BedrockTester.h>
+
+struct CreateJobsTest : tpunit::TestFixture {
+    CreateJobsTest()
+        : tpunit::TestFixture("CreateJobs",
+                              BEFORE_CLASS(CreateJobsTest::setupClass),
+                              TEST(CreateJobsTest::create),
+                              TEST(CreateJobsTest::createWithInvalidJson),
+                              TEST(CreateJobsTest::createWithParentIDNotRunning),
+                              AFTER(CreateJobsTest::tearDown),
+                              AFTER_CLASS(CreateJobsTest::tearDownClass)) { }
+
+    BedrockTester* tester;
+
+    void setupClass() { tester = new BedrockTester({{"-plugins", "Jobs,DB"}}, {});}
+
+    // Reset the jobs table
+    void tearDown() {
+        SData command("Query");
+        command["query"] = "DELETE FROM jobs WHERE jobID > 0;";
+        tester->executeWaitVerifyContent(command);
+    }
+
+    void tearDownClass() { delete tester; }
+
+    void create() {
+        SData command("CreateJobs");
+        command["jobs"] = "[{\"name\":\"testCreate\", \"data\":{\"blabla\":\"blabla\"}, \"repeat\": \"SCHEDULED, +1 HOUR\"}, {\"name\":\"testCreate2\", \"data\":{\"nope\":\"nope\"}}]";
+        STable response = getJsonResult(command);
+        list<string> jobIDList = SParseJSONArray(response["jobIDs"]);
+        ASSERT_EQUAL(jobIDList.size(), 2);
+        string jobID1 = jobIDList.front();
+        string jobID2 = jobIDList.back();
+        ASSERT_NOT_EQUAL(jobID1, jobID2);
+    }
+
+    void createWithInvalidJson() {
+        SData command("CreateJobs");
+        command["jobs"] = "[{\"name\":\"testCreate\", \"data\":{\"blabla\":\"blabla\"}, \"parentJobID\":\"1000\", \"repeat\": \"SCHEDULED, +1 HOUR\"}, {\"testCreate2\", \"data\":{\"nope\":\"nope\"}}]";
+        tester->executeWaitVerifyContent(command, "401 Invalid JSON");
+    }
+
+    void createWithParentIDNotRunning() {
+        // First create parent job
+        SData command("CreateJob");
+        command["name"] = "blabla";
+        STable response = getJsonResult(command);
+
+        // Now try to create two new jobs
+        command.clear();
+        command.methodLine = "CreateJobs";
+        command["jobs"] = "[{\"name\":\"testCreate\", \"data\":{\"blabla\":\"blabla\"}, \"parentJobID\":\"" + response["jobID"] +"\", \"repeat\": \"SCHEDULED, +1 HOUR\"}, {\"name\":\"testCreate2\", \"data\":{\"nope\":\"nope\"}}]";
+        tester->executeWaitVerifyContent(command, "405 Can only create child job when parent is RUNNING or PAUSED");
+    }
+
+    STable getJsonResult(SData command) {
+        string resultJson = tester->executeWaitVerifyContent(command);
+        return SParseJSONObject(resultJson);
+    }
+} __CreateJobsTest;

--- a/test/tests/jobs/FinishJobTest.cpp
+++ b/test/tests/jobs/FinishJobTest.cpp
@@ -1,0 +1,356 @@
+#include <test/lib/BedrockTester.h>
+
+struct FinishJobTest : tpunit::TestFixture {
+    FinishJobTest()
+        : tpunit::TestFixture("FinishJob",
+                              BEFORE_CLASS(FinishJobTest::setupClass),
+                              TEST(FinishJobTest::nonExistentJob),
+                              TEST(FinishJobTest::notInRunningState),
+                              TEST(FinishJobTest::parentIsNotPaused),
+                              TEST(FinishJobTest::removeFinishedAndCancelledChildren),
+                              TEST(FinishJobTest::updateData),
+                              TEST(FinishJobTest::finishingParentUnPausesChildren),
+                              TEST(FinishJobTest::deleteFinishedJobWithNoChildren),
+                              TEST(FinishJobTest::hasRepeat),
+                              AFTER(FinishJobTest::tearDown),
+                              AFTER_CLASS(FinishJobTest::tearDownClass)) { }
+
+    BedrockTester* tester;
+
+    void setupClass() { tester = new BedrockTester({{"-plugins", "Jobs,DB"}}, {});}
+
+    // Reset the jobs table
+    void tearDown() {
+        SData command("Query");
+        command["query"] = "DELETE FROM jobs WHERE jobID > 0;";
+        tester->executeWaitVerifyContent(command);
+    }
+
+    void tearDownClass() { delete tester; }
+
+    // Throw an error if the job doesn't exist
+    void nonExistentJob() {
+        SData command("FinishJob");
+        command["jobID"] = "1";
+        tester->executeWaitVerifyContent(command, "404 No job with this jobID");
+    }
+
+    // Throw an error if the job is not in RUNNING state
+    void notInRunningState() {
+        // Create a job
+        SData command("CreateJob");
+        command["name"] = "job";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Finish it
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command, "405 Can only retry/finish RUNNING jobs");
+    }
+
+    // If job has a parentID, the parent should be paused
+    void parentIsNotPaused() {
+        // Create the parent
+        SData command("CreateJob");
+        command["name"] = "parent";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string parentID = response["jobID"];
+
+        // Get the parent
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "parent";
+        tester->executeWaitVerifyContent(command);
+
+        // Create the child
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string childID = response["jobID"];
+
+        // It's not possible to put the child in the QUEUED state without the parent being paused
+        // and a child cannot being the RUNNING state without first being the QUEUED state
+        // but we check for this to make sure something funky didn't occur.
+        // We'll manually put the child in the RUNNING state to hit this condition
+        command.clear();
+        command.methodLine = "Query";
+        command["query"] = "UPDATE jobs SET state = 'RUNNING' WHERE jobID = " + childID + ";";
+        tester->executeWaitVerifyContent(command);
+
+        // Finish the child
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = childID;
+        tester->executeWaitVerifyContent(command, "405 Can only retry/finish child job when parent is PAUSED");
+    }
+
+    // Child jobs that are in the FINISHED or CANCELLED state should be deleted when the parent is finished
+    void removeFinishedAndCancelledChildren() {
+        // Create the parent
+        SData command("CreateJob");
+        command["name"] = "parent";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string parentID = response["jobID"];
+
+        // Get the parent
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "parent";
+        tester->executeWaitVerifyContent(command);
+
+        // Create the children
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child_finished";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string finishedChildID = response["jobID"];
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child_cancelled";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string cancelledChildID = response["jobID"];
+        command.clear();
+
+        // Finish the parent
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = parentID;
+        tester->executeWaitVerifyContent(command);
+
+        // Cancel a child
+        // if this goes 2nd this doesn't requeue the parent job
+        command.clear();
+        command.methodLine = "CancelJob";
+        command["jobID"] = cancelledChildID;
+        tester->executeWaitVerifyContent(command);
+
+        // Finish a child
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "child_finished";
+        tester->executeWaitVerifyContent(command);
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = finishedChildID;
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm the parent is set to QUEUED
+        SQResult result;
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + parentID + ";", result);
+        ASSERT_EQUAL(result[0][0], "QUEUED");
+
+        // Finish the parent
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "parent";
+        tester->executeWaitVerifyContent(command);
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = parentID;
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm that the FINISHED and CANCELLED children are deleted
+        tester->readDB("SELECT count(*) FROM jobs WHERE jobID != " + parentID + ";", result);
+        ASSERT_EQUAL(SToInt(result[0][0]), 0);
+    }
+
+    // Update the job data if new data is passed
+    void updateData() {
+        // Create the job
+        SData command("CreateJob");
+        command["name"] = "job";
+        command["repeat"] = "STARTED, +1 HOUR";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Finish it
+        STable data;
+        data["foo"] = "bar";
+        data["bar"] = "foo";
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = jobID;
+        command["data"] = SComposeJSONObject(data);
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm the data updated
+        SQResult result;
+        tester->readDB("SELECT data FROM jobs WHERE jobID = " + jobID + ";", result);
+        ASSERT_EQUAL(result[0][0], SComposeJSONObject(data));
+    }
+
+    void finishingParentUnPausesChildren() {
+        // Create the parent
+        SData command("CreateJob");
+        command["name"] = "parent";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string parentID = response["jobID"];
+
+        // Get the parent
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "parent";
+        tester->executeWaitVerifyContent(command);
+
+        // Create the children
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child_finished";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string finishedChildID = response["jobID"];
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child_cancelled";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string cancelledChildID = response["jobID"];
+        command.clear();
+
+        // Finish the parent
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = parentID;
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm that the parent is in the PAUSED state and the chilrden are in the QUEUED state
+        SQResult result;
+        tester->readDB("SELECT jobID, state FROM jobs;", result);
+        ASSERT_EQUAL(result[0][0], parentID);
+        ASSERT_EQUAL(result[0][1], "PAUSED");
+        ASSERT_EQUAL(result[1][0], finishedChildID);
+        ASSERT_EQUAL(result[1][1], "QUEUED");
+        ASSERT_EQUAL(result[2][0], cancelledChildID);
+        ASSERT_EQUAL(result[2][1], "QUEUED");
+    }
+
+    void deleteFinishedJobWithNoChildren() {
+        // Create the job
+        SData command("CreateJob");
+        command["name"] = "job";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Finish it
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm the job was deleted
+        SQResult result;
+        tester->readDB("SELECT * FROM jobs WHERE jobID = " + jobID + ";", result);
+        ASSERT_TRUE(result.empty());
+    }
+
+    // Cannot retry with a negative delay
+    void negativeDelay() {
+        // Create the job
+        SData command("CreateJob");
+        command["name"] = "job";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Finish it
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = jobID;
+        command["delay"] = "-5";
+        tester->executeWaitVerifyContent(command, "402 Must specify a non-negative delay when retrying");
+    }
+
+    // Finish with a positive delay and confirm nextRun is updated appropriately
+    void positiveDelay() {
+        // Create the job
+        SData command("CreateJob");
+        command["name"] = "job";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the nextRun value
+        SQResult result;
+        tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
+        string originalNextRun = result[0][0];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Finish it
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = jobID;
+        command["delay"] = "5";
+        tester->executeWaitVerifyContent(command);
+
+        // Assert the new nextRun value is correct
+        tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
+        string currentNextRun = result[0][0];
+        struct tm tm1;
+        struct tm tm2;
+        strptime(originalNextRun.c_str(), "%Y-%m-%d %H:%M:%S", &tm1);
+        time_t originalNextRunTime = mktime(&tm1);
+        strptime(currentNextRun.c_str(), "%Y-%m-%d %H:%M:%S", &tm2);
+        time_t currentNextRunTime = mktime(&tm2);
+        ASSERT_EQUAL(difftime(currentNextRunTime, originalNextRunTime), 5);
+    }
+
+    // Finish a job with a repeat
+    void hasRepeat() {
+        // Create the job
+        SData command("CreateJob");
+        command["name"] = "job";
+        command["repeat"] = "STARTED, +1 HOUR";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Finish it
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm nextRun is in 1 hour
+        SQResult result;
+        tester->readDB("SELECT created, nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
+        struct tm tm1;
+        struct tm tm2;
+        strptime(result[0][0].c_str(), "%Y-%m-%d %H:%M:%S", &tm1);
+        time_t createdTime = mktime(&tm1);
+        strptime(result[0][1].c_str(), "%Y-%m-%d %H:%M:%S", &tm2);
+        time_t nextRunTime = mktime(&tm2);
+        ASSERT_EQUAL(difftime(nextRunTime, createdTime), 3600);
+    }
+} __FinishJobTest;

--- a/test/tests/jobs/RetryJobTest.cpp
+++ b/test/tests/jobs/RetryJobTest.cpp
@@ -1,0 +1,281 @@
+#include <test/lib/BedrockTester.h>
+
+struct RetryJobTest : tpunit::TestFixture {
+    RetryJobTest()
+        : tpunit::TestFixture("RetryJob",
+                              BEFORE_CLASS(RetryJobTest::setupClass),
+                              TEST(RetryJobTest::nonExistentJob),
+                              TEST(RetryJobTest::notInRunningState),
+                              TEST(RetryJobTest::parentIsNotPaused),
+                              TEST(RetryJobTest::removeFinishedAndCancelledChildren),
+                              TEST(RetryJobTest::updateData),
+                              TEST(RetryJobTest::negativeDelay),
+                              TEST(RetryJobTest::positiveDelay),
+                              TEST(RetryJobTest::hasRepeat),
+                              AFTER(RetryJobTest::tearDown),
+                              AFTER_CLASS(RetryJobTest::tearDownClass)) { }
+
+    BedrockTester* tester;
+
+    void setupClass() { tester = new BedrockTester({{"-plugins", "Jobs,DB"}}, {});}
+
+    // Reset the jobs table
+    void tearDown() {
+        SData command("Query");
+        command["query"] = "DELETE FROM jobs WHERE jobID > 0;";
+        tester->executeWaitVerifyContent(command);
+    }
+
+    void tearDownClass() { delete tester; }
+
+    // Throw an error if the job doesn't exist
+    void nonExistentJob() {
+        SData command("RetryJob");
+        command["jobID"] = "1";
+        tester->executeWaitVerifyContent(command, "404 No job with this jobID");
+    }
+
+    // Throw an error if the job is not in RUNNING state
+    void notInRunningState() {
+        // Create a job
+        SData command("CreateJob");
+        command["name"] = "job";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Retry it
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command, "405 Can only retry/finish RUNNING jobs");
+    }
+
+    // If job has a parentID, the parent should be paused
+    void parentIsNotPaused() {
+        // Create the parent
+        SData command("CreateJob");
+        command["name"] = "parent";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string parentID = response["jobID"];
+
+        // Get the parent
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "parent";
+        tester->executeWaitVerifyContent(command);
+
+        // Create the child
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string childID = response["jobID"];
+
+        // It's not possible to put the child in the QUEUED state without the parent being paused
+        // and a child cannot being the RUNNING state without first being the QUEUED state
+        // but we check for this to make sure something funky didn't occur.
+        // We'll manually put the child in the RUNNING state to hit this condition
+        command.clear();
+        command.methodLine = "Query";
+        command["query"] = "UPDATE jobs SET state = 'RUNNING' WHERE jobID = " + childID + ";";
+        tester->executeWaitVerifyContent(command);
+
+        // Retry the child
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = childID;
+        tester->executeWaitVerifyContent(command, "405 Can only retry/finish child job when parent is PAUSED");
+    }
+
+    // Child jobs that are in the FINISHED or CANCELLED state should be deleted when the parent is finished
+    void removeFinishedAndCancelledChildren() {
+        // Create the parent
+        SData command("CreateJob");
+        command["name"] = "parent";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string parentID = response["jobID"];
+
+        // Get the parent
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "parent";
+        tester->executeWaitVerifyContent(command);
+
+        // Create the children
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child_finished";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string finishedChildID = response["jobID"];
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "child_cancelled";
+        command["parentJobID"] = parentID;
+        response = tester->executeWaitVerifyContentTable(command);
+        string cancelledChildID = response["jobID"];
+        command.clear();
+
+        // Finish the parent
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = parentID;
+        tester->executeWaitVerifyContent(command);
+
+        // Cancel a child
+        // if this goes 2nd this doesn't requeue the parent job
+        command.clear();
+        command.methodLine = "CancelJob";
+        command["jobID"] = cancelledChildID;
+        tester->executeWaitVerifyContent(command);
+
+        // Finish a child
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "child_finished";
+        tester->executeWaitVerifyContent(command);
+        command.clear();
+        command.methodLine = "FinishJob";
+        command["jobID"] = finishedChildID;
+        tester->executeWaitVerifyContent(command);
+
+        // Retry the parent
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "parent";
+        tester->executeWaitVerifyContent(command);
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = parentID;
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm that the FINISHED and CANCELLED children are deleted
+        SQResult result;
+        tester->readDB("SELECT count(*) FROM jobs WHERE jobID != " + parentID + ";", result);
+        ASSERT_EQUAL(SToInt(result[0][0]), 0);
+    }
+
+    // Update the job data if new data is passed
+    void updateData() {
+        // Create the job
+        SData command("CreateJob");
+        command["name"] = "job";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Retry it
+        STable data;
+        data["foo"] = "bar";
+        data["bar"] = "foo";
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = jobID;
+        command["data"] = SComposeJSONObject(data);
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm the data updated
+        SQResult result;
+        tester->readDB("SELECT data FROM jobs WHERE jobID = " + jobID + ";", result);
+        ASSERT_EQUAL(result[0][0], SComposeJSONObject(data));
+    }
+
+    // Cannot retry with a negative delay
+    void negativeDelay() {
+        // Create the job
+        SData command("CreateJob");
+        command["name"] = "job";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Retry it
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = jobID;
+        command["delay"] = "-5";
+        tester->executeWaitVerifyContent(command, "402 Must specify a non-negative delay when retrying");
+    }
+
+    // Retry with a positive delay and confirm nextRun is updated appropriately
+    void positiveDelay() {
+        // Create the job
+        SData command("CreateJob");
+        command["name"] = "job";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the nextRun value
+        SQResult result;
+        tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
+        string originalNextRun = result[0][0];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Retry it
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = jobID;
+        command["delay"] = "5";
+        tester->executeWaitVerifyContent(command);
+
+        // Assert the new nextRun value is correct
+        tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
+        string currentNextRun = result[0][0];
+        struct tm tm1;
+        struct tm tm2;
+        strptime(originalNextRun.c_str(), "%Y-%m-%d %H:%M:%S", &tm1);
+        time_t originalNextRunTime = mktime(&tm1);
+        strptime(currentNextRun.c_str(), "%Y-%m-%d %H:%M:%S", &tm2);
+        time_t currentNextRunTime = mktime(&tm2);
+        ASSERT_EQUAL(difftime(currentNextRunTime, originalNextRunTime), 5);
+    }
+
+    // Retry a job with a repeat
+    void hasRepeat() {
+        // Create the job
+        SData command("CreateJob");
+        command["name"] = "job";
+        command["repeat"] = "STARTED, +1 HOUR";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Retry it
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm nextRun is in 1 hour
+        SQResult result;
+        tester->readDB("SELECT created, nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
+        struct tm tm1;
+        struct tm tm2;
+        strptime(result[0][0].c_str(), "%Y-%m-%d %H:%M:%S", &tm1);
+        time_t createdTime = mktime(&tm1);
+        strptime(result[0][1].c_str(), "%Y-%m-%d %H:%M:%S", &tm2);
+        time_t nextRunTime = mktime(&tm2);
+        ASSERT_EQUAL(difftime(nextRunTime, createdTime), 3600);
+    }
+} __RetryJobTest;


### PR DESCRIPTION
For the [`retryAfter`](https://github.com/Expensify/Bedrock/pull/243/) functionality we wanted to add tests from https://github.com/Expensify/Bedrock/pull/195, https://github.com/Expensify/Bedrock/pull/169, and https://github.com/Expensify/Bedrock/pull/191

I don't think it makes sense for these tests to sit in a PR when they have nothing to do with the new code, so I created this PR

I also added tests for https://github.com/Expensify/Bedrock/pull/240

Lastly, I'm changing the functionality of `RetryJob` so I made tests for `RetryJob` and `FinishJob` to ensure that I'm not breaking any functionality in https://github.com/Expensify/Bedrock/pull/270