### PR TITLE
Add sync node priority to status command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1406,6 +1406,7 @@ void BedrockServer::_status(BedrockCommand& command) {
                 content["syncNodeAvailable"] = "true";
                 // Set some information about this node.
                 content["CommitCount"] = to_string(_syncNode->getCommitCount());
+                content["priority"] = to_string(_syncNode->getPriority());
 
                 // Retrieve information about our peers.
                 for (SQLiteNode::Peer* peer : _syncNode->peerList) {


### PR DESCRIPTION
Adds the sync node's priority to the `status` command output.

Fixes https://github.com/Expensify/Expensify/issues/63116

#### Tests
1. `nc auth 4444` in the Dev VM
2. `status`
3. Check output.
```
status

200 OK
nodeName: auth-on-bedrock
totalTime: 131
Content-Length: 494

{"CommitCount":259,"escalatedCommandList":[],"host":"localhost:4445","isMaster":true,"multiWriteAutoBlacklist":"","multiWriteEnabled":true,"multiWriteManualBlacklist":[],"peerList":[],"plugins":[{"name":"Auth","version":"83612c1001b33c45a53e6a13596edc7049dd8113"},{"name":"DB"}],"priority":200,"queuedCommandList":[],"state":"MASTERING","syncNodeAvailable":true,"syncThreadQueuedCommandList":[],"version":"6b6065cb7e7a4c50b5e58863f229ed94a1073610:Auth_83612c1001b33c45a53e6a13596edc7049dd8113"}
```