### PR TITLE
Make SQLite thread-safe for reads

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -303,7 +303,11 @@ bool SQLite::read(const string& query, SQResult& result) {
     SASSERTWARN(!SContains(SToUpper(query), "DELETE "));
     SASSERTWARN(!SContains(SToUpper(query), "REPLACE "));
     uint64_t before = STimeNow();
-    bool queryResult = !SQuery(_db, "read only query", query, result);
+    bool queryResult = false;
+    {
+        lock_guard<decltype(_readMutex)> lock(_readMutex);
+        queryResult = !SQuery(_db, "read only query", query, result);
+    }
     _checkTiming("timeout in SQLite::read"s);
     _readElapsed += STimeNow() - before;
     return queryResult;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -273,4 +273,7 @@ class SQLite {
 
     // Called internally by _sqliteAuthorizerCallback to authorize columns for a query.
     int _authorize(int actionCode, const char* table, const char* column);
+
+    // Avoid sqlite errors if multiple threads want to use the same DB handle.
+    mutex _readMutex;
 };


### PR DESCRIPTION
SQLite (the database, not the C++ class with the same name) is perfectly thread-safe as long as that feature is enabled, and you use a separate database handle in each thread.

This works fine now because we have a strict 1:1 thread->dbhandle mapping. However, as we prepare to scale up to massively parallel servers, it would be nice to remove this restriction.

This change allows for multiple threads to use the same DB handle for multiple reads, serializing around `SQuery`. Ultimately, I plan to add the ability to create arbitrary numbers of db handles, so no serialization is required. Before this change, the following code would likely fail due to simultaneous queries in the same DB handle:
```
list <int> accountIDs = ...;
for (int i : accountIDs) {
    auto data = db->read("SELECT some stuff WHERE accountID = " + i + ";");
    doExpensiveStuffWithResult(data);
}
```

After this change, the above code will serialize on the query, but each thread can call `doExpensiveStuffWithResult` in parallel, starting as soon as the first query finishes. This code is intended to make it easy to use parallelization everywhere.

