### PR TITLE
Add switch to disable multi-write from command line

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -692,7 +692,8 @@ void BedrockServer::worker(SData& args,
 BedrockServer::BedrockServer(const SData& args)
   : SQLiteServer(""), _args(args), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),
-    _syncNode(nullptr), _shutdownState(RUNNING), _multiWriteEnabled(true), _backupOnShutdown(false), _controlPort(nullptr), _commandPort(nullptr)
+    _syncNode(nullptr), _shutdownState(RUNNING), _multiWriteEnabled(args.test("-enableMultiWrite")),
+    _backupOnShutdown(false), _controlPort(nullptr), _commandPort(nullptr)
 {
     _version = SVERSION;
 

--- a/main.cpp
+++ b/main.cpp
@@ -196,6 +196,7 @@ int main(int argc, char* argv[]) {
         cout << "-v                          Enables verbose logging" << endl;
         cout << "-q                          Enables quiet logging" << endl;
         cout << "-clean                      Recreate a new database from scratch" << endl;
+        cout << "-enableMultiWrite           Enable multi-write mode (default: true)" << endl;
         cout << "-versionOverride <version>  Pretends to be a different version when talking to peers" << endl;
         cout << "-db             <filename>  Use a database with the given name (default 'bedrock.db')" << endl;
         cout
@@ -269,6 +270,7 @@ int main(int argc, char* argv[]) {
     SETDEFAULT("-priority", "100");
     SETDEFAULT("-maxJournalSize", "1000000");
     SETDEFAULT("-queryLog", "queryLog.csv");
+    SETDEFAULT("-enableMultiWrite", "true");
 
     args["-plugins"] = SComposeList(loadPlugins(args));
 


### PR DESCRIPTION
@coleaeason 

Adds a switch to disable multi-write from the command line. It is enabled by default.

Tests:
watch the logs for `'committed.*on worker'` while running `clustertest` and verified that commands were being committed on workers. Added `-enableMultiWrite false` to the list of default arguments in `BedrockTester`, recompiled and re-ran, verified nothing was committed on workers.
