### PR TITLE
Prevent unnecessary rollbacks when commands weren't peeked but have https connections

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -647,7 +647,6 @@ void BedrockServer::worker(SData& args,
                     calledPeek = true;
                 }
 
-
                 if (!calledPeek || !peekResult) {
                     // We've just unsuccessfully peeked a command, which means we're in a state where we might want to
                     // write it. We'll flag that here, to keep the node from falling out of MASTERING/STANDINGDOWN

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -640,7 +640,15 @@ void BedrockServer::worker(SData& args,
                 // If the command doesn't already have an httpsRequest from a previous peek attempt, try peeking it
                 // now. We don't duplicate peeks for commands that make https requests.
                 // If peek succeeds, then it's finished, and all we need to do is respond to the command at the bottom.
-                if (command.httpsRequest || !core.peekCommand(command)) {
+                bool calledPeek = false;
+                bool peekResult = false;
+                if (!command.httpsRequest) {
+                    peekResult = core.peekCommand(command);
+                    calledPeek = true;
+                }
+
+
+                if (!calledPeek || !peekResult) {
                     // We've just unsuccessfully peeked a command, which means we're in a state where we might want to
                     // write it. We'll flag that here, to keep the node from falling out of MASTERING/STANDINGDOWN
                     // until we're finished with this command.
@@ -661,10 +669,10 @@ void BedrockServer::worker(SData& args,
                         // If the command isn't complete, we'll move it into our map of outstanding HTTPS requests.
                         if (!command.httpsRequest->response) {
                             // Roll back the existing transaction, but only if we are inside an transaction
-                            if (db.insideTransaction()) {
+                            if (calledPeek) {
                                 core.rollback();
                             }
-                            
+
                             // We're not handling a writable command anymore (at the moment). We need to make sure we
                             // don't shut down without checking for outstanding HTTPS commands.
                             lock_guard<mutex> lock(server._httpsCommandMutex);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -658,13 +658,13 @@ void BedrockServer::worker(SData& args,
                             break;
                         }
 
-                        // Roll back the existing transaction, but only if we peeked the command.
-                        // This prevents unneccesary rollbacks for commands that have https requests
-                        // but no response yet
-                        core.rollback();
-
                         // If the command isn't complete, we'll move it into our map of outstanding HTTPS requests.
                         if (!command.httpsRequest->response) {
+                            // Roll back the existing transaction, but only if we are inside an transaction
+                            if (db.insideTransaction()) {
+                                core.rollback();
+                            }
+                            
                             // We're not handling a writable command anymore (at the moment). We need to make sure we
                             // don't shut down without checking for outstanding HTTPS commands.
                             lock_guard<mutex> lock(server._httpsCommandMutex);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -587,7 +587,7 @@ void SQLite::rollback() {
             g_commitLock.unlock();
         }
     } else {
-        SHMMM("Rolling back but not inside transaction, ignoring.");
+        SWARN("Rolling back but not inside transaction, ignoring.");
     }
 }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -7,7 +7,7 @@
 recursive_mutex SQLite::_commitLock;
 
 // Global map for looking up shared data by file when creating new instances.
-map<string, pair<int, SQLite::SharedData*>> SQLite::_sharedDataLookupMap; 
+map<string, pair<int, SQLite::SharedData*>> SQLite::_sharedDataLookupMap;
 
 // This is our only public static variable. It needs to be initialized after `_commitLock`.
 SLockTimer<recursive_mutex> SQLite::g_commitLock("Commit Lock", SQLite::_commitLock);
@@ -587,7 +587,7 @@ void SQLite::rollback() {
             g_commitLock.unlock();
         }
     } else {
-        SWARN("Rolling back but not inside transaction, ignoring.");
+        SHMMM("Rolling back but not inside transaction, ignoring.");
     }
 }
 


### PR DESCRIPTION
@tylerkaraszewski we're seeing a ton of these now that master is multi-writing https commands, presumably because of https://github.com/Expensify/Bedrock/blob/master/BedrockServer.cpp#L664. So we could either stop rolling back there, or just demote this to a hmmm. I don't think there's any harm in not warning on this, as it's pretty benign to rollback outside of a transaction, however there could be harm from not rolling back there (maybe?). If you think I should switch the solution here, let me know.