### PR TITLE
Simplified version of queue size logging

### DIFF
--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -21,38 +21,6 @@ size_t BedrockCommandQueue::size()  {
     return size;
 }
 
-size_t BedrockCommandQueue::runnableSize(size_t* totalSize)  {
-    SAUTOLOCK(_queueMutex);
-    uint64_t now = STimeNow();
-    size_t size = 0;
-    for (const auto& queue : _commandQueue) {
-        const auto& subQueue = queue.second;
-
-        // Skip this queue if it's empty.
-        if (subQueue.empty()) {
-            continue;
-        }
-
-        // If the caller asked for the total size, record that as well.
-        if (totalSize) {
-            *totalSize += subQueue.size();
-        }
-
-        // If the last item isn't in the future, then we can just use size().
-        if (subQueue.rbegin()->first < now) {
-            size += subQueue.size();
-        } else {
-            // Otherwise, we need to only count items scheduled before now.
-            // Start with the first item after now.
-            auto it = subQueue.upper_bound(now);
-
-            // And count the number of increments it takes to get there.
-            size += distance(subQueue.begin(), it);
-        }
-    }
-    return size;
-}
-
 BedrockCommand BedrockCommandQueue::get(uint64_t timeoutUS) {
     unique_lock<mutex> queueLock(_queueMutex);
 

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -34,10 +34,6 @@ class BedrockCommandQueue {
     // This will inspect every command in the case the command does not exist.
     bool removeByID(const string& id);
 
-    // Returns the size of the queue, only counting items that aren't scheduled in the future, optionally counting all
-    // the items in the queue.
-    size_t runnableSize(size_t* totalSize);
-
   private:
     // Removes and returns the first workable command in the queue. A command is workable if it's executeTimestamp is
     // not in the future.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -21,10 +21,8 @@ void BedrockServer::acceptCommand(SQLiteCommand&& command) {
         _crashCommands.insert(make_pair(request.methodLine, request.nameValueMap));
         SALERT("Blacklisting command (now have " << _crashCommands.size() << " blacklisted commands): " << request.serialize());
     } else {
-        size_t totalQueueSize = 0;
-        size_t runnableQueueSize = _commandQueue.runnableSize(&totalQueueSize);
-        SINFO("Queued new '" << command.request.methodLine << "' command from bedrock node, with " << runnableQueueSize
-              << " runnable commands already queued (" << totalQueueSize << " total commands queued).");
+        SINFO("Queued new '" << command.request.methodLine << "' command from bedrock node, with " << _commandQueue.size()
+              << " commands already queued.");
         _commandQueue.push(BedrockCommand(move(command)));
     }
 }
@@ -1287,11 +1285,8 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                         }
                     } else if (_shutdownState < PORTS_CLOSED) {
                         // Otherwise we queue it for later processing.
-                        size_t totalQueueSize = 0;
-                        size_t runnableQueueSize = _commandQueue.runnableSize(&totalQueueSize);
                         SINFO("Queued new '" << command.request.methodLine << "' command from local client, with "
-                              << runnableQueueSize << " runnable commands already queued (" << totalQueueSize
-                              << " total commands queued).");
+                              << _commandQueue.size() << " commands already queued.");
                         _commandQueue.push(move(command));
                     }
                 }


### PR DESCRIPTION
This backs out the controversial O(n) portion of this change: https://github.com/Expensify/Bedrock/pull/358

This is for this issue: https://github.com/Expensify/Expensify/issues/70739

This leaves us with just overall queue size to log, which is fast, but could potentially be misleading if we queue lots of commands in the future (but we probably don't).