### PR TITLE
Allow blank queries temporarily

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -148,10 +148,12 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
 
         // If we have no uncommitted query, just rollback the empty transaction. Otherwise, we need to commit.
         if (_db.getUncommittedQuery().empty()) {
-            _db.rollback();
+            //_db.rollback();
+            SALERT("Committing blank query.");
         } else {
-            needsCommit = true;
+            // The `needsCommit` line below is supposed to be here.
         }
+        needsCommit = true;
 
         // If no response was set, assume 200 OK
         if (response.methodLine == "") {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -343,7 +343,7 @@ bool SQLite::write(const string& query) {
 
 bool SQLite::writeIdempotent(const string& query) {
     SASSERT(_insideTransaction);
-    SASSERT(SEndsWith(query, ";"));                                         // Must finish everything with semicolon
+    SASSERT(query.empty() || SEndsWith(query, ";"));                        // Must finish everything with semicolon
     SASSERTWARN(SToUpper(query).find("CURRENT_TIMESTAMP") == string::npos); // Else will be replayed wrong
 
     // First, check our current state
@@ -554,7 +554,7 @@ bool SQLite::getCommit(uint64_t id, string& query, string& hash) {
         SASSERTWARN(!query.empty());
         SASSERTWARN(!hash.empty());
     }
-    return (!query.empty() && !hash.empty());
+    return (/*!query.empty() && */!hash.empty());
 }
 
 string SQLite::getCommittedHash() {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -848,7 +848,8 @@ bool SQLiteNode::update() {
             uint64_t commitCount = _db.getCommitCount();
 
             // If there was nothing changed, then we shouldn't have anything to commit.
-            SASSERT(!_db.getUncommittedQuery().empty());
+            // Except that this is allowed right now.
+            // SASSERT(!_db.getUncommittedQuery().empty());
 
             // There's no handling for a failed prepare. This should only happen if the DB has been corrupted or
             // something catastrophic like that.
@@ -2060,7 +2061,8 @@ void SQLiteNode::_recvSynchronize(Peer* peer, const SData& message) {
         if (!commit.isSet("Hash"))
             STHROW("missing Hash");
         if (commit.content.empty())
-            STHROW("missing content");
+            SALERT("Synchronized blank query");
+        //    STHROW("missing content");
         if (commit.calcU64("CommitIndex") != _db.getCommitCount() + 1)
             STHROW("commit index mismatch");
         if (!_db.beginTransaction())

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -126,6 +126,9 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
         int* i = 0;
         int x = *i;
         command.response["invalid"] = to_string(x);
+    } else if (command.request.methodLine == "ineffectiveUpdate") {
+        // This command does nothing on purpose so that we can run it in 10x mode and verify it replicates OK.
+        return true;
     }
     return false;
 }

--- a/test/clustertest/tests/a_MasteringTest.cpp
+++ b/test/clustertest/tests/a_MasteringTest.cpp
@@ -134,6 +134,9 @@ struct a_MasteringTest : tpunit::TestFixture {
         BedrockTester* master = tester->getBedrockTester(0);
         master->executeWaitMultipleData(requests);
 
+        SData blankQuery("ineffectiveUpdate");
+        master->executeWaitMultipleData({blankQuery});
+
         // Start the slave back up.
         bool wasSynchronizing = false;
         string startstatus = tester->startNodeDontWait(1);


### PR DESCRIPTION
@coleaeason 

This change is intended to be temporary and removed when no longer needed. 

This change has been tested by the modified tests included here, verifying that the various alerts are logged. Also, the test DBs have been manually verified to contain blank queries on multiple nodes.