### PR TITLE
Add created to GetJob(s) commands

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -605,9 +605,9 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         string safeNumResults = SQ(max(request.calc("numResults"),1));
         string operation = command.request.isSet("mockRequest") ? "IS NOT" : "IS";
         string selectQuery =
-            "SELECT jobID, name, data, parentJobID, retryAfter FROM ( "
+            "SELECT jobID, name, data, parentJobID, retryAfter, created FROM ( "
                 "SELECT * FROM ("
-                    "SELECT jobID, name, data, priority, parentJobID, retryAfter "
+                    "SELECT jobID, name, data, priority, parentJobID, retryAfter, created "
                     "FROM jobs "
                     "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                     "  AND priority=1000"
@@ -618,7 +618,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 ") "
             "UNION ALL "
                 "SELECT * FROM ("
-                    "SELECT jobID, name, data, priority, parentJobID, retryAfter "
+                    "SELECT jobID, name, data, priority, parentJobID, retryAfter, created "
                     "FROM jobs "
                     "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                     "  AND priority=500"
@@ -629,7 +629,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 ") "
             "UNION ALL "
                 "SELECT * FROM ("
-                    "SELECT jobID, name, data, priority, parentJobID, retryAfter "
+                    "SELECT jobID, name, data, priority, parentJobID, retryAfter, created "
                     "FROM jobs "
                     "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                     "  AND priority=0"
@@ -664,7 +664,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         list<STable> retriableJobs;
         list<string> jobList;
         for (size_t c=0; c<result.size(); ++c) {
-            SASSERT(result[c].size() == 5); // jobID, name, data, parentJobID, retryAfter
+            SASSERT(result[c].size() == 6); // jobID, name, data, parentJobID, retryAfter, created
 
             // Add this object to our output
             STable job;
@@ -672,6 +672,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             job["jobID"] = result[c][0];
             job["name"] = result[c][1];
             job["data"] = result[c][2];
+            job["created"] = result[c][5];
             int64_t parentJobID = SToInt64(result[c][3]);
 
             if (parentJobID) {

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -49,6 +49,7 @@ struct GetJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(response["jobID"], jobID);
         ASSERT_EQUAL(response["name"], jobName);
         ASSERT_EQUAL(response["data"], "{}");
+        SASSERT(!response["created"].empty());
 
         // Check that nothing changed after we created the job except for the state and lastRun value
         SQResult currentJob;

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -45,7 +45,7 @@ struct GetJobTest : tpunit::TestFixture {
         command["name"] = jobName;
         response = tester->executeWaitVerifyContentTable(command);
 
-        ASSERT_EQUAL(response.size(), 3);
+        ASSERT_EQUAL(response.size(), 4);
         ASSERT_EQUAL(response["jobID"], jobID);
         ASSERT_EQUAL(response["name"], jobName);
         ASSERT_EQUAL(response["data"], "{}");
@@ -272,7 +272,7 @@ struct GetJobTest : tpunit::TestFixture {
         tester->executeWaitVerifyContent(command);
 
         // Confirm the child has data about the parent in the response
-        ASSERT_EQUAL(response.size(), 5);
+        ASSERT_EQUAL(response.size(), 6);
         ASSERT_EQUAL(response["jobID"], finishedChildID);
         ASSERT_EQUAL(response["name"], "child_finished");
         ASSERT_EQUAL(response["data"], finishedChildData);
@@ -303,7 +303,7 @@ struct GetJobTest : tpunit::TestFixture {
         response = tester->executeWaitVerifyContentTable(command);
 
         // Confirm data on the children are in the response
-        ASSERT_EQUAL(response.size(), 5);
+        ASSERT_EQUAL(response.size(), 6);
         ASSERT_EQUAL(response["jobID"], parentID);
         ASSERT_EQUAL(response["name"], "parent");
         ASSERT_EQUAL(response["data"], parentData);


### PR DESCRIPTION
Needed for https://github.com/Expensify/Expensify/issues/66744

Returns the time the job was created in GetJob(s) commands.