### PR TITLE
Remove `commitCount` check in handling SUBSCRIPTION_APPROVED

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1363,9 +1363,6 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         try {
             // Done synchronizing
             _recvSynchronize(peer, message);
-            if (_db.getCommitCount() != _masterPeer->calcU64("CommitCount")) {
-                STHROW("Incomplete synchronization");
-            }
             SINFO("Subscription complete, at commitCount #" << _db.getCommitCount() << " (" << _db.getCommittedHash()
                   << "), SLAVING");
             _changeState(SLAVING);


### PR DESCRIPTION
@coleaeason @righdforsa 

Earlier we made this change to not sync unsent transactions in a SUBSCRIPTION_APPROVED message: https://github.com/Expensify/Bedrock/pull/295

However, we missed a change in handling that message where the slave compares that value to master's `CommitCount`. Since these values are no longer required to be equal, we have removed this check so that slaves don't reconnect on seeing this.