### PR TITLE
Make separate x509 objects per socket.

### DIFF
--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -33,6 +33,12 @@ class SHTTPSManager : public STCPManager {
     void closeTransaction(Transaction* transaction);
 
   protected: // Child API
+
+    // Used to create the signing certificate.
+    const string _pem;
+    const string _srvCrt;
+    const string _caCrt;
+
     // Methods
     Transaction* _httpsSend(const string& url, const SData& request);
     Transaction* _createErrorTransaction();
@@ -41,7 +47,6 @@ class SHTTPSManager : public STCPManager {
   private: // Internal API
     list<Transaction*> _activeTransactionList;
     list<Transaction*> _completedTransactionList;
-    SX509* _x509;
 
     // SHTTPSManager operations are thread-safe, we lock around any accesses to our transaction lists, so that
     // multiple threads can add/remove from them.

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -7,7 +7,8 @@ struct STCPManager {
     class Socket {
       public:
         enum State { CONNECTING, CONNECTED, SHUTTINGDOWN, CLOSED };
-        Socket(int sock = 0, State state_ = CONNECTING);
+        Socket(int sock = 0, State state_ = CONNECTING, SX509* x509 = nullptr);
+        ~Socket();
         // Attributes
         int s;
         sockaddr_in addr;
@@ -36,6 +37,11 @@ struct STCPManager {
         // be accessed through the (also synchronized) wrapper functions above.
         // NOTE: Currently there's no synchronization around `recvBuffer`. It can only be accessed by one thread.
         string sendBuffer;
+
+        // Each socket owns it's own SX509 object to avoid thread-safety issues reading/writing the same certificate in
+        // the underlying ssl code. Once assigned, the socket owns this object for it's lifetime and will delete it
+        // upon destruction.
+        SX509* _x509;
     };
 
     // Cleans up outstanding sockets


### PR DESCRIPTION
@quinthar 
cc @coleaeason 

This is a bit of a speculative fix for the crash we saw after deploying the change to be able to [send directly to peers from workers](https://github.com/Expensify/Bedrock/pull/315).

The stack trace shows us crashing here:
```
_SSignal_StackTrace [sync] [warn] /usr/sbin/bedrock(mbedtls_ssl_parse_certificate+0x41) [0x5dd3c1]
```

Each socket has it's own ssl context, but as per a warning in the [mbedtls docs](https://tls.mbed.org/kb/development/thread-safety-and-multi-threading), they share an underlying certificate object, which is not thread safe.

We saw this crash on `ScrapeCard`. The stack trace we logged was in `postPoll`, trying to call `recv()` on a socket with SSL enabled (probably a request to a scraper). If we tried to parse the certificate here, while doing the same in another thread (perhaps creating a new scraper request from a worker), we could have two threads looking at this certificate at the same time, which could cause problems in the mbedtls library.

The attempted fix here is to create an `x509` object for each socket that needs one, rather than one global one for the `HTTPSManager` object, preventing two threads from looking at the same one at the same time.

This fix is speculative though, as I can't prove this is the real problem. None of the new code that actually sent to peers from workers was active (no peers were synchronizing). My guess is that changes to when we lock and unlock enabled an existing bug to come to light, possibly by changing the timing of exactly when we do and don't look at this certificate.

I don't have any other good ideas though except to deploy this and see if it helps. We independently made [this change](https://github.com/Expensify/Bedrock/pull/323) to log stack traces before we send out `CRASH` messages to peers, to avoid potentially changing the stack that actually generated the problem.

If we deploy this, hopefully it fixes the problem, and if not, maybe we get a better stack trace to work from, and we can roll back this change.