### PR TITLE
Fix repeated journal initialization

### DIFF
--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -149,72 +149,89 @@ class SQLite {
     map<string, set<string>>* whitelist;
 
   private:
-    // This is the last committed hash by *any* thread.
-    static atomic<string> _lastCommittedHash;
 
-    // This is a set of transactions IDs that have been successfully committed to the database, but not yet sent to
-    // peers.
-    static set<uint64_t> _committedTransactionIDs;
+    // This structure contains all of the data that's shared between a set of SQLite objects that share the same
+    // underlying database file.
+    struct SharedData {
+        // This is the last committed hash by *any* thread for this file.
+        atomic<string> _lastCommittedHash;
 
-    // You're only supposed to configure SQLite options before initializing the library, but the library provides no
-    // way to check if it's been initialized, so we store our own value here.
-    static atomic_flag _sqliteInitialized;
+        // This is a set of transactions IDs that have been successfully committed to the database, but not yet sent to
+        // peers.
+        set<uint64_t> _committedTransactionIDs;
+
+        // The current commit count, loaded at initialization from the highest commit ID in the DB, and then accessed
+        // though this atomic integer. getCommitCount() returns the value of this variable.
+        atomic<uint64_t> _commitCount;
+
+        // Names of journal tables for this database.
+        list<string> _journalNames;
+
+        // Explanation: Why do we keep a list of outstanding transactions, instead of just looking them up when we need
+        // them (i.e., look up all transaction with an ID greater than the last one sent to peers when we need to send them
+        // to peers)?
+        // Originally, that had been the idea, but we ran into a problem with the way we send transactions to peers. When
+        // doing parallel writes, we'll always write commits to the database in order. We particularly construct locks
+        // around both `prepare()` and `commit()` in SQLiteNode to handle this (and yes, the fact that I'm discussing
+        // SQLiteNode in SQlite.h is not a sign of great encapsulation). In general then, since rows are always added to
+        // the DB and then committed in order, we could just keep a pointer to the last-sent transaction, and send all
+        // transactions following that one to peers.
+        //
+        // However, this breaks down when we need to do a quorum command. In this case, we perform the following actions
+        // from the sync thread:
+        //
+        // 1) processCommand()
+        // 2) mutex.lock()
+        // 3) sendOutstandingTransactions()
+        // 4) prepare()
+        // 5) commit() <- this is a distributed commit.
+        //
+        // We need to sendOutstandingTransactions() before calling commit(), because this is a distributed commit and if we
+        // don't send any outstanding transactions to peers before sending the current one, then transactions will arrive
+        // at peers out of order. We also need to lock our mutex before calling sendOutstandingTransactions() to prevent
+        // any other threads from making new commits while we're sending them, which would result in the same out-of-order
+        // sending when we completed sendOutstandingTransactions(), but still had (newly committed) transactions to send.
+        //
+        // The problem that requires us to keep lists of outstanding transactions is that when we call processCommand() in
+        // the current thread, sqlite will use a snapshot of the database taken at that point (the point at which we do
+        // `BEGIN CONCURRENT`) until we either commit or rollback the transaction.
+        // That means that if any other thread makes a new commit to the database after we've started process(), but before
+        // we call sendOutstandingTransactions(), we won't see it from the current thread, because we're operating on on
+        // old database snpashot until we either rollback(), which defeats the purpose of committing a new transaction, or
+        // we commit(), which we can't do yet because we need to send outstanding transactions first.
+        //
+        // We could grab out mutex earlier, before calling processCommand(), which would avoid this situation, but it would
+        // cause all other threads to wait for the entire duration of processCommand() in this thread, which is the sort of
+        // performance problem we're trying to avoid in the first place with parallel writes. Instead, when each thread
+        // adds new commits, it makes them available in the following lists, so that we'll have access to them in
+        // sendOutstandingTransactions(), even if the current thread is operating on an old DB snapshot.
+        //
+        // NOTE: Both of the following collections (_inFlightTransactions and _committedtransactionIDs) are shared between
+        // all threads and need to be accessed in a synchronized fashion. They do *NOT* implement their own synchronization
+        // and must be protected by locking `_commitLock`.
+        //
+        // This is a map of all currently "in flight" transactions. These are transactions for which a `prepare()` has been
+        // called to generate a journal row, but have not yet been sent to peers.
+        map<uint64_t, pair<string, string>> _inFlightTransactions;
+    };
 
     // We have designed this so that multiple threads can write to multiple journals simultaneously, but we want
     // monotonically increasing commit numbers, so we implement a lock around changing that value. This lock is wrapped
-    // and publicly exposed only through 'g_commitLock'.
+    // and publicly exposed only through 'g_commitLock'. This *should* be part of SharedData and specific to each file
+    // we're using, but it isn't because it's externally referenced as a static class member, because we didn't used to
+    // support multiple files here. This will cause a performance bottleneck if using multiple files, as they'll both
+    // unnecessarily compete for the same commit lock. We also use this global lock for inserting and removing items in
+    // _sharedDataLookupMap, and if we were to move this to being per-filename, we'd need a separate lock just for
+    // _sharedDataLookupMap.
     static recursive_mutex _commitLock;
 
-    // The current commit count, loaded at initialization from the highest commit ID in the DB, and then accessed
-    // though this atomic integer. getCommitCount() returns the value of this variable.
-    static atomic<uint64_t> _commitCount;
+    // This map is how a new SQLite object can look up the existing state for the other SQLite objects sharing the same
+    // database file. It's a map of canonicalized filename to a reference count and a sharedData object.
+    static map<string, pair<int, SharedData*>> _sharedDataLookupMap; 
 
-    // Explanation: Why do we keep a list of outstanding transactions, instead of just looking them up when we need
-    // them (i.e., look up all transaction with an ID greater than the last one sent to peers when we need to send them
-    // to peers)?
-    // Originally, that had been the idea, but we ran into a problem with the way we send transactions to peers. When
-    // doing parallel writes, we'll always write commits to the database in order. We particularly construct locks
-    // around both `prepare()` and `commit()` in SQLiteNode to handle this (and yes, the fact that I'm discussing
-    // SQLiteNode in SQlite.h is not a sign of great encapsulation). In general then, since rows are always added to
-    // the DB and then committed in order, we could just keep a pointer to the last-sent transaction, and send all
-    // transactions following that one to peers.
-    //
-    // However, this breaks down when we need to do a quorum command. In this case, we perform the following actions
-    // from the sync thread:
-    //
-    // 1) processCommand()
-    // 2) mutex.lock()
-    // 3) sendOutstandingTransactions()
-    // 4) prepare()
-    // 5) commit() <- this is a distributed commit.
-    //
-    // We need to sendOutstandingTransactions() before calling commit(), because this is a distributed commit and if we
-    // don't send any outstanding transactions to peers before sending the current one, then transactions will arrive
-    // at peers out of order. We also need to lock our mutex before calling sendOutstandingTransactions() to prevent
-    // any other threads from making new commits while we're sending them, which would result in the same out-of-order
-    // sending when we completed sendOutstandingTransactions(), but still had (newly committed) transactions to send.
-    //
-    // The problem that requires us to keep lists of outstanding transactions is that when we call processCommand() in
-    // the current thread, sqlite will use a snapshot of the database taken at that point (the point at which we do
-    // `BEGIN CONCURRENT`) until we either commit or rollback the transaction.
-    // That means that if any other thread makes a new commit to the database after we've started process(), but before
-    // we call sendOutstandingTransactions(), we won't see it from the current thread, because we're operating on on
-    // old database snpashot until we either rollback(), which defeats the purpose of committing a new transaction, or
-    // we commit(), which we can't do yet because we need to send outstanding transactions first.
-    //
-    // We could grab out mutex earlier, before calling processCommand(), which would avoid this situation, but it would
-    // cause all other threads to wait for the entire duration of processCommand() in this thread, which is the sort of
-    // performance problem we're trying to avoid in the first place with parallel writes. Instead, when each thread
-    // adds new commits, it makes them available in the following lists, so that we'll have access to them in
-    // sendOutstandingTransactions(), even if the current thread is operating on an old DB snapshot.
-    //
-    // NOTE: Both of the following collections (_inFlightTransactions and _committedtransactionIDs) are shared between
-    // all threads and need to be accessed in a synchronized fashion. They do *NOT* implement their own synchronization
-    // and must be protected by locking `_commitLock`.
-    //
-    // This is a map of all currently "in flight" transactions. These are transactions for which a `prepare()` has been
-    // called to generate a journal row, but have not yet been sent to peers.
-    static map<uint64_t, pair<string, string>> _inFlightTransactions;
+    // Pointer to our SharedData object. Having a pointer directly to the object avoids having to lock the lookup map
+    // to access this memory.
+    SharedData* _sharedData;
 
     // This is the callback function we use to log SQLite's internal errors.
     static void _sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg);
@@ -233,19 +250,6 @@ class SQLite {
 
     // The name of the journal table, computed from the 'journalTable' parameter passed to our constructor.
     string _journalName;
-
-    const list<string>* _journalNames;
-
-    // We keep a map of filenames identifying individual databases to pairs of count, list<journal tables names>/
-    // Whenever we initialize a new SQLite object (or call the destructor), we lock here, as we will potentially modify the map.
-    // If this is a new filename with no entry, we add the entry with the list of journal tables for this map, and a
-    // count of 1.
-    // If the this filename already exists in the map, we increment it's count.
-    // On destruction of an SQLite object, we decrement the count, destroying the object if we're the last one
-    // referencing it.
-    // The lock exists only to control modifying the map, we do not need to lock on accessing the list it contains, as
-    // it's constant and persists as long as the reference count is non-zero.
-    static map<string, pair<size_t, const list<string>*>> _journalLookupMap; 
 
     // Timing information.
     uint64_t _beginElapsed;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -38,14 +38,14 @@ class SQLite {
            int maxRequiredJournalTableID, const string& synchronous = "");
     ~SQLite();
 
-    // Returns the filename for this database
+    // Returns the canonicalized filename for this database
     string getFilename() { return _filename; }
 
     // Performs a read-only query (eg, SELECT). This can be done inside or outside a transaction. Returns true on
     // success, and fills the 'result' with the result of the query.
     bool read(const string& query, SQResult& result);
 
-    // Performs a read-only query (eg, SELECT) that returns a single cell.
+    // Performs a read-only query (eg, SELECT) that returns a single value.
     string read(const string& query);
 
     // Begins a new transaction. Returns true on success.

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -34,13 +34,13 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         // This exposes just enough to test the peer selection logic.
         SQLite db(":memory:", 1000000, 100, 5000, -1, -1);
         TestServer server("");
-        SQLiteNode testNode(server, db, "test", "localhost:9999", "", 1, 1000000000, "1.0", 100);
+        SQLiteNode testNode(server, db, "test", "localhost:19999", "", 1, 1000000000, "1.0", 100);
 
         STable dummyParams;
-        testNode.addPeer("peer1", "host1.fake:5555", dummyParams);
-        testNode.addPeer("peer2", "host2.fake:6666", dummyParams);
-        testNode.addPeer("peer3", "host3.fake:7777", dummyParams);
-        testNode.addPeer("peer4", "host4.fake:8888", dummyParams);
+        testNode.addPeer("peer1", "host1.fake:15555", dummyParams);
+        testNode.addPeer("peer2", "host2.fake:16666", dummyParams);
+        testNode.addPeer("peer3", "host3.fake:17777", dummyParams);
+        testNode.addPeer("peer4", "host4.fake:18888", dummyParams);
 
         // Do a base test, with one peer with no latency.
         SQLiteNode::Peer* fastest = nullptr;


### PR DESCRIPTION
This change fixes the problem where we'd see each thread (384 of them on db3.la) re-check each journal table at startup, which made for 109,056 total journal checks (because there's the same number of threads as journals, essentially).

https://github.com/Expensify/Expensify/issues/72149

However, the change to do that is more complex than you might guess, because it also fixes a fundamental issue in how `SQLite` keeps track of files.

To manage multi-write, we have a separate DB handle for each thread, but all of those threads share some state about the DB, which includes the list of journal table names, but also things like the current commit count.

Up until now, these were all stored in static globals, and we assumed that every `SQLite` object you opened would refer to the same database file, which wasn't actually true. For instance, we'd open up `SQLite` objects referring to the `:memory:` database in the tests, but these would actually share state with all other databases in the same process.

This mostly worked OK, because we never relied on this behavior, and we never did any replication with these ancillary databases, so it didn't matter if they each corrupted one-another's commit counts and such. Fundamentally, though, doing this was broken:

```
SQLite("onefile.db");
SQLite("anotherfile.db");
```

Because both would share the same `commitCount` and journal list, etc. This worked OK enough for what we were doing when each `SQLite` object verified it's own journals, but as soon as I changed the code to only have the first thread check the journal, any other `SQLite` object that used a different file would break, because it would look at the wrong journals.

I decided the correct fix was to group database handles by the file they're actually attached to, so I created a map of filenames (normalized by resolving the entire path of the file) to `SharedData` objects, where a `SharedData` is just a struct that encapsulates all of the shared data that used to be global.

Now, when you instantiate an SQLite object, the constructor looks up it's filename in the map. If it's not found, it allocates a new `SharedData` object, and adds it to the map. If there was already an entry for that filename, it keeps a pointer to the existing `SharedData` object. The constructor increments a reference count for this `SharedData`.

In each `SQLite` object, we store a pointer to a `SharedData` that's allocated on the heap. The lookup map also only stores pointers. This allows us to avoid any global locking around each file's `SharedData` object, as all the internal accounting for that has already been taken care of. The only new locking is around changes to the map, which only happens in the `SQLite` constructor and destructor.

The destructor for an `SQLite` decrements a reference count, and, if it becomes 0, deletes the `SharedData` object for that filename, and then removes the filename from the map.

This fixes a long-known deficiency in the `SQLite` class (I won't go as far as to call it a bug, cause it worked as long as you were careful to only ever use the same file in every `SQLite` instance).

Now that database handles are grouped by the file they refer to, we can safely initialize each file's journals only once.

One other thing this makes possible is replication of multiple database files in a single bedrock cluster (we'd need to add a file identifier to replication messages), which would make it easy to implement various types of sharding.