### PR TITLE
Only wait 3ms before giving up on sync thread lock.

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -129,21 +129,27 @@ void BedrockCommand::startTiming(TIMING_INFO type) {
     get<2>(_inProgressTiming) = 0;
 }
 
-void BedrockCommand::stopTiming(TIMING_INFO type) {
+uint64_t BedrockCommand::stopTiming(TIMING_INFO type) {
+    // Add it to the list of timing info.
+    get<2>(_inProgressTiming) = STimeNow();
+    timingInfo.push_back(_inProgressTiming);
+
+    // Warn if it looks like it was set incorrectly.
+    uint64_t retVal = 0;
     if (get<0>(_inProgressTiming) != type ||
         get<1>(_inProgressTiming) == 0
        ) {
         SWARN("Stopping timing, but looks like it wasn't already running.");
+    } else {
+        // If it was correct, return the time.
+        retVal = get<2>(_inProgressTiming) - get<1>(_inProgressTiming);
     }
-
-    // Add it to the list of timing info.
-    get<2>(_inProgressTiming) = STimeNow();
-    timingInfo.push_back(_inProgressTiming);
 
     // And reset it for next use.
     get<0>(_inProgressTiming) = INVALID;
     get<1>(_inProgressTiming) = 0;
     get<2>(_inProgressTiming) = 0;
+    return retVal;
 }
 
 void BedrockCommand::finalizeTimingInfo() {

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -46,8 +46,8 @@ class BedrockCommand : public SQLiteCommand {
     void startTiming(TIMING_INFO type);
 
     // Finish recording time for a given action type. `type` must match what was passed to the most recent call to
-    // `startTiming`.
-    void stopTiming(TIMING_INFO type);
+    // `startTiming`. Returns the amount of time recorded in microseconds.
+    uint64_t stopTiming(TIMING_INFO type);
 
     // Add a summary of our timing info to our response object.
     void finalizeTimingInfo();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -284,7 +284,8 @@ void BedrockServer::sync(SData& args,
             SASSERT(nodeState == SQLiteNode::MASTERING || nodeState == SQLiteNode::STANDINGDOWN);
 
             // Record the time spent.
-            command.stopTiming(BedrockCommand::COMMIT_SYNC);
+            uint64_t syncCommitTime = command.stopTiming(BedrockCommand::COMMIT_SYNC);
+            SINFO("Sync thread committed command " << command.request.methodLine << " in " << (syncCommitTime/1000) << "ms.");
 
             // We're done with the commit, we unlock our mutex and decrement our counter.
             server._syncThreadCommitMutex.unlock();
@@ -739,7 +740,7 @@ void BedrockServer::worker(SData& args,
                                 // locks in the same order. Always acquiring the locks in the same order prevents the
                                 // deadlocks.
                                 try {
-                                    shared_lock<decltype(server._syncNode->stateMutex)> lock2(server._syncNode->stateMutex);
+                                    shared_lock<decltype(server._syncNode->stateMutex)> lock(server._syncNode->stateMutex);
                                     if (replicationState.load() != SQLiteNode::MASTERING &&
                                         replicationState.load() != SQLiteNode::STANDINGDOWN) {
                                         SWARN("Node State changed from MASTERING to "

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -723,9 +723,10 @@ void BedrockServer::worker(SData& args,
                             // conflict as long as we don't commit while it's performing a transaction. This is scoped
                             // to the minimum time required.
                             bool commitSuccess = false;
-                            {
-                                shared_lock<decltype(server._syncThreadCommitMutex)> lock1(server._syncThreadCommitMutex);
 
+                            // We'll wait up to 3ms for this lock, and if we don't get it, we treat that like a
+                            // conflict.
+                            if (server._syncThreadCommitMutex.try_lock_for(chrono::milliseconds(3))) {
                                 // This is the first place we get really particular with the state of the node from a
                                 // worker thread. We only want to do this commit if we're *SURE* we're mastering, and
                                 // not allow the state of the node to change while we're committing. If it turns out
@@ -737,17 +738,29 @@ void BedrockServer::worker(SData& args,
                                 // sync thread to to change states mid-commit, meaning that it needs to acquire these
                                 // locks in the same order. Always acquiring the locks in the same order prevents the
                                 // deadlocks.
-                                shared_lock<decltype(server._syncNode->stateMutex)> lock2(server._syncNode->stateMutex);
-                                if (replicationState.load() != SQLiteNode::MASTERING &&
-                                    replicationState.load() != SQLiteNode::STANDINGDOWN) {
-                                    SWARN("Node State changed from MASTERING to "
-                                          << SQLiteNode::stateNames[replicationState.load()]
-                                          << " during worker commit. Rolling back transaction!");
-                                    core.rollback();
-                                } else {
-                                    BedrockCore::AutoTimer(command, BedrockCommand::COMMIT_WORKER);
-                                    commitSuccess = core.commit();
+                                try {
+                                    shared_lock<decltype(server._syncNode->stateMutex)> lock2(server._syncNode->stateMutex);
+                                    if (replicationState.load() != SQLiteNode::MASTERING &&
+                                        replicationState.load() != SQLiteNode::STANDINGDOWN) {
+                                        SWARN("Node State changed from MASTERING to "
+                                              << SQLiteNode::stateNames[replicationState.load()]
+                                              << " during worker commit. Rolling back transaction!");
+                                        core.rollback();
+                                    } else {
+                                        BedrockCore::AutoTimer(command, BedrockCommand::COMMIT_WORKER);
+                                        commitSuccess = core.commit();
+                                    }
+                                } catch (...) {
+                                    SWARN("Caught exception while trying to commit. Freeing mutex and re-throwing.");
+                                    server._syncThreadCommitMutex.unlock();
+                                    throw;
                                 }
+
+                                // Done with this, we need to unlock it.
+                                server._syncThreadCommitMutex.unlock();
+                            } else {
+                                SINFO("Timeout attempting to lock _syncThreadCommitMutex for command " << command.request.methodLine << ", treating as conflict.");
+                                core.rollback();
                             }
                             if (commitSuccess) {
                                 BedrockConflictMetrics::recordSuccess(command.request.methodLine);


### PR DESCRIPTION
Give up on locking the sync thread commit mutex after 3ms, and treat like a conflict. This allows workers to go on processing commands even if the sync thread is completely blocked (note that this will still cause a backlog of sync thread commands, but at least read commands can get processed).