### PR TITLE
Close outstanding sockets *after* sync thread finishes

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -893,17 +893,19 @@ BedrockServer::~BedrockServer() {
     // Just warn if we have outstanding requests
     SASSERTWARN(_requestCountSocketMap.empty());
 
-    // Shut down any outstanding keepalive connections
+    // Shut down the sync thread, (which will shut down worker threads in turn).
+    SINFO("Closing sync thread '" << _syncThreadName << "'");
+    _syncThread.join();
+    SINFO("Threads closed.");
+
+    // Close any sockets that are still open. We wait until the sync thread has completed to do this, as until it's
+    // finished, it may keep writing to these sockets.
     for (list<Socket*>::iterator socketIt = socketList.begin(); socketIt != socketList.end();) {
         // Shut it down and go to the next (because closeSocket will invalidate this iterator otherwise)
         Socket* s = *socketIt++;
         closeSocket(s);
     }
-
-    // Shut down the sync thread, (which will shut down worker threads in turn).
-    SINFO("Closing sync thread '" << _syncThreadName << "'");
-    _syncThread.join();
-    SINFO("Threads closed.");
+    SINFO("Sockets closed.");
 }
 
 bool BedrockServer::shutdownComplete() {
@@ -1082,7 +1084,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     Port* acceptPort = nullptr;
     while ((s = acceptSocket(acceptPort))) {
         // Accepted a new socket
-        // NOTE: SQLiteNode doesn't need to keep a new list; we'll just reuse the STCPManager::socketList.
+        // NOTE: BedrockServer doesn't need to keep a new list; there's already STCPManager::socketList.
         // Look up the plugin that owns this port (if any).
         if (SContains(_portPluginMap, acceptPort)) {
             BedrockPlugin* plugin = _portPluginMap[acceptPort];


### PR DESCRIPTION
@coleaeason 

Attempt to fix: https://github.com/Expensify/Expensify/issues/63234

This rearranges the destructor such that it doesn't try to destroy outstanding socket objects until the sync thread (and in turn, all the worker threads) have finished, as they will try and write to these sockets when they finish commands.