### PR TITLE
Reduce callback frequency by 10x

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -154,7 +154,7 @@ SQLite::SQLite(const string& filename, int cacheSize, int autoCheckpoint, int ma
 
     // I tested and found that we could set about 10,000,000 and the number of steps to run and get a callback once a
     // second. This is set to be a bit more granular than that, which is probably adequate.
-    sqlite3_progress_handler(_db, 100'000, _progressHandlerCallback, this);
+    sqlite3_progress_handler(_db, 1'000'000, _progressHandlerCallback, this);
 }
 
 int SQLite::_progressHandlerCallback(void* arg) {


### PR DESCRIPTION
@righdforsa 

Attempt to fix this: https://github.com/Expensify/Expensify/issues/65360

If this actually makes a noticeable difference (which I doubt), we should investigate reducing this even further, as there's no reason it wouldn't make another noticeable change to reduce it again, except the diminishing returns you get from any exponential change.