### PR TITLE
Change default timeout to 30 seconds

### DIFF
--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -5,7 +5,7 @@ class BedrockServer;
 
 class BedrockCore : public SQLiteCore {
   public:
-    const uint64_t DEFAULT_TIMEOUT = 60'000'000; // one minute.
+    const uint64_t DEFAULT_TIMEOUT = 30'000'000; // 30 seconds.
     BedrockCore(SQLite& db, const BedrockServer& server);
 
     // Automatic timing class that records an entry corresponding to its lifespan.


### PR DESCRIPTION
Fixes https://github.com/Expensify/Expensify/issues/72920