### PR TITLE
When WAL file falls behind, block and perform full checkpoint.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -101,7 +101,7 @@ void BedrockServer::sync(SData& args,
     workerThreads = workerThreads ? workerThreads : max(1u, thread::hardware_concurrency());
 
     // Initialize the DB.
-    SQLite db(args["-db"], args.calc("-cacheSize"), 1024, args.calc("-maxJournalSize"), -1, workerThreads - 1, args["-synchronous"]);
+    SQLite db(args["-db"], args.calc("-cacheSize"), true, args.calc("-maxJournalSize"), -1, workerThreads - 1, args["-synchronous"]);
 
     // And the command processor.
     BedrockCore core(db, server);
@@ -505,10 +505,7 @@ void BedrockServer::worker(SData& args,
                            int threadCount)
 {
     SInitialize("worker" + to_string(threadId));
-
-    // We pass `0` as the checkpoint size to disable checkpointing from workers. This can be a slow operation, and we
-    // don't want workers to be able to block the sync thread while it happens.
-    SQLite db(args["-db"], args.calc("-cacheSize"), 0/* should we let workers do checkpoints?*/, args.calc("-maxJournalSize"), threadId, threadCount - 1, args["-synchronous"]);
+    SQLite db(args["-db"], args.calc("-cacheSize"), false, args.calc("-maxJournalSize"), threadId, threadCount - 1, args["-synchronous"]);
     BedrockCore core(db, server);
 
     // Command to work on. This default command is replaced when we find work to do.
@@ -1632,12 +1629,13 @@ void BedrockServer::_status(BedrockCommand& command) {
 }
 
 bool BedrockServer::_isControlCommand(BedrockCommand& command) {
-    if (SIEquals(command.request.methodLine, "BeginBackup")         ||
-        SIEquals(command.request.methodLine, "SuppressCommandPort") ||
-        SIEquals(command.request.methodLine, "ClearCommandPort")    ||
-        SIEquals(command.request.methodLine, "ClearCrashCommands") ||
-        SIEquals(command.request.methodLine, "Detach")              ||
-        SIEquals(command.request.methodLine, "Attach")
+    if (SIEquals(command.request.methodLine, "BeginBackup")            ||
+        SIEquals(command.request.methodLine, "SuppressCommandPort")    ||
+        SIEquals(command.request.methodLine, "ClearCommandPort")       ||
+        SIEquals(command.request.methodLine, "ClearCrashCommands")     ||
+        SIEquals(command.request.methodLine, "Detach")                 ||
+        SIEquals(command.request.methodLine, "Attach")                 ||
+        SIEquals(command.request.methodLine, "SetCheckpointIntervals")
         ) {
         return true;
     }
@@ -1663,6 +1661,15 @@ void BedrockServer::_control(BedrockCommand& command) {
     } else if (SIEquals(command.request.methodLine, "Attach")) {
         response.methodLine = "204 ATTACHING";
         _detach = false;
+    } else if (SIEquals(command.request.methodLine, "SetCheckpointIntervals")) {
+        response["passiveCheckpointPageMin"] = to_string(SQLite::passiveCheckpointPageMin.load());
+        response["fullCheckpointPageMin"] = to_string(SQLite::fullCheckpointPageMin.load());
+        if (command.request.isSet("passiveCheckpointPageMin")) {
+            SQLite::passiveCheckpointPageMin.store(command.request.calc("passiveCheckpointPageMin"));
+        }
+        if (command.request.isSet("fullCheckpointPageMin")) {
+            SQLite::fullCheckpointPageMin.store(command.request.calc("fullCheckpointPageMin"));
+        }
     }
 }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -223,10 +223,10 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
             int walSizeFrames = 0;
             int framesCheckpointed = 0;
             uint64_t start = STimeNow();
-            sqlite3_wal_checkpoint_v2(db, dbName, SQLITE_CHECKPOINT_PASSIVE, &walSizeFrames, &framesCheckpointed);
+            int result = sqlite3_wal_checkpoint_v2(db, dbName, SQLITE_CHECKPOINT_PASSIVE, &walSizeFrames, &framesCheckpointed);
             SINFO("[checkpoint] passive checkpoint complete with " << pageCount
-                  << " pages in WAL file. Frames checkpointed: " << framesCheckpointed << " of " << walSizeFrames
-                  << " in " << ((STimeNow() - start) / 1000) << "ms.");
+                  << " pages in WAL file. Result: " << result << ". Frames checkpointed: "
+                  << framesCheckpointed << " of " << walSizeFrames << " in " << ((STimeNow() - start) / 1000) << "ms.");
         }
     } else {
         // If we get here, then full checkpoints are enabled, and we have enough pages in the WAL file to perform one.
@@ -273,8 +273,8 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
                           << "ms for pending transactions. Starting complete checkpoint.");
                     int walSizeFrames = 0;
                     int framesCheckpointed = 0;
-                    sqlite3_wal_checkpoint_v2(object->_db, dbNameCopy.c_str(), SQLITE_CHECKPOINT_RESTART, &walSizeFrames, &framesCheckpointed);
-                    SINFO("[checkpoint] restart checkpoint complete. Frames checkpointed: "
+                    int result = sqlite3_wal_checkpoint_v2(object->_db, dbNameCopy.c_str(), SQLITE_CHECKPOINT_RESTART, &walSizeFrames, &framesCheckpointed);
+                    SINFO("[checkpoint] restart checkpoint complete. Result: " << result << ". Frames checkpointed: "
                           << framesCheckpointed << " of " << walSizeFrames
                           << " in " << ((STimeNow() - checkpointStart) / 1000) << "ms.");
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -225,7 +225,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
             uint64_t start = STimeNow();
             int result = sqlite3_wal_checkpoint_v2(db, dbName, SQLITE_CHECKPOINT_PASSIVE, &walSizeFrames, &framesCheckpointed);
             SINFO("[checkpoint] passive checkpoint complete with " << pageCount
-                  << " pages in WAL file. Result: " << result << ". Frames checkpointed: "
+                  << " pages in WAL file. Result: " << result << ". Total frames checkpointed: "
                   << framesCheckpointed << " of " << walSizeFrames << " in " << ((STimeNow() - start) / 1000) << "ms.");
         }
     } else {
@@ -274,7 +274,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
                     int walSizeFrames = 0;
                     int framesCheckpointed = 0;
                     int result = sqlite3_wal_checkpoint_v2(object->_db, dbNameCopy.c_str(), SQLITE_CHECKPOINT_RESTART, &walSizeFrames, &framesCheckpointed);
-                    SINFO("[checkpoint] restart checkpoint complete. Result: " << result << ". Frames checkpointed: "
+                    SINFO("[checkpoint] restart checkpoint complete. Result: " << result << ". Total frames checkpointed: "
                           << framesCheckpointed << " of " << walSizeFrames
                           << " in " << ((STimeNow() - checkpointStart) / 1000) << "ms.");
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -34,7 +34,7 @@ class SQLite {
     //
     // maxRequiredJournalTableID: This is the maximum journal table ID that we'll verify. If it's -1, we'll only verify
     //                            'journal' and no numbered tables.
-    SQLite(const string& filename, int cacheSize, int checkpointInterval, int maxJournalSize, int journalTable,
+    SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints, int maxJournalSize, int journalTable,
            int maxRequiredJournalTableID, const string& synchronous = "");
     ~SQLite();
 
@@ -151,6 +151,11 @@ class SQLite {
     // Call before starting a transaction to make sure we don't interrupt a checkpoint operation.
     void waitForCheckpoint();
 
+    // These are the minimum thresholds for the WAL file, in pages, that will cause us to trigger either a full or
+    // passive checkpoint. They're public, non-const, and atomic so that they can be configured on the fly.
+    static atomic<int> passiveCheckpointPageMin;
+    static atomic<int> fullCheckpointPageMin;
+    
   private:
 
     // This structure contains all of the data that's shared between a set of SQLite objects that share the same
@@ -337,5 +342,6 @@ class SQLite {
     bool _autoRolledBack;
 
     bool _noopUpdateMode;
-    int _checkpointInterval;
+
+    bool _enableFullCheckpoints;
 };


### PR DESCRIPTION
This change notices when we're not keeping up-to-date on the WAL file, and when that happens, it blocks any new transactions from starting, waits for any existing ones to finish, and then performs a complete checkpoint.

Marked as WIP because I'm not 100% sure I'm done tweaking it yet. We also probably don't want to merge it until we verify the WAL file falling behind is the actual reason we have periodic slowdowns.

One other thing to consider with this issue is that we could do checkpoints in workers. With 99% offload and only the sync thread doing checkpoints, it's maybe more likely to fall behind than if workers did these more frequently.