### PR TITLE
Commit entire transaction on replicate/synchronize

### DIFF
--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -72,6 +72,11 @@ class SQLite {
     // known to be repeatable. What counts as repeatable is up to the individual command.
     bool writeIdempotent(const string& query);
 
+    // This runs a query completely unchanged, always adding it to the uncommitted query, such that it will be recorded
+    // in the journal even if it had no effect on the database. This lets replicated or synchronized queries be added
+    // to the journal *even if they have no effect* on the rest of the database.
+    bool writeUnmodified(const string& query);
+
     // Enable or disable update-noop mode.
     void setUpdateNoopMode(bool enabled);
     bool getUpdateNoopMode();
@@ -247,6 +252,8 @@ class SQLite {
     // Like getCommitCount(), but only callable internally, when we know for certain that we're not in the middle of
     // any transactions. Instead of reading from an atomic var, reads directly from the database.
     uint64_t _getCommitCount();
+
+    bool _writeIdempotent(const string& query, bool alwaysKeepQueries = false);
 
     // Constructs a UNION query from a list of 'query parts' over each of our journal tables.
     // Fore each table, queryParts will be joined with that table's name as a separator. I.e., if you have a tables

--- a/test/clustertest/main.cpp
+++ b/test/clustertest/main.cpp
@@ -31,13 +31,11 @@ int main(int argc, char* argv[]) {
     // Catch sigint.
     signal(SIGINT, sigclean);
 
-    /*
-    int pid = fork();
-    if (!pid) {
-        log();
-        return 0;
+    if (args.isSet("-duplicateRequests")) {
+        // Duplicate every request N times.
+        cout << "Setting load testing to: " << SToInt(args["-duplicateRequests"]) << endl;
+        BedrockTester::mockRequestMode = SToInt(args["-duplicateRequests"]);
     }
-    */
 
     int retval = 0;
     {
@@ -56,11 +54,6 @@ int main(int argc, char* argv[]) {
             retval = 1;
         }
     }
-
-    // Kill the logger.
-    /*
-    kill(pid, 9);
-    */
 
     // Tester gets destroyed here. Everything's done.
     return retval;


### PR DESCRIPTION
This change retains the ability to synchronize and/or replicate blank queries. The design decision behind this is even though it's inefficient to save blank queries, if master says it committed one, then slaves should do the same thing and stay in sync with master. Note that master does not actually commit blank queries currently, but this defends against any possible future bug where it does.

This change also adds an extra write method to `SQLite` called `writeUnmodified`. What `writeUnmodifed` does is writes the entire query, as-is, to the current `_uncommittedQuery` which will be what gets put in the journal and hashed. The normal `write` tries to be smart about not adding queries to `_uncommittedQuery` unless they have actually changed the database.

The only places `writeUnmodifed` are called are from inside `SQLiteNode`, when receiving replicated or synchronized transactions. This prevents a slave from dropping queries that it thinks have no effect on the database, and thus no longer matching what was sent by master. The slave will just insert whatever master sent it, verbatim.

In particular, this allows the non-blank but non-database-changing query `PRAGMA noop_update=ON;PRAGMA noop_update=OFF;` which can be sent by a mockedRequest where the original request would have changed the database but the mocked request did not, because the change it would have made would not have been idempotent, and thus it was omitted.

This change will also allow us to synchronize a read-only query (i.e., `SELECT 1;`) should master send that, though that is still not the intention to send such queries.

## Testing

Firstly, a `-duplicateRequests` parameter was added to the `clustertest` command. This was set to `2` and run. All the tests continue to pass, and the following examinations were done:

The databases for all three nodes in the test cluster were compared by running the following query:

```
SELECT * FROM journal UNION ALL
SELECT * FROM journal0000 UNION ALL
SELECT * FROM journal0001 UNION ALL
SELECT * FROM journal0002 UNION ALL
SELECT * FROM journal0003 UNION ALL
SELECT * FROM journal0004 UNION ALL
SELECT * FROM journal0005 UNION ALL
SELECT * FROM journal0006 UNION ALL
SELECT * FROM journal0007 ORDER BY id;
```

This returns all journal entries across all journal tables in order. These were each saved to a separate file and compared to make sure they were identical. The comparison was:

```
 Desktop:$  shasum node*
6f5051bc44915e6401f065e7e710eadaefe7f460  node0journal.log
6f5051bc44915e6401f065e7e710eadaefe7f460  node1journal.log
6f5051bc44915e6401f065e7e710eadaefe7f460  node2journal.log
```

Additionally, the journals were inspected to verify they contained the particular query that had been problematic. Example row:
```
12|PRAGMA noop_update=ON;PRAGMA noop_update=OFF;|12907EF40E50A26574037250C8E08DD30A3D18A6
```

This is the query that would have been stripped to the empty string and then hashed to the wrong value before this change.

Also, three new debug log lines were added, indicating when we were about to commit a query from inside the sync node, which can happen in three places: on receiving a synchronize response, on receiving a commit transaction message, and when the master sync thread does it's own commit after sending to slaves.

The logs were inspected to see that all three cases occurred and functioned correctly, even with the non-changing query:

Master sync thread commits:
```
Jan 17 00:15:58 vagrant-ubuntu-trusty-64 bedrock: xxxxx (SQLiteNode.cpp:760) update [sync] [dbug] {brcluster_node_0/MASTERING} Committing current transaction because consistentEnough: PRAGMA noop_update=ON;PRAGMA noop_update=OFF;
Jan 17 00:15:58 vagrant-ubuntu-trusty-64 bedrock: xxxxx (SQLiteNode.cpp:760) update [sync] [dbug] {brcluster_node_0/MASTERING} Committing current transaction because consistentEnough: UPDATE test SET value = 'xxx14' WHERE id = 12345;;
```

Commit transaction commits:
```
Jan 17 00:15:58 vagrant-ubuntu-trusty-64 bedrock: xxxxx (SQLiteNode.cpp:1555) _onMESSAGE [sync] [dbug] {brcluster_node_2/SLAVING} Committing current transaction because COMMIT_TRANSACTION: PRAGMA noop_update=ON;PRAGMA noop_update=OFF;
Jan 17 00:16:30 vagrant-ubuntu-trusty-64 bedrock: xxxxx (SQLiteNode.cpp:1555) _onMESSAGE [sync] [dbug] {brcluster_node_1/SLAVING} Committing current transaction because COMMIT_TRANSACTION: INSERT INTO TEST VALUES(50014, 'default');
```

Synchronize response commits:
```
Jan 17 00:16:06 vagrant-ubuntu-trusty-64 bedrock: xxxxx (SQLiteNode.cpp:2086) _recvSynchronize [sync] [dbug] {brcluster_node_1/SYNCHRONIZING} Committing current transaction because _recvSynchronize: INSERT INTO test VALUES(12345, '');;
Jan 17 00:16:06 vagrant-ubuntu-trusty-64 bedrock: xxxxx (SQLiteNode.cpp:2086) _recvSynchronize [sync] [dbug] {brcluster_node_1/SYNCHRONIZING} Committing current transaction because _recvSynchronize: PRAGMA noop_update=ON;PRAGMA noop_update=OFF;
```

The entire journal tables and logs for the test run are here for further inspection:
[Archive.zip](https://github.com/Expensify/Bedrock/files/1637249/Archive.zip)
