### PR TITLE
Use commit-count from after command was actually committed.

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -144,9 +144,6 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
             response.methodLine = "200 OK";
         }
 
-        // Add the commitCount header to the response.
-        response["commitCount"] = to_string(_db.getCommitCount());
-
         // Success, this command will be committed.
         SINFO("Processed '" << response.methodLine << "' for '" << request.methodLine << "'.");
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -301,7 +301,8 @@ void BedrockServer::sync(SData& args,
                 BedrockConflictMetrics::recordSuccess(command.request.methodLine);
                 SINFO("[performance] Sync thread finished committing command " << command.request.methodLine);
 
-                // Otherwise, mark this command as complete and reply.
+                // Otherwise, save the commit count, mark this command as complete, and reply.
+                command.response["commitCount"] = to_string(db.getCommitCount());
                 command.complete = true;
                 if (command.initiatingPeerID) {
                     // This is a command that came from a peer. Have the sync node send the response back to the peer.
@@ -737,7 +738,8 @@ void BedrockServer::worker(SData& args,
                                 BedrockConflictMetrics::recordSuccess(command.request.methodLine);
                                 SINFO("Successfully committed " << command.request.methodLine << " on worker thread.");
                                 // So we must still be mastering, and at this point our commit has succeeded, let's
-                                // mark it as complete!
+                                // mark it as complete. We add the currentCommit count here as well.
+                                command.response["commitCount"] = to_string(db.getCommitCount());
                                 command.complete = true;
                             } else {
                                 BedrockConflictMetrics::recordConflict(command.request.methodLine);


### PR DESCRIPTION
@iwiznia 
cc @cead22 

Fixes: https://github.com/Expensify/Expensify/issues/64093

It turns out we were setting `CommitCount` in responses from bedrock when `process()` completed, which is before the command is actually committed. Thus, we'd return values to clients that didn't include the commit for the transaction they just performed.

This meant that if a subsequent transaction relied on the results of that commit, we could run it too early (because we returned the commit too early), which would result in an error.