### PR TITLE
Increase warn threshold for slow queries to 2 seconds 

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -753,8 +753,8 @@ void SQueryLogClose();
 
 // Returns an SQLite result code.
 int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result,
-           int64_t warnThreshold = 1000 * STIME_US_PER_MS);
-inline int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 1000 * STIME_US_PER_MS) {
+           int64_t warnThreshold = 2000 * STIME_US_PER_MS);
+inline int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS) {
     SQResult ignore;
     return SQuery(db, e, sql, ignore, warnThreshold);
 }


### PR DESCRIPTION
@Expensify/infra @tylerkaraszewski please review
cc @iwiznia @cead22 

My reasoning is that a _ton_ of queries take between 1-2 seconds, but realistically that doesn't matter much. What really matters is queries that are much slower. 
This threshold was defined a very long time ago, Bedrock performance has come a very long way since then -- we know that 1 second queries don't have an impact like they used to have prior to multi-read.

Please do comment if you disagree with my reasoning. Thanks! 

Not tested. 