### PR TITLE
Add pragma noop_update to replicated query

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -123,10 +123,12 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
 
         // Loop across the plugins to see which wants to take this.
         bool pluginProcessed = false;
+
+        // If the command is mocked, turn on UpdateNoopMode.
+        _db.setUpdateNoopMode(command.request.isSet("mockRequest"));
         for (auto plugin : _server.plugins) {
             // Try to process the command.
             try {
-                _db.setUpdateNoopMode(command.request.isSet("mockRequest"));
                 if (plugin->processCommand(_db, command)) {
                     SINFO("Plugin '" << plugin->getName() << "' processed command '" << request.methodLine << "'");
                     pluginProcessed = true;
@@ -181,7 +183,7 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         needsCommit = false;
     }
 
-    // Turn off noop-update mode.
+    // We can turn this back off now, this is a noop if it's not turned on.
     _db.setUpdateNoopMode(false);
 
     // We can reset the timing info for the next command.

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -707,7 +707,7 @@ void SQLite::setUpdateNoopMode(bool enabled) {
 
     // Enable or disable this query.
     string query = "PRAGMA noop_update="s + (enabled ? "ON" : "OFF") + ";";
-    SQuery(_db, "enabling noop-update mode", query);
+    SQuery(_db, "setting noop-update mode", query);
     _noopUpdateMode = enabled;
 
     // If we're inside a transaction, make sure this gets saved so it can be replicated.

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -704,12 +704,17 @@ void SQLite::setUpdateNoopMode(bool enabled) {
     if (_noopUpdateMode == enabled) {
         return;
     }
-    if (enabled) {
-        SQuery(_db, "enabling noop-update mode", "PRAGMA noop_update=ON;");
-    } else {
-        SQuery(_db, "disabling noop-update mode", "PRAGMA noop_update=OFF;");
-    }
+
+    // Enable or disable this query.
+    string query = "PRAGMA noop_update="s + (enabled ? "ON" : "OFF") + ";";
+    SQuery(_db, "enabling noop-update mode", query);
     _noopUpdateMode = enabled;
+
+    // If we're inside a transaction, make sure this gets saved so it can be replicated.
+    // If we're not (i.e., a transaction's already been rolled back), no need, there's nothing to replicate.
+    if (_insideTransaction) {
+        _uncommittedQuery += query;
+    }
 }
 
 bool SQLite::getUpdateNoopMode() {


### PR DESCRIPTION
@coleaeason 

Fixes: https://github.com/Expensify/Expensify/issues/70689

The fix here is to add the pragma change to turn on/off noop_update to the query that's replicated.