### PR TITLE
Rollback regardless of whether anything needed committing.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1889,9 +1889,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
                 // Abort this command
                 SWARN("Stopping MASTERING/STANDINGDOWN with commit in progress. Canceling.");
                 _commitState = CommitState::FAILED;
-                if (!_db.getUncommittedHash().empty()) {
-                    _db.rollback();
-                }
+                _db.rollback();
             }
         }
 


### PR DESCRIPTION
@coleaeason 

Fixes: https://github.com/Expensify/Expensify/issues/63235

When we drop out of master, we need to rollback the current transaction *even if* it doesn't have anything to commit, as this resets the `SQLite` object, and (specifically) clears `_insideTransaction`.

Otherwise, when we stand back up later, that flag can still be set and we'll crash when we start the next transaction.