### PR TITLE
Allows to cancel jobs without running siblings

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -997,7 +997,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         if (!db.read("SELECT count(1) "
                      "FROM jobs "
                      "WHERE parentJobID=" + safeParentJobID + " AND "
-                       "state IN ('QUEUED', 'RUNQUEUED');",
+                       "state IN ('QUEUED', 'RUNQUEUED', 'RUNNING');",
                      result)) {
             STHROW("502 Select failed");
         }

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1002,7 +1002,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             STHROW("502 Select failed");
         }
         if (SToInt(result[0][0]) == 0) {
-            SINFO("Cancelled last QUEUED child, resuming the parent");
+            SINFO("Cancelled last QUEUED child, resuming the parent: " << safeParentJobID);
             if (!db.write("UPDATE jobs SET state='QUEUED' WHERE jobID=" + safeParentJobID + ";")) {
                 STHROW("502 Failed to update job data");
             }


### PR DESCRIPTION
This allows to cancel child jobs regardless of the state of its siblings and re-queues the parent when it's the last child queued.