### PR TITLE
Write HTTPS commands in worker threads

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -107,11 +107,6 @@ void BedrockServer::sync(SData& args,
     // that just needs to be returned to a peer.
     CommandQueue completedCommands;
 
-    // And we keep a list of commands with outstanding HTTPS requests. This is not synchronized because it's only used
-    // internally in this thread. We temporarily move commands here while we wait for their HTTPS requests to complete,
-    // so that we don't clog up the regular command queue with commands that are waiting.
-    list<BedrockCommand> httpsCommands;
-
     // The node is now coming up, and should eventually end up in a `MASTERING` or `SLAVING` state. We can start adding
     // our worker threads now. We don't wait until the node is `MASTERING` or `SLAVING`, as it's state can change while
     // it's running, and our workers will have to maintain awareness of that state anyway.
@@ -204,18 +199,6 @@ void BedrockServer::sync(SData& args,
         syncNode.postPoll(fdm, nextActivity);
         syncNodeQueuedCommands.postPoll(fdm);
         completedCommands.postPoll(fdm);
-
-        // If any of our plugins finished any outstanding HTTPS requests, we'll move those commands back into the
-        // regular queue. This code modifies a list while iterating over it.
-        auto httpsIt = httpsCommands.begin();
-        while (httpsIt != httpsCommands.end()) {
-            if (httpsIt->httpsRequest->response) {
-                syncNodeQueuedCommands.push(move(*httpsIt));
-                httpsIt = httpsCommands.erase(httpsIt);
-            } else {
-                httpsIt++;
-            }
-        }
 
         // Ok, let the sync node to it's updating for as many iterations as it requires. We'll update the replication
         // state when it's finished.
@@ -406,26 +389,6 @@ void BedrockServer::sync(SData& args,
                     }
                 }
 
-                // If we've dequeued a command with an incomplete HTTPS request, we move it to httpsCommands so that every
-                // subsequent dequeue doesn't have to iterate past it while ignoring it. Then we'll just start on the next
-                // command.
-                if (command.httpsRequest && !command.httpsRequest->response) {
-                    // We can't finish this transaction right now. We'll restart it later when the httpsRequest is
-                    // complete.
-                    if (db.insideTransaction()) {
-                        // We only rollback if we're inside a transaction. This will happen if `peekCommand` created an
-                        // httpsRequest above. However, if `peekCommand` was done in a worker thread, then this has
-                        // already been done, so we won't roll it back again.
-                        core.rollback();
-                    }
-
-                    // Done with the lock.
-                    server._syncThreadCommitMutex.unlock();
-
-                    // Set this aside and move on to the next command.
-                    httpsCommands.push_back(move(command));
-                    continue;
-                }
                 if (core.processCommand(command)) {
                     // The processor says we need to commit this, so let's start that process.
                     committingCommand = true;
@@ -661,9 +624,10 @@ void BedrockServer::worker(SData& args,
             // iteration.
             bool multiWriteOK = BedrockConflictMetrics::multiWriteOK(command.request.methodLine);
             while (retry) {
-                // Try peeking the command. If this succeeds, then it's finished, and all we need to do is respond to
-                // the command at the bottom.
-                if (!core.peekCommand(command)) {
+                // If the command doesn't already have an httpsRequest from a previous peek attempt, try peeking it
+                // now. We don't duplicate peeks for commands that make https requests.
+                // If peek succeeds, then it's finished, and all we need to do is respond to the command at the bottom.
+                if (command.httpsRequest || !core.peekCommand(command)) {
                     // We've just unsuccessfully peeked a command, which means we're in a state where we might want to
                     // write it. We'll flag that here, to keep the node from falling out of MASTERING/STANDINGDOWN
                     // until we're finished with this command.
@@ -676,6 +640,25 @@ void BedrockServer::worker(SData& args,
                         // peeking certain commands on the sync thread, but even still, we could lose HTTP responses
                         // due to a crash or network event, so we don't try to hard to be perfect here.
                         SASSERTWARN(state == SQLiteNode::MASTERING);
+
+                        // If the command isn't complete, we'll move it into our map of outstanding HTTPS requests.
+                        if (!command.httpsRequest->response) {
+                            // Roll back the existing transaction.
+                            core.rollback();
+
+                            // We're not handling a writable command anymore (at the moment). We need to make sure we
+                            // don't shut down without checking for outstanding HTTPS commands.
+                            lock_guard<mutex> lock(server._httpsCommandMutex);
+                            SINFO("[performance] Waiting on HTTPS response " << command.request.methodLine
+                                  << ", " << server._outstandingHTTPSRequests.size() << " queued HTTPS commands.");
+                            server._writableCommandsInProgress--;
+
+                            // Save this in our https commads queue.
+                            server._outstandingHTTPSRequests.emplace(make_pair(command.httpsRequest, move(command)));
+
+                            // Move on to the next command until this one finishes.
+                            break;
+                        }
                     }
                     // Peek wasn't enough to handle this command. Now we need to decide if we should try and process
                     // it, or if we should send it off to the sync node.
@@ -693,7 +676,6 @@ void BedrockServer::worker(SData& args,
                     if (!canWriteParallel                 ||
                         server._suppressMultiWrite.load() ||
                         state != SQLiteNode::MASTERING    ||
-                        command.httpsRequest              ||
                         command.onlyProcessOnSyncThread   ||
                         command.writeConsistency != SQLiteNode::ASYNC)
                     {
@@ -1629,7 +1611,20 @@ void BedrockServer::_prePollPlugins(fd_map& fdm) {
 void BedrockServer::_postPollPlugins(fd_map& fdm, uint64_t nextActivity) {
     for (auto plugin : plugins) {
         for (auto manager : plugin->httpsManagers) {
-            manager->postPoll(fdm, nextActivity);
+            list<SHTTPSManager::Transaction*> completedHTTPSRequests;
+            manager->postPoll(fdm, nextActivity, completedHTTPSRequests);
+
+            // Move these back to the main queue to finish.
+            lock_guard<mutex> lock(_httpsCommandMutex);
+            for (auto request : completedHTTPSRequests) {
+                auto pairIt = _outstandingHTTPSRequests.find(request);
+                if (pairIt != _outstandingHTTPSRequests.end()) {
+                    _commandQueue.push(move(pairIt->second));
+                    _outstandingHTTPSRequests.erase(pairIt);
+                } else {
+                    SWARN("HTTPS request said it completed, but we can't find it.");
+                }
+            }
         }
     }
 }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -269,4 +269,9 @@ class BedrockServer : public SQLiteServer {
 
     // Generate a CRASH_COMMAND command for a given bad command.
     static SData _generateCrashMessage(const BedrockCommand* command);
+
+    // This is a map of HTTPS requests to the commands that contain them. We use this to quickly look up commands when
+    // their https requests finish and move them back to the main queue.
+    mutex _httpsCommandMutex;
+    map<SHTTPSManager::Transaction*, BedrockCommand> _outstandingHTTPSRequests;
 };

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -56,6 +56,11 @@ void SHTTPSManager::prePoll(fd_map& fdm) {
 }
 
 void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity) {
+    list<SHTTPSManager::Transaction*> completedRequests;
+    postPoll(fdm, nextActivity, completedRequests);
+}
+
+void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSManager::Transaction*>& completedRequests) {
     SAUTOLOCK(_listMutex);
 
     // Let the base class do its thing
@@ -83,6 +88,7 @@ void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                     // If true, then the transaction was closed in onRecv.
                     continue;
                 }
+                completedRequests.push_back(active);
                 SASSERT(active->response);
             } else {
                 // Error, failed to authenticate or receive a valid server response.

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -26,6 +26,7 @@ class SHTTPSManager : public STCPManager {
     // STCPServer API. Except for postPoll, these are just threadsafe wrappers around base class functions.
     void prePoll(fd_map& fdm);
     void postPoll(fd_map& fdm, uint64_t& nextActivity);
+    void postPoll(fd_map& fdm, uint64_t& nextActivity, list<Transaction*>& completedRequests);
     Socket* openSocket(const string& host, SX509* x509 = nullptr);
     void closeSocket(Socket* socket);
 

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -45,7 +45,6 @@ class SHTTPSManager : public STCPManager {
     Transaction* _createErrorTransaction();
     virtual bool _onRecv(Transaction* transaction) = 0;
 
-  private: // Internal API
     list<Transaction*> _activeTransactionList;
     list<Transaction*> _completedTransactionList;
 

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -160,6 +160,9 @@ class SQLiteNode : public STCPNode {
     // Stopwatch to track if we're going to give up on gracefully shutting down and force it.
     SStopwatch _gracefulShutdownTimeout;
 
+    // Stopwatch to track if we're giving up on the server preventing a standdown.
+    SStopwatch _standDownTimeOut;
+
     // Our version string. Supplied by constructor.
     string _version;
 

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -31,9 +31,9 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
             return false;
         }
         SData request("GET / HTTP/1.1");
-        request["Host"] = "www.expensify.com";
+        request["Host"] = "www.google.com";
         command.request["httpsRequests"] = to_string(command.request.calc("httpsRequests") + 1);
-        command.httpsRequest = httpsManager.send("https://www.expensify.com/", request);
+        command.httpsRequest = httpsManager.send("https://www.google.com/", request);
         return false; // Not complete.
     } else if (command.request.methodLine == "slowquery") {
         int size = 100000000;
@@ -56,9 +56,9 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
         // It *does* eventually connect and return, so that we can also verify that the leftover command gets cleaned
         // up correctly on the former master.
         SData request("GET / HTTP/1.1");
-        request["Host"] = "www.expensify.com";
+        request["Host"] = "www.google.com";
         command.request["httpsRequests"] = to_string(command.request.calc("httpsRequests") + 1);
-        auto transaction = httpsManager.httpsDontSend("https://www.expensify.com/", request);
+        auto transaction = httpsManager.httpsDontSend("https://www.google.com/", request);
         command.httpsRequest = transaction;
         thread([transaction, request](){sleep(35);transaction->s->send(request.serialize());}).detach();
     } else if (command.request.methodLine == "dieinpeek") {

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -6,6 +6,9 @@ class TestHTTPSMananager : public SHTTPSManager {
   public:
     Transaction* send(const string& url, const SData& request);
     virtual bool _onRecv(Transaction* transaction);
+
+    // Like _httpsSend in the base class, but doesn't actually send, so we can test timeouts.
+    Transaction* httpsDontSend(const string& url, const SData& request);
     virtual ~TestHTTPSMananager();
 };
 

--- a/test/clustertest/tests/a_MasteringTest.cpp
+++ b/test/clustertest/tests/a_MasteringTest.cpp
@@ -5,6 +5,7 @@ struct a_MasteringTest : tpunit::TestFixture {
         : tpunit::TestFixture("a_Mastering",
                               TEST(a_MasteringTest::clusterUp),
                               TEST(a_MasteringTest::failover),
+                              TEST(a_MasteringTest::standDownTimeout),
                               TEST(a_MasteringTest::restoreMaster),
                               TEST(a_MasteringTest::synchronizing)
                              ) { }
@@ -64,6 +65,15 @@ struct a_MasteringTest : tpunit::TestFixture {
         }
 
         ASSERT_TRUE(success);
+    }
+
+    // The only point of this test is to verify that a new master comes up even if the old one has a stuck HTTPS
+    // request. It's slow so is disabled.
+    void standDownTimeout() {
+        BedrockTester* newMaster = tester->getBedrockTester(1);
+        SData cmd("httpstimeout");
+        cmd["Connection"] = "forget";
+        auto result = newMaster->executeWaitVerifyContent(cmd, "202");
     }
 
     void restoreMaster()

--- a/test/clustertest/tests/a_MasteringTest.cpp
+++ b/test/clustertest/tests/a_MasteringTest.cpp
@@ -5,7 +5,8 @@ struct a_MasteringTest : tpunit::TestFixture {
         : tpunit::TestFixture("a_Mastering",
                               TEST(a_MasteringTest::clusterUp),
                               TEST(a_MasteringTest::failover),
-                              TEST(a_MasteringTest::standDownTimeout),
+                              // Disabled for speed. Enable to test stand down timeout.
+                              // TEST(a_MasteringTest::standDownTimeout),
                               TEST(a_MasteringTest::restoreMaster),
                               TEST(a_MasteringTest::synchronizing)
                              ) { }


### PR DESCRIPTION
@coleaeason 

Added code for checking to make sure there aren't outstanding https requests on shutdown. I'd like to deploy this during tomorrow's high-risk window.