### PR TITLE
Duplicate commands for beta testing.

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -254,4 +254,8 @@ class BedrockServer : public SQLiteServer {
     // Pointer to the control port, so we know which port not to shut down when we close the command ports.
     Port* _controlPort;
     Port* _commandPort;
+
+    // For doing A/B testing, we have a map of commands paired with their beta version names and frequencies.
+    mutex _abLock;
+    map <string, tuple<string, unsigned int>> _abList;
 };


### PR DESCRIPTION
@righdforsa - reassign review if desired.

This adds a control command called `SetABTestList` which takes parameters in the following format:
```
SetABTestList
CommandName: BETACommandName, fraction
CommandName2: BETACommandName2, fraction2
etc...

```

The fraction is an integer from 1 to 100, specifying what percentage of the time a BETA command will be generated for that command.

## Tests
This has been tested manually. Build and start a bedrock server.

Send the following command to port 9999:
```
SetABTestList
Get: BetaGet, 50

```

Send a `STATUS` command and verify `BetaGet` appears in the output with a fraction of 50%.

Tail the logs watching for `BetaGet`. Issue several `Get` commands, i.e.,
```
Get

``

About half the time, you should see a group of logs trying to handle a `BetaGet` command (that will fail with `unrecognized command`, but that's OK).
