### PR TITLE
Continue as soon as we see a command will crash.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -524,6 +524,7 @@ void BedrockServer::worker(SData& args,
                 } else {
                     server._reply(command);
                 }
+                continue;
             }
 
             // If this was a command initiated by a peer as part of a cluster operation, then we process it separately


### PR DESCRIPTION
We should continue on to the next command as soon as we respond to it.

Currently this gets caught here: https://github.com/Expensify/Bedrock/blob/master/BedrockServer.cpp#L600

So in practice we already get this, but we should make it explicit.