### PR TITLE
Improve performance for GetJob query

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -605,7 +605,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                     "  AND priority=1000"
                     "  AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                     "  AND name GLOB " + SQ(name) + " "
-                    "ORDER BY nextRun ASC, jobID ASC LIMIT " + safeNumResults +
+                    "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
             "UNION ALL "
                 "SELECT * FROM ("
@@ -615,7 +615,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                     "  AND priority=500"
                     "  AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                     "  AND name GLOB " + SQ(name) + " "
-                    "ORDER BY nextRun ASC, jobID ASC LIMIT " + safeNumResults +
+                    "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
             "UNION ALL "
                 "SELECT * FROM ("
@@ -625,7 +625,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                     "  AND priority=0"
                     "  AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                     "  AND name GLOB " + SQ(name) + " "
-                    "ORDER BY nextRun ASC, jobID ASC LIMIT " + safeNumResults +
+                    "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
             ") "
             "ORDER BY priority DESC "


### PR DESCRIPTION
cc @cead22 

Removing `jobID ASC` from the `ORDER BY` clause increases performance
by almost 500%

I tested on a table with ~1700000 rows.
The average performance of the query with `jobID ASC` and `LIMIT 1` in the inner query `ORDER BY` clauses was `2.33696`
Without `jobID ASC` the average performance was `0.00497`

Fixes
$ https://github.com/Expensify/Expensify/issues/61957