### PR TITLE
If we don't upgrade, turn off supressMultiwrite

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1357,7 +1357,6 @@ void BedrockServer::_status(BedrockCommand& command) {
             // Both of these need to be in the correct state for multi-write to be enabled.
             bool multiWriteOn =  _multiWriteEnabled.load() && !_suppressMultiWrite;
             content["multiWriteEnabled"] = multiWriteOn ? "true" : "false";
-
             content["multiWriteAutoBlacklist"] = BedrockConflictMetrics::getMultiWriteDeniedCommands();
             content["multiWriteManualBlacklist"] = SComposeJSONArray(_blacklistedParallelCommands);
         }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1352,12 +1352,12 @@ void BedrockServer::_status(BedrockCommand& command) {
         content["version"]  = _version;
         content["host"]     = _args["-nodeHost"];
 
-        // Both of these need to be in the correct state for multi-write to be enabled.
-        bool multiWriteOn =  _multiWriteEnabled.load() && !_suppressMultiWrite;
-        content["multiWriteEnabled"] = multiWriteOn ? "true" : "false";
-
         // On master, return the current multi-write blacklists.
         if (state == SQLiteNode::MASTERING) {
+            // Both of these need to be in the correct state for multi-write to be enabled.
+            bool multiWriteOn =  _multiWriteEnabled.load() && !_suppressMultiWrite;
+            content["multiWriteEnabled"] = multiWriteOn ? "true" : "false";
+
             content["multiWriteAutoBlacklist"] = BedrockConflictMetrics::getMultiWriteDeniedCommands();
             content["multiWriteManualBlacklist"] = SComposeJSONArray(_blacklistedParallelCommands);
         }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -233,6 +233,9 @@ void BedrockServer::sync(SData& args,
 
                 // As it's a quorum commit, we'll need to read from peers. Let's start the next loop iteration.
                 continue;
+            } else {
+                // If we're not doing an upgrade, we don't need to keep suppressing multi-write.
+                server._suppressMultiWrite.store(false);
             }
         } else if ((preUpdateState == SQLiteNode::MASTERING || preUpdateState == SQLiteNode::STANDINGDOWN)
                    && nodeState == SQLiteNode::SEARCHING) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1352,6 +1352,10 @@ void BedrockServer::_status(BedrockCommand& command) {
         content["version"]  = _version;
         content["host"]     = _args["-nodeHost"];
 
+        // Both of these need to be in the correct state for multi-write to be enabled.
+        bool multiWriteOn =  _multiWriteEnabled.load() && !_suppressMultiWrite;
+        content["multiWriteEnabled"] = multiWriteOn ? "true" : "false";
+
         // On master, return the current multi-write blacklists.
         if (state == SQLiteNode::MASTERING) {
             content["multiWriteAutoBlacklist"] = BedrockConflictMetrics::getMultiWriteDeniedCommands();


### PR DESCRIPTION
In our haste to get a working deploy out the door on Saturday, we added a feature that would disable multi-write until after the `upgradeDB` call had completed shortly after becoming master.

Unfortunately, if there was nothing to do for the upgrade (i.e., the DB schema was current), we'd never finish the upgrade and then turn multi-write back on.

This change turns multi-write on immediately when there's no upgrade to be done.

fixes: https://github.com/Expensify/Expensify/issues/63344

## Tests
You can test by following the logs of the `./clustertest` test. 

Before this fix, the following command:
```
tail -f /var/log/syslog | grep bedrock | grep 'on worker'
```
Has no output. After this fix, you see many lines like: 
```
Oct  4 19:40:15 vagrant-ubuntu-trusty-64 bedrock: xxxxx (BedrockServer.cpp:720) worker [worker4] [info] Successfully committed Query on worker thread.
```

Indicating that multi-write is indeed on.

Update: second commit adds status message line indicating if multi-write is enabled.