### PR TITLE
Never send the response of a connection:forget command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1239,8 +1239,9 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                     // won't get routed properly from slave to master and back.
                     command.id = _args["-nodeName"] + "#" + to_string(_requestCount++);
 
-                    // And we and keep track of the client that initiated this command, so we can respond later.
-                    command.initiatingClientID = s->id;
+                    // And we and keep track of the client that initiated this command, so we can respond later, except
+                    // if we received connection:forget in which case we don't respond later
+                    command.initiatingClientID = SIEquals(request["Connection"], "forget") ? -1 : s->id;
 
                     // Status and control requests are handled specially.
                     if (_isStatusCommand(command)) {
@@ -1306,15 +1307,9 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
 
 void BedrockServer::_reply(BedrockCommand& command) {
     SAUTOLOCK(_socketIDMutex);
-    auto socketIt = _socketIDMap.find(command.initiatingClientID);
-
-    // We don't want to send any response for a command with connection forget so that it's response doesn't get mixed
-    // up with a command we send through the same socket later.
-    if (SIEquals(command.request["Connection"], "forget")) {
-        return;
-    }
 
     // Do we have a socket for this command?
+    auto socketIt = _socketIDMap.find(command.initiatingClientID);
     if (socketIt != _socketIDMap.end()) {
 
         // The last thing we do is total up our timing info and add it to the response.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1306,9 +1306,15 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
 
 void BedrockServer::_reply(BedrockCommand& command) {
     SAUTOLOCK(_socketIDMutex);
+    auto socketIt = _socketIDMap.find(command.initiatingClientID);
+
+    // We don't want to send any response for a command with connection forget so that it's response doesn't get mixed
+    // up with a command we send through the same socket later.
+    if (SIEquals(command.request["Connection"], "forget")) {
+        return;
+    }
 
     // Do we have a socket for this command?
-    auto socketIt = _socketIDMap.find(command.initiatingClientID);
     if (socketIt != _socketIDMap.end()) {
 
         // The last thing we do is total up our timing info and add it to the response.


### PR DESCRIPTION
@tylerkaraszewski please review. /cc @flodnv 

Is this the correct fix? Especially the fact that I'm not doing `_socketIDMap.erase(socketIt);`, which not sure if is necessary or not. The thing is that we _might_ use the socket for another command or we might not. If we don't, then we could never free that socket, but if we do we need to keep the socket.... 🤔 
Locally it makes the tests pass, that used to fail in this PR https://github.com/Expensify/Web-Expensify/pull/19313

Needed to fix https://github.com/Expensify/Expensify/issues/66144