### PR TITLE
Missed check in earlier PR

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1175,7 +1175,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                             command.response.methodLine = "401 Unauthorized";
                             _reply(command);
                         }
-                    } else {
+                    } else if (_shutdownState < PORTS_CLOSED) {
                         // Otherwise we queue it for later processing.
                         _commandQueue.push(move(command));
                     }


### PR DESCRIPTION
@coleaeason 

I missed one thing in this PR: https://github.com/Expensify/Bedrock/pull/299

That PR has items 1 and 2 in it. In item 2, I failed to actually keep from queueing the dropped command (item 1 would cause us to drop it later, but I'd rather not add it to the queue at all).

This change prevents us adding it to the queue at all.