### PR TITLE
Add queue size logging on enqueue

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -256,10 +256,11 @@ BedrockCommand SSynchronizedQueue<BedrockCommand>::pop() {
 }
 
 template<>
-void SSynchronizedQueue<BedrockCommand>::push(BedrockCommand&& rhs) {
+void SSynchronizedQueue<BedrockCommand>::push(BedrockCommand&& cmd) {
     SAUTOLOCK(_queueMutex);
+    SINFO("Enqueuing command '" << cmd.request.methodLine << "', with " << _queue.size() << " commands already queued.");
     // Just add to the queue
-    _queue.push_back(move(rhs));
+    _queue.push_back(move(cmd));
     _queue.back().startTiming(BedrockCommand::QUEUE_SYNC);
 
     // Write arbitrary buffer to the pipe so any subscribers will be awoken.

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -51,4 +51,9 @@ class BedrockCommandQueue {
     // The priority queue in which we store commands. This is a map of integer priorities to their respective maps.
     // Each of those maps maps timestamps to commands.
     map<int, multimap<uint64_t, BedrockCommand>> _commandQueue;
+
+    // Returns the size of the queue, only counting items that aren't scheduled in the future, optionally counting all
+    // the items in the queue. This function does *not* lock _queueMutex, as it's only intended to be called
+    // internally.
+    size_t _runnableSize(size_t* totalSize);
 };

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -34,6 +34,10 @@ class BedrockCommandQueue {
     // This will inspect every command in the case the command does not exist.
     bool removeByID(const string& id);
 
+    // Returns the size of the queue, only counting items that aren't scheduled in the future, optionally counting all
+    // the items in the queue.
+    size_t runnableSize(size_t* totalSize);
+
   private:
     // Removes and returns the first workable command in the queue. A command is workable if it's executeTimestamp is
     // not in the future.
@@ -51,9 +55,4 @@ class BedrockCommandQueue {
     // The priority queue in which we store commands. This is a map of integer priorities to their respective maps.
     // Each of those maps maps timestamps to commands.
     map<int, multimap<uint64_t, BedrockCommand>> _commandQueue;
-
-    // Returns the size of the queue, only counting items that aren't scheduled in the future, optionally counting all
-    // the items in the queue. This function does *not* lock _queueMutex, as it's only intended to be called
-    // internally.
-    size_t _runnableSize(size_t* totalSize);
 };

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -21,7 +21,10 @@ void BedrockServer::acceptCommand(SQLiteCommand&& command) {
         _crashCommands.insert(make_pair(request.methodLine, request.nameValueMap));
         SALERT("Blacklisting command (now have " << _crashCommands.size() << " blacklisted commands): " << request.serialize());
     } else {
-        SINFO("Queued new '" << command.request.methodLine << "' command from bedrock node.");
+        size_t totalQueueSize = 0;
+        size_t runnableQueueSize = _commandQueue.runnableSize(&totalQueueSize);
+        SINFO("Queued new '" << command.request.methodLine << "' command from bedrock node, with " << runnableQueueSize
+              << " runnable commands already queued (" << totalQueueSize << " total commands queued).");
         _commandQueue.push(BedrockCommand(move(command)));
     }
 }
@@ -1271,7 +1274,11 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                         }
                     } else if (_shutdownState < PORTS_CLOSED) {
                         // Otherwise we queue it for later processing.
-                        SINFO("Queued new '" << command.request.methodLine << "' command from local client.");
+                        size_t totalQueueSize = 0;
+                        size_t runnableQueueSize = _commandQueue.runnableSize(&totalQueueSize);
+                        SINFO("Queued new '" << command.request.methodLine << "' command from local client, with "
+                              << runnableQueueSize << " runnable commands already queued (" << totalQueueSize
+                              << " total commands queued).");
                         _commandQueue.push(move(command));
                     }
                 }


### PR DESCRIPTION
This is for:
https://github.com/Expensify/Expensify/issues/70739

This adds logging of queue size on enqueuing commands in the main command queue, and the sync thread queue.

There's a new function `_runnableSize` in `BedrockCommandQueue.cpp` that is special in two ways:

1. It excludes commands scheduled to execute in the future.
2. It doesn't lock the command queue's mutex (because it's only called internally from a location where the mutex is already locked).

One concern here is that `std::distance` runs in linear time, so if we get enough of a backlog of commands while we have commands scheduled to execute in the future, each new enqueue operation has to count the existing list of commands. I doubt this will be significant in practice, though.