### PR TITLE
Add logging of DNS resolutions

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1516,6 +1516,9 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking) {
             }
             in_addr* addr = (in_addr*)hostent->h_addr_list[0];
             ip = addr->s_addr;
+            char plainTextIP[INET_ADDRSTRLEN];
+            inet_ntop(AF_INET, addr, plainTextIP, INET_ADDRSTRLEN);
+            SINFO("Resolved " << domain << " to ip: " << plainTextIP << ".");
         }
 
         // Open a socket


### PR DESCRIPTION
@tylerkaraszewski please review. This adds logging of DNS resolutions so we can attempt to diagnose https://github.com/Expensify/Expensify/issues/63156, where some of our outbound HTTPS requests are ending up at the wrong address.

We can revert this after we've figured out what's happening, as I don't think it's actually that helpful to leave in.

## Tests
Ran billing tests, ensured I got these log lines:
```
2018-01-24T23:30:51.827712+00:00 vagrant-ubuntu-trusty-64 bedrock: xxxxx (libstuff.cpp:1521) S_socket [worker0] [info] Resolved api.stripe.com to ip: 54.187.208.163.
2018-01-24T23:30:59.631189+00:00 vagrant-ubuntu-trusty-64 bedrock: xxxxx (libstuff.cpp:1521) S_socket [worker0] [info] Resolved api.stripe.com to ip: 54.149.153.72.
```