### PR TITLE
Figure out where we slow down when sync queue backs up.

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -491,7 +491,9 @@ int SQLite::commit() {
     // Make sure one is ready to commit
     SDEBUG("Committing transaction");
     uint64_t before = STimeNow();
+    uint64_t beforeCommit = STimeNow();
     result = SQuery(_db, "committing db transaction", "COMMIT");
+    SINFO("SQuery 'COMMIT' took " << ((STimeNow() - beforeCommit)/1000) << "ms.");
 
     // If there were conflicting commits, will return SQLITE_BUSY_SNAPSHOT
     SASSERT(result == SQLITE_OK || result == SQLITE_BUSY_SNAPSHOT);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -758,7 +758,9 @@ bool SQLiteNode::update() {
             } else if (consistentEnough) {
                 // Commit this distributed transaction. Either we have quorum, or we don't need it.
                 SDEBUG("Committing current transaction because consistentEnough: " << _db.getUncommittedQuery());
+                uint64_t beforeCommit = STimeNow();
                 int result = _db.commit();
+                SINFO("SQLite::commit in SQLiteNode took " << ((STimeNow() - beforeCommit)/1000) << "ms.");
 
                 // If this is the case, there was a commit conflict.
                 if (result == SQLITE_BUSY_SNAPSHOT) {
@@ -875,7 +877,9 @@ bool SQLiteNode::update() {
             }
 
             // And send it to everyone who's subscribed.
+            uint64_t beforeSend = STimeNow();
             _sendToAllPeers(transaction, true);
+            SINFO("SQLite::_sendToAllPeers in SQLiteNode took " << ((STimeNow() - beforeSend)/1000) << "ms.");
 
             // We return `true` here to immediately re-update and thus commit this transaction immediately if it was
             // asynchronous.


### PR DESCRIPTION
This PR adds logging to do what's in the title. The change is straightforward, my reasoning for it is outlined here:

We deployed bedrock with new code to run https commands on workers, which worked (there was one bug in closing timed out connections, but it was unrelated), and increased worker offload, but we still got into a state where the sync thread falls behind on its queue, even with a smaller queue.

I grabbed the logs from the slow period, and chose two successive instances of the following log line:
```
Sync thread dequeued command ...
```

To use as an example command. The particular command I looked at as a `CreateReceipt` command that took 232ms to complete.

I inspected the logs further, looking at the following two lines:

```
2018-02-14T23:47:53.386198+00:00 db2.sc bedrock: xxxxx (SQLiteNode.cpp:862) update [sync] [info] {auth.db2.sc/MASTERING} beginning distributed transaction for commit #4313407889 (8D4FCF0F515FAD4CB294CF401F09DB5EC95E0830)
2018-02-14T23:47:53.609685+00:00 db2.sc bedrock: xxxxx (SQLiteNode.cpp:793) update [sync] [info] {auth.db2.sc/MASTERING} [performance] Successfully committed ASYNC transaction. Sending COMMIT_TRANSACTION to peers.
```

These lines happen 223ms apart, indicating that almost all of this command's time happens between these lines.

To confirm this was the general case, and not limited to this particular command, I captured all instances from the slow period of the above loglines with the following command:

```
grep 'beginning distributed transaction for commit\|Sending COMMIT_TRANSACTION to peers' worker-https-slow | grep -B 1 ASYNC | grep bedrock > worker-https-slow_timing
```

And I ran the results through this perl script, to print the difference in timing between beginning and finishing each commit:

```
#!/usr/bin/perl
use strict;
open LOG, $ARGV[0] or die;
my $previous_sec_time;
my $previous_was_start = 0;
while (my $line = <LOG>) {
    my $ts = substr $line, 14, 9;
    my $min = substr $ts, 0, 2;
    my $sec = substr $ts, 3;
    my $sec_time = $min * 60 + $sec;
    my $start = (substr($line, 71, 1) == 8 ? 1 : 0);
    if (!$start) {
        if ($previous_was_start) {
            my $elapsed = $sec_time - $previous_sec_time;
            my $elapsed_ms = int($elapsed * 1000);
            print "$ts - $elapsed_ms\n";
        } else {
            print "Found end but not start!\n";
        }
    }
    $previous_was_start = $start;
    $previous_sec_time = $sec_time;
}
close LOG;
```

This showed commit times taking, in general, 200-300ms during the slow period for all commands, indicating that this was the general case.

I then inspected every line of code called between `SQLiteNode.cpp:862` and `SQLiteNode.cpp:793` for things that looked like they might be slow, finding two things:

1. `_sendToAllPeers`. Sending to a peer requires grabbing a lock around its socket, since multiple threads do this, so it's possible that lock contention could make this slow.
2. calling `_db.commit()`. I don't have a particular reason this could be slow, but it's an important DB operation, so it's worth considering.

I've added logging to capture the times of the above two operations so we can confirm if it's one or the other.

Speculation:
Since turning off the command port fixes this issue, I doubt it's `_sendToAllPeers` being slow. We only call this function in worker threads for commands that were escalated (and thus need to be returned to a peer, rather than a locally connected client), so the number of calls here shouldn't change much with the command port closed (in fact, it might go up, as all of the writes that would have been initiated by locally connected clients now have to be sent to a different node and escalated).

My guess is that sqlite3 waits for readers to finish current operations before executing a `commit`, and so when we have lots of readers, this can take longer. If we confirm that the slowdown is inside sqlite3's commit, then we can discuss the details of this with sqlite.