### PR TITLE
Removing committing blank queries, but still allow them to synchronize

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -148,11 +148,10 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
 
         // If we have no uncommitted query, just rollback the empty transaction. Otherwise, we need to commit.
         if (_db.getUncommittedQuery().empty()) {
-            //_db.rollback();
+            _db.rollback();
         } else {
-            // The `needsCommit` line below is supposed to be here.
+            needsCommit = true;
         }
-        needsCommit = true;
 
         // If no response was set, assume 200 OK
         if (response.methodLine == "") {

--- a/test/clustertest/tests/a_MasteringTest.cpp
+++ b/test/clustertest/tests/a_MasteringTest.cpp
@@ -134,9 +134,6 @@ struct a_MasteringTest : tpunit::TestFixture {
         BedrockTester* master = tester->getBedrockTester(0);
         master->executeWaitMultipleData(requests);
 
-        SData blankQuery("ineffectiveUpdate");
-        master->executeWaitMultipleData({blankQuery});
-
         // Start the slave back up.
         bool wasSynchronizing = false;
         string startstatus = tester->startNodeDontWait(1);


### PR DESCRIPTION
@coleaeason 

Partially reverts: https://github.com/Expensify/Bedrock/pull/346

This stops us committing blank queries as standard practice, but still allows any blank queries in the journal to replicate to other nodes.

This keeps us from committing/replicating/synchronizing a bunch of ineffectual commands.