### PR TITLE
Let workers process SYNCHRONIZE messages

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -562,7 +562,6 @@ void BedrockServer::worker(SData& args,
             // If this was a command initiated by a peer as part of a cluster operation, then we process it separately
             // and respond immediately. This allows SQLiteNode to offload read-only operations to worker threads.
             if (SQLiteNode::isPeerCommand(command)) {
-                cout << "GOT: " << command.request.methodLine << endl;
                 SQLiteNode::peekPeerCommand(server._syncNode, db, command);
                 command.complete = true;
                 syncNodeCompletedCommands.push(move(command));

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1151,7 +1151,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     // over it, we'll keep a list of sockets that need closing.
     list<STCPManager::Socket*> socketsToClose;
     for (auto s : socketList) {
-        switch (s->state) {
+        switch (s->state.load()) {
             case STCPManager::Socket::CLOSED:
             {
                 // TODO: Cancel any outstanding commands initiated by this socket. This isn't critical, and is an

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -188,7 +188,7 @@ class BedrockServer : public SQLiteServer {
     // until all references to it go out of scope. Since an STCPNode never deletes `Peer` objects until it's being
     // destroyed, we are also guaranteed that all peers are accesible as long as we hold a shared pointer to this
     // object.
-    shared_ptr<SQLiteNode> _syncNode;
+    SQLiteNode* _syncNode;
 
     // Because status will access internal sync node data, we lock in both places that will access the pointer above.
     mutex _syncMutex;

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -102,7 +102,7 @@ void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity) {
             // Net problem. Did this transaction end in an inconsistent state?
             SWARN("Connection " << (elapsed > TIMEOUT ? "timed out" : "died prematurely") << " after "
                   << elapsed / STIME_US_PER_MS << "ms");
-            active->response = active->s->sendBuffer.empty() ? 501 : 500;
+            active->response = active->s->sendBufferEmpty() ? 501 : 500;
             if (active->response == 501) {
                 // This is pretty serious. Let us know.
                 SHMMM("SHTTPSManager: '" << active->fullRequest.methodLine
@@ -169,7 +169,7 @@ SHTTPSManager::Transaction* SHTTPSManager::_httpsSend(const string& url, const S
     transaction->fullRequest = request;
 
     // Ship it.
-    transaction->s->sendBuffer = request.serialize();
+    transaction->s->setSendBuffer(request.serialize());
 
     // Keep track of the transaction.
     SAUTOLOCK(_listMutex);

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -98,7 +98,7 @@ void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 SWARN("Message failed: '" << active->fullResponse.methodLine << "'");
                 active->response = 500;
             }
-        } else if (active->s->state > Socket::CONNECTED || elapsed > TIMEOUT) {
+        } else if (active->s->state.load() > Socket::CONNECTED || elapsed > TIMEOUT) {
             // Net problem. Did this transaction end in an inconsistent state?
             SWARN("Connection " << (elapsed > TIMEOUT ? "timed out" : "died prematurely") << " after "
                   << elapsed / STIME_US_PER_MS << "ms");
@@ -169,7 +169,7 @@ SHTTPSManager::Transaction* SHTTPSManager::_httpsSend(const string& url, const S
     transaction->fullRequest = request;
 
     // Ship it.
-    transaction->s->setSendBuffer(request.serialize());
+    transaction->s->send(request.serialize());
 
     // Keep track of the transaction.
     SAUTOLOCK(_listMutex);

--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -255,7 +255,7 @@ bool STCPManager::Socket::send(const string& buffer) {
     if (state.load() < Socket::State::SHUTTINGDOWN) {
         sendBuffer += buffer;
     } else if (!sendBuffer.empty()) {
-        SWARN("Not appending to sendBuffer in socket state " << state.load());
+        SWARN("Not appending to sendBuffer in socket state " << state.load() << ", tried to send: " << buffer);
     }
 
     // Send anything we've got.

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -12,7 +12,7 @@ struct STCPManager {
         int s;
         sockaddr_in addr;
         string recvBuffer;
-        State state;
+        atomic<State> state;
         bool connectFailure;
         uint64_t openTime;
         uint64_t lastSendTime;

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -11,7 +11,6 @@ struct STCPManager {
         // Attributes
         int s;
         sockaddr_in addr;
-        string sendBuffer;
         string recvBuffer;
         State state;
         bool connectFailure;
@@ -25,9 +24,18 @@ struct STCPManager {
         bool recv();
         uint64_t id;
 
+        bool sendBufferEmpty();
+        string sendBufferCopy();
+        void setSendBuffer(const string& buffer);
+
       private:
         static atomic<uint64_t> socketCount;
         recursive_mutex sendRecvMutex;
+
+        // This is private because it's used by our synchronized send() functions. This requires it to only
+        // be accessed through the (also synchronized) wrapper functions above.
+        // NOTE: Currently there's no synchronization around `recvBuffer`. It can only be accessed by one thread.
+        string sendBuffer;
     };
 
     // Cleans up outstanding sockets

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -77,7 +77,7 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
         Socket* socket = *socketIt;
         try {
             // Verify it's still alive
-            if (socket->state != Socket::CONNECTED)
+            if (socket->state.load() != Socket::CONNECTED)
                 STHROW("premature disconnect");
 
             // Still alive; try to login
@@ -140,7 +140,7 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
         // See if we're connected
         if (peer->s) {
             // We have a socket; process based on its state
-            switch (peer->s->state) {
+            switch (peer->s->state.load()) {
             case Socket::CONNECTED: {
                 // See if there is anything new.
                 peer->failedConnections = 0; // Success; reset failures

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -407,4 +407,3 @@ uint64_t STCPNode::Peer::socketOpenTime()
         return 0;
     }
 }
-

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -29,7 +29,7 @@ struct STCPNode : public STCPServer {
           : name(name_), host(host_), params(params_), s(nullptr), latency(0), nextReconnect(0), id(id_),
             failedConnections(0), externalPeerCount(0)
         { }
-        bool connected() { return (s && s->state == STCPManager::Socket::CONNECTED); }
+        bool connected() { return (s && s->state.load() == STCPManager::Socket::CONNECTED); }
         void reset() {
             clear();
             s = nullptr;

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -32,8 +32,7 @@ struct STCPNode : public STCPServer {
             latency = 0;
         }
 
-        // Synchronized access.
-        // TODO: Implement synchronized versions of these.
+        // Synchronized access to socket objects.
         bool socketSendBufferEmpty();
         string socketSendBuffer();
         string socketRecvBuffer();

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -69,14 +69,8 @@ struct STCPNode : public STCPServer {
     // Connects to a peer in the database cluster
     void addPeer(const string& name, const string& host, const STable& params);
 
-    // Returns a peer by it's ID. If the ID is invalid, returns nullptr.
-    Peer* getPeerByID(uint64_t id);
-
     // Get an externally accessible peer object by its ID.
     ExternalPeer getExternalPeerByID(uint64_t id);
-
-    // Inverse of the above function. If the peer is not found, returns 0.
-    uint64_t getIDByPeer(Peer* peer);
 
     // Attributes
     string name;
@@ -92,6 +86,13 @@ struct STCPNode : public STCPServer {
 
     // Called when the peer sends us a message; throw an SException to reconnect.
     virtual void _onMESSAGE(Peer* peer, const SData& message) = 0;
+
+  protected:
+    // Returns a peer by it's ID. If the ID is invalid, returns nullptr.
+    Peer* getPeerByID(uint64_t id);
+
+    // Inverse of the above function. If the peer is not found, returns 0.
+    uint64_t getIDByPeer(Peer* peer);
 
   private:
     // Override dead function

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -45,8 +45,6 @@ struct STCPNode : public STCPServer {
     };
 
     class ExternalPeer {
-        friend class Peer;
-
       public:
         // Standard constructor.
         ExternalPeer(Peer* peer);

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -36,14 +36,11 @@ struct STCPNode : public STCPServer {
             latency = 0;
         }
 
-        // Get an externally accessible object that can thread-safely write responses to peers.
-        static ExternalPeer getExternalPeer(Peer* peer);
-
         // Close the peer's socket
         void closeSocket(STCPManager& manager);
 
       private:
-        recursive_mutex socketMutex;
+        recursive_mutex refCountMutex;
         atomic<int> externalPeerCount;
     };
 
@@ -51,6 +48,9 @@ struct STCPNode : public STCPServer {
         friend class Peer;
 
       public:
+        // Standard constructor.
+        ExternalPeer(Peer* peer);
+
         // Move constructor.
         ExternalPeer(ExternalPeer && other);
 
@@ -61,9 +61,6 @@ struct STCPNode : public STCPServer {
         ~ExternalPeer();
 
       private:
-        // Only instantiated by a Peer object.
-        ExternalPeer(Peer* peer);
-
         // The peer object that instantiated this object.
         Peer* _peer;
 

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -10,11 +10,15 @@ struct STCPNode : public STCPServer {
     void postPoll(fd_map& fdm, uint64_t& nextActivity);
 
     // Represents a single peer in the database cluster
+    class ExternalPeer;
     struct Peer : public SData {
+        friend class ExternalPeer;
+
         // Attributes
         string name;
         string host;
         STable params;
+        Socket* s;
         uint64_t latency;
         uint64_t nextReconnect;
         uint64_t id;
@@ -22,8 +26,8 @@ struct STCPNode : public STCPServer {
 
         // Helper methods
         Peer(const string& name_, const string& host_, const STable& params_, uint64_t id_)
-          : name(name_), host(host_), params(params_), latency(0), nextReconnect(0), id(id_),
-            failedConnections(0), s(nullptr)
+          : name(name_), host(host_), params(params_), s(nullptr), latency(0), nextReconnect(0), id(id_),
+            failedConnections(0), externalPeerCount(0)
         { }
         bool connected() { return (s && s->state == STCPManager::Socket::CONNECTED); }
         void reset() {
@@ -32,24 +36,39 @@ struct STCPNode : public STCPServer {
             latency = 0;
         }
 
-        // Synchronized access to socket objects.
-        bool socketSendBufferEmpty();
-        string socketSendBuffer();
-        string socketRecvBuffer();
-        bool hasSocket();
-        void socketSend(const string& message);
-        void shutdownSocket(STCPManager& manager);
+        // Get an externally accessible object that can thread-safely write responses to peers.
+        static ExternalPeer getExternalPeer(Peer* peer);
+
+        // Close the peer's socket
         void closeSocket(STCPManager& manager);
-        void setSocket(Socket* socket);
-        STCPManager::Socket::State socketState();
-        uint64_t socketLastRecvTime();
-        uint64_t socketLastSendTime();
-        void socketRecvBufferConsumeFront(size_t size);
-        bool socketConnectFailure();
-        uint64_t socketOpenTime();
+
       private:
-        Socket* s;
         recursive_mutex socketMutex;
+        atomic<int> externalPeerCount;
+    };
+
+    class ExternalPeer {
+        friend class Peer;
+
+      public:
+        // Move constructor.
+        ExternalPeer(ExternalPeer && other);
+
+        // Send a request to this peer.
+        void sendRequest(const SData& request);
+
+        // Destructor
+        ~ExternalPeer();
+
+      private:
+        // Only instantiated by a Peer object.
+        ExternalPeer(Peer* peer);
+
+        // The peer object that instantiated this object.
+        Peer* _peer;
+
+        // A name for this object, since SWARN requires it.
+        string name;
     };
     
     // Connects to a peer in the database cluster
@@ -57,6 +76,9 @@ struct STCPNode : public STCPServer {
 
     // Returns a peer by it's ID. If the ID is invalid, returns nullptr.
     Peer* getPeerByID(uint64_t id);
+
+    // Get an externally accessible peer object by its ID.
+    ExternalPeer getExternalPeerByID(uint64_t id);
 
     // Inverse of the above function. If the peer is not found, returns 0.
     uint64_t getIDByPeer(Peer* peer);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1931,6 +1931,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
             // Seed our last sent transaction.
             {
                 SQLITE_COMMIT_AUTOLOCK;
+                unsentTransactions.store(false);
                 _lastSentTransactionID = _db.getCommitCount();
                 // Clear these.
                 _db.getCommittedTransactions();
@@ -2022,7 +2023,7 @@ void SQLiteNode::_queueSynchronizeStateless(const STable& params, const string& 
         response["NumCommits"] = SToStr(result.size());
         for (size_t c = 0; c < result.size(); ++c) {
             // Queue the result
-            //SASSERT(result[c].size() == 2);
+            SASSERT(result[c].size() == 2);
             SData commit("COMMIT");
             commit["CommitIndex"] = SToStr(peerCommitCount + c + 1);
             commit["Hash"] = result[c][0];

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -174,7 +174,7 @@ bool SQLiteNode::shutdownComplete() {
 
     // If we have unsent data, not done
     for (auto peer : peerList) {
-        if (peer->s && !peer->s->sendBuffer.empty()) {
+        if (peer->s && !peer->s->sendBufferEmpty()) {
             // Still sending data
             SINFO("Can't graceful shutdown yet because unsent data to peer '" << peer->name << "'");
             return false;
@@ -1752,8 +1752,8 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
     ///   is out of touch with reality: we processed a command and reality doesn't
     ///   know it.  Not cool!
     ///
-    if (peer->s && peer->s->sendBuffer.find("ESCALATE_RESPONSE") != string::npos)
-        PWARN("Initiating slave died before receiving response to escalation: " << peer->s->sendBuffer);
+    if (peer->s && peer->s->sendBufferCopy().find("ESCALATE_RESPONSE") != string::npos)
+        PWARN("Initiating slave died before receiving response to escalation: " << peer->s->sendBufferCopy());
 
     /// - Verify we didn't just lose contact with our master.  This should
     ///   only be possible if we're SUBSCRIBING or SLAVING.  If we did lose our
@@ -1968,8 +1968,8 @@ void SQLiteNode::_queueSynchronize(Peer* peer, SData& response, bool sendAll) {
 
 void SQLiteNode::_queueSynchronizeStateless(const STable& params, const string& name, const string& peerName, int _state, uint64_t targetCommit, SQLite& db, SData& response, bool sendAll) {
     // This is a hack to make the PXXXX macros works, since they expect `peer->name` to be defined.
-    static struct {string name;} peerBase;
-    static auto peer = &peerBase;
+    struct {string name;} peerBase;
+    auto peer = &peerBase;
     peerBase.name = peerName;
 
     // Peer is requesting synchronization.  First, does it have any data?

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -93,6 +93,14 @@ class SQLiteNode : public STCPNode {
     // node, or if this command doesn't have an `initiatingPeerID`, then calling this function is an error.
     void sendResponse(const SQLiteCommand& command);
 
+    // This returns true if the command is one of our peer message commands that can be handled asynchronously by a
+    // worker. Currently, this is only true for SYNCHRONIZE commands.
+    static bool isPeerCommand(const SQLiteCommand& command);
+
+    // This is a static function that can 'peek' a command initiated by a peer, but can be called by any thread.
+    // Importantly for thread safety, this cannot depend on the current state of the cluster or s specific node.
+    static void peekPeerCommand(SQLiteNode* node, SQLite& db, SQLiteCommand& command);
+
     // This is a static and thus *global* indicator of whether or not we have transactions that need replicating to
     // peers. It's global because it can be set by any thread. Because SQLite can run in parallel, we can have multiple
     // threads making commits to the database, and they communicate that to the node via this flag.
@@ -167,7 +175,7 @@ class SQLiteNode : public STCPNode {
     void _sendToPeer(Peer* peer, const SData& message);
     void _sendToAllPeers(const SData& message, bool subscribedOnly = false);
     void _changeState(State newState);
-    void _queueSynchronize(Peer* peer, SData& response, bool sendAll);
+    static void _queueSynchronize(const STable& params, SQLite& db, SData& response, bool sendAll);
     void _recvSynchronize(Peer* peer, const SData& message);
     void _reconnectPeer(Peer* peer);
     void _reconnectAll();

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -93,13 +93,10 @@ class SQLiteNode : public STCPNode {
     // node, or if this command doesn't have an `initiatingPeerID`, then calling this function is an error.
     void sendResponse(const SQLiteCommand& command);
 
-    // This returns true if the command is one of our peer message commands that can be handled asynchronously by a
-    // worker. Currently, this is only true for SYNCHRONIZE commands.
-    static bool isPeerCommand(const SQLiteCommand& command);
-
     // This is a static function that can 'peek' a command initiated by a peer, but can be called by any thread.
-    // Importantly for thread safety, this cannot depend on the current state of the cluster or s specific node.
-    static void peekPeerCommand(shared_ptr<SQLiteNode> node, SQLite& db, SQLiteCommand& command);
+    // Importantly for thread safety, this cannot depend on the current state of the cluster or a specific node.
+    // Returns false if the node can't peek the command.
+    static bool peekPeerCommand(SQLiteNode* node, SQLite& db, SQLiteCommand& command);
 
     // This is a static and thus *global* indicator of whether or not we have transactions that need replicating to
     // peers. It's global because it can be set by any thread. Because SQLite can run in parallel, we can have multiple

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -175,7 +175,12 @@ class SQLiteNode : public STCPNode {
     void _sendToPeer(Peer* peer, const SData& message);
     void _sendToAllPeers(const SData& message, bool subscribedOnly = false);
     void _changeState(State newState);
-    static void _queueSynchronize(const STable& params, SQLite& db, SData& response, bool sendAll);
+
+    // Queue a SYNCHRONIZE message based on the current state of the node.
+    void _queueSynchronize(Peer* peer, SData& response, bool sendAll);
+
+    // Queue a SYNCHRONIZE message based on pre-computed state of the node. This version is thread-safe.
+    static void _queueSynchronizeStateless(const STable& params, const string& name, const string& peerName, int _state, uint64_t targetCommit, SQLite& db, SData& response, bool sendAll);
     void _recvSynchronize(Peer* peer, const SData& message);
     void _reconnectPeer(Peer* peer);
     void _reconnectAll();

--- a/test/clustertest/BedrockClusterTester.cpp
+++ b/test/clustertest/BedrockClusterTester.cpp
@@ -123,7 +123,12 @@ void BedrockClusterTester::stopNode(size_t nodeIndex)
     _cluster[nodeIndex].stopServer();
 }
 
-void BedrockClusterTester::startNode(size_t nodeIndex)
+string BedrockClusterTester::startNode(size_t nodeIndex)
 {
-    _cluster[nodeIndex].startServer();
+    return _cluster[nodeIndex].startServer();
+}
+
+string BedrockClusterTester::startNodeDontWait(size_t nodeIndex)
+{
+    return _cluster[nodeIndex].startServer(true);
 }

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -35,7 +35,10 @@ class BedrockClusterTester {
     BedrockTester* getBedrockTester(size_t index);
 
     // Starts a given node, given the same arguments given by the constructor.
-    void startNode(size_t nodeIndex);
+    string startNode(size_t nodeIndex);
+
+    // Same as above but don't wait for the command port to be ready.
+    string startNodeDontWait(size_t nodeIndex);
 
     // Stops a given node.
     void stopNode(size_t nodeIndex);

--- a/test/clustertest/tests/a_MasteringTest.cpp
+++ b/test/clustertest/tests/a_MasteringTest.cpp
@@ -5,7 +5,8 @@ struct a_MasteringTest : tpunit::TestFixture {
         : tpunit::TestFixture("a_Mastering",
                               TEST(a_MasteringTest::clusterUp),
                               TEST(a_MasteringTest::failover),
-                              TEST(a_MasteringTest::restoreMaster)
+                              TEST(a_MasteringTest::restoreMaster),
+                              TEST(a_MasteringTest::synchronizing)
                              ) { }
 
     BedrockClusterTester* tester;
@@ -107,6 +108,64 @@ struct a_MasteringTest : tpunit::TestFixture {
         }
 
         ASSERT_TRUE(count <= 10);
+    }
+
+    void synchronizing() {
+        // Stop a slave.
+        tester->stopNode(1);
+
+        // Create a bunch of commands.
+        vector<SData> requests(1000);
+        int count = 0;
+        for (auto& request : requests) {
+            if (!count) {
+                request.methodLine = "Query";
+                request["writeConsistency"] = "ASYNC";
+                request["query"] = "INSERT INTO test VALUES(12345, '');";
+                count++;
+            } else {
+                request.methodLine = "Query";
+                request["writeConsistency"] = "ASYNC";
+                request["query"] = "UPDATE test SET value = 'xxx" + to_string(count++) + "' WHERE id = 12345;";
+            }
+        }
+
+        // Send these all to master.
+        BedrockTester* master = tester->getBedrockTester(0);
+        master->executeWaitMultipleData(requests);
+
+        // Start the slave back up.
+        bool wasSynchronizing = false;
+        string startstatus = tester->startNodeDontWait(1);
+        STable json = SParseJSONObject(startstatus);
+        if (json["state"] == "SYNCHRONIZING") {
+            wasSynchronizing = true;
+        }
+
+        // Verify it goes SYNCHRONIZING and then SLAVING.
+        BedrockTester* slave = tester->getBedrockTester(1);
+        int tries = 0;
+        while (1) {
+            SData status("Status");
+            auto result = slave->executeWaitVerifyContent(status, "200", true);
+            STable json = SParseJSONObject(result);
+
+            if (!wasSynchronizing) {
+                if(json["state"] == "SYNCHRONIZING") {
+                    wasSynchronizing = true;
+                    continue;
+                }
+            }
+            if(json["state"] == "SLAVING") {
+                break;
+            }
+            tries++;
+            if (tries > 6000) {
+                STHROW("Timed out waiting for synchronizing and then mastering.");
+            }
+            usleep(10'000); // 1/100th of a second
+        }
+        ASSERT_TRUE(wasSynchronizing);
     }
 
 } __a_MasteringTest;

--- a/test/clustertest/tests/b_ConflictSpamTest.cpp
+++ b/test/clustertest/tests/b_ConflictSpamTest.cpp
@@ -250,13 +250,6 @@ struct b_ConflictSpamTest : tpunit::TestFixture {
         }
         threads.clear();
 
-        /*
-        for (auto i : {0, 1, 2}) {
-            cout << "TEST Table, Node " << i << endl;
-            cout << allResults[0] << endl << endl;
-        }
-        */
-
         // Verify the actual table contains the right number of rows.
         allResults.clear();
         allResults.resize(3);
@@ -289,9 +282,8 @@ struct b_ConflictSpamTest : tpunit::TestFixture {
         // And that they're all 66.
         list<string> resultCount = SParseList(allResults[0], '\n');
         resultCount.pop_front();
-        int rows = SToInt(resultCount.front());
-        cout << "Rows in test: " << rows << endl;
-        ASSERT_EQUAL(cmdID.load(), SToInt(resultCount.front()));
+        // The "+1" is because the `synchronizing` test in `a_masteringTest` inserts one row in this table.
+        ASSERT_EQUAL(cmdID.load() + 1, SToInt(resultCount.front()));
 
         int fail = totalRequestFailures.load();
         if (fail > 0) {

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -37,17 +37,19 @@ class BedrockTester {
                   bool keepFilesWhenFinished = false);
     ~BedrockTester();
 
-    // Start and stop the bedrock server.
-    void startServer();
+    // Start and stop the bedrock server. If `dontWait` is specified, return as soon as the control port, rather that
+    // the cmmand port, is ready.
+    string startServer(bool dontWait = false);
     void stopServer();
 
     // Takes a list of requests, and returns a corresponding list of responses.
     // Uses `connections` parallel connections to the server to send the requests.
-    vector<SData> executeWaitMultipleData(vector<SData> requests, int connections = 10);
+    // If `control` is set, sends the message to the control port.
+    vector<SData> executeWaitMultipleData(vector<SData> requests, int connections = 10, bool control = false);
 
     // Sends a single request, returning the response content.
     // If the response method line doesn't begin with the expected result, throws.
-    string executeWaitVerifyContent(SData request, const string& expectedResult = "200");
+    string executeWaitVerifyContent(SData request, const string& expectedResult = "200", bool control = false);
 
     // Sends a single request, returning the response content as a STable.
     // If the response method line doesn't begin with the expected result, throws.
@@ -66,6 +68,8 @@ class BedrockTester {
     // If these are set, they'll be used instead of the global defaults.
     string _serverAddr;
     string _dbName;
+
+    string _controlAddr;
 
     // The PID of the bedrock server we started.
     int _serverPID = 0;


### PR DESCRIPTION
@quinthar 

Fixes: https://github.com/Expensify/Expensify/issues/64477

~HOLD until https://github.com/Expensify/Bedrock/pull/306 is merged, this change was built on top of that one.~

This change allows the sync node to forward certain cluster commands (currently only SYNCHRONIZE) to the BedrockServer, so that worker threads can handle and respond to these commands. The actual code to handle these commands is in `SQLiteNode::peekPeerCommand`, as the SQLiteNode is and should remain the central location that knows how to communicate with peer nodes.

`STCPNode::Peer` has been changed so that it's `Socket` object is now private. This forces all access to a Peer's socket to be done through wrapper functions, which allows us to synchronize access to the socket so that multiple threads can safely write responses to it. This was necessary because the Socket can be deleted by the sync thread at any time (if it's detected in `postPoll` that it's not longer connected).

We don't need to worry about the same condition for Peer objects themselves, as once created, they're never deleted until the destruction of the `SQLiteNode` that owns them. We always maintain a valid reference to the current sync node (which we've achieved by wrapping our pointer to it in a `shared_ptr`) when we want to access Peer objects, and thus can guarantee they're validity while worker threads process peer commands.

after this is merged, we can build on top of it and let workers respond directly to peers after processing commands.