### PR TITLE
Demoting SQLite assert warning to hmmm

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -27,6 +27,9 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
             STHROW("501 Failed to begin concurrent transaction");
         }
 
+        // Make sure no writes happen while in peek command
+        _db.setQueryOnlyPragma(true);
+
         // Try each plugin, and go with the first one that says it succeeded.
         bool pluginPeeked = false;
         for (auto plugin : _server.plugins) {
@@ -42,6 +45,9 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
                 STHROW("555 Timeout peeking command");
             }
         }
+
+        // Peeking is over now, allow writes
+        _db.setQueryOnlyPragma(false);
 
         // If nobody succeeded in peeking it, then we'll need to process it.
         // TODO: Would be nice to be able to check if a plugin *can* handle a command, so that we can differentiate
@@ -73,6 +79,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
             }
         }
     } catch (const SException& e) {
+        _db.setQueryOnlyPragma(false);
         _handleCommandException(command, e);
     }
 

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -28,7 +28,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
         }
 
         // Make sure no writes happen while in peek command
-        _db.setQueryOnlyPragma(true);
+        _db.read("PRAGMA query_only = true;");
 
         // Try each plugin, and go with the first one that says it succeeded.
         bool pluginPeeked = false;
@@ -47,7 +47,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
         }
 
         // Peeking is over now, allow writes
-        _db.setQueryOnlyPragma(false);
+        _db.read("PRAGMA query_only = false;");
 
         // If nobody succeeded in peeking it, then we'll need to process it.
         // TODO: Would be nice to be able to check if a plugin *can* handle a command, so that we can differentiate
@@ -79,9 +79,10 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
             }
         }
     } catch (const SException& e) {
-        _db.setQueryOnlyPragma(false);
+        _db.read("PRAGMA query_only = false;");
         _handleCommandException(command, e);
     } catch (...) {
+        _db.read("PRAGMA query_only = false;");
         SALERT("Unhandled exception typename: " << _getExceptionName() << ", command: " << command.request.serialize());
         command.response.methodLine = "500 Unhandled Exception";
     }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -298,9 +298,12 @@ string SQLite::read(const string& query) {
 }
 
 bool SQLite::read(const string& query, SQResult& result) {
+    
     // Execute the read-only query
+    if (!SContains(SToUpper(query), "UPDATE ")) {
+        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"UPDATE \")) != true");
+    }
     SASSERTWARN(!SContains(SToUpper(query), "INSERT "));
-    SASSERT(!SContains(SToUpper(query), "UPDATE "));
     SASSERTWARN(!SContains(SToUpper(query), "DELETE "));
     SASSERTWARN(!SContains(SToUpper(query), "REPLACE "));
     uint64_t before = STimeNow();

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -300,7 +300,7 @@ string SQLite::read(const string& query) {
 bool SQLite::read(const string& query, SQResult& result) {
     // Execute the read-only query
     SASSERTWARN(!SContains(SToUpper(query), "INSERT "));
-    SASSERTWARN(!SContains(SToUpper(query), "UPDATE "));
+    SASSERT(!SContains(SToUpper(query), "UPDATE "));
     SASSERTWARN(!SContains(SToUpper(query), "DELETE "));
     SASSERTWARN(!SContains(SToUpper(query), "REPLACE "));
     uint64_t before = STimeNow();

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -303,9 +303,15 @@ bool SQLite::read(const string& query, SQResult& result) {
     if (!SContains(SToUpper(query), "UPDATE ")) {
         SHMMM("Assertion failed: (!SContains(SToUpper(query), \"UPDATE \")) != true");
     }
-    SASSERTWARN(!SContains(SToUpper(query), "INSERT "));
-    SASSERTWARN(!SContains(SToUpper(query), "DELETE "));
-    SASSERTWARN(!SContains(SToUpper(query), "REPLACE "));
+    if (!SContains(SToUpper(query), "INSERT ")) {
+        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"UPDATE \")) != true");
+    }
+    if (!SContains(SToUpper(query), "DELETE ")) {
+        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"UPDATE \")) != true");
+    }
+    if (!SContains(SToUpper(query), "REPLACE ")) {
+        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"UPDATE \")) != true");
+    }
     uint64_t before = STimeNow();
     bool queryResult = !SQuery(_db, "read only query", query, result);
     _checkTiming("timeout in SQLite::read"s);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -238,15 +238,6 @@ bool SQLite::beginConcurrentTransaction() {
     return _insideTransaction;
 }
 
-bool SQLite::setQueryOnlyPragma(bool on) {
-    if (on) {
-        SASSERT(!SQuery(_db, "setting query_only on", "PRAGMA query_only = true;"));
-    } else {
-        SASSERT(!SQuery(_db, "setting query_only off", "PRAGMA query_only = false;"));
-    }
-    return true;
-}
-
 bool SQLite::verifyTable(const string& tableName, const string& sql, bool& created) {
     // sqlite trims semicolon, so let's not supply it else we get confused later
     SASSERT(!SEndsWith(sql, ";"));

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -304,13 +304,13 @@ bool SQLite::read(const string& query, SQResult& result) {
         SHMMM("Assertion failed: (!SContains(SToUpper(query), \"UPDATE \")) != true");
     }
     if (!SContains(SToUpper(query), "INSERT ")) {
-        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"UPDATE \")) != true");
+        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"INSERT \")) != true");
     }
     if (!SContains(SToUpper(query), "DELETE ")) {
-        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"UPDATE \")) != true");
+        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"DELETE \")) != true");
     }
     if (!SContains(SToUpper(query), "REPLACE ")) {
-        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"UPDATE \")) != true");
+        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"REPLACE \")) != true");
     }
     uint64_t before = STimeNow();
     bool queryResult = !SQuery(_db, "read only query", query, result);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -238,6 +238,15 @@ bool SQLite::beginConcurrentTransaction() {
     return _insideTransaction;
 }
 
+bool SQLite::setQueryOnlyPragma(bool on) {
+    if (on) {
+        SASSERT(!SQuery(_db, "setting query_only on", "PRAGMA query_only = true;"));
+    } else {
+        SASSERT(!SQuery(_db, "setting query_only off", "PRAGMA query_only = false;"));
+    }
+    return true;
+}
+
 bool SQLite::verifyTable(const string& tableName, const string& sql, bool& created) {
     // sqlite trims semicolon, so let's not supply it else we get confused later
     SASSERT(!SEndsWith(sql, ";"));
@@ -298,20 +307,6 @@ string SQLite::read(const string& query) {
 }
 
 bool SQLite::read(const string& query, SQResult& result) {
-    
-    // Execute the read-only query
-    if (!SContains(SToUpper(query), "UPDATE ")) {
-        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"UPDATE \")) != true");
-    }
-    if (!SContains(SToUpper(query), "INSERT ")) {
-        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"INSERT \")) != true");
-    }
-    if (!SContains(SToUpper(query), "DELETE ")) {
-        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"DELETE \")) != true");
-    }
-    if (!SContains(SToUpper(query), "REPLACE ")) {
-        SHMMM("Assertion failed: (!SContains(SToUpper(query), \"REPLACE \")) != true");
-    }
     uint64_t before = STimeNow();
     bool queryResult = !SQuery(_db, "read only query", query, result);
     _checkTiming("timeout in SQLite::read"s);

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -54,9 +54,6 @@ class SQLite {
     // Begins a new concurrent transaction. Returns true on success.
     bool beginConcurrentTransaction();
 
-    // Sets the "query_only" PRAGMA on or off.
-    bool setQueryOnlyPragma(bool on);
-
     // Verifies a table exists and has a particular definition. If the database is left with the right schema, it
     // returns true. If it had to create a new table (ie, the table was missing), it also sets created to true. If the
     // table is already there with the wrong schema, it returns false.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -54,6 +54,9 @@ class SQLite {
     // Begins a new concurrent transaction. Returns true on success.
     bool beginConcurrentTransaction();
 
+    // Sets the "query_only" PRAGMA on or off.
+    bool setQueryOnlyPragma(bool on);
+
     // Verifies a table exists and has a particular definition. If the database is left with the right schema, it
     // returns true. If it had to create a new table (ie, the table was missing), it also sets created to true. If the
     // table is already there with the wrong schema, it returns false.


### PR DESCRIPTION
@tylerkaraszewski pls review.

Demoting a log that was spamming us.

### Fixes issue
$ https://github.com/Expensify/Expensify/issues/63698

# Tests
1. Did a bunch of read only operations like fetching expense, reports, etc.
2. Checked the logs and made sure that I saw "setting query_only on" and "setting query_only off" indicating that the pragma was being turned on and off for those requests.
3. Also made sure each "setting query_only_off" was proceeded by a matching "setting query_only off" to make sure we never end up setting the flag and leaving it on
4. I left Bedrock on this branch throughout an entire day as I moved on to other issues and made sure no weirdness occurred.

# QA
none