### PR TITLE
Fix Deadlock, use shared mutex

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -915,8 +915,6 @@ bool SQLiteNode::update() {
             // Do we want to stand down, and can we?
             if (!standDownReason.empty()) {
                 SHMMM(standDownReason);
-
-                // As we fall out of mastering, make sure no lingering transactions are left behind.
                 _changeState(STANDINGDOWN);
                 SINFO("Standing down: " << standDownReason);
             }
@@ -935,8 +933,6 @@ bool SQLiteNode::update() {
             }
             // Standdown complete
             SINFO("STANDDOWN complete, SEARCHING");
-
-            // As we fall out of mastering, make sure no lingering transactions are left behind.
             _changeState(SEARCHING);
 
             // We're no longer waiting on responses from peers, we can re-update immediately and start becoming a

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -917,8 +917,6 @@ bool SQLiteNode::update() {
                 SHMMM(standDownReason);
 
                 // As we fall out of mastering, make sure no lingering transactions are left behind.
-                SAUTOLOCK(stateMutex);
-                _sendOutstandingTransactions();
                 _changeState(STANDINGDOWN);
                 SINFO("Standing down: " << standDownReason);
             }
@@ -939,8 +937,6 @@ bool SQLiteNode::update() {
             SINFO("STANDDOWN complete, SEARCHING");
 
             // As we fall out of mastering, make sure no lingering transactions are left behind.
-            SAUTOLOCK(stateMutex);
-            _sendOutstandingTransactions();
             _changeState(SEARCHING);
 
             // We're no longer waiting on responses from peers, we can re-update immediately and start becoming a
@@ -1823,7 +1819,13 @@ void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly) {
 }
 
 void SQLiteNode::_changeState(SQLiteNode::State newState) {
-    SAUTOLOCK(stateMutex);
+    // Exclusively lock the stateMutex, nobody else will be able to get a shared lock until this is released.
+    unique_lock<decltype(stateMutex)> lock(stateMutex);
+
+    // We send any unsent transactions here before we finish switching states. Normally, this does nothing, unless
+    // we're switching down from MASTERING or STANDINGDOWN, but we need to make sure these are all sent to the new
+    // mater before we complete the transition.
+    _sendOutstandingTransactions();
 
     // Did we actually change _state?
     SQLiteNode::State oldState = _state;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -105,7 +105,7 @@ class SQLiteNode : public STCPNode {
     // state of the node. When working with this and SQLite::g_commitLock, the correct order of acquisition is always:
     // 1. stateMutex
     // 2. SQLite::g_commitLock
-    recursive_mutex stateMutex;
+    shared_timed_mutex stateMutex;
 
   private:
     // STCPNode API: Peer handling framework functions


### PR DESCRIPTION
@coleaeason @quinthar @cead22 


Fixes: https://github.com/Expensify/Expensify/issues/61962

## Deadlock bug

So, there are several mutexes in bedrock. There are two relevant ones here:

1. A lock around the state of the node: SQLiteCluster::stateMutex
2. A lock around commits in BedrockServer::_syncThreadCommitMutex

The first one allows BedrockServer to know, for sure, the state of the sync node when it attempts a commit. Workers grab this lock before doing a commit, to guarantee that the server is MASTERING when they commit. The server won't be able to change states until the worker completes.

The second one is a shared lock around all commits, that guarantees workers can't begin a commit while a commit is in progress on the sync thread, thus guaranteeing that the sync thread never generates commit conflicts.

The problem is that the sync node can change states while it's mid-commit. If we're MASTERING, and we call `update()` with a commit in-progress, we can either finish the commit, or decide we need to wait on the cluster to approve the commit, and then after that we'll update the node state. If we've received a message from a peer that indicates we should stand down, we'll go ahead and grab the `stateMutex` and change to `STANDINGDOWN`. Normnally, this is fine -- we're allowed to complete commits in `STANDINGDOWN` as well. But, we're holding `_syncThreadCommitMutex` through this whole process. Importantly, we've first acquired `_syncThreadCommitMutex`, and then attempt to acquire `stateMutex`

Meanwhile, worker threads that attempt to commit transactions need to grab the `_syncThreadCommitMutex`, so that they'll be forced to wait if the sync thread has it exclusively locked. They also need to grab `stateMutex`, to prevent the sync thread from changing states mid-commit. The problem is that this happened in the opposite order: the worker would grab `stateMutex` first, and `_syncThreadCommitMutex` next, which allowed the possibility of a deadlock.

The fix is to make the worker grab the locks in the same order as the sync thread.

## Shared Mutex Change

We use a shared mutex `_syncThreadCommitMutex` so that many workers can lock it simultaneously, and they'll only need to wait if the sync thread has locked it exclusively. The idea is this keeps the serialized point of contention where we call `commit()` in worker threads as small as possible. However, we didn't do that with `stateMutex`, so each worker would need to wait for the others to finish with it, which negated any performance benefit there, since the two mutexes were acquired at the same time. This change makes `stateMutex` a shared mutex as well.