### PR TITLE
Be less aggressive about blacklisting commands.

### DIFF
--- a/BedrockConflictMetrics.cpp
+++ b/BedrockConflictMetrics.cpp
@@ -83,6 +83,11 @@ bool BedrockConflictMetrics::multiWriteOK(const string& commandName) {
     // And now that we know whether or not we can multi-write this, see if that's different than the last time we
     // checked for this command, so we can do extra logging if so.
     if (result != metric._lastCheckOK) {
+        if (result) {
+            // Give a fresh start on making this OK again, so that we don't fall back into a DENIED state on the next
+            // check.
+            metric._results.reset();
+        }
         SINFO("Multi-write changing to " << resultString << " for command '" << commandName
               << "' recent conflicts: " << conflicts << "/" << min((uint64_t)COMMAND_COUNT, totalAttempts)
               << ", total conflicts: " << metric._totalConflictCount << "/" << totalAttempts << ".");


### PR DESCRIPTION
We're overly aggressive when blacklisting commands after conflicts. We check whether a command is blacklisted inside the loop where we intend to allow a command three failures before forwarding it to the sync thread, but the result of this is that we almost never actually do all three checks on a command, and rather, forward it to the sync thread early. We also count conflicts on each conflict, rather than each command, meaning that if we *do* run through all three failures, we'll have recorded three conflicts for the command, causing it to get blacklisted much sooner.

This combines with the way we track conflicts: we keep track of the last 100 attempts to commit a command, and if 10 or more of them were conflicts, we've blacklisted the command. The problem with this is that what tends to happen is that as we drop to 9/100 of the last commands being conflicts, we allow multi-write for that command, but that means that a single conflict can bump the command back into being blacklisted.

This change does two things:

1. It *always* gives a command three attempts to conflict before forwarding to the sync thread (assuming it wasn't already blacklisted before the loop). Assuming the conflict rates don't increase when re-running the same commands more often (and they probably will to some degree), this *drastically* reduces the number of commands that need to be forwarded to the sync thread. For instance, if a command has a 20% chance of conflict, the chance that it conflicts three times in a row is only 0.8%.
2. It resets the conflict count when we un-blacklist a command. That way, instead of coming back at 9/100 conflicts and having the potential to be immediately re-blacklisted, it will come out at 0/100 and will need 10 new conflicts to be re-blacklisted.

I think this might push worker offload well above 95%. We'll see if there are any other complications with increased conflicts, but the numbers I've looked at so far are promising - most commands actually have fairly low conflict rates.