### PR TITLE
give up on HTTPS requests if shutdown timer is ringing.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -803,9 +803,13 @@ void BedrockServer::worker(SData& args,
             {
                 lock_guard<mutex> lock(server._httpsCommandMutex);
                 if (!server._outstandingHTTPSRequests.empty()) {
-                    SINFO("Outstanding HTTPS requests blocking shutdown ("
-                          << server._outstandingHTTPSRequests.size() << ").");
-                    continue;
+                    if (server._gracefulShutdownTimeout.ringing()) {
+                        SINFO("Shutdown timed out waiting on HTTPS requests.");
+                    } else {
+                        SINFO("Outstanding HTTPS requests blocking shutdown ("
+                              << server._outstandingHTTPSRequests.size() << ").");
+                        continue;
+                    }
                 }
             }
 

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -248,27 +248,27 @@ timeval SToTimeval(uint64_t when);
 // Helpful class for timing
 struct SStopwatch {
     // Attributes
-    uint64_t startTime;
-    uint64_t alarmDuration;
+    atomic<uint64_t> startTime;
+    atomic<uint64_t> alarmDuration;
 
     // Constructors -- If constructed with an alarm, starts out in the
     // ringing state.  If constructed without an alarm, starts out timing
     // from construction.
     SStopwatch() {
         start();
-        alarmDuration = 0;
+        alarmDuration.store(0);
     }
     SStopwatch(uint64_t alarm) {
-        startTime = 0;
-        alarmDuration = alarm;
+        startTime.store(0);
+        alarmDuration.store(alarm);
     }
 
     // Accessors
-    uint64_t elapsed() { return STimeNow() - startTime; }
-    uint64_t ringing() { return alarmDuration && (elapsed() > alarmDuration); }
+    uint64_t elapsed() { return STimeNow() - startTime.load(); }
+    uint64_t ringing() { return alarmDuration && (elapsed() > alarmDuration.load()); }
 
     // Mutators
-    void start() { startTime = STimeNow(); }
+    void start() { startTime.store(STimeNow()); }
     bool ding() {
         if (!ringing())
             return false;

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -265,7 +265,7 @@ struct SStopwatch {
 
     // Accessors
     uint64_t elapsed() { return STimeNow() - startTime.load(); }
-    uint64_t ringing() { return alarmDuration && (elapsed() > alarmDuration.load()); }
+    uint64_t ringing() { return alarmDuration.load() && (elapsed() > alarmDuration.load()); }
 
     // Mutators
     void start() { startTime.store(STimeNow()); }


### PR DESCRIPTION
@coleaeason 

This lets shutdown continue if we hit the regular timeout and there are still pending HTTPS requests.

It also makes SStopwatch threadsafe.