### PR TITLE
Add flag to disable multi-write until upgradeDB is complete

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -646,7 +646,7 @@ void BedrockServer::worker(SData& args,
                     // needs to not be automatically blacklisted.
                     canWriteParallel = canWriteParallel && BedrockConflictMetrics::multiWriteOK(command.request.methodLine);
                     if (!canWriteParallel                  ||
-                        !server._suppressMultiWrite.load() ||
+                        server._suppressMultiWrite.load() ||
                         state != SQLiteNode::MASTERING     ||
                         command.httpsRequest               ||
                         command.onlyProcessOnSyncThread    ||

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -645,11 +645,11 @@ void BedrockServer::worker(SData& args,
                     // We need to have multi-write enabled, the command needs to not be explicitly blacklisted, and it
                     // needs to not be automatically blacklisted.
                     canWriteParallel = canWriteParallel && BedrockConflictMetrics::multiWriteOK(command.request.methodLine);
-                    if (!canWriteParallel                  ||
+                    if (!canWriteParallel                 ||
                         server._suppressMultiWrite.load() ||
-                        state != SQLiteNode::MASTERING     ||
-                        command.httpsRequest               ||
-                        command.onlyProcessOnSyncThread    ||
+                        state != SQLiteNode::MASTERING    ||
+                        command.httpsRequest              ||
+                        command.onlyProcessOnSyncThread   ||
                         command.writeConsistency != SQLiteNode::ASYNC)
                     {
                         // Roll back the transaction, it'll get re-run in the sync thread.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -206,6 +206,12 @@ void BedrockServer::sync(SData& args,
         replicationState.store(nodeState);
         masterVersion.store(syncNode.getMasterVersion());
 
+        // If we're not mastering, we turn off multi-write until we've finished upgrading the DB. This persists until
+        // after we're mastering  again.
+        if (nodeState != SQLiteNode::MASTERING) {
+            server._suppressMultiWrite.store(true);
+        }
+
         // If the node's not in a ready state at this point, we'll probably need to read from the network, so start the
         // main loop over. This can let us wait for logins from peers (for example).
         if (nodeState != SQLiteNode::MASTERING &&
@@ -268,6 +274,7 @@ void BedrockServer::sync(SData& args,
                 // If we were upgrading, there's no response to send, we're just done.
                 if (upgradeInProgress.load()) {
                     upgradeInProgress.store(false);
+                    server._suppressMultiWrite.store(false);
                     continue;
                 }
                 BedrockConflictMetrics::recordSuccess(command.request.methodLine);
@@ -523,6 +530,7 @@ void BedrockServer::worker(SData& args,
     // We just run this loop looking for commands to process forever. There's a check for appropriate exit conditions
     // at the bottom, which will cause our loop and thus this thread to exit when that becomes true.
     while (true) {
+        // Wait on condition.
         try {
             // If we can't find any work to do, this will throw.
             command = server._commandQueue.get(1000000);
@@ -638,10 +646,11 @@ void BedrockServer::worker(SData& args,
                     // We need to have multi-write enabled, the command needs to not be explicitly blacklisted, and it
                     // needs to not be automatically blacklisted.
                     canWriteParallel = canWriteParallel && BedrockConflictMetrics::multiWriteOK(command.request.methodLine);
-                    if (!canWriteParallel               ||
-                        state != SQLiteNode::MASTERING  ||
-                        command.httpsRequest            ||
-                        command.onlyProcessOnSyncThread ||
+                    if (!canWriteParallel                  ||
+                        !server._suppressMultiWrite.load() ||
+                        state != SQLiteNode::MASTERING     ||
+                        command.httpsRequest               ||
+                        command.onlyProcessOnSyncThread    ||
                         command.writeConsistency != SQLiteNode::ASYNC)
                     {
                         // Roll back the transaction, it'll get re-run in the sync thread.
@@ -769,8 +778,9 @@ void BedrockServer::worker(SData& args,
 BedrockServer::BedrockServer(const SData& args)
   : SQLiteServer(""), _args(args), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),
-    _syncNode(nullptr), _shutdownState(RUNNING), _multiWriteEnabled(args.test("-enableMultiWrite")),
-    _backupOnShutdown(false), _controlPort(nullptr), _commandPort(nullptr)
+    _syncNode(nullptr), _suppressMultiWrite(true), _shutdownState(RUNNING),
+    _multiWriteEnabled(args.test("-enableMultiWrite")), _backupOnShutdown(false), _controlPort(nullptr),
+    _commandPort(nullptr)
 {
     _version = SVERSION;
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -530,7 +530,6 @@ void BedrockServer::worker(SData& args,
     // We just run this loop looking for commands to process forever. There's a check for appropriate exit conditions
     // at the bottom, which will cause our loop and thus this thread to exit when that becomes true.
     while (true) {
-        // Wait on condition.
         try {
             // If we can't find any work to do, this will throw.
             command = server._commandQueue.get(1000000);

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -227,6 +227,9 @@ class BedrockServer : public SQLiteServer {
     // is committing. This mutex is *not* recursive.
     shared_timed_mutex _syncThreadCommitMutex;
 
+    // Set this when we switch mastering.
+    atomic<bool> _suppressMultiWrite;
+
     // A set of command names that will always be run with QUORUM consistency level.
     // Specified by the `-synchronousCommands` command-line switch.
     set<string> _syncCommands;


### PR DESCRIPTION
Adds a flag that disables multi-write any time we're not mastering, and doesn't re-enable it until the DB upgrade has completed. This should prevent us from making commits on workers before the upgrade is done, resulting in conflicts.

## Tests
 ¯\\\_(ツ)_/¯