### PR TITLE
Handle C-string without creating a reference so it works with constexpr values

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -131,6 +131,12 @@ class SString : public string {
         return *this;
     }
 
+    // Handle C-strings
+    SString& operator=(const char* from) {
+        string::operator=(from);
+        return *this;
+    }
+
     // Booleans get converted to strings.
     SString& operator=(const bool from) {
         string::operator=(from ? "true" : "false");


### PR DESCRIPTION
@ctkochan22 

Check out this bedrock branch and build your current code against it (you'll probably need to clean and build from scratch) and see if it fixes your problem.