### PR TITLE
Revert lock timeout, wait indefinitely for commit mutex.

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -129,27 +129,21 @@ void BedrockCommand::startTiming(TIMING_INFO type) {
     get<2>(_inProgressTiming) = 0;
 }
 
-uint64_t BedrockCommand::stopTiming(TIMING_INFO type) {
-    // Add it to the list of timing info.
-    get<2>(_inProgressTiming) = STimeNow();
-    timingInfo.push_back(_inProgressTiming);
-
-    // Warn if it looks like it was set incorrectly.
-    uint64_t retVal = 0;
+void BedrockCommand::stopTiming(TIMING_INFO type) {
     if (get<0>(_inProgressTiming) != type ||
         get<1>(_inProgressTiming) == 0
        ) {
         SWARN("Stopping timing, but looks like it wasn't already running.");
-    } else {
-        // If it was correct, return the time.
-        retVal = get<2>(_inProgressTiming) - get<1>(_inProgressTiming);
     }
+
+    // Add it to the list of timing info.
+    get<2>(_inProgressTiming) = STimeNow();
+    timingInfo.push_back(_inProgressTiming);
 
     // And reset it for next use.
     get<0>(_inProgressTiming) = INVALID;
     get<1>(_inProgressTiming) = 0;
     get<2>(_inProgressTiming) = 0;
-    return retVal;
 }
 
 void BedrockCommand::finalizeTimingInfo() {

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -46,8 +46,8 @@ class BedrockCommand : public SQLiteCommand {
     void startTiming(TIMING_INFO type);
 
     // Finish recording time for a given action type. `type` must match what was passed to the most recent call to
-    // `startTiming`. Returns the amount of time recorded in microseconds.
-    uint64_t stopTiming(TIMING_INFO type);
+    // `startTiming`.
+    void stopTiming(TIMING_INFO type);
 
     // Add a summary of our timing info to our response object.
     void finalizeTimingInfo();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -285,8 +285,7 @@ void BedrockServer::sync(SData& args,
             SASSERT(nodeState == SQLiteNode::MASTERING || nodeState == SQLiteNode::STANDINGDOWN);
 
             // Record the time spent.
-            uint64_t syncCommitTime = command.stopTiming(BedrockCommand::COMMIT_SYNC);
-            SINFO("Sync thread committed command " << command.request.methodLine << " in " << (syncCommitTime/1000) << "ms.");
+            command.stopTiming(BedrockCommand::COMMIT_SYNC);
 
             // We're done with the commit, we unlock our mutex and decrement our counter.
             server._syncThreadCommitMutex.unlock();
@@ -725,14 +724,12 @@ void BedrockServer::worker(SData& args,
                             // conflict as long as we don't commit while it's performing a transaction. This is scoped
                             // to the minimum time required.
                             bool commitSuccess = false;
+                            {
+                                uint64_t preLockTime = STimeNow();
+                                shared_lock<decltype(server._syncThreadCommitMutex)> lock1(server._syncThreadCommitMutex);
+                                SINFO("_syncThreadCommitMutex acquired in worker in " << fixed << setprecision(2)
+                                      << ((STimeNow() - preLockTime)/1000.0) << "ms.");
 
-                            // We'll wait up to 3ms for this lock, and if we don't get it, we treat that like a
-                            // conflict.
-                            uint64_t preLockTime = STimeNow();
-                            if (server._syncThreadCommitMutex.try_lock_for(chrono::milliseconds(10))) {
-                                uint64_t lockTime = STimeNow() - preLockTime;
-                                SINFO("_syncThreadCommitMutex successfully acquired in worker in " << fixed
-                                      << setprecision(2) << double(lockTime/1000.0) << "ms.");
                                 // This is the first place we get really particular with the state of the node from a
                                 // worker thread. We only want to do this commit if we're *SURE* we're mastering, and
                                 // not allow the state of the node to change while we're committing. If it turns out
@@ -744,32 +741,17 @@ void BedrockServer::worker(SData& args,
                                 // sync thread to to change states mid-commit, meaning that it needs to acquire these
                                 // locks in the same order. Always acquiring the locks in the same order prevents the
                                 // deadlocks.
-                                try {
-                                    shared_lock<decltype(server._syncNode->stateMutex)> lock(server._syncNode->stateMutex);
-                                    if (replicationState.load() != SQLiteNode::MASTERING &&
-                                        replicationState.load() != SQLiteNode::STANDINGDOWN) {
-                                        SWARN("Node State changed from MASTERING to "
-                                              << SQLiteNode::stateNames[replicationState.load()]
-                                              << " during worker commit. Rolling back transaction!");
-                                        core.rollback();
-                                    } else {
-                                        BedrockCore::AutoTimer(command, BedrockCommand::COMMIT_WORKER);
-                                        commitSuccess = core.commit();
-                                    }
-                                } catch (...) {
-                                    SWARN("Caught exception while trying to commit. Freeing mutex and re-throwing.");
-                                    server._syncThreadCommitMutex.unlock();
-                                    throw;
+                                shared_lock<decltype(server._syncNode->stateMutex)> lock2(server._syncNode->stateMutex);
+                                if (replicationState.load() != SQLiteNode::MASTERING &&
+                                    replicationState.load() != SQLiteNode::STANDINGDOWN) {
+                                    SWARN("Node State changed from MASTERING to "
+                                          << SQLiteNode::stateNames[replicationState.load()]
+                                          << " during worker commit. Rolling back transaction!");
+                                    core.rollback();
+                                } else {
+                                    BedrockCore::AutoTimer(command, BedrockCommand::COMMIT_WORKER);
+                                    commitSuccess = core.commit();
                                 }
-
-                                // Done with this, we need to unlock it.
-                                server._syncThreadCommitMutex.unlock();
-                            } else {
-                                uint64_t lockWaitTime = STimeNow() - preLockTime;
-                                SINFO("Timeout attempting to lock _syncThreadCommitMutex (waited " << fixed
-                                      << setprecision(2) << double(lockWaitTime/1000.0) << "ms) for command "
-                                      << command.request.methodLine << ", treating as conflict.");
-                                core.rollback();
                             }
                             if (commitSuccess) {
                                 BedrockConflictMetrics::recordSuccess(command.request.methodLine);


### PR DESCRIPTION
This reverts the following two changes:

https://github.com/Expensify/Bedrock/pull/369
https://github.com/Expensify/Bedrock/pull/368

In practice, these ended up increasing conflict rates and reducing worker offload to help increase read performance in the case that master is backlogged on writes, which ultimately seemed unproductive.
