### PR TITLE
Add Encryption functions with different parameters.

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1894,6 +1894,7 @@ string SAESEncrypt(const string& buffer, unsigned char* iv, const string& key) {
 }
 
 string SAESEncrypt(const string& buffer, const string& ivStr, const string& key) {
+    SASSERT(ivStr.size() == SAES_IV_SIZE);
     unsigned char iv[SAES_IV_SIZE];
     memcpy(iv, ivStr.c_str(), SAES_IV_SIZE);
     return SAESEncrypt(buffer, iv, key);
@@ -1924,6 +1925,7 @@ string SAESDecrypt(const string& buffer, unsigned char* iv, const string& key) {
 }
 
 string SAESDecrypt(const string& buffer, const string& ivStr, const string& key) {
+    SASSERT(ivStr.size() == SAES_IV_SIZE);
     unsigned char iv[SAES_IV_SIZE];
     memcpy(iv, ivStr.c_str(), SAES_IV_SIZE);
     return SAESDecrypt(buffer, iv, key);
@@ -2117,8 +2119,7 @@ string SEncodeBase64(const unsigned char* buffer, int size) {
 }
 
 string SEncodeBase64(const string& bufferString) {
-    unsigned char* buffer = (unsigned char*)bufferString.c_str();
-    return SEncodeBase64(buffer, bufferString.size());
+    return SEncodeBase64((unsigned char*)bufferString.c_str(), bufferString.size());
 }
 
 // --------------------------------------------------------------------------
@@ -2135,8 +2136,7 @@ string SDecodeBase64(const unsigned char* buffer, int size) {
 }
 
 string SDecodeBase64(const string& bufferString) {
-    unsigned char* buffer = (unsigned char*)bufferString.c_str();
-    return SDecodeBase64(buffer, bufferString.size());
+    return SDecodeBase64((unsigned char*)bufferString.c_str(), bufferString.size());
 }
 
 // --------------------------------------------------------------------------

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1876,7 +1876,7 @@ string SGetPeerName(int s) {
 }
 
 // --------------------------------------------------------------------------
-string SAESEncrypt(const string& buffer, const string& ivStr, const string& key) {
+string SAESEncrypt(const string& buffer, unsigned char* iv, const string& key) {
     SASSERT(key.size() == SAES_KEY_SIZE);
     // Pad the buffer to land on SAES_BLOCK_SIZE boundary (required).
     string paddedBuffer = buffer;
@@ -1885,19 +1885,22 @@ string SAESEncrypt(const string& buffer, const string& ivStr, const string& key)
     }
 
     // Encrypt
-    unsigned char iv[SAES_BLOCK_SIZE];
-    memcpy(iv, ivStr.c_str(), SAES_BLOCK_SIZE);
     mbedtls_aes_context ctx;
     mbedtls_aes_setkey_enc(&ctx, (unsigned char*)key.c_str(), 8 * SAES_KEY_SIZE);
     string encryptedBuffer;
     encryptedBuffer.resize(paddedBuffer.size());
-    mbedtls_aes_crypt_cbc(&ctx, MBEDTLS_AES_ENCRYPT, (int)paddedBuffer.size(), iv, (unsigned char*)paddedBuffer.c_str(),
-                          (unsigned char*)encryptedBuffer.c_str());
+    mbedtls_aes_crypt_cbc(&ctx, MBEDTLS_AES_ENCRYPT, (int)paddedBuffer.size(), iv, (unsigned char*)paddedBuffer.c_str(), (unsigned char*)encryptedBuffer.c_str());
     return encryptedBuffer;
 }
 
+string SAESEncrypt(const string& buffer, const string& ivStr, const string& key) {
+    unsigned char iv[SAES_IV_SIZE];
+    memcpy(iv, ivStr.c_str(), SAES_IV_SIZE);
+    return SAESEncrypt(buffer, iv, key);
+}
+
 // --------------------------------------------------------------------------
-string SAESDecrypt(const string& buffer, const string& ivStr, const string& key) {
+string SAESDecrypt(const string& buffer, unsigned char* iv, const string& key) {
     SASSERT(key.size() == SAES_KEY_SIZE);
     // If the message is invalid.
     if (buffer.size() % SAES_BLOCK_SIZE != 0) {
@@ -1905,8 +1908,6 @@ string SAESDecrypt(const string& buffer, const string& ivStr, const string& key)
     }
 
     // Decrypt
-    unsigned char iv[SAES_BLOCK_SIZE];
-    memcpy(iv, ivStr.c_str(), SAES_BLOCK_SIZE);
     mbedtls_aes_context ctx;
     string decryptedBuffer;
     decryptedBuffer.resize(buffer.size());
@@ -1920,6 +1921,12 @@ string SAESDecrypt(const string& buffer, const string& ivStr, const string& key)
         decryptedBuffer.resize(size);
     }
     return decryptedBuffer;
+}
+
+string SAESDecrypt(const string& buffer, const string& ivStr, const string& key) {
+    unsigned char iv[SAES_IV_SIZE];
+    memcpy(iv, ivStr.c_str(), SAES_IV_SIZE);
+    return SAESDecrypt(buffer, iv, key);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -2097,29 +2104,39 @@ string SHashSHA1(const string& buffer) {
 
 // --------------------------------------------------------------------------
 
-string SEncodeBase64(const string& buffer) {
+string SEncodeBase64(const unsigned char* buffer, int size) {
     // First, get the required buffer size
     size_t olen = 0;
-    mbedtls_base64_encode(0, 0, &olen, (unsigned char*)buffer.c_str(), buffer.size());
+    mbedtls_base64_encode(0, 0, &olen, buffer, size);
 
     // Next, do the encode
     string out;
     out.resize(olen - 1); // -1 because trailing 0 is implied
-    mbedtls_base64_encode((unsigned char*)&out[0], olen, &olen, (unsigned char*)buffer.c_str(), buffer.size());
+    mbedtls_base64_encode((unsigned char*)&out[0], olen, &olen, buffer, size);
     return out;
 }
 
+string SEncodeBase64(const string& bufferString) {
+    unsigned char* buffer = (unsigned char*)bufferString.c_str();
+    return SEncodeBase64(buffer, bufferString.size());
+}
+
 // --------------------------------------------------------------------------
-string SDecodeBase64(const string& buffer) {
+string SDecodeBase64(const unsigned char* buffer, int size) {
     // First, get the required buffer size
     size_t olen = 0;
-    mbedtls_base64_decode(0, 0, &olen, (unsigned char*)buffer.c_str(), buffer.size());
+    mbedtls_base64_decode(0, 0, &olen, buffer, size);
 
     // Next, do the decode
     string out;
     out.resize(olen);
-    mbedtls_base64_decode((unsigned char*)&out[0], olen, &olen, (unsigned char*)buffer.c_str(), buffer.size());
+    mbedtls_base64_decode((unsigned char*)&out[0], olen, &olen, buffer, size);
     return out;
+}
+
+string SDecodeBase64(const string& bufferString) {
+    unsigned char* buffer = (unsigned char*)bufferString.c_str();
+    return SDecodeBase64(buffer, bufferString.size());
 }
 
 // --------------------------------------------------------------------------

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -714,7 +714,9 @@ uint64_t SFileSize(const string& path);
 string SHashSHA1(const string& buffer);
 
 // Various encoding/decoding functions
+string SEncodeBase64(const unsigned char* buffer, const int size);
 string SEncodeBase64(const string& buffer);
+string SDecodeBase64(const unsigned char* buffer, const int size);
 string SDecodeBase64(const string& buffer);
 
 // HMAC (for use with Amazon S3)
@@ -722,8 +724,11 @@ string SHMACSHA1(const string& key, const string& buffer);
 
 // Encryption/Decryption
 #define SAES_KEY_SIZE 32 // AES256 32 bytes = 256 bits
+#define SAES_IV_SIZE 16
 #define SAES_BLOCK_SIZE 16
+string SAESEncrypt(const string& buffer, const unsigned char* iv, const string& key);
 string SAESEncrypt(const string& buffer, const string& iv, const string& key);
+string SAESDecrypt(const string& buffer, const unsigned char* iv, const string& key);
 string SAESDecrypt(const string& buffer, const string& iv, const string& key);
 
 // --------------------------------------------------------------------------

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -726,9 +726,9 @@ string SHMACSHA1(const string& key, const string& buffer);
 #define SAES_KEY_SIZE 32 // AES256 32 bytes = 256 bits
 #define SAES_IV_SIZE 16
 #define SAES_BLOCK_SIZE 16
-string SAESEncrypt(const string& buffer, const unsigned char* iv, const string& key);
+string SAESEncrypt(const string& buffer, unsigned char* iv, const string& key);
 string SAESEncrypt(const string& buffer, const string& iv, const string& key);
-string SAESDecrypt(const string& buffer, const unsigned char* iv, const string& key);
+string SAESDecrypt(const string& buffer, unsigned char* iv, const string& key);
 string SAESDecrypt(const string& buffer, const string& iv, const string& key);
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Adding these functions to be used in Encryption.cpp in Server-Expensify so we can avoid converting `unsigned char*` to string and back to `unsigned char*`.

Tested with the following PRs: https://github.com/Expensify/Server-Expensify/pull/2442, https://github.com/Expensify/Web-Expensify/pull/20077, and https://github.com/Expensify/Web-Secure/pull/729