### PR TITLE
Allow to cancel jobs which siblings are in RUNQUEUED state

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -329,14 +329,14 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
                      "FROM jobs "
                      "WHERE parentJobID = " + SQ(result[0][2]) + " "
                         "AND jobID != " + SQ(jobID) + " "
-                        "AND state = 'RUNNING' "
+                        "AND state IN ('RUNNING', 'RUNQUEUED') "
                      "LIMIT 1;",
                     result)) {
             STHROW("502 Select failed");
         }
 
         if (result.empty()) {
-            STHROW("404 Invalid jobID - Cannot cancel a job that has no RUNNING siblings");
+            STHROW("404 Invalid jobID - Cannot cancel a job that has no RUNNING/RUNQUEUED siblings");
         }
 
         return false; // Need to process command

--- a/test/tests/jobs/CancelJobTest.cpp
+++ b/test/tests/jobs/CancelJobTest.cpp
@@ -331,6 +331,6 @@ struct CancelJobTest : tpunit::TestFixture {
         command.clear();
         command.methodLine = "CancelJob";
         command["jobID"] = childID;
-        tester->executeWaitVerifyContent(command, "404 Invalid jobID - Cannot cancel a job that has no RUNNING siblings");
+        tester->executeWaitVerifyContent(command, "404 Invalid jobID - Cannot cancel a job that has no RUNNING/RUNQUEUED siblings");
     }
 } __CancelJobTest;


### PR DESCRIPTION
@pecanoro @mea36 please review.

Fixes https://github.com/Expensify/Expensify/issues/62539 check last logs:
`2017-09-26T14:53:53.173977+00:00 www2.sc php: ayUmL6 /git/expensify.com/vendor/bin/BedrockWorkerManager.php A3N0Q5IHK2XCM8@turkWorkerFakeDomain.com !script! ?api? [info] [SmartScanDos] Expensify\SmartScanDos\AssignmentReviewer - Answer was marked as illegible, cancelling the other jobs`
`Bedrock request finished ~~ command: 'CancelJob' jsonCode: '404 Invalid jobID - Cannot cancel a job that has no RUNNING siblings' duration: '0' net: '-6690' wait: '6690' proc: '0'`

```
Query: Select * from jobs where parentJobID = 232419132;

200 OK
commitCount: 1112247010
nodeName: staging-www1.la
peekTime: 1273
totalTime: 1392
Content-Length: 857

created | jobID | state | name | nextRun | lastRun | repeat | data | priority | parentJobID | retryAfter
2017-09-25 17:56:35 | 232419677 | QUEUED | manual/SmartScanMerchantAndCategory?minimumLevelOfTrust=0 | 2017-09-25 17:56:35 |  |  | {"receiptID":166566744,"filename":"w_1dbe0407af6a500b710edf4fac675daf978757c1.jpg"} | 500 | 232419132 | +660 SECONDS
2017-09-25 17:56:35 | 232419678 | QUEUED | manual/SmartScanAmountAndCurrency?minimumLevelOfTrust=0 | 2017-09-25 17:56:35 |  |  | {"receiptID":166566744,"filename":"w_1dbe0407af6a500b710edf4fac675daf978757c1.jpg"} | 500 | 232419132 | +660 SECONDS
2017-09-25 17:56:35 | 232419679 | RUNQUEUED | manual/SmartScanCreated?minimumLevelOfTrust=0 | 2017-09-26 15:03:08 | 2017-09-26 14:52:08 |  | {"receiptID":166566744,"filename":"w_1dbe0407af6a500b710edf4fac675daf978757c1.jpg"} | 500 | 232419132 | +660 SECONDS
```