### PR TITLE
Updates Sexception

### DIFF
--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -43,6 +43,6 @@ class BedrockCore : public SQLiteCore {
     bool processCommand(BedrockCommand& command);
 
   private:
-    void _handleCommandException(BedrockCommand& command, const string& e, bool wasProcessing);
+    void _handleCommandException(BedrockCommand& command, const SException& e, bool wasProcessing);
     const BedrockServer& _server;
 };

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -75,17 +75,22 @@ void SLogSetThreadName(const string& logName) {
     SThreadLogName = logName;
 }
 
-SException::SException(string message, string file, int line, bool generateCallstack)
-  : _message(message), _file(file), _line(line) {
+SException::SException(const string& file,
+                       int line,
+                       bool generateCallstack,
+                       const string& _method,
+                       const STable& _headers,
+                       const string& _body)
+  : _file(file), _line(line), method(_method), headers(_headers), body(_body) {
     // Build a callstack. We don't convert it to symbols unless someone asks for it later.
     if (generateCallstack) {
         _depth = backtrace(_callstack, CALLSTACK_LIMIT);
     }
-    SINFO("Throwing exception with message: '" << message << "' from " << file << ":" << line);
+    SINFO("Throwing exception with message: '" << _method << "' from " << file << ":" << line);
 }
 
 const char* SException::what() const noexcept {
-    return _message.c_str();
+    return method.c_str();
 }
 
 vector<string> SException::details() const noexcept {


### PR DESCRIPTION
@flodnv 

This adds some capabilities to `SException`, allowing it to represent an entire HTTP response, including method line, headers, and body. This allows for plugins to send more data in exceptions without having to build their own exception mechanisms.

This is required for: https://github.com/Expensify/Server-Expensify/pull/2199