### PR TITLE
Handle interrupted queries being automatically rolled back.

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -154,7 +154,7 @@ SQLite::SQLite(const string& filename, int cacheSize, int autoCheckpoint, int ma
 
     // I tested and found that we could set about 10,000,000 and the number of steps to run and get a callback once a
     // second. This is set to be a bit more granular than that, which is probably adequate.
-    sqlite3_progress_handler(_db, 1'000'000, _progressHandlerCallback, this);
+    sqlite3_progress_handler(_db, 100'000, _progressHandlerCallback, this);
 }
 
 int SQLite::_progressHandlerCallback(void* arg) {

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -273,4 +273,12 @@ class SQLite {
 
     // Called internally by _sqliteAuthorizerCallback to authorize columns for a query.
     int _authorize(int actionCode, const char* table, const char* column);
+
+    // It's possible for certain transactions (namely, timing out a write operation, see here:
+    // https://sqlite.org/c3ref/interrupt.html) to cause a transaction to be automatically rolled back. If this
+    // happens, we store a flag internally indicating that we don't need to perform the rollback ourselves. Then when
+    // `rollback` is called, we don't double-rollback, generating an error. This allows the externally visible SQLite
+    // API to be consistent and not have to handle this special case. Consumers can just always call `rollback` after a
+    // failed query, regardless of whether or not it was already rolled back internally.
+    bool _autoRolledBack;
 };

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -86,7 +86,12 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
         SASSERT(db.write("INSERT INTO TEST VALUES(" + SQ(nextID) + ", " + SQ(command.request["value"]) + ");"));
         return true;
     } else if (command.request.methodLine == "slowprocessquery") {
-        int size = 100000000;
+        SQResult result;
+        db.read("SELECT MAX(id) FROM test", result);
+        SASSERT(result.size());
+        int nextID = SToInt(result[0][0]) + 1;
+
+        int size = 1;
         int count = 1;
         if (command.request.isSet("size")) {
             size = SToInt(command.request["size"]);
@@ -94,9 +99,17 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
         if (command.request.isSet("count")) {
             count = SToInt(command.request["count"]);
         }
+
         for (int i = 0; i < count; i++) {
-            string query = "WITH RECURSIVE cnt(x) AS ( SELECT 1 UNION ALL SELECT x+1 FROM cnt LIMIT " + SQ(size) + ") SELECT MAX(x) FROM cnt;";
-            SQResult result;
+            string query = "INSERT INTO test (id, value) VALUES ";
+            for (int j = 0; j < size; j++) {
+                if (j) {
+                    query += ", ";
+                }
+                query += "(" + to_string(nextID) + ", " + to_string(nextID) + ")";
+                nextID++;
+            }
+            query += ";";
             db.read(query, result);
         }
     }

--- a/test/clustertest/tests/i_TimeoutTest.cpp
+++ b/test/clustertest/tests/i_TimeoutTest.cpp
@@ -33,11 +33,13 @@ struct i_TimeoutTest : tpunit::TestFixture {
 
         // Run one long query.
         SData slow("slowprocessquery");
-        slow["timeout"] = "5000000"; // 5s
+        slow["timeout"] = "500000"; // 0.5s
+        slow["size"] = "1000000";
+        slow["count"] = "1";
         brtester->executeWaitVerifyContent(slow, "555 Timeout processing command");
 
         // And a bunch of faster ones.
-        slow["size"] = "10000";
+        slow["size"] = "100";
         slow["count"] = "10000";
         brtester->executeWaitVerifyContent(slow, "555 Timeout processing command");
     }


### PR DESCRIPTION
@mea36 

Fixes: https://github.com/Expensify/Expensify/issues/64796

When we added timeouts, to command we neglected a tidbit of information described here: https://sqlite.org/c3ref/interrupt.html

Specifically, that if an operation returns `SQLITE_INTERRUPT` and was an `INSERT`, `UPDATE` or `DELETE`, the transaction will be rolled back.

We handle this in our timeout code - we check if we're in `AUTOCOMMIT` mode, meaning that we're not inside a transaction, and if so, set a flag for our next call to `rollback` to indicate that the rollback was already done. This keeps callers of SQLite from having to keep track of this special case.

##Tests:
Automated tests updated to do a long write operation.