### PR TITLE
stop building bedrock tests in Jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ INTERMEDIATEDIR = .build
 
 # This sets our default by being the first target, and also sets `all` in case someone types `make all`.
 all: bedrock test clustertest
+bedrock: bedrock
 test: test/test
 clustertest: test/clustertest/clustertest testplugin
 


### PR DESCRIPTION
@tylerkaraszewski How does this look? 

Goes along with https://github.com/Expensify/Server-Expensify/pull/2519

Creates a separate Makefile entry for building only bedrock (without tests)

### Fixed Issues
https://github.com/Expensify/Expensify/issues/72068

# Tests
ran the make.sh script from within my Expensidev VM, and viewed that tests weren't build
```
vagrant-ubuntu-trusty-64 22:31:29 /vagrant/Server-Expensify $> ./make.sh -p=true
...
<lots of output shown below in separate comment>
...
```

# Query Timings/Plans
- N/A