### PR TITLE
Only include each crash command once

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -262,7 +262,7 @@ class BedrockServer : public SQLiteServer {
 
     // Definitions of crash-causing commands. This is a map of methodLine to name/value pairs required to match a
     // particular command for it count as a match likely to cause a crash.
-    multimap<string, STable> _crashCommands;
+    map<string, set<STable>> _crashCommands;
 
     // Check a command against the list of crash commands, and return whether we think the command would crash.
     bool _wouldCrash(const BedrockCommand& command);


### PR DESCRIPTION
@coleaeason 

This modifies the `_crashCommands` list somewhat, so that it can't contain duplicate commands.

Previously, it was a `multimap`, which is allowed to have the same value in it multiple times. This meant that if a user kept repeating the same action, we'd end up with a bunch of duplicate entries for that command.

It's not a map of command names to sets of values. Since a `set` can't have duplicate entries, the same user taking the same action won't result in a bunch of identical entries.