### PR TITLE
Improve Bedrock's exceptions.

### DIFF
--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -1,6 +1,13 @@
 #pragma once
 class BedrockCommand;
 
+class timeout_error : exception {
+  public:
+    const char* what() const noexcept {
+        return "timeout";
+    }
+};
+
 class BedrockCommandQueue {
   public:
     // Remove all items from the queue.

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -16,10 +16,6 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
     SDEBUG("Peeking at '" << request.methodLine << "'");
     command.peekCount++;
 
-    if (SStartsWith(command.request.methodLine, "DIE")) {
-        STHROW_STACK("Dying.");
-    }
-
     // We catch any exception and handle in `_handleCommandException`.
     try {
         // We start a transaction in `peekCommand` because we want to support having atomic transactions from peek

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -16,13 +16,17 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
     SDEBUG("Peeking at '" << request.methodLine << "'");
     command.peekCount++;
 
+    if (SStartsWith(command.request.methodLine, "DIE")) {
+        STHROW_STACK("Dying.");
+    }
+
     // We catch any exception and handle in `_handleCommandException`.
     try {
         // We start a transaction in `peekCommand` because we want to support having atomic transactions from peek
         // through process. This allows for consistency through this two-phase process. I.e., anything checked in
         // peek is guaranteed to still be valid in process, because they're done together as one transaction.
         if (!_db.beginConcurrentTransaction()) {
-            throw "501 Failed to begin concurrent transaction";
+            STHROW("501 Failed to begin concurrent transaction");
         }
 
         // Try each plugin, and go with the first one that says it succeeded.
@@ -64,12 +68,8 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
                 response.content = newContent;
             }
         }
-    } catch (const char* e) {
-        _handleCommandException(command, e, false);
-    } catch (const string e) {
-        _handleCommandException(command, e, false);
-    } catch (...) {
-        _handleCommandException(command, "", false);
+    } catch (const SException& e) {
+        _handleCommandException(command, e.what(), false);
     }
 
     // If we get here, it means the command is fully completed.
@@ -99,7 +99,7 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         // peek created a httpsRequest and closed it's first transaction until the httpsRequest was complete, in which
         // case we need to open a new transaction.
         if (!_db.insideTransaction() && !_db.beginConcurrentTransaction()) {
-            throw "501 Failed to begin concurrent transaction";
+            STHROW("501 Failed to begin concurrent transaction");
         }
 
         // Loop across the plugins to see which wants to take this.
@@ -116,7 +116,7 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         // If no plugin processed it, respond accordingly.
         if (!pluginProcessed) {
             SWARN("Command '" << request.methodLine << "' does not exist.");
-            throw "430 Unrecognized command";
+            STHROW("430 Unrecognized command");
         }
 
         // If we have no uncommitted query, just rollback the empty transaction. Otherwise, we need to commit.
@@ -148,12 +148,8 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
                 response.content = newContent;
             }
         }
-    } catch (const char* e) {
-        _handleCommandException(command, e, true);
-    } catch (const string e) {
-        _handleCommandException(command, e, true);
-    } catch (...) {
-        _handleCommandException(command, "", true);
+    } catch (const SException& e) {
+        _handleCommandException(command, e.what(), true);
     }
 
     // Done, return whether or not we need the parent to commit our transaction.

--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -18,29 +18,29 @@ BedrockPlugin::BedrockPlugin() {
 
 void BedrockPlugin::verifyAttributeInt64(const SData& request, const string& name, size_t minSize) {
     if (request[name].size() < minSize) {
-        throw "402 Missing " + name;
+        STHROW("402 Missing " + name);
     }
     if (!request[name].empty() && request[name] != SToStr(SToInt64(request[name]))) {
-        throw "402 Malformed " + name;
+        STHROW("402 Malformed " + name);
     }
 }
 
 void BedrockPlugin::verifyAttributeSize(const SData& request, const string& name, size_t minSize, size_t maxSize) {
     if (request[name].size() < minSize) {
-        throw "402 Missing " + name;
+        STHROW("402 Missing " + name);
     }
     if (request[name].size() > maxSize) {
-        throw "402 Malformed " + name;
+        STHROW("402 Malformed " + name);
     }
 }
 
 void BedrockPlugin::verifyAttributeBool(const SData& request, const string& name, bool require)
 {
     if (require && !request[name].size()) {
-        throw "402 Missing " + name;
+        STHROW("402 Missing " + name);
     }
     if (!request[name].empty() && !SIEquals(request[name], "true") && !SIEquals(request[name], "false")) {
-        throw "402 Malformed " + name;
+        STHROW("402 Malformed " + name);
     }
 }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -30,12 +30,20 @@ void BedrockServer::syncWrapper(SData& args,
     try {
         sync(args, replicationState, upgradeInProgress, masterVersion, syncNodeQueuedCommands, server);
     } catch (const SException& e) {
-        SALERT("Caught exception '" << e.what() << "' at top of sync thread. Logging info and exiting.");
+        SALERT("Caught SException '" << e.what() << "' at top of sync thread. Logging info and exiting.");
         auto rows = e.details();
         for (auto& i : rows) {
             SALERT(i);
         }
-        exit(1); // Die.
+        exit(1);
+    } catch (const exception& e) {
+        SALERT("Caught exception '" << e.what() << "' at top of sync thread. Exiting.");
+        exit(1);
+    } catch (...) {
+        SALERT("Caught unknown exception at top of sync thread (this should never happen).");
+        // Do our best to deduce the type here, regardless.
+        SALERT("exception typename (probably mangled): " << abi::__cxa_current_exception_type()->name());
+        exit(1);
     }
 }
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -152,8 +152,27 @@ class BedrockServer : public SQLiteServer {
                      CommandQueue& syncNodeQueuedCommands,
                      BedrockServer& server);
 
+    // Wraps the sync thread main function to make it easy to add exception handling.
+    static void syncWrapper(SData& args,
+                     atomic<SQLiteNode::State>& replicationState,
+                     atomic<bool>& upgradeInProgress,
+                     atomic<string>& masterVersion,
+                     CommandQueue& syncNodeQueuedCommands,
+                     BedrockServer& server);
+
     // Each worker thread runs this function. It gets the same data as the sync thread, plus its individual thread ID.
     static void worker(SData& args,
+                       atomic<SQLiteNode::State>& _replicationState,
+                       atomic<bool>& upgradeInProgress,
+                       atomic<string>& masterVersion,
+                       CommandQueue& syncNodeQueuedCommands,
+                       CommandQueue& syncNodeCompletedCommands,
+                       BedrockServer& server,
+                       int threadId,
+                       int threadCount);
+
+    // Wraps the worker thread main function to make it easy to add exception handling.
+    static void workerWrapper(SData& args,
                        atomic<SQLiteNode::State>& _replicationState,
                        atomic<bool>& upgradeInProgress,
                        atomic<string>& masterVersion,

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -40,10 +40,10 @@ bool SQResult::deserialize(const string& json) {
         // Verify we have the basic components
         STable content = SParseJSONObject(json);
         if (!SContains(content, "headers")) {
-            throw "Missing 'headers'";
+            STHROW("Missing 'headers'");
         }
         if (!SContains(content, "rows")) {
-            throw "Missing 'rows'";
+            STHROW("Missing 'rows'");
         }
 
         // Add the headers
@@ -58,7 +58,7 @@ bool SQResult::deserialize(const string& json) {
             // Get the row and make sure it has the right number of columns
             list<string> jsonRow = SParseJSONArray(jsonRowStr);
             if (jsonRow.size() != headers.size()) {
-                throw "Incorrect number of columns in row";
+                STHROW("Incorrect number of columns in row");
             }
 
             // Insert the values
@@ -68,8 +68,8 @@ bool SQResult::deserialize(const string& json) {
 
         // Success!
         return true;
-    } catch (const char* e) {
-        SDEBUG("Failed to deserialize JSON-encoded SQResult (" << e << "): " << json);
+    } catch (const SException& e) {
+        SDEBUG("Failed to deserialize JSON-encoded SQResult (" << e.what() << "): " << json);
     }
 
     // Failed, reset and report failure

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -52,7 +52,7 @@ struct STCPNode : public STCPServer {
     // Called when we lose connection with a peer
     virtual void _onDisconnect(Peer* peer) = 0;
 
-    // Called when the peer sends us a message; throw a (const char*) to reconnect.
+    // Called when the peer sends us a message; throw an SException to reconnect.
     virtual void _onMESSAGE(Peer* peer, const SData& message) = 0;
 
   private:

--- a/libstuff/SX509.cpp
+++ b/libstuff/SX509.cpp
@@ -21,18 +21,18 @@ SX509* SX509Open(const string& pem, const string& srvCrt, const string& caCrt) {
     try {
         // Load and initialize this key
         if (mbedtls_pk_parse_key(&x509->pk, (unsigned char*)pemPtr, (int)strlen(pemPtr) + 1, NULL, 0)) {
-            throw "parsing key";
+            STHROW("parsing key");
         }
         if (mbedtls_x509_crt_parse(&x509->srvcert, (unsigned char*)srvCrtPtr, (int)strlen(srvCrtPtr) + 1)) {
-            throw "parsing server certificate";
+            STHROW("parsing server certificate");
         }
         if (mbedtls_x509_crt_parse(&x509->srvcert, (unsigned char*)caCrtPtr, (int)strlen(caCrtPtr) + 1)) {
-            throw "parsing CA certificate";
+            STHROW("parsing CA certificate");
         }
         return x509;
-    } catch (const char* e) {
+    } catch (const SException& e) {
         // Failed
-        SWARN("X509 creation failed while '" << e << "', cancelling.");
+        SWARN("X509 creation failed while '" << e.what() << "', cancelling.");
         SX509Close(x509);
         return 0;
     }

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -3,6 +3,8 @@
 
 // C library
 #include <arpa/inet.h>
+#include <cxxabi.h>
+#include <execinfo.h> // for backtrace
 #include <fcntl.h>
 #include <libgen.h>   // for basename()
 #include <netinet/in.h>
@@ -95,6 +97,23 @@ class STableComp : binary_function<string, string, bool> {
       public:
         bool operator()(const unsigned char& c1, const unsigned char& c2) const { return tolower(c1) < tolower(c2); }
     };
+};
+
+#define STHROW(_MSG_) throw SException(_MSG_, __FILE__, __LINE__)
+#define STHROW_STACK(_MSG_) throw SException(_MSG_, __FILE__, __LINE__, true)
+class SException : public exception {
+  private:
+    static const int CALLSTACK_LIMIT = 100;
+    const string _message;
+    const string _file;
+    const int _line;
+    void* _callstack[CALLSTACK_LIMIT];
+    int _depth = 0;
+
+  public:
+    SException(string message, string file = "unknown", int line = 0, bool generateCallstack = false);
+    const char* what() const noexcept;
+    vector<string> details() const noexcept;
 };
 
 // An SString is just a string with special assignment operators so that we get automatic conversion from arithmetic

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -53,7 +53,7 @@ bool BedrockPlugin_DB::peekCommand(SQLite& db, BedrockCommand& command) {
 
         if (!SEndsWith(upperQuery, ";")) {
             SALERT("Query aborted, query must end in ';'");
-            throw "502 Query aborted";
+            STHROW("502 Query aborted");
         }
 
         if (SStartsWith(upperQuery, "SELECT ")) {
@@ -64,7 +64,7 @@ bool BedrockPlugin_DB::peekCommand(SQLite& db, BedrockCommand& command) {
                (SStartsWith(upperQuery, "UPDATE") || SStartsWith(upperQuery, "DELETE")) &&
                !SContains(upperQuery, " WHERE ")) {
                 SALERT("Query aborted, it has no 'where' clause: '" << query << "'");
-                throw "502 Query aborted";
+                STHROW("502 Query aborted");
             }
 
             // Assume it's read/write
@@ -79,7 +79,7 @@ bool BedrockPlugin_DB::peekCommand(SQLite& db, BedrockCommand& command) {
             // Query failed
             SALERT("Query failed: '" << query << "'");
             response["error"] = db.getLastError();
-            throw "502 Query failed";
+            STHROW("502 Query failed");
         }
 
         // Verify it didn't change anything -- assert because if we did, we did so
@@ -121,7 +121,7 @@ bool BedrockPlugin_DB::processCommand(SQLite& db, BedrockCommand& command) {
             // Query failed
             SALERT("Query failed: '" << query << "'");
             response["error"] = db.getLastError();
-            throw "502 Query failed";
+            STHROW("502 Query failed");
         }
 
         // Worked!  Let's save the last inserted row id

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -47,14 +47,14 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
             // return the number of times we made an HTTPS request on this command.
             int tries = SToInt(command.request["httpsRequests"]);
             if (tries != 1) {
-                throw "500 Retried HTTPS request!";
+                STHROW("500 Retried HTTPS request!");
             }
             command.response.content = " " + command.httpsRequest->fullResponse.content;
 
             // Update the DB so we can test conflicts.
             if (!command.request["Query"].empty()) {
                 if (!db.write(command.request["Query"])) {
-                    throw "502 Query failed.";
+                    STHROW("502 Query failed.");
                 }
             }
         } else {

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -196,10 +196,10 @@ void BedrockTester::stopServer() {
 string BedrockTester::executeWaitVerifyContent(SData request, const string& expectedResult) {
     auto results = executeWaitMultipleData({request}, 1);
     if (results.size() == 0) {
-        throw BedrockTestException("No result.");
+        STHROW("No result.");
     }
     if (!SStartsWith(results[0].methodLine, expectedResult)) {
-        throw BedrockTestException("Expected " + expectedResult + ", but got: " + results[0].methodLine);
+        STHROW("Expected " + expectedResult + ", but got: " + results[0].methodLine);
     }
     return results[0].content;
 }

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -4,15 +4,6 @@
 #include <test/lib/TestHTTPS.h>
 #include <test/lib/tpunit++.hpp>
 
-class BedrockTestException : public std::exception {
-  private:
-    const string message;
-
-  public:
-    BedrockTestException(string message_) : message(message_) {};
-    const char* what() const noexcept { return message.c_str(); };
-};
-
 class BedrockTester {
   public:
     // Generate a temporary filename for a test DB, with an optional prefix.


### PR DESCRIPTION
@flodnv @cead22 @coleaeason 

This improves our exceptions in Bedrock, both in how we handle them and how we'll be able to debug them when things go wrong.

Historically, we've thrown `const char*` exceptions everywhere, which has generally worked fine. However, there are some weaknesses to this. The first is that it's really easy to accidentally throw a `std::string` instead, which won't be caught by an exception handler for a `const char *`.

This throws a `const char*`:
```
throw "401 Unauthorized, no user with that name.";
```

But if you change that to:
```
throw "401 Unauthorized, no user with the name: " + name;
```

(where `name` is a `string`), then the same handler won't catch it, and it will propagate up to the top of the whole program, and crash it. You'll be able to figure out that there was an unhandled exception, but you won't know the type of the unhandled exception, so your only choice to catch it is to add a `catch (...) {}` block, which doesn't give you much information, either. You can use the ABI interface to get a name for the type of the exception, which will just tell you that it's a string, which still doesn't tell you where it came from.

This has caused real bugs in recent bedrock releases (the crash on switching to slaving recently was throwing a string instead of a `const char*` by accident).

If we derived our exceptions from `std::exception`, we could at least call `what()` on them all, and print out a reasonable error message.

That's the point of this change. It adds an `SException` class that we use everywhere, which means that we can always catch a reasonable exception type. It can take a `const char*` or a `string` and will store that so that you can look at it by calling `what()` (This also means we don't need redundant catch blocks for `const char*` and `string`).

This change also adds and fixes a few other things. There's a `STHROW` macro that throws a new `SException` and saves the filename and line number (and optionally, with `STHROW_STACK`, an entire stack trace). This helps when you have a top level exception handler, because if catch an exception and calling `what()` just prints `401 Unauthorized`, which you throw in 20 different places, and the stack's already been unwound to catch the exception. You can call `details()` on your `SException` and it will tell you the file and line number where the exception was originally thrown.

It also adds top-level exception handlers in the `sync` and `worker` threads, as exceptions don't propagate across threads, thus allowing us to catch and log the details of an `SException` happening in any of these threads.

We also replace `catch (...) {}` blocks with blocks designed to catch specific exceptions. I found that it was possible to throw any exception from a worker thread, and it could disappear into a black hole, with any unexpected consequences. Instead, it will now propagate up to the top-level worker try/catch block and be logged correctly. I also added a simple `timeout_error` class so that we could catch a specific exception type here and allow others (including `SException`) to propagate normally without being caught here.

Finally, we can remove `BedrockTesterException`, which existed because `tpunit++` can handle any `std::exception` nicely and print a specific error by calling `what()` on it, but couldn't handle `const char*` exceptions. Now we can use `SException` instead of `BedrockTesterException.

There is a corresponding (6 line) auth change for compatibility with this.
