### PR TITLE
When a node logs in, send it the current set of crash commands.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1647,7 +1647,7 @@ void BedrockServer::onNodeLogin(SQLiteNode::Peer* peer)
 {
     shared_lock<decltype(_crashCommandMutex)> lock(_crashCommandMutex);
     for (const auto& p : _crashCommands) {
-        SINFO("Sending crash command " << p.first << " to node " << peer->name << " on login");
+        SALERT("Sending crash command " << p.first << " to node " << peer->name << " on login");
         SData command(p.first);
         command.nameValueMap = p.second;
         BedrockCommand cmd(command);

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -67,6 +67,9 @@ class BedrockServer : public SQLiteServer {
     // STCPNode API.
     void prePoll(fd_map& fdm);
 
+    // When a peer node logs in, we'll send it our crash command list.
+    void onNodeLogin(SQLiteNode::Peer* peer);
+
     // Accept connections and dispatch requests
     // STCPNode API.
     void postPoll(fd_map& fdm, uint64_t& nextActivity);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1062,6 +1062,9 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         peer->set("State",    message["State"]);
         peer->set("LoggedIn", "true");
         peer->set("Version",  message["Version"]);
+
+        // Let the server know that a peer has logged in.
+        _server.onNodeLogin(peer);
     } else if (!SIEquals((*peer)["LoggedIn"], "true")) {
         STHROW("not logged in");
     }
@@ -1867,9 +1870,14 @@ void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly) {
     }
 }
 
-void SQLiteNode::emergencyBroadcast(const SData& message) {
-    SALERT("Sending emergency broadcast: " << message.serialize());
-    _sendToAllPeers(message, false);
+void SQLiteNode::emergencyBroadcast(const SData& message, Peer* peer) {
+    if (peer) {
+        SALERT("Sending emergency broadcast: " << message.serialize() << " to peer: " << peer->name);
+        _sendToPeer(peer, message);
+    } else {
+        SALERT("Sending emergency broadcast: " << message.serialize());
+        _sendToAllPeers(message, false);
+    }
 }
 
 void SQLiteNode::_changeState(SQLiteNode::State newState) {

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -115,7 +115,7 @@ class SQLiteNode : public STCPNode {
     // This allows the caller to immediately send a message to all peers that something horrible has happened,
     // typically, we've segfaulted and are trying to warn other servers of a bad command before we finish crashing.
     // This is not to be used as a general messaging mechanism.
-    void emergencyBroadcast(const SData& message);
+    void emergencyBroadcast(const SData& message, Peer* peer = nullptr);
 
   private:
     // STCPNode API: Peer handling framework functions

--- a/sqlitecluster/SQLiteServer.h
+++ b/sqlitecluster/SQLiteServer.h
@@ -18,4 +18,7 @@ class SQLiteServer : public STCPServer {
     // This will return true if there's no outstanding writable activity that we're waiting on. It's called by an
     // SQLiteNode in a STANDINGDOWN state to know that it can switch to searching.
     virtual bool canStandDown() = 0;
+
+    // When a node connects to the cluster, this function will be called on the sync thread.
+    virtual void onNodeLogin(SQLiteNode::Peer* peer) = 0;
 };

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -19,9 +19,10 @@ class TestServer : public SQLiteServer {
   public:
     TestServer(const string& host) : SQLiteServer(host) { }
 
-    virtual void acceptCommand(SQLiteCommand&& command) { };
-    virtual void cancelCommand(const string& commandID) { };
-    virtual bool canStandDown() { return true; };
+    virtual void acceptCommand(SQLiteCommand&& command) { }
+    virtual void cancelCommand(const string& commandID) { }
+    virtual bool canStandDown() { return true; }
+    virtual void onNodeLogin(SQLiteNode::Peer* peer) { }
 };
 
 struct SQLiteNodeTest : tpunit::TestFixture {


### PR DESCRIPTION
@coleaeason 
@quinthar 

This change causes the crash commands list to be sent to nodes on login. The result is that a master that has crashed and re-joined the cluster will be aware of the command that caused the original crash.

Fixes: https://github.com/Expensify/Expensify/issues/68894
  