### PR TITLE
Catch string exceptions the same way as char *

### DIFF
--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -1,5 +1,4 @@
 #include "libstuff.h"
-#include <cxxabi.h>
 #include <execinfo.h> // for backtrace
 #undef SLOGPREFIX
 #define SLOGPREFIX "{" << name << "} "
@@ -174,31 +173,19 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                             SINFO("Received PONG from peer '" << peer->name << "' (" << peer->latency << "us latency)");
                         } else {
                             // Not a PING or PONG; pass to the child class
-                            try {
-                                _onMESSAGE(peer, message);
-                            } catch (const string& e) {
-                                SWARN("Caught string in _onMESSAGE: " << e);
-                                throw;
-                            } catch (const char* e) {
-                                SWARN("Caught char* in _onMESSAGE: " << e);
-                                throw;
-                            } catch (...) {
-                                string exName(abi::__cxa_current_exception_type()->name());
-                                int status;
-                                char* demangled = abi::__cxa_demangle(exName.c_str(), 0, 0, &status);
-                                SWARN("Unknown exception in _onMESSAGE: " << exName << "("
-                                      << demangled << "). Generating a stack track before the stack unwinds...");
-                                void* callstack[100];
-                                int depth = backtrace(callstack, 100);
-                                char** symbols = backtrace_symbols(callstack, depth);
-                                for (int c = 0; c < depth; ++c) {
-                                    SWARN(symbols[c]);
-                                }
-                                throw;
-                            }
+                            _onMESSAGE(peer, message);
                         }
                     }
                 } catch (const char* e) {
+                    // Error -- reconnect
+                    PWARN("Error processing message '" << message.methodLine << "' (" << e
+                                                       << "), reconnecting:" << message.serialize());
+                    SData reconnect("RECONNECT");
+                    reconnect["Reason"] = e;
+                    peer->s->send(reconnect.serialize());
+                    shutdownSocket(peer->s);
+                    break;
+                } catch (const string& e) {
                     // Error -- reconnect
                     PWARN("Error processing message '" << message.methodLine << "' (" << e
                                                        << "), reconnecting:" << message.serialize());

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2,7 +2,6 @@
 #include "SQLiteNode.h"
 #include "SQLiteServer.h"
 #include "SQLiteCommand.h"
-#include <cxxabi.h>
 
 // Introduction
 // ------------
@@ -1377,13 +1376,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             }
             SINFO("Subscription complete, at commitCount #" << _db.getCommitCount() << " (" << _db.getCommittedHash()
                   << "), SLAVING");
-            try {
-                _changeState(SLAVING);
-            } catch (...) {
-                string exName(abi::__cxa_current_exception_type()->name());
-                SWARN("Unknown exception in _changeState: " << exName);
-                throw;
-            }
+            _changeState(SLAVING);
         } catch (const char* e) {
             // Transaction failed
             SWARN("Subscription failed '" << e << "', reconnecting to master and re-SEARCHING.");
@@ -1906,13 +1899,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
         SData state("STATE");
         state["State"] = stateNames[_state];
         state["Priority"] = SToStr(_priority);
-        try {
-            _sendToAllPeers(state);
-        } catch (...) {
-            string exName(abi::__cxa_current_exception_type()->name());
-            SWARN("Unknown exception in _sendToAllPeers: " << exName);
-            throw;
-        }
+        _sendToAllPeers(state);
     }
 }
 


### PR DESCRIPTION
@coleaeason 

This should fix the crash on switching to slaving. There's still an exception being thrown, but now we can catch it and handle as intended, so we can diagnose the underlying problem after this goes out, and see if we need to do anything different from reconnecting in this case.