### PR TITLE
Add detached mode

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -866,6 +866,10 @@ BedrockServer::BedrockServer(const SData& args)
         }
     }
 
+    // Allow sending control commands when the server's not MASTERING/SLAVING.
+    SINFO("Opening control port on '" << _args["-controlPort"] << "'");
+    _controlPort = openPort(_args["-controlPort"]);
+
     // Start the sync thread, which will start the worker threads.
     SINFO("Launching sync thread '" << _syncThreadName << "'");
     _syncThread = thread(syncWrapper,

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -28,7 +28,25 @@ void BedrockServer::syncWrapper(SData& args,
                          BedrockServer& server)
 {
     try {
-        sync(args, replicationState, upgradeInProgress, masterVersion, syncNodeQueuedCommands, server);
+        while(true) {
+            // If the server's set to be detached, we wait until that flag is unset, and then start the sync thread.
+            if (server._detach) {
+                SINFO("Bedrock server entering detached state.");
+                // If we're set detached, we assume we'll be re-attached eventually, and then be `RUNNING`.
+                server._shutdownState = RUNNING;
+                while (server._detach) {
+                    // Just wait until we're attached.
+                    sleep(1);
+                }
+                SINFO("Bedrock server entering attached state.");
+            }
+            sync(args, replicationState, upgradeInProgress, masterVersion, syncNodeQueuedCommands, server);
+
+            // Now that we've run the sync thread, we can exit if it hasn't set _detach again.
+            if (!server._detach) {
+                break;
+            }
+        }
     } catch (const SException& e) {
         SALERT("Caught SException '" << e.what() << "' at top of sync thread. Logging info and exiting.");
         auto rows = e.details();
@@ -770,7 +788,7 @@ BedrockServer::BedrockServer(const SData& args)
   : SQLiteServer(""), _args(args), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),
     _syncNode(nullptr), _shutdownState(RUNNING), _multiWriteEnabled(args.test("-enableMultiWrite")),
-    _backupOnShutdown(false), _controlPort(nullptr), _commandPort(nullptr)
+    _backupOnShutdown(false), _detach(false), _controlPort(nullptr), _commandPort(nullptr)
 {
     _version = SVERSION;
 
@@ -861,6 +879,10 @@ BedrockServer::~BedrockServer() {
 }
 
 bool BedrockServer::shutdownComplete() {
+    if (_detach) {
+        // We don't want main() to stop calling `poll` for us, we are listening on the control port.
+        return false;
+    }
     // If nobody's asked us to shut down, we're not done.
     if (_shutdownState.load() == RUNNING) {
         return false;
@@ -1408,7 +1430,10 @@ void BedrockServer::_status(BedrockCommand& command) {
 bool BedrockServer::_isControlCommand(BedrockCommand& command) {
     if (SIEquals(command.request.methodLine, "BeginBackup")         ||
         SIEquals(command.request.methodLine, "SuppressCommandPort") ||
-        SIEquals(command.request.methodLine, "ClearCommandPort")) {
+        SIEquals(command.request.methodLine, "ClearCommandPort")    ||
+        SIEquals(command.request.methodLine, "Detach")              ||
+        SIEquals(command.request.methodLine, "Attach")
+        ) {
         return true;
     }
     return false;
@@ -1424,6 +1449,12 @@ void BedrockServer::_control(BedrockCommand& command) {
         suppressCommandPort("SuppressCommandPort", true, true);
     } else if (SIEquals(command.request.methodLine, "ClearCommandPort")) {
         suppressCommandPort("ClearCommandPort", false, true);
+    } else if (SIEquals(command.request.methodLine, "Detach")) {
+        response.methodLine = "203 DETACHING";
+        _beginShutdown("Detach", true);
+    } else if (SIEquals(command.request.methodLine, "Attach")) {
+        response.methodLine = "204 ATTACHING";
+        _detach = false;
     }
 }
 
@@ -1455,19 +1486,25 @@ void BedrockServer::_postPollPlugins(fd_map& fdm, uint64_t nextActivity) {
     }
 }
 
-void BedrockServer::_beginShutdown(const string& reason) {
+void BedrockServer::_beginShutdown(const string& reason, bool detach) {
     if (_shutdownState.load() == RUNNING) {
+        _detach = detach;
         // Begin a graceful shutdown; close our port
         SINFO("Beginning graceful shutdown due to '" << reason
               << "', closing command port on '" << _args["-serverHost"] << "'");
         _gracefulShutdownTimeout.alarmDuration = STIME_US_PER_S * 30; // 30s timeout before we give up
         _gracefulShutdownTimeout.start();
 
-        // Close our listening ports, we won't accept any new connections on them.
-        closePorts();
+        // Close our listening ports, we won't accept any new connections on them, except the control port, if we're
+        // detaching. It needs to keep listening.
+        if (_detach) {
+            closePorts({_controlPort});
+        } else {
+            closePorts();
+            _controlPort = nullptr;
+        }
         _portPluginMap.clear();
         _commandPort = nullptr;
-        _controlPort = nullptr;
         _shutdownState.store(START_SHUTDOWN);
         SINFO("START_SHUTDOWN. Ports shutdown, will perform final socket read.");
     }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -207,7 +207,7 @@ class BedrockServer : public SQLiteServer {
     void _control(BedrockCommand& command);
 
     // This stars the server shutting down.
-    void _beginShutdown(const string& reason);
+    void _beginShutdown(const string& reason, bool detach = false);
 
     // This counts the number of commands that are being processed that might be able to write to the database. We
     // won't start any of these unless we're mastering, and we won't allow SQLiteNode to drop out of STANDINGDOWN until
@@ -246,6 +246,7 @@ class BedrockServer : public SQLiteServer {
 
     // Set this to cause a backup to run when the server shuts down.
     bool _backupOnShutdown;
+    bool _detach;
 
     // Pointer to the control port, so we know which port not to shut down when we close the command ports.
     Port* _controlPort;


### PR DESCRIPTION
@cead22 (reassign if you want)

~HOLD until after cluster sync issue is fixed.~

Issue: https://github.com/Expensify/Bedrock/pull/297

This change allows bedrock to operate in a "detached mode" This effectively shuts down the server, allowing the main`sync` function (and all the `worker` threads it spawns) to finish, but keeps running the main event loop, so that we can continue to receive commands on the control port.

The main use case for this is for the following flow:

send `Detach` message.

Server (mostly) shuts down.

Backup scripts perform backup without needing to spend 6 hours copying the entire DB file.

send `Attach` message.

Sever comes back up where it left off.

This also allows the future possibility of a lot of "live" changes to servers. We could, for instance, `detach` a server, send a `changeNodePriority` message, and then send an `attach` message to bring the node back up at a different priority without restarting it.

## Tests

To test this, build and start auth on your dev VM (with this branch checked out, obviously).

1. Verify that you can connect to the dev website and it works as normal.
2. Send a `Detach` command to bedrock (in, on the VM, `nc localhost 9999` and follow it with `Detach` and a blank line).
3. tail the logs and watch for `Bedrock server entering detached state.`
4. Refresh the dev website and verify it *doesn't* work. Auth is now effectively down.
5. Send an `Attach` message the same was as before.
6. tail the logs and watch for `Bedrock server entering attached state.`
7. Refresh the dev website and verify it works as normal again.
8. Shut down auth normally (`sudo stop auth`) and verify the process exits as expected.