### PR TITLE
Support Mocked Unique Jobs

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -253,10 +253,13 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
             // Verify unique, but only do so when creating a single job using CreateJob
             if (SIEquals(request.methodLine, "CreateJob") && SContains(job, "unique") && job["unique"] == "true") {
                 SQResult result;
-                SINFO("Unique flag was passed, checking existing job with name " << job["name"]);
+                SINFO("Unique flag was passed, checking existing job with name " << job["name"] << ", mocked? "
+                      << (command.request.isSet("mockRequest") ? "true" : "false"));
+                string operation = command.request.isSet("mockRequest") ? "IS NOT" : "IS";
                 if (!db.read("SELECT jobID, data "
                              "FROM jobs "
-                             "WHERE name=" + SQ(job["name"]) + ";",
+                             "WHERE name=" + SQ(job["name"]) +
+                             "  AND JSON_EXTRACT(data, '$.mockRequest') " + operation + " NULL;",
                              result)) {
                     STHROW("502 Select failed");
                 }
@@ -264,7 +267,8 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
                 // If there's no job or the existing job doesn't match the data we've been passed, escalate to master.
                 if (!result.empty() && ((job["data"].empty() && result[0][1] == "{}") || (!job["data"].empty() && result[0][1] == job["data"]))) {
                     // Return early, no need to pass to master, there are no more jobs to create.
-                    SINFO("Job already existed and unique flag was passed, reusing existing job " << result[0][0]);
+                    SINFO("Job already existed and unique flag was passed, reusing existing job " << result[0][0] << ", mocked? "
+                      << (command.request.isSet("mockRequest") ? "true" : "false"));
                     content["jobID"] = result[0][0];
                     return true;
                 }
@@ -424,24 +428,22 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
 
             uint64_t updateJobID = 0;
             if (SContains(job, "unique") && job["unique"] == "true") {
-                // We don't try to handle unique jobs in mock requests.
-                if (command.request.isSet("mockRequest")) {
-                    return true;
-                }
-
                 SQResult result;
-                SINFO("Unique flag was passed, checking existing job with name " << job["name"]);
+                SINFO("Unique flag was passed, checking existing job with name " << job["name"] << ", mocked? "
+                      << (command.request.isSet("mockRequest") ? "true" : "false"));
+                string operation = command.request.isSet("mockRequest") ? "IS NOT" : "IS";
                 if (!db.read("SELECT jobID, data "
                              "FROM jobs "
-                             "WHERE name=" + SQ(job["name"]) + ";",
+                             "WHERE name=" + SQ(job["name"]) +
+                             "  AND JSON_EXTRACT(data, '$.mockRequest') " + operation + " NULL;",
                              result)) {
                     STHROW("502 Select failed");
                 }
 
                 // If we got a result, and it's data is the same as passed, we won't change anything.
-                if (!result.empty() && ((job["data"].empty() && result[0][1] == "{}") || (!job["data"].empty() && result[0][1] == originalData))) {
+                if (!result.empty() && ((job["data"].empty() && result[0][1] == "{}") || (!job["data"].empty() && result[0][1] == job["data"]))) {
                     SINFO("Job already existed with matching data, and unique flag was passed, reusing existing job "
-                          << result[0][0]);
+                          << result[0][0] << ", mocked? " << (command.request.isSet("mockRequest") ? "true" : "false"));
 
                     // If we are calling CreateJob, return early, there are no more jobs to create.
                     if (SIEquals(request.methodLine, "CreateJob")) {
@@ -518,7 +520,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 // Update the existing job.
                 if(!db.writeIdempotent("UPDATE jobs SET "
                                          "repeat   = " + SQ(SToUpper(job["repeat"])) + ", " +
-                                         "data     = JSON_PATCH(data, " + safeOriginalData + "), " +
+                                         "data     = JSON_PATCH(data, " + safeData + "), " +
                                          "priority = " + SQ(priority) + " " +
                                        "WHERE jobID = " + SQ(updateJobID) + ";"))
                 {

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -5,12 +5,12 @@ struct CreateJobTest : tpunit::TestFixture {
     CreateJobTest()
         : tpunit::TestFixture("CreateJob",
                               BEFORE_CLASS(CreateJobTest::setupClass),
-                              /*TEST(CreateJobTest::create),
+                              TEST(CreateJobTest::create),
                               TEST(CreateJobTest::createWithPriority),
                               TEST(CreateJobTest::createWithData),
                               TEST(CreateJobTest::createWithRepeat),
-                              */TEST(CreateJobTest::uniqueJob),
-                              /*TEST(CreateJobTest::createWithBadData),
+                              TEST(CreateJobTest::uniqueJob),
+                              TEST(CreateJobTest::createWithBadData),
                               TEST(CreateJobTest::createWithBadRepeat),
                               TEST(CreateJobTest::createChildWithQueuedParent),
                               TEST(CreateJobTest::createChildWithRunningGrandparent),
@@ -20,7 +20,7 @@ struct CreateJobTest : tpunit::TestFixture {
                               TEST(CreateJobTest::retryLifecycle),
                               TEST(CreateJobTest::retryWithChildren),
                               AFTER(CreateJobTest::tearDown),
-                              */AFTER_CLASS(CreateJobTest::tearDownClass)) { }
+                              AFTER_CLASS(CreateJobTest::tearDownClass)) { }
 
     BedrockTester* tester;
 

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -5,12 +5,12 @@ struct CreateJobTest : tpunit::TestFixture {
     CreateJobTest()
         : tpunit::TestFixture("CreateJob",
                               BEFORE_CLASS(CreateJobTest::setupClass),
-                              TEST(CreateJobTest::create),
+                              /*TEST(CreateJobTest::create),
                               TEST(CreateJobTest::createWithPriority),
                               TEST(CreateJobTest::createWithData),
                               TEST(CreateJobTest::createWithRepeat),
-                              TEST(CreateJobTest::uniqueJob),
-                              TEST(CreateJobTest::createWithBadData),
+                              */TEST(CreateJobTest::uniqueJob),
+                              /*TEST(CreateJobTest::createWithBadData),
                               TEST(CreateJobTest::createWithBadRepeat),
                               TEST(CreateJobTest::createChildWithQueuedParent),
                               TEST(CreateJobTest::createChildWithRunningGrandparent),
@@ -20,7 +20,7 @@ struct CreateJobTest : tpunit::TestFixture {
                               TEST(CreateJobTest::retryLifecycle),
                               TEST(CreateJobTest::retryWithChildren),
                               AFTER(CreateJobTest::tearDown),
-                              AFTER_CLASS(CreateJobTest::tearDownClass)) { }
+                              */AFTER_CLASS(CreateJobTest::tearDownClass)) { }
 
     BedrockTester* tester;
 
@@ -149,12 +149,12 @@ struct CreateJobTest : tpunit::TestFixture {
         SQResult originalJob;
         tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", originalJob);
 
-        // Try to recreate the job with new data
+        // Try to recreate the job with the same data.
+        response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_EQUAL(SToInt(response["jobID"]), jobID);
+
+        // Try to recreate the job with new data, it should get updated.
         string data = "{\"blabla\":\"test\"}";
-        command.clear();
-        command.methodLine = "CreateJob";
-        command["name"] = jobName;
-        command["unique"] = "true";
         command["data"] = data;
         response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(SToInt(response["jobID"]), jobID);


### PR DESCRIPTION
@iwiznia 

Fixes: https://github.com/Expensify/Expensify/issues/68858

This adds support for unique jobs to mockRequests.

It does this by counting the state of `mockRequest` as part of what makes a job `unique`. Thus, if you run `CreateJob` twice with `unique` set, and the same name, but one has `mockRequest` and one doesn't, you get two jobs created, one with `mockRequest: true` in its data, and one without.

This means that in a 10x test scenario, where the first request is real and the remaining 9 are mocked and `unique` is set, the first request creates one (non-mocked) job. The second request creates a (mocked) job, and the remaining 8 requests return the second job (because they'd be duplicates of the existing unique job).

Tests:
Run `CreateJobTest::uniqueJob`  with 2x enabled, i.e.:
```
./test -only CreateJob -duplicateRequests 2
```

Watch the logs, and you . should see 6 `CreateJob` requests.

1. The first created a non-mocked job.
2. The second created a mocked job.
3. The third looks up and returns the ID of the first job.
4. The fourth looks up and returns the ID of the second job.
5. The fifth updates the first job and returns its ID.
6. The sixth updates the second job and returns its ID.

requests 1, 3, and 5 are not mocked. Requests 2, 4, and 6 are mocked.