### PR TITLE
Blacklist commands that cause crashes

### DIFF
--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -69,9 +69,12 @@ class BedrockCommand : public SQLiteCommand {
     // to the sync thread for processing, thus guaranteeing that process() will not result in a conflict.
     bool onlyProcessOnSyncThread;
 
-    // A plugin can set values in here that will cause headers from the `request` object to be broadcast alongside any
-    // messages to blacklist bad commands.
-    set<string> blacklistableValues;
+    // This is a set of name/value pairs that must be present and matching for two commands to compare as "equivalent"
+    // for the sake of determining whether they're likely to cause a crash.
+    // i.e., if this command has set this to {userID, reportList}, and the server crashes while processing this
+    // command, then any other command with the same methodLine, userID, and reportList will be flagged as likely to
+    // cause a crash, and not processed.
+    set<string> crashIdentifyingValues;
 
   private:
     // Set certain initial state on construction. Common functionality to several constructors.

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -69,6 +69,10 @@ class BedrockCommand : public SQLiteCommand {
     // to the sync thread for processing, thus guaranteeing that process() will not result in a conflict.
     bool onlyProcessOnSyncThread;
 
+    // A plugin can set values in here that will cause headers from the `request` object to be broadcast alongside any
+    // messages to blacklist bad commands.
+    set<string> blacklistableValues;
+
   private:
     // Set certain initial state on construction. Common functionality to several constructors.
     void _init();

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -1,15 +1,16 @@
 #pragma once
 class BedrockCommand;
 
-class timeout_error : exception {
-  public:
-    const char* what() const noexcept {
-        return "timeout";
-    }
-};
-
 class BedrockCommandQueue {
   public:
+
+    class timeout_error : exception {
+      public:
+        const char* what() const noexcept {
+            return "timeout";
+        }
+    };
+
     // Remove all items from the queue.
     void clear();
 

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -3,7 +3,6 @@ class BedrockCommand;
 
 class BedrockCommandQueue {
   public:
-
     class timeout_error : exception {
       public:
         const char* what() const noexcept {

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -44,6 +44,8 @@ class BedrockCore : public SQLiteCore {
     bool processCommand(BedrockCommand& command);
 
   private:
+    // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.
+    string _getExceptionName();
     void _handleCommandException(BedrockCommand& command, const SException& e);
     const BedrockServer& _server;
 };

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -369,8 +369,8 @@ void BedrockServer::sync(SData& args,
                 server._syncNode->broadcastImmediate(_generateBlacklistMessage(command));
             });
 
-            // This try block lasts the lifetime of our command, we use it to catch any unhandled exceptions so that we
-            // can notify peers about a command that seems to have caused a failure before we crash.
+            // We catch *any* exception thrown from handling a command, alert, log the command, and continue.
+            // This try block lasts the lifetime of the command.
             try {
                 SINFO("[performance] Sync thread dequeued command " << command.request.methodLine << ". Sync thread has "
                       << syncNodeQueuedCommands.size() << " queued commands.");
@@ -565,8 +565,8 @@ void BedrockServer::worker(SData& args,
                 server._waitForBroadcast.wait(lock, [&server]{return !server._hasBroadcastMessage.load();});
             });
 
-            // This try block lasts the lifetime of our command, we use it to catch any unhandled exceptions so that we
-            // can notify peers about a command that seems to have caused a failure before we crash.
+            // We catch *any* exception thrown from handling a command, alert, log the command, and continue.
+            // This try block lasts the lifetime of the command.
             try {
                 // Check if this is a blacklisted command.
                 if (server._isBlacklisted(command)) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -9,7 +9,19 @@ set<string>BedrockServer::_blacklistedParallelCommands;
 recursive_mutex BedrockServer::_blacklistedParallelCommandMutex;
 
 void BedrockServer::acceptCommand(SQLiteCommand&& command) {
-    _commandQueue.push(BedrockCommand(move(command)));
+    // If the server tells us to blacklist a command, we'll do it immediately, bypassing all queuing.
+    if(command.request.methodLine == "BLACKLIST_COMMAND") {
+        SData request;
+        request.deserialize(command.request.content);
+        // Take a unique lock so nobody else can read from this table while we update it.
+        unique_lock<decltype(_blackListCommandMutex)> lock(_blackListCommandMutex);
+
+        // Add the blacklisted command to the map.
+        _blacklistedCommands.insert(make_pair(request.methodLine, request.nameValueMap));
+        SALERT("Blacklisting command (now have " << _blacklistedCommands.size() << " blacklisted commands): " << request.serialize());
+    } else {
+        _commandQueue.push(BedrockCommand(move(command)));
+    }
 }
 
 void BedrockServer::cancelCommand(const string& commandID) {
@@ -142,6 +154,18 @@ void BedrockServer::sync(SData& args,
     // the logic of this loop simpler.
     server._syncMutex.lock();
     while (!syncNode.shutdownComplete()) {
+
+        if (server._hasBroadcastMessage.load()) {
+            // Oh shit, we broken.
+            SALERT("Broadcasting message immediately.");
+            server._syncNode->broadcastImmediate(server._broadcastMessage);
+
+            // Done.
+            server._hasBroadcastMessage.store(0);
+            server._waitForBroadcast.notify_one();
+        }
+
+
         // If there were commands waiting on our commit count to come up-to-date, we'll move them back to the main
         // command queue here. There's no place in particular that's best to do this, so we do it at the top of this
         // main loop, as that prevents it from ever getting skipped in the event that we `continue` early from a loop
@@ -354,106 +378,125 @@ void BedrockServer::sync(SData& args,
             if (nodeState == SQLiteNode::STANDINGDOWN) {
                 continue;
             }
-
             // Now we can pull the next command off the queue and start on it.
             command = syncNodeQueuedCommands.pop();
-            SINFO("[performance] Sync thread dequeued command " << command.request.methodLine << ". Sync thread has "
-                  << syncNodeQueuedCommands.size() << " queued commands.");
 
-            // We got a command to work on! Set our log prefix to the request ID.
-            SAUTOPREFIX(command.request["requestID"]);
+            // This try block lasts the lifetime of our command.
+            try {
+                SINFO("[performance] Sync thread dequeued command " << command.request.methodLine << ". Sync thread has "
+                      << syncNodeQueuedCommands.size() << " queued commands.");
 
-            // And now we'll decide how to handle it.
-            if (nodeState == SQLiteNode::MASTERING) {
-                // We need to grab this before peekCommand (or wherever our transaction is started), to verify that
-                // no worker thread can commit in the middle of our transaction. We need our entire transaction to
-                // happen with no other commits to ensure that we can't get a conflict.
-                uint64_t beforeLock = STimeNow();
-                server._syncThreadCommitMutex.lock();
+                // We got a command to work on! Set our log prefix to the request ID.
+                SAUTOPREFIX(command.request["requestID"]);
 
-                // It appears that this might be taking significantly longer with multi-write enabled, so we're adding
-                // explicit logging for it to check.
-                SINFO("[performance] Waited " << (STimeNow() - beforeLock) << "us for _syncThreadCommitMutex.");
+                // And now we'll decide how to handle it.
+                if (nodeState == SQLiteNode::MASTERING) {
+                    // We need to grab this before peekCommand (or wherever our transaction is started), to verify that
+                    // no worker thread can commit in the middle of our transaction. We need our entire transaction to
+                    // happen with no other commits to ensure that we can't get a conflict.
+                    uint64_t beforeLock = STimeNow();
+                    server._syncThreadCommitMutex.lock();
 
-                // We peek commands here in the sync thread to be able to run peek and process as part of the same
-                // transaction. This guarantees that any checks made in peek are still valid in process, as the DB can't
-                // have changed in the meantime.
-                // IMPORTANT: This check is omitted for commands with an HTTPS request object, because we don't want to
-                // risk duplicating that request. If your command creates an HTTPS request, it needs to explicitly
-                // re-verify that any checks made in peek are still valid in process.
-                if (!command.httpsRequest) {
-                    if (core.peekCommand(command)) {
-                        // Finished with this.
+                    // It appears that this might be taking significantly longer with multi-write enabled, so we're adding
+                    // explicit logging for it to check.
+                    SINFO("[performance] Waited " << (STimeNow() - beforeLock) << "us for _syncThreadCommitMutex.");
+
+                    // We peek commands here in the sync thread to be able to run peek and process as part of the same
+                    // transaction. This guarantees that any checks made in peek are still valid in process, as the DB can't
+                    // have changed in the meantime.
+                    // IMPORTANT: This check is omitted for commands with an HTTPS request object, because we don't want to
+                    // risk duplicating that request. If your command creates an HTTPS request, it needs to explicitly
+                    // re-verify that any checks made in peek are still valid in process.
+                    if (!command.httpsRequest) {
+                        if (core.peekCommand(command)) {
+                            // Finished with this.
+                            server._syncThreadCommitMutex.unlock();
+
+                            // This command completed in peek, respond to it appropriately, either directly or by sending it
+                            // back to the sync thread.
+                            SASSERT(command.complete);
+                            if (command.initiatingPeerID) {
+                                command.finalizeTimingInfo();
+                                syncNode.sendResponse(command);
+                            } else {
+                                server._reply(command);
+                            }
+                            continue;
+                        }
+                    }
+
+                    // If we've dequeued a command with an incomplete HTTPS request, we move it to httpsCommands so that every
+                    // subsequent dequeue doesn't have to iterate past it while ignoring it. Then we'll just start on the next
+                    // command.
+                    if (command.httpsRequest && !command.httpsRequest->response) {
+                        // We can't finish this transaction right now. We'll restart it later when the httpsRequest is
+                        // complete.
+                        if (db.insideTransaction()) {
+                            // We only rollback if we're inside a transaction. This will happen if `peekCommand` created an
+                            // httpsRequest above. However, if `peekCommand` was done in a worker thread, then this has
+                            // already been done, so we won't roll it back again.
+                            core.rollback();
+                        }
+
+                        // Done with the lock.
                         server._syncThreadCommitMutex.unlock();
 
-                        // This command completed in peek, respond to it appropriately, either directly or by sending it
-                        // back to the sync thread.
-                        SASSERT(command.complete);
+                        // Set this aside and move on to the next command.
+                        httpsCommands.push_back(move(command));
+                        continue;
+                    }
+                    if (core.processCommand(command)) {
+                        // The processor says we need to commit this, so let's start that process.
+                        committingCommand = true;
+                        SINFO("[performance] Sync thread beginning committing command " << command.request.methodLine);
+                        server._writableCommandsInProgress++;
+                        // START TIMING.
+                        command.startTiming(BedrockCommand::COMMIT_SYNC);
+                        syncNode.startCommit(command.writeConsistency);
+
+                        // And we'll start the next main loop.
+                        // NOTE: This will cause us to read from the network again. This, in theory, is fine, but we saw
+                        // performance problems in the past trying to do something similar on every commit. This may be
+                        // alleviated now that we're only doing this on *sync* commits instead of all commits, which should
+                        // be a much smaller fraction of all our traffic. We set nextActivity here so that there's no
+                        // timeout before we'll give up on poll() if there's nothing to read.
+                        nextActivity = STimeNow();
+
+                        // Don't unlock _syncThreadCommitMutex here, we'll hold the lock till the commit completes.
+                        continue;
+                    } else {
+                        // Otherwise, the command doesn't need a commit (maybe it was an error, or it didn't have any work
+                        // to do). We'll just respond.
+                        server._syncThreadCommitMutex.unlock();
                         if (command.initiatingPeerID) {
                             command.finalizeTimingInfo();
                             syncNode.sendResponse(command);
                         } else {
                             server._reply(command);
                         }
-                        continue;
+                    }
+                } else if (nodeState == SQLiteNode::SLAVING) {
+                    // If we're slaving, we just escalate directly to master without peeking. We can only get an incomplete
+                    // command on the slave sync thread if a slave worker thread peeked it unsuccessfully, so we don't
+                    // bother peeking it again.
+                    syncNode.escalateCommand(move(command));
+                }
+            } catch (...) {
+                // Catch absolutely anything.
+                // Since we're the sync node, we don't have to wait here, we can send right away.
+                SData message("BLACKLIST_COMMAND");
+                SData subMessage(command.request.methodLine);
+                for (auto& field : command.blacklistableValues) {
+                    auto it = command.request.nameValueMap.find(field);
+                    if (it != command.request.nameValueMap.end()) {
+                        subMessage[field] = it->second;
                     }
                 }
+                message.content = subMessage.serialize();
+                server._syncNode->broadcastImmediate(message);
 
-                // If we've dequeued a command with an incomplete HTTPS request, we move it to httpsCommands so that every
-                // subsequent dequeue doesn't have to iterate past it while ignoring it. Then we'll just start on the next
-                // command.
-                if (command.httpsRequest && !command.httpsRequest->response) {
-                    // We can't finish this transaction right now. We'll restart it later when the httpsRequest is
-                    // complete.
-                    if (db.insideTransaction()) {
-                        // We only rollback if we're inside a transaction. This will happen if `peekCommand` created an
-                        // httpsRequest above. However, if `peekCommand` was done in a worker thread, then this has
-                        // already been done, so we won't roll it back again.
-                        core.rollback();
-                    }
-
-                    // Done with the lock.
-                    server._syncThreadCommitMutex.unlock();
-
-                    // Set this aside and move on to the next command.
-                    httpsCommands.push_back(move(command));
-                    continue;
-                }
-                if (core.processCommand(command)) {
-                    // The processor says we need to commit this, so let's start that process.
-                    committingCommand = true;
-                    SINFO("[performance] Sync thread beginning committing command " << command.request.methodLine);
-                    server._writableCommandsInProgress++;
-                    // START TIMING.
-                    command.startTiming(BedrockCommand::COMMIT_SYNC);
-                    syncNode.startCommit(command.writeConsistency);
-
-                    // And we'll start the next main loop.
-                    // NOTE: This will cause us to read from the network again. This, in theory, is fine, but we saw
-                    // performance problems in the past trying to do something similar on every commit. This may be
-                    // alleviated now that we're only doing this on *sync* commits instead of all commits, which should
-                    // be a much smaller fraction of all our traffic. We set nextActivity here so that there's no
-                    // timeout before we'll give up on poll() if there's nothing to read.
-                    nextActivity = STimeNow();
-
-                    // Don't unlock _syncThreadCommitMutex here, we'll hold the lock till the commit completes.
-                    continue;
-                } else {
-                    // Otherwise, the command doesn't need a commit (maybe it was an error, or it didn't have any work
-                    // to do). We'll just respond.
-                    server._syncThreadCommitMutex.unlock();
-                    if (command.initiatingPeerID) {
-                        command.finalizeTimingInfo();
-                        syncNode.sendResponse(command);
-                    } else {
-                        server._reply(command);
-                    }
-                }
-            } else if (nodeState == SQLiteNode::SLAVING) {
-                // If we're slaving, we just escalate directly to master without peeking. We can only get an incomplete
-                // command on the slave sync thread if a slave worker thread peeked it unsuccessfully, so we don't
-                // bother peeking it again.
-                syncNode.escalateCommand(move(command));
+                // And re-throw the exception, which will cause us to die.
+                rethrow_exception(current_exception());
             }
         } catch (const out_of_range& e) {
             // syncNodeQueuedCommands had no commands to work on, we'll need to re-poll for some.
@@ -554,207 +597,15 @@ void BedrockServer::worker(SData& args,
         try {
             // If we can't find any work to do, this will throw.
             command = server._commandQueue.get(1000000);
-            SAUTOPREFIX(command.request["requestID"]);
-            SINFO("[performance] Dequeued command " << command.request.methodLine << " in worker, "
-                  << server._commandQueue.size() << " commands in queue.");
 
-            // We just spin until the node looks ready to go. Typically, this doesn't happen expect briefly at startup.
-            while (upgradeInProgress.load() ||
-                   (replicationState.load() != SQLiteNode::MASTERING &&
-                    replicationState.load() != SQLiteNode::SLAVING &&
-                    replicationState.load() != SQLiteNode::STANDINGDOWN)
-            ) {
-                // Make sure that the node isn't shutting down, leaving us in an endless loop.
-                if (server._shutdownState == SYNC_SHUTDOWN) {
-                    SWARN("Sync thread shut down while were waiting for it to come up. Discarding command '"
-                          << command.request.methodLine << "'.");
-                    return;
-                }
-
-                // This sleep call is pretty ugly, but it should almost never happen. We're accepting the potential
-                // looping sleep call for the general case where we just check some bools and continue, instead of
-                // avoiding the sleep call but having every thread lock a mutex here on every loop.
-                usleep(10000);
-            }
-
-            // If this command is dependent on a commitCount newer than what we have (maybe it's a follow-up to a
-            // command that was escalated to master), we'll set it aside for later processing. When the sync node
-            // finishes its update loop, it will re-queue any of these commands that are no longer blocked on our
-            // updated commit count.
-            uint64_t commitCount = db.getCommitCount();
-            uint64_t commandCommitCount = command.request.calcU64("commitCount");
-            if (commandCommitCount > commitCount) {
-                SAUTOLOCK(server._futureCommitCommandMutex);
-                auto newQueueSize = server._futureCommitCommands.size() + 1;
-                SINFO("Command (" << command.request.methodLine << ") depends on future commit(" << commandCommitCount
-                      << "), Currently at: " << commitCount << ", storing for later. Queue size: " << newQueueSize);
-                server._futureCommitCommands.insert(make_pair(commandCommitCount, move(command)));
-                if (newQueueSize > 100) {
-                    SHMMM("server._futureCommitCommands.size() == " << newQueueSize);
-                }
-                continue;
-            }
-
-            // OK, so this is the state right now, which isn't necessarily anything in particular, because the sync
-            // node can change it at any time, and we're not synchronizing on it. We're going to go ahead and assume
-            // it's something reasonable, because in most cases, that's pretty safe. If we think we're anything but
-            // MASTERING, we'll just peek this command and return it's result, which should be harmless. If we think
-            // we're mastering, we'll go ahead and start a `process` for the command, but we'll synchronously verify
-            // our state right before we commit.
-            SQLiteNode::State state = replicationState.load();
-
-            // If we find that we've gotten a command with an initiatingPeerID, but we're not in a mastering or
-            // standing down state, we'll have no way of returning this command to the caller, so we discard it. The
-            // original caller will need to re-send the request. This can happen if we're mastering, and receive a
-            // request from a peer, but then we stand down from mastering. The SQLiteNode should have already told its
-            // peers that their outstanding requests were being canceled at this point.
-            if (command.initiatingPeerID && !(state == SQLiteNode::MASTERING || SQLiteNode::STANDINGDOWN)) {
-                SWARN("Found " << (command.complete ? "" : "in") << "complete " << "command "
-                      << command.request.methodLine << " from peer, but not mastering. Too late for it, discarding.");
-                continue;
-            }
-
-            // If this command is already complete, then we should be a slave, and the sync node got a response back
-            // from a command that had been escalated to master, and queued it for a worker to respond to. We'll send
-            // that response now.
-            if (command.complete) {
-                // If this command is already complete, we can return it to the caller.
-                // If it has an initiator, it should have been returned to a peer by a sync node instead, but if we've
-                // just switched states out of mastering, we might have an old command in the queue. All we can do here
-                // is note that and discard it, as we have nobody to deliver it to.
-                if (command.initiatingPeerID) {
-                    // Let's note how old this command is.
-                    uint64_t ageSeconds = (STimeNow() - command.creationTime) / STIME_US_PER_S;
-                    SWARN("Found unexpected complete command " << command.request.methodLine
-                          << " from peer in worker thread. Discarding (command was " << ageSeconds << "s old).");
-                    continue;
-                }
-
-                // Make sure we have an initiatingClientID at this point. If we do, but it's negative, it's for a
-                // client that we can't respond to, so we don't bother sending the response.
-                SASSERT(command.initiatingClientID);
-                if (command.initiatingClientID > 0) {
-                    server._reply(command);
-                }
-
-                // This command is done, move on to the next one.
-                continue;
-            }
-
-            // We'll retry on conflict up to this many times.
-            int retry = 3;
-            while (retry) {
-                // Try peeking the command. If this succeeds, then it's finished, and all we need to do is respond to
-                // the command at the bottom.
-                if (!core.peekCommand(command)) {
-                    // We've just unsuccessfully peeked a command, which means we're in a state where we might want to
-                    // write it. We'll flag that here, to keep the node from falling out of MASTERING/STANDINGDOWN
-                    // until we're finished with this command.
-                    server._writableCommandsInProgress++;
-                    if (command.httpsRequest) {
-                        // It's an error to open an HTTPS request unless we're mastering, since we won't be able to
-                        // record the response. Note that it's *possible* that the state of the node differs from what
-                        // it was when we set `state`, and `peekCommand` will have looked at the current state of the
-                        // node, not the one we saved in `state`. We could potentially mitigate this by only ever
-                        // peeking certain commands on the sync thread, but even still, we could lose HTTP responses
-                        // due to a crash or network event, so we don't try to hard to be perfect here.
-                        SASSERTWARN(state == SQLiteNode::MASTERING);
-                    }
-                    // Peek wasn't enough to handle this command. Now we need to decide if we should try and process
-                    // it, or if we should send it off to the sync node.
-                    bool canWriteParallel = server._multiWriteEnabled.load();
-                    if (canWriteParallel) {
-                        // If multi-write is enabled, then we need to make sure the command isn't blacklisted.
-                        SAUTOLOCK(_blacklistedParallelCommandMutex);
-                        canWriteParallel =
-                            (_blacklistedParallelCommands.find(command.request.methodLine) == _blacklistedParallelCommands.end());
-                    }
-
-                    // We need to have multi-write enabled, the command needs to not be explicitly blacklisted, and it
-                    // needs to not be automatically blacklisted.
-                    canWriteParallel = canWriteParallel && BedrockConflictMetrics::multiWriteOK(command.request.methodLine);
-                    if (!canWriteParallel                 ||
-                        server._suppressMultiWrite.load() ||
-                        state != SQLiteNode::MASTERING    ||
-                        command.httpsRequest              ||
-                        command.onlyProcessOnSyncThread   ||
-                        command.writeConsistency != SQLiteNode::ASYNC)
-                    {
-                        // Roll back the transaction, it'll get re-run in the sync thread.
-                        core.rollback();
-
-                        // We're not handling a writable command anymore.
-                        SINFO("[performance] Sending non-parallel command " << command.request.methodLine
-                              << " to sync thread. Sync thread has " << syncNodeQueuedCommands.size()
-                              << " queued commands.");
-                        server._writableCommandsInProgress--;
-                        syncNodeQueuedCommands.push(move(command));
-
-                        // We'll break out of our retry loop here, as we don't need to do anything else, we can just
-                        // look for another command to work on.
-                        break;
-                    } else {
-                        // In this case, there's nothing blocking us from processing this in a worker, so let's try it.
-                        if (core.processCommand(command)) {
-                            // If processCommand returned true, then we need to do a commit. Otherwise, the command is
-                            // done, and we just need to respond. Before we commit, we need to grab the sync thread
-                            // lock. Because the sync thread grabs an exclusive lock on this wrapping any transactions
-                            // that it performs, we'll get this lock while the sync thread isn't in the process of
-                            // handling a transaction, thus guaranteeing that we can't commit and cause a conflict on
-                            // the sync thread. We can still get conflicts here, as the sync thread might have
-                            // performed a transaction after we called `processCommand` and before we call `commit`,
-                            // or we could conflict with another worker thread, but the sync thread will never see a
-                            // conflict as long as we don't commit while it's performing a transaction. This is scoped
-                            // to the minimum time required.
-                            bool commitSuccess = false;
-                            {
-                                shared_lock<decltype(server._syncThreadCommitMutex)> lock1(server._syncThreadCommitMutex);
-
-                                // This is the first place we get really particular with the state of the node from a
-                                // worker thread. We only want to do this commit if we're *SURE* we're mastering, and
-                                // not allow the state of the node to change while we're committing. If it turns out
-                                // we've changed states, we'll roll this command back, so we lock the node's state
-                                // until we complete.
-                                //
-                                // IMPORTANT: If we acquire both _syncThreadCommitMutex and stateMutex, they always
-                                // need to be locked in that order. The reason for this is that it's possible for the
-                                // sync thread to to change states mid-commit, meaning that it needs to acquire these
-                                // locks in the same order. Always acquiring the locks in the same order prevents the
-                                // deadlocks.
-                                shared_lock<decltype(server._syncNode->stateMutex)> lock2(server._syncNode->stateMutex);
-                                if (replicationState.load() != SQLiteNode::MASTERING &&
-                                    replicationState.load() != SQLiteNode::STANDINGDOWN) {
-                                    SWARN("Node State changed from MASTERING to "
-                                          << SQLiteNode::stateNames[replicationState.load()]
-                                          << " during worker commit. Rolling back transaction!");
-                                    core.rollback();
-                                } else {
-                                    BedrockCore::AutoTimer(command, BedrockCommand::COMMIT_WORKER);
-                                    commitSuccess = core.commit();
-                                }
-                            }
-                            if (commitSuccess) {
-                                BedrockConflictMetrics::recordSuccess(command.request.methodLine);
-                                SINFO("Successfully committed " << command.request.methodLine << " on worker thread.");
-                                // So we must still be mastering, and at this point our commit has succeeded, let's
-                                // mark it as complete!
-                                command.complete = true;
-                            } else {
-                                BedrockConflictMetrics::recordConflict(command.request.methodLine);
-                                SINFO("Conflict or state change committing " << command.request.methodLine
-                                      << " on worker thread with " << retry << " retries remaining.");
-                            }
-                        }
-
-                        // Whether we rolled it back or committed it, it's no longer potentially getting written, so we
-                        // can decrement our counter.
-                        server._writableCommandsInProgress--;
-                    }
-                }
-
-                // If the command was completed above, then we'll go ahead and respond. Otherwise there must have been
-                // a conflict, and we'll retry.
-                if (command.complete) {
+            // This try block encapsulates the entirety of the time this command is in scope.
+            try {
+                // Check if this is a blacklisted command.
+                if (server._isBlacklisted(command)) {
+                    // If so, make a lot of noise, and respond 500 without processing it.
+                    SALERT("BLACKLISTED COMMAND FOUND: " << command.request.methodLine);
+                    command.response.methodLine = "500 Blacklisted";
+                    command.complete = true;
                     if (command.initiatingPeerID) {
                         // Escalated command. Give it back to the sync thread to respond.
                         syncNodeCompletedCommands.push(move(command));
@@ -762,21 +613,260 @@ void BedrockServer::worker(SData& args,
                         server._reply(command);
                     }
 
-                    // Don't need to retry.
-                    break;
+                    // Move on to the next command.
+                    continue;
                 }
 
-                // We're about to retry, decrement the retry count.
-                --retry;
-            }
+                SAUTOPREFIX(command.request["requestID"]);
+                SINFO("[performance] Dequeued command " << command.request.methodLine << " in worker, "
+                      << server._commandQueue.size() << " commands in queue.");
 
-            // We ran out of retries without finishing! We give it to the sync thread.
-            if (!retry) {
-                SINFO("[performance] Max retries hit in worker, forwarding command " << command.request.methodLine
-                      << " to sync thread. Sync thread has " << syncNodeQueuedCommands.size() << " queued commands.");
-                syncNodeQueuedCommands.push(move(command));
+                // We just spin until the node looks ready to go. Typically, this doesn't happen expect briefly at startup.
+                while (upgradeInProgress.load() ||
+                       (replicationState.load() != SQLiteNode::MASTERING &&
+                        replicationState.load() != SQLiteNode::SLAVING &&
+                        replicationState.load() != SQLiteNode::STANDINGDOWN)
+                ) {
+                    // Make sure that the node isn't shutting down, leaving us in an endless loop.
+                    if (server._shutdownState == SYNC_SHUTDOWN) {
+                        SWARN("Sync thread shut down while were waiting for it to come up. Discarding command '"
+                              << command.request.methodLine << "'.");
+                        return;
+                    }
+
+                    // This sleep call is pretty ugly, but it should almost never happen. We're accepting the potential
+                    // looping sleep call for the general case where we just check some bools and continue, instead of
+                    // avoiding the sleep call but having every thread lock a mutex here on every loop.
+                    usleep(10000);
+                }
+
+                // If this command is dependent on a commitCount newer than what we have (maybe it's a follow-up to a
+                // command that was escalated to master), we'll set it aside for later processing. When the sync node
+                // finishes its update loop, it will re-queue any of these commands that are no longer blocked on our
+                // updated commit count.
+                uint64_t commitCount = db.getCommitCount();
+                uint64_t commandCommitCount = command.request.calcU64("commitCount");
+                if (commandCommitCount > commitCount) {
+                    SAUTOLOCK(server._futureCommitCommandMutex);
+                    auto newQueueSize = server._futureCommitCommands.size() + 1;
+                    SINFO("Command (" << command.request.methodLine << ") depends on future commit(" << commandCommitCount
+                          << "), Currently at: " << commitCount << ", storing for later. Queue size: " << newQueueSize);
+                    server._futureCommitCommands.insert(make_pair(commandCommitCount, move(command)));
+                    if (newQueueSize > 100) {
+                        SHMMM("server._futureCommitCommands.size() == " << newQueueSize);
+                    }
+                    continue;
+                }
+
+                // OK, so this is the state right now, which isn't necessarily anything in particular, because the sync
+                // node can change it at any time, and we're not synchronizing on it. We're going to go ahead and assume
+                // it's something reasonable, because in most cases, that's pretty safe. If we think we're anything but
+                // MASTERING, we'll just peek this command and return it's result, which should be harmless. If we think
+                // we're mastering, we'll go ahead and start a `process` for the command, but we'll synchronously verify
+                // our state right before we commit.
+                SQLiteNode::State state = replicationState.load();
+
+                // If we find that we've gotten a command with an initiatingPeerID, but we're not in a mastering or
+                // standing down state, we'll have no way of returning this command to the caller, so we discard it. The
+                // original caller will need to re-send the request. This can happen if we're mastering, and receive a
+                // request from a peer, but then we stand down from mastering. The SQLiteNode should have already told its
+                // peers that their outstanding requests were being canceled at this point.
+                if (command.initiatingPeerID && !(state == SQLiteNode::MASTERING || SQLiteNode::STANDINGDOWN)) {
+                    SWARN("Found " << (command.complete ? "" : "in") << "complete " << "command "
+                          << command.request.methodLine << " from peer, but not mastering. Too late for it, discarding.");
+                    continue;
+                }
+
+                // If this command is already complete, then we should be a slave, and the sync node got a response back
+                // from a command that had been escalated to master, and queued it for a worker to respond to. We'll send
+                // that response now.
+                if (command.complete) {
+                    // If this command is already complete, we can return it to the caller.
+                    // If it has an initiator, it should have been returned to a peer by a sync node instead, but if we've
+                    // just switched states out of mastering, we might have an old command in the queue. All we can do here
+                    // is note that and discard it, as we have nobody to deliver it to.
+                    if (command.initiatingPeerID) {
+                        // Let's note how old this command is.
+                        uint64_t ageSeconds = (STimeNow() - command.creationTime) / STIME_US_PER_S;
+                        SWARN("Found unexpected complete command " << command.request.methodLine
+                              << " from peer in worker thread. Discarding (command was " << ageSeconds << "s old).");
+                        continue;
+                    }
+
+                    // Make sure we have an initiatingClientID at this point. If we do, but it's negative, it's for a
+                    // client that we can't respond to, so we don't bother sending the response.
+                    SASSERT(command.initiatingClientID);
+                    if (command.initiatingClientID > 0) {
+                        server._reply(command);
+                    }
+
+                    // This command is done, move on to the next one.
+                    continue;
+                }
+
+                // We'll retry on conflict up to this many times.
+                int retry = 3;
+                while (retry) {
+                    // Try peeking the command. If this succeeds, then it's finished, and all we need to do is respond to
+                    // the command at the bottom.
+                    if (!core.peekCommand(command)) {
+                        // We've just unsuccessfully peeked a command, which means we're in a state where we might want to
+                        // write it. We'll flag that here, to keep the node from falling out of MASTERING/STANDINGDOWN
+                        // until we're finished with this command.
+                        server._writableCommandsInProgress++;
+                        if (command.httpsRequest) {
+                            // It's an error to open an HTTPS request unless we're mastering, since we won't be able to
+                            // record the response. Note that it's *possible* that the state of the node differs from what
+                            // it was when we set `state`, and `peekCommand` will have looked at the current state of the
+                            // node, not the one we saved in `state`. We could potentially mitigate this by only ever
+                            // peeking certain commands on the sync thread, but even still, we could lose HTTP responses
+                            // due to a crash or network event, so we don't try to hard to be perfect here.
+                            SASSERTWARN(state == SQLiteNode::MASTERING);
+                        }
+                        // Peek wasn't enough to handle this command. Now we need to decide if we should try and process
+                        // it, or if we should send it off to the sync node.
+                        bool canWriteParallel = server._multiWriteEnabled.load();
+                        if (canWriteParallel) {
+                            // If multi-write is enabled, then we need to make sure the command isn't blacklisted.
+                            SAUTOLOCK(_blacklistedParallelCommandMutex);
+                            canWriteParallel =
+                                (_blacklistedParallelCommands.find(command.request.methodLine) == _blacklistedParallelCommands.end());
+                        }
+
+                        // We need to have multi-write enabled, the command needs to not be explicitly blacklisted, and it
+                        // needs to not be automatically blacklisted.
+                        canWriteParallel = canWriteParallel && BedrockConflictMetrics::multiWriteOK(command.request.methodLine);
+                        if (!canWriteParallel                 ||
+                            server._suppressMultiWrite.load() ||
+                            state != SQLiteNode::MASTERING    ||
+                            command.httpsRequest              ||
+                            command.onlyProcessOnSyncThread   ||
+                            command.writeConsistency != SQLiteNode::ASYNC)
+                        {
+                            // Roll back the transaction, it'll get re-run in the sync thread.
+                            core.rollback();
+
+                            // We're not handling a writable command anymore.
+                            SINFO("[performance] Sending non-parallel command " << command.request.methodLine
+                                  << " to sync thread. Sync thread has " << syncNodeQueuedCommands.size()
+                                  << " queued commands.");
+                            server._writableCommandsInProgress--;
+                            syncNodeQueuedCommands.push(move(command));
+
+                            // We'll break out of our retry loop here, as we don't need to do anything else, we can just
+                            // look for another command to work on.
+                            break;
+                        } else {
+                            // In this case, there's nothing blocking us from processing this in a worker, so let's try it.
+                            if (core.processCommand(command)) {
+                                // If processCommand returned true, then we need to do a commit. Otherwise, the command is
+                                // done, and we just need to respond. Before we commit, we need to grab the sync thread
+                                // lock. Because the sync thread grabs an exclusive lock on this wrapping any transactions
+                                // that it performs, we'll get this lock while the sync thread isn't in the process of
+                                // handling a transaction, thus guaranteeing that we can't commit and cause a conflict on
+                                // the sync thread. We can still get conflicts here, as the sync thread might have
+                                // performed a transaction after we called `processCommand` and before we call `commit`,
+                                // or we could conflict with another worker thread, but the sync thread will never see a
+                                // conflict as long as we don't commit while it's performing a transaction. This is scoped
+                                // to the minimum time required.
+                                bool commitSuccess = false;
+                                {
+                                    shared_lock<decltype(server._syncThreadCommitMutex)> lock1(server._syncThreadCommitMutex);
+
+                                    // This is the first place we get really particular with the state of the node from a
+                                    // worker thread. We only want to do this commit if we're *SURE* we're mastering, and
+                                    // not allow the state of the node to change while we're committing. If it turns out
+                                    // we've changed states, we'll roll this command back, so we lock the node's state
+                                    // until we complete.
+                                    //
+                                    // IMPORTANT: If we acquire both _syncThreadCommitMutex and stateMutex, they always
+                                    // need to be locked in that order. The reason for this is that it's possible for the
+                                    // sync thread to to change states mid-commit, meaning that it needs to acquire these
+                                    // locks in the same order. Always acquiring the locks in the same order prevents the
+                                    // deadlocks.
+                                    shared_lock<decltype(server._syncNode->stateMutex)> lock2(server._syncNode->stateMutex);
+                                    if (replicationState.load() != SQLiteNode::MASTERING &&
+                                        replicationState.load() != SQLiteNode::STANDINGDOWN) {
+                                        SWARN("Node State changed from MASTERING to "
+                                              << SQLiteNode::stateNames[replicationState.load()]
+                                              << " during worker commit. Rolling back transaction!");
+                                        core.rollback();
+                                    } else {
+                                        BedrockCore::AutoTimer(command, BedrockCommand::COMMIT_WORKER);
+                                        commitSuccess = core.commit();
+                                    }
+                                }
+                                if (commitSuccess) {
+                                    BedrockConflictMetrics::recordSuccess(command.request.methodLine);
+                                    SINFO("Successfully committed " << command.request.methodLine << " on worker thread.");
+                                    // So we must still be mastering, and at this point our commit has succeeded, let's
+                                    // mark it as complete!
+                                    command.complete = true;
+                                } else {
+                                    BedrockConflictMetrics::recordConflict(command.request.methodLine);
+                                    SINFO("Conflict or state change committing " << command.request.methodLine
+                                          << " on worker thread with " << retry << " retries remaining.");
+                                }
+                            }
+
+                            // Whether we rolled it back or committed it, it's no longer potentially getting written, so we
+                            // can decrement our counter.
+                            server._writableCommandsInProgress--;
+                        }
+                    }
+
+                    // If the command was completed above, then we'll go ahead and respond. Otherwise there must have been
+                    // a conflict, and we'll retry.
+                    if (command.complete) {
+                        if (command.initiatingPeerID) {
+                            // Escalated command. Give it back to the sync thread to respond.
+                            syncNodeCompletedCommands.push(move(command));
+                        } else {
+                            server._reply(command);
+                        }
+
+                        // Don't need to retry.
+                        break;
+                    }
+
+                    // We're about to retry, decrement the retry count.
+                    --retry;
+                }
+
+                // We ran out of retries without finishing! We give it to the sync thread.
+                if (!retry) {
+                    SINFO("[performance] Max retries hit in worker, forwarding command " << command.request.methodLine
+                          << " to sync thread. Sync thread has " << syncNodeQueuedCommands.size() << " queued commands.");
+                    syncNodeQueuedCommands.push(move(command));
+                }
+            } catch (...) {
+                // Catch absolutely anything.
+                // If we haven't already set a broadcast message, set one now.
+                if (!server._hasBroadcastMessage.fetch_add(1)) {
+                    // Set the message to broadcast.
+                    SData message("BLACKLIST_COMMAND");
+                    SData subMessage(command.request.methodLine);
+                    for (auto& field : command.blacklistableValues) {
+                        auto it = command.request.nameValueMap.find(field);
+                        if (it != command.request.nameValueMap.end()) {
+                            subMessage[field] = it->second;
+                        }
+                    }
+                    message.content = subMessage.serialize();
+                    SALERT("Caught unexpected exception, setting broadcast message: " << message.serialize());
+                    server._setBroadcastMessage(message);
+
+                    // Lock to wait.
+                    unique_lock<decltype(server._waitForBroadcastMutex)> lock(server._waitForBroadcastMutex);
+
+                    // Wait for the broadcast to have been sent.
+                    server._waitForBroadcast.wait(lock, [&server]{return !server._hasBroadcastMessage.load();});
+                    SALERT("Message was broadcast. re-throwing.");
+                }
+                // And re-throw the exception, which will cause us to die.
+                rethrow_exception(current_exception());
             }
-        } catch(const timeout_error& e) {
+        } catch (const BedrockCommandQueue::timeout_error& e) {
             // No commands to process after 1 second.
         }
 
@@ -802,12 +892,57 @@ void BedrockServer::worker(SData& args,
     }
 }
 
+bool BedrockServer::_isBlacklisted(const BedrockCommand& command) {
+    // Get a shared lock so that all the workers can look at this map simultaneously.
+    shared_lock<decltype(_blackListCommandMutex)> lock(_blackListCommandMutex);
+
+    // Typically, this map is empty and this returns no results.
+    auto itpair = _blacklistedCommands.equal_range(command.request.methodLine);
+    auto& current = itpair.first;
+    auto& end = itpair.second;
+
+    // Look at each blacklisted command that has the same methodLine.
+    while (current != end && current != _blacklistedCommands.end()) {
+        const STable& values = current->second;
+
+        // These are all of the blacklisted keys that need to match to kill this command.
+        bool isMatch = true;
+        for (auto& pair : values) {
+            // See if our current command even has the blacklisted key.
+            auto it = command.request.nameValueMap.find(pair.first);
+            if (it ==  command.request.nameValueMap.end()) {
+                // If we didn't find it, the command's not sufficiently similar, and is not blacklisted.
+                isMatch = false;
+                break;
+            }
+
+            // At this point, we must have the same key, but if it doesn't have the same value, then it doesn't match.
+            if (it->second != pair.second) {
+                isMatch = false;
+                break;
+            }
+        }
+
+        if (isMatch) {
+            // If we got through the whole list and everything was a match, then this is blacklisted.
+            return true;
+        }
+        
+        // Otherwise, check the next entry in our range.
+        current++;
+    }
+
+    // If nothing in our range returned true, then not blacklisted.
+    return false;
+}
+
+
 BedrockServer::BedrockServer(const SData& args)
   : SQLiteServer(""), _args(args), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),
     _syncNode(nullptr), _suppressMultiWrite(true), _shutdownState(RUNNING),
     _multiWriteEnabled(args.test("-enableMultiWrite")), _backupOnShutdown(false), _detach(false),
-    _controlPort(nullptr), _commandPort(nullptr)
+    _controlPort(nullptr), _commandPort(nullptr), _hasBroadcastMessage(0)
 {
     _version = SVERSION;
 
@@ -1547,4 +1682,9 @@ void BedrockServer::_beginShutdown(const string& reason, bool detach) {
 
 bool BedrockServer::backupOnShutdown() {
     return _backupOnShutdown;
+}
+
+void BedrockServer::_setBroadcastMessage(const SData& message) {
+    _broadcastMessage = message;
+    _hasBroadcastMessage.store(true);
 }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -171,17 +171,6 @@ class BedrockServer : public SQLiteServer {
                        int threadId,
                        int threadCount);
 
-    // Wraps the worker thread main function to make it easy to add exception handling.
-    static void workerWrapper(SData& args,
-                       atomic<SQLiteNode::State>& _replicationState,
-                       atomic<bool>& upgradeInProgress,
-                       atomic<string>& masterVersion,
-                       CommandQueue& syncNodeQueuedCommands,
-                       CommandQueue& syncNodeCompletedCommands,
-                       BedrockServer& server,
-                       int threadId,
-                       int threadCount);
-
     // Send a reply for a completed command back to the initiating client. If the `originator` of the command is set,
     // then this is an error, as the command should have been sent back to a peer.
     void _reply(BedrockCommand&);

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -254,4 +254,17 @@ class BedrockServer : public SQLiteServer {
     // Pointer to the control port, so we know which port not to shut down when we close the command ports.
     Port* _controlPort;
     Port* _commandPort;
+
+    // The blacklist mutex.
+    shared_timed_mutex _blackListCommandMutex;
+
+    // The blacklist is a multimap. Each entry has a command name, and then a map.
+    // For a command to be blacklisted, it must have all of the key/value pairs in the map, and they must match.
+    multimap<string, STable> _blacklistedCommands;
+    bool _isBlacklisted(const BedrockCommand& command);
+    void _setBroadcastMessage(const SData& message);
+    SData _broadcastMessage;
+    atomic<int> _hasBroadcastMessage;
+    mutex _waitForBroadcastMutex;
+    condition_variable _waitForBroadcast;
 };

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -280,4 +280,7 @@ class BedrockServer : public SQLiteServer {
     // that message has been sent, and continue doing whatever it was doing before (namely, crashing).
     mutex _waitForBroadcastMutex;
     condition_variable _waitForBroadcast;
+
+    // Generate a BLACKLIST_COMMAND command for a given bad command.
+    static SData _generateBlacklistMessage(const BedrockCommand& command);
 };

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -251,7 +251,7 @@ class BedrockServer : public SQLiteServer {
     // message before the worker exits.
 
     // A shared mutex to control access to the list of crash-inducing commands.
-    shared_timed_mutex _crashCommandListMutex;
+    shared_timed_mutex _crashCommandMutex;
 
     // Definitions of crash-causing commands. This is a map of methodLine to name/value pairs required to match a
     // particular command for it count as a match likely to cause a crash.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -260,15 +260,6 @@ class BedrockServer : public SQLiteServer {
     // Check a command against the list of crash commands, and return whether we think the command would crash.
     bool _wouldCrash(const BedrockCommand& command);
 
-    // A worker thread can set this to point to the command that caused a crash that it's currently handling (in a
-    // signal handler), to let the sync thread know it needs to warn other nodes about this command.
-    atomic<BedrockCommand*> _crashCommandPtr;
-
-    // We use a condition variable to block a thread that has set `_crashCommandPtr` until a message has been sent to
-    // peers. This keeps the signal handler from returning and causing us to exit before the message is sent.
-    mutex _emergencyBroadcastMutex;
-    condition_variable _emergencyBroadcastCondition;
-
     // Generate a CRASH_COMMAND command for a given bad command.
     static SData _generateCrashMessage(const BedrockCommand* command);
 };

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -269,6 +269,6 @@ class BedrockServer : public SQLiteServer {
     mutex _emergencyBroadcastMutex;
     condition_variable _emergencyBroadcastCondition;
 
-    // Generate a BLACKLIST_COMMAND command for a given bad command.
+    // Generate a CRASH_COMMAND command for a given bad command.
     static SData _generateCrashMessage(const BedrockCommand* command);
 };

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -27,6 +27,7 @@ struct STCPManager {
 
       private:
         static atomic<uint64_t> socketCount;
+        recursive_mutex sendRecvMutex;
     };
 
     // Cleans up outstanding sockets

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -649,6 +649,9 @@ int SParseHTTP(const char* buffer, size_t length, string& methodLine, STable& na
         // Found the end of the line; is the line blank?
         if (lineEnd == lineStart) {
             // Blank line -- if we have at least the method, then we're done.  Otherwise, ignore.
+
+            // We want to look this up without inserting it.
+            auto it = nameValueMap.find("Transfer-Encoding");
             if (!methodLine.empty()) {
                 // If we are done processing a chunked body.
                 if (isChunked) {
@@ -663,7 +666,7 @@ int SParseHTTP(const char* buffer, size_t length, string& methodLine, STable& na
                 }
 
                 // If not processing a chunked body, then finish up.
-                else if (!SIEquals(nameValueMap["Transfer-Encoding"], "chunked")) {
+                else if (it == nameValueMap.end() || !SIEquals(it->second, "chunked")) {
                     // We have a method -- we're done.  Figure out the end of the message
                     // by consuming up to 2 EOL characters, then return the total length.
                     const char* parseEnd = lineEnd;

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -689,10 +689,6 @@ inline string S_recv(int s) {
     return buf;
 }
 bool S_sendconsume(int s, string& sendBuffer);
-inline bool S_send(int s, string sendBuffer) {
-    S_sendconsume(s, sendBuffer);
-    return sendBuffer.empty();
-}
 int S_poll(fd_map& fdm, uint64_t timeout);
 
 // Network helpers

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -44,6 +44,8 @@ using namespace std;
 // Initialize libstuff on every thread before calling any of its functions
 void SInitialize(string threadName = "");
 
+void SSetSignalHandlerDieFunc(function<void()>&& func);
+
 // --------------------------------------------------------------------------
 // Assertion stuff
 // --------------------------------------------------------------------------

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1688,9 +1688,9 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             _escalatedCommandMap.erase(commandIt);
         } else
             SWARN("Received ESCALATE_ABORTED for unescalated command " << message["ID"] << ", ignoring.");
-    } else if (SIEquals(message.methodLine, "BLACKLIST_COMMAND")) {
+    } else if (SIEquals(message.methodLine, "CRASH_COMMAND")) {
         // Create a new Command and send to the server.
-        PINFO("Received BLACKLIST_COMMAND command, forwarding to server.");
+        PINFO("Received CRASH_COMMAND command, forwarding to server.");
         SData messageCopy = message;
         _server.acceptCommand(SQLiteCommand(move(messageCopy)));
     } else {
@@ -1846,7 +1846,8 @@ void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly) {
     }
 }
 
-void SQLiteNode::broadcastImmediate(const SData& message) {
+void SQLiteNode::emergencyBroadcast(const SData& message) {
+    SALERT("Sending emergency broadcast: " << message.serialize());
     _sendToAllPeers(message, false);
 }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1688,6 +1688,11 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             _escalatedCommandMap.erase(commandIt);
         } else
             SWARN("Received ESCALATE_ABORTED for unescalated command " << message["ID"] << ", ignoring.");
+    } else if (SIEquals(message.methodLine, "BLACKLIST_COMMAND")) {
+        // Create a new Command and send to the server.
+        PINFO("Received BLACKLIST_COMMAND command, forwarding to server.");
+        SData messageCopy = message;
+        _server.acceptCommand(SQLiteCommand(move(messageCopy)));
     } else {
         STHROW("unrecognized message");
     }
@@ -1839,6 +1844,10 @@ void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly) {
             peer->s->send(serializedMessage);
         }
     }
+}
+
+void SQLiteNode::broadcastImmediate(const SData& message) {
+    _sendToAllPeers(message, false);
 }
 
 void SQLiteNode::_changeState(SQLiteNode::State newState) {

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -107,6 +107,9 @@ class SQLiteNode : public STCPNode {
     // 2. SQLite::g_commitLock
     shared_timed_mutex stateMutex;
 
+    // Allows the caller to send a message to all peers immediately.
+    void broadcastImmediate(const SData& message);
+
   private:
     // STCPNode API: Peer handling framework functions
     void _onConnect(Peer* peer);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -107,8 +107,10 @@ class SQLiteNode : public STCPNode {
     // 2. SQLite::g_commitLock
     shared_timed_mutex stateMutex;
 
-    // Allows the caller to send a message to all peers immediately.
-    void broadcastImmediate(const SData& message);
+    // This allows the caller to immediately send a message to all peers that something horrible has happened,
+    // typically, we've segfaulted and are trying to warn other servers of a bad command before we finish crashing.
+    // This is not to be used as a general messaging mechanism.
+    void emergencyBroadcast(const SData& message);
 
   private:
     // STCPNode API: Peer handling framework functions

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -17,6 +17,8 @@ void BedrockPlugin_TestPlugin::initialize(const SData& args, BedrockServer& serv
 }
 
 bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) {
+    // Always blacklist on userID.
+    command.blacklistableValues.insert("userID");
     // This should never exist when calling peek.
     SASSERT(!command.httpsRequest);
     if (command.request.methodLine == "testcommand") {
@@ -48,6 +50,8 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
             db.read(query, result);
         }
         return true;
+    } else if (command.request.methodLine == "dieinpeek") {
+        throw 1;
     }
 
     return false;
@@ -99,6 +103,8 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
             SQResult result;
             db.read(query, result);
         }
+    } else if (command.request.methodLine == "dieinprocess") {
+        throw 2;
     }
     return false;
 }

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -52,6 +52,10 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
         return true;
     } else if (command.request.methodLine == "dieinpeek") {
         throw 1;
+    } else if (command.request.methodLine == "generatesegfaultpeek") {
+        int* i = 0;
+        int x = *i;
+        command.response["invalid"] = to_string(x);
     }
 
     return false;
@@ -105,7 +109,7 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
         }
     } else if (command.request.methodLine == "dieinprocess") {
         throw 2;
-    } else if (command.request.methodLine == "generatesegfault") {
+    } else if (command.request.methodLine == "generatesegfaultprocess") {
         int* i = 0;
         int x = *i;
         command.response["invalid"] = to_string(x);

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -105,6 +105,10 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
         }
     } else if (command.request.methodLine == "dieinprocess") {
         throw 2;
+    } else if (command.request.methodLine == "generatesegfault") {
+        int* i = 0;
+        int x = *i;
+        command.response["invalid"] = to_string(x);
     }
     return false;
 }

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -18,7 +18,7 @@ void BedrockPlugin_TestPlugin::initialize(const SData& args, BedrockServer& serv
 
 bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) {
     // Always blacklist on userID.
-    command.blacklistableValues.insert("userID");
+    command.crashIdentifyingValues.insert("userID");
     // This should never exist when calling peek.
     SASSERT(!command.httpsRequest);
     if (command.request.methodLine == "testcommand") {

--- a/test/clustertest/tests/j_BadCommandTest.cpp
+++ b/test/clustertest/tests/j_BadCommandTest.cpp
@@ -14,28 +14,32 @@ struct j_BadCommandTest : tpunit::TestFixture {
         BedrockTester* master = tester->getBedrockTester(0);
         BedrockTester* slave = tester->getBedrockTester(1);
 
+        // Make sure unhandled exceptions send the right response.
+        SData cmd("dieinpeek");
+        cmd["userID"] = "31";
+        string response = master->executeWaitVerifyContent(cmd, "500 Unhandled Exception");
+
+        cmd = SData("dieinprocess");
+        cmd["userID"] = "31";
+        response = master->executeWaitVerifyContent(cmd, "500 Unhandled Exception");
+
+        // Segfault in peek.
         bool diedCorrectly = false;
         try {
-            SData cmd("dieinpeek");
-            cmd["userID"] = "31";
+            SData cmd("generatesegfaultpeek");
+            cmd["userID"] = "32";
             string response = master->executeWaitVerifyContent(cmd);
         } catch (const SException& e) {
             diedCorrectly = (e.what() == "Empty response"s);
         }
-
         ASSERT_TRUE(diedCorrectly);
 
-        // Wait for something to be mastering.
-        sleep(1);
+        // Send the same command to the slave.
+        cmd = SData("generatesegfaultpeek");
+        cmd["userID"] = "32";
+        response = slave->executeWaitVerifyContent(cmd, "500 Blacklisted");
 
-        // Send the same command to a slave. It should blacklist it.
-        SData cmd("dieinpeek");
-        cmd["userID"] = "31";
-        string response = slave->executeWaitVerifyContent(cmd, "500 Blacklisted");
-
-        // Slave blacklisted it ok
-
-        // Try and bring master back up.
+        // Bring master back up.
         tester->startNode(0);
         int count = 0;
         bool success = false;
@@ -47,69 +51,43 @@ struct j_BadCommandTest : tpunit::TestFixture {
                 success = true;
                 break;
             }
-
-            // Give it another second...
             sleep(1);
         }
-
         ASSERT_TRUE(success);
 
-        // Master is back up.
-
-        // Kill it in process.
+        // Segfault in process.
         diedCorrectly = false;
         try {
-            SData cmd("dieinprocess");
-            cmd["userID"] = "32";
-            string response = master->executeWaitVerifyContent(cmd);
-        } catch (const SException& e) {
-            diedCorrectly = (e.what() == "Empty response"s);
-        }
-        ASSERT_TRUE(diedCorrectly);
-
-        // Wait until the old slave was mastering.
-        count = 0;
-        success = false;
-        while (count++ < 50) {
-            SData cmd("Status");
-            string response = slave->executeWaitVerifyContent(cmd);
-            STable json = SParseJSONObject(response);
-            if (json["state"] == "MASTERING") {
-                success = true;
-                break;
-            }
-
-            // Give it another second...
-            sleep(1);
-        }
-
-        ASSERT_TRUE(success);
-
-        // Slave promoted to master.
-
-        // Send the same command to the slave (now master).
-        cmd = SData("dieinprocess");
-        cmd["userID"] = "32";
-        response = slave->executeWaitVerifyContent(cmd, "500 Blacklisted");
-
-        // Promoted slave successfully blacklisted command.
-
-        // Kill it in process again with a different userID, since it won't count as blacklisted with a different user.
-        diedCorrectly = false;
-        try {
-            SData cmd("dieinprocess");
+            SData cmd("generatesegfaultprocess");
             cmd["userID"] = "33";
-            string response = slave->executeWaitVerifyContent(cmd);
+            string response = master->executeWaitVerifyContent(cmd);
         } catch (const SException& e) {
             diedCorrectly = (e.what() == "Empty response"s);
         }
         ASSERT_TRUE(diedCorrectly);
 
-        // Bring them both back up.
-        tester->startNode(0);
-        tester->startNode(1);
+        // Verify the slave is now mastering.
+        count = 0;
+        success = false;
+        while (count++ < 50) {
+            SData cmd("Status");
+            string response = slave->executeWaitVerifyContent(cmd);
+            STable json = SParseJSONObject(response);
+            if (json["state"] == "MASTERING") {
+                success = true;
+                break;
+            }
+            sleep(1);
+        }
+        ASSERT_TRUE(success);
 
-        // Wait for master to master.
+        // Send the slave the same command, it should be blacklisted.
+        cmd = SData("generatesegfaultprocess");
+        cmd["userID"] = "33";
+        response = slave->executeWaitVerifyContent(cmd, "500 Blacklisted");
+
+        // Try and bring master back up, just because the next test will expect it.
+        tester->startNode(0);
         count = 0;
         success = false;
         while (count++ < 50) {
@@ -120,41 +98,9 @@ struct j_BadCommandTest : tpunit::TestFixture {
                 success = true;
                 break;
             }
-
-            // Give it another second...
             sleep(1);
         }
         ASSERT_TRUE(success);
-
-        // Wait for slave to slave.
-        count = 0;
-        success = false;
-        while (count++ < 50) {
-            SData cmd("Status");
-            string response = slave->executeWaitVerifyContent(cmd);
-            STable json = SParseJSONObject(response);
-            if (json["state"] == "SLAVING") {
-                success = true;
-                break;
-            }
-            // Give it another second...
-            sleep(1);
-        }
-        ASSERT_TRUE(success);
-
-        diedCorrectly = false;
-        try {
-            SData cmd("generatesegfault");
-            cmd["userID"] = "34";
-            string response = master->executeWaitVerifyContent(cmd);
-        } catch (const SException& e) {
-            diedCorrectly = (e.what() == "Empty response"s);
-        }
-        ASSERT_TRUE(diedCorrectly);
-
-        cmd = SData("generatesegfault");
-        cmd["userID"] = "34";
-        response = slave->executeWaitVerifyContent(cmd, "500 Blacklisted");
     }
 
 } __j_BadCommandTest;

--- a/test/clustertest/tests/j_BadCommandTest.cpp
+++ b/test/clustertest/tests/j_BadCommandTest.cpp
@@ -37,7 +37,7 @@ struct j_BadCommandTest : tpunit::TestFixture {
         // Send the same command to the slave.
         cmd = SData("generatesegfaultpeek");
         cmd["userID"] = "32";
-        response = slave->executeWaitVerifyContent(cmd, "500 Blacklisted");
+        response = slave->executeWaitVerifyContent(cmd, "500 Refused");
 
         // Bring master back up.
         tester->startNode(0);
@@ -84,7 +84,7 @@ struct j_BadCommandTest : tpunit::TestFixture {
         // Send the slave the same command, it should be blacklisted.
         cmd = SData("generatesegfaultprocess");
         cmd["userID"] = "33";
-        response = slave->executeWaitVerifyContent(cmd, "500 Blacklisted");
+        response = slave->executeWaitVerifyContent(cmd, "500 Refused");
 
         // Try and bring master back up, just because the next test will expect it.
         tester->startNode(0);

--- a/test/clustertest/tests/j_BadCommandTest.cpp
+++ b/test/clustertest/tests/j_BadCommandTest.cpp
@@ -20,7 +20,6 @@ struct j_BadCommandTest : tpunit::TestFixture {
             cmd["userID"] = "31";
             string response = master->executeWaitVerifyContent(cmd);
         } catch (const SException& e) {
-            cout << "Looks like it died in peek (" << e.what() << ")." << endl;
             diedCorrectly = (e.what() == "Empty response"s);
         }
 
@@ -33,7 +32,8 @@ struct j_BadCommandTest : tpunit::TestFixture {
         SData cmd("dieinpeek");
         cmd["userID"] = "31";
         string response = slave->executeWaitVerifyContent(cmd, "500 Blacklisted");
-        cout << "Slave blacklisted it ok" << endl;
+
+        // Slave blacklisted it ok
 
         // Try and bring master back up.
         tester->startNode(0);
@@ -54,7 +54,7 @@ struct j_BadCommandTest : tpunit::TestFixture {
 
         ASSERT_TRUE(success);
 
-        cout << "Master is back up." << endl;
+        // Master is back up.
 
         // Kill it in process.
         diedCorrectly = false;
@@ -63,7 +63,6 @@ struct j_BadCommandTest : tpunit::TestFixture {
             cmd["userID"] = "32";
             string response = master->executeWaitVerifyContent(cmd);
         } catch (const SException& e) {
-            cout << "Looks like it died in process(" << e.what() << ")." << endl;
             diedCorrectly = (e.what() == "Empty response"s);
         }
         ASSERT_TRUE(diedCorrectly);
@@ -86,14 +85,14 @@ struct j_BadCommandTest : tpunit::TestFixture {
 
         ASSERT_TRUE(success);
 
-        cout << "Slave promoted to master." << endl;
+        // Slave promoted to master.
 
         // Send the same command to the slave (now master).
         cmd = SData("dieinprocess");
         cmd["userID"] = "32";
         response = slave->executeWaitVerifyContent(cmd, "500 Blacklisted");
 
-        cout << "Promoted slave successfully blacklisted command." << endl;
+        // Promoted slave successfully blacklisted command.
 
         // Kill it in process again with a different userID, since it won't count as blacklisted with a different user.
         diedCorrectly = false;
@@ -102,7 +101,6 @@ struct j_BadCommandTest : tpunit::TestFixture {
             cmd["userID"] = "33";
             string response = slave->executeWaitVerifyContent(cmd);
         } catch (const SException& e) {
-            cout << "Looks like it died in process(" << e.what() << ")." << endl;
             diedCorrectly = (e.what() == "Empty response"s);
         }
         ASSERT_TRUE(diedCorrectly);

--- a/test/clustertest/tests/j_BadCommandTest.cpp
+++ b/test/clustertest/tests/j_BadCommandTest.cpp
@@ -142,8 +142,6 @@ struct j_BadCommandTest : tpunit::TestFixture {
         }
         ASSERT_TRUE(success);
 
-        cout << "Ready to segfault." << endl;
-
         diedCorrectly = false;
         try {
             SData cmd("generatesegfault");
@@ -151,17 +149,12 @@ struct j_BadCommandTest : tpunit::TestFixture {
             string response = master->executeWaitVerifyContent(cmd);
         } catch (const SException& e) {
             diedCorrectly = (e.what() == "Empty response"s);
-            cout << "Died in segfault." << endl;
         }
         ASSERT_TRUE(diedCorrectly);
-
-        cout << "Master died as expected." << endl;
 
         cmd = SData("generatesegfault");
         cmd["userID"] = "34";
         response = slave->executeWaitVerifyContent(cmd, "500 Blacklisted");
-
-        cout << "Slave blacklisted, all done!" << endl;
     }
 
 } __j_BadCommandTest;

--- a/test/clustertest/tests/j_BadCommandTest.cpp
+++ b/test/clustertest/tests/j_BadCommandTest.cpp
@@ -1,0 +1,111 @@
+#include "../BedrockClusterTester.h"
+
+struct j_BadCommandTest : tpunit::TestFixture {
+    j_BadCommandTest()
+        : tpunit::TestFixture("j_BadCommand",
+                              TEST(j_BadCommandTest::test)
+                             ) { }
+
+    BedrockClusterTester* tester;
+
+    void test()
+    {
+        tester = BedrockClusterTester::testers.front();
+        BedrockTester* master = tester->getBedrockTester(0);
+        BedrockTester* slave = tester->getBedrockTester(1);
+
+        bool diedCorrectly = false;
+        try {
+            SData cmd("dieinpeek");
+            cmd["userID"] = "31";
+            string response = master->executeWaitVerifyContent(cmd);
+        } catch (const SException& e) {
+            cout << "Looks like it died in peek (" << e.what() << ")." << endl;
+            diedCorrectly = (e.what() == "Empty response"s);
+        }
+
+        ASSERT_TRUE(diedCorrectly);
+
+        // Wait for something to be mastering.
+        sleep(1);
+
+        // Send the same command to a slave. It should blacklist it.
+        SData cmd("dieinpeek");
+        cmd["userID"] = "31";
+        string response = slave->executeWaitVerifyContent(cmd, "500 Blacklisted");
+        cout << "Slave blacklisted it ok" << endl;
+
+        // Try and bring master back up.
+        tester->startNode(0);
+        int count = 0;
+        bool success = false;
+        while (count++ < 50) {
+            SData cmd("Status");
+            string response = master->executeWaitVerifyContent(cmd);
+            STable json = SParseJSONObject(response);
+            if (json["state"] == "MASTERING") {
+                success = true;
+                break;
+            }
+
+            // Give it another second...
+            sleep(1);
+        }
+
+        ASSERT_TRUE(success);
+
+        cout << "Master is back up." << endl;
+
+        // Kill it in process.
+        diedCorrectly = false;
+        try {
+            SData cmd("dieinprocess");
+            cmd["userID"] = "32";
+            string response = master->executeWaitVerifyContent(cmd);
+        } catch (const SException& e) {
+            cout << "Looks like it died in process(" << e.what() << ")." << endl;
+            diedCorrectly = (e.what() == "Empty response"s);
+        }
+        ASSERT_TRUE(diedCorrectly);
+
+        // Wait until the old slave was mastering.
+        count = 0;
+        success = false;
+        while (count++ < 50) {
+            SData cmd("Status");
+            string response = slave->executeWaitVerifyContent(cmd);
+            STable json = SParseJSONObject(response);
+            if (json["state"] == "MASTERING") {
+                success = true;
+                break;
+            }
+
+            // Give it another second...
+            sleep(1);
+        }
+
+        ASSERT_TRUE(success);
+
+        cout << "Slave promoted to master." << endl;
+
+        // Send the same command to the slave (now master).
+        cmd = SData("dieinprocess");
+        cmd["userID"] = "32";
+        response = slave->executeWaitVerifyContent(cmd, "500 Blacklisted");
+
+        cout << "Promoted slave successfully blacklisted command." << endl;
+
+        // Kill it in process again with a different userID, since it won't count as blacklisted with a different user.
+        diedCorrectly = false;
+        try {
+            SData cmd("dieinprocess");
+            cmd["userID"] = "33";
+            string response = slave->executeWaitVerifyContent(cmd);
+        } catch (const SException& e) {
+            cout << "Looks like it died in process(" << e.what() << ")." << endl;
+            diedCorrectly = (e.what() == "Empty response"s);
+        }
+        ASSERT_TRUE(diedCorrectly);
+    }
+
+} __j_BadCommandTest;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -198,6 +198,9 @@ string BedrockTester::executeWaitVerifyContent(SData request, const string& expe
     if (results.size() == 0) {
         STHROW("No result.");
     }
+    if (results[0].methodLine == "") {
+        STHROW("Empty response");
+    }
     if (!SStartsWith(results[0].methodLine, expectedResult)) {
         STHROW("Expected " + expectedResult + ", but got: " + results[0].methodLine);
     }


### PR DESCRIPTION
@quinthar 
cc @coleaeason

~HOLD on: https://github.com/Expensify/Server-Expensify/pull/2290~

Fixes: https://github.com/Expensify/Expensify/issues/63840

This change causes a server to broadcast a message upon crashing, so that other servers can blacklist similar commands from running, preventing cascading crashes of the entire cluster.

## Blacklist format - What gets blacklisted?
A set of command properties has been added to `BedrockCommand`. This is named `blacklistableValues`. A plugin may set any string as a `blacklistableValue`. What this means is tha for a command to be blacklisted, it must have the same values for all of the keys in `blacklistableValues`. Let's use an example:

Pretend we have a problematic command called `SetPolicy`. We set no `blacklistableValues` for this command, and it causes a crash. The blacklisted command, then, is jsut:

```
SetPolicy
```

But say we update Auth to add `accountID` to `blacklistableValues`. Say this command causes a crash on accountID `N`.

Now, the blacklisted command is:

```
SetPolicy
accountID: N
```

Whenever Bedrock receives a `SetPolicy` command, it will check whether `accountID` for that command is `N`, and if so, the command is blacklisted, and returns `500 Blacklisted`.

If more than one key is added to `blacklistableValues`, then *all* of those keys must match to blacklist a command. If *no* keys are added, then all commands with the same methodLine are blacklisted.

The blacklist can be reset by sending the control command `ClearCrashBlacklist`.

## How does it work?

Fundamentally, when a server is about to crash, it creates a `BLACKLIST_COMMAND` command, and populates the body of that command with all of the key/value pairs from the command that caused the crash that are included in `blacklistableValues` for that command. It broadcasts this command to all of its peers.

When a server receives a `BLACKLIST_COMMAND` it bypasses all command queueing and makes an entry in its blacklist for that command and its `blacklistableValues`.

## But really, how does it do that?

We add extra functionality to the signal handler, and when it receives any of SIGSEGV, SIGABRT, SIGFPE, SIGILL, or SIGBUS it will call a function before stacktracing and dying. By default, this function is a no-op, and does nothing. However, in the `sync` and `worker` threads, whenever they dequeue a command, they create a lambda, which is bound to the current command and server state, and set their own signal handler function to that lambda. The signal handler function is stored in thread local storage, and since the signals we're handling here are delivered to the thread that generated them, the signal handler will be able to run the function corresponding to the current command on the correct thread.

What the signal handling function does differs depending on which thread calls it. On the sync thread, this is pretty trivial - it instructs the syncNode to broadcast a message to all peers. When that returns, it exits, and the signal handler resumes killing the program.

On a worker thread, this is somewhat more complex, as the worker cannot write directly to the sync node. What the function does here is generate a message to send, set a flag, and then wait on a condition variable.

The top of the sync thread main loop checks for this flag, and if it's set, it will send the message generated by the worker thread to its peers, then notify the thread waiting on the condition variable.

The worker, now that it's done waiting on the condition variable, will then unblock and finish crashing, but the message will have been sent.

It's entirely possible that anything in this signal handling code will fail, as most of this is not allowed in a signal handler, but the penalty for failure is low, as we're crashing anyway.

## Tests

New automated tests have been added.