### PR TITLE
Do a better job of keeping request IDs.

### DIFF
--- a/libstuff/SSignal.cpp
+++ b/libstuff/SSignal.cpp
@@ -111,7 +111,7 @@ void SInitializeSignals() {
 void _SSignal_signalHandlerThreadFunc() {
     // Initialize logging for this thread.
     SLogSetThreadName("signal");
-    SLogSetThreadPrefix("xxxxx ");
+    SLogSetThreadPrefix("xxxxxx ");
 
     // Make a set of all signals.
     sigset_t signals;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -62,7 +62,7 @@ thread_local string SThreadLogName;
 void SInitialize(string threadName) {
     // Initialize signal handling
     SLogSetThreadName(threadName);
-    SLogSetThreadPrefix("xxxxx ");
+    SLogSetThreadPrefix("xxxxxx ");
     SInitializeSignals();
 }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -677,7 +677,9 @@ void SQLite::rollback() {
             SINFO("Transaction was automatically rolled back, not sending 'ROLLBACK'.");
             _autoRolledBack = false;
         } else {
-            SINFO("Rolling back transaction: " << _uncommittedQuery.substr(0, 100));
+            if (_uncommittedQuery.size()) {
+                SINFO("Rolling back transaction: " << _uncommittedQuery.substr(0, 100));
+            }
             uint64_t before = STimeNow();
             SASSERT(!SQuery(_db, "rolling back db transaction", "ROLLBACK"));
             _rollbackElapsed += STimeNow() - before;
@@ -686,8 +688,10 @@ void SQLite::rollback() {
         // Finally done with this.
         _insideTransaction = false;
         _uncommittedHash.clear();
+        if (_uncommittedQuery.size()) {
+            SINFO("Rollback successful.");
+        }
         _uncommittedQuery.clear();
-        SINFO("Rollback successful.");
 
         // Only unlock the mutex if we've previously locked it. We can call `rollback` to cancel a transaction without
         // ever having called `prepare`, which would have locked our mutex.


### PR DESCRIPTION
@coleaeason 
@flodnv 

This tries to keep request IDs in bedrock in a couple places that they are currently not set. It also stops logging when we roll back a blank query.