### PR TITLE
Allow broadcasting commands to slaves, expose more info to plugins, improve test infrastructure.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -93,7 +93,7 @@ void BedrockServer::sync(SData& args,
                          BedrockServer& server)
 {
     // Initialize the thread.
-    SInitialize(_syncThreadName, (args.isSet("-overrideProcessName") ? args["-overrideProcessName"].c_str() : 0));
+    SInitialize(_syncThreadName);
 
     // We currently have no writable commands in progress.
     server._writableCommandsInProgress.store(0);
@@ -513,7 +513,7 @@ void BedrockServer::worker(SData& args,
                            int threadId,
                            int threadCount)
 {
-    SInitialize("worker" + to_string(threadId), (args.isSet("-overrideProcessName") ? args["-overrideProcessName"].c_str() : 0));
+    SInitialize("worker" + to_string(threadId));
     SQLite db(args["-db"], args.calc("-cacheSize"), false, args.calc("-maxJournalSize"), threadId, threadCount - 1, args["-synchronous"]);
     BedrockCore core(db, server);
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1491,6 +1491,7 @@ list<STable> BedrockServer::getPeerInfo() {
         for (SQLiteNode::Peer* peer : _syncNode->peerList) {
             peerData.emplace_back(peer->nameValueMap);
             peerData.back()["host"] = peer->host;
+            peerData.back()["name"] = peer->name;
         }
     }
     return peerData;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -271,6 +271,10 @@ class BedrockServer : public SQLiteServer {
     // particular command for it count as a match likely to cause a crash.
     map<string, set<STable>> _crashCommands;
 
+    // Returns whether or not the command was a status or control command. If it was, it will have already been handled
+    // and responded to upon return
+    bool _handleIfStatusOrControlCommand(BedrockCommand& command);
+
     // Check a command against the list of crash commands, and return whether we think the command would crash.
     bool _wouldCrash(const BedrockCommand& command);
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -85,6 +85,13 @@ class BedrockServer : public SQLiteServer {
     // Returns whether or not this server was configured to backup when it completed shutdown.
     bool backupOnShutdown();
 
+    // Returns a copy of the internal state of the sync node's peers. This can be empty if there are no peers, or no
+    // sync node.
+    list<STable> getPeerInfo();
+
+    // Send a command to all of our peers. It will be wrapped appropriately.
+    void broadcastCommand(const SData& message);
+
   private:
     // The name of the sync thread.
     static constexpr auto _syncThreadName = "sync";
@@ -194,7 +201,7 @@ class BedrockServer : public SQLiteServer {
     SQLiteNode* _syncNode;
 
     // Because status will access internal sync node data, we lock in both places that will access the pointer above.
-    mutex _syncMutex;
+    recursive_mutex _syncMutex;
 
     // Functions for checking for and responding to status and control commands.
     bool _isStatusCommand(BedrockCommand& command);

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -59,7 +59,12 @@
 thread_local string SThreadLogPrefix;
 thread_local string SThreadLogName;
 
-void SInitialize(string threadName) {
+void SInitialize(string threadName, const char* processName) {
+    // If a specific process name has been supplied, initialize syslog with it.
+    if (processName) {
+        openlog(processName, 0, 0);
+    }
+
     // Initialize signal handling
     SLogSetThreadName(threadName);
     SLogSetThreadPrefix("xxxxxx ");

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1498,7 +1498,7 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking) {
         string domain;
         uint16_t port = 0;
         if (!SParseHost(host, domain, port)) {
-            STHROW("invalid host");
+            STHROW("invalid host: " + host);
         }
 
         // Is the domain just a raw IP?

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -42,7 +42,7 @@ using namespace std;
 #include <pcrecpp.h> // sudo apt-get install libpcre++-dev
 
 // Initialize libstuff on every thread before calling any of its functions
-void SInitialize(string threadName = "");
+void SInitialize(string threadName = "", const char* processName = 0);
 
 void SSetSignalHandlerDieFunc(function<void()>&& func);
 

--- a/main.cpp
+++ b/main.cpp
@@ -170,7 +170,7 @@ int main(int argc, char* argv[]) {
 
     // Start libstuff. Generally, we want to initialize libstuff immediately on any new thread, but we wait until after
     // the `fork` above has completed, as we can get strange behaviors from signal handlers across forked processes.
-    SInitialize("main");
+    SInitialize("main", (args.isSet("-overrideProcessName") ? args["-overrideProcessName"].c_str() : 0));
     SLogLevel(LOG_INFO);
 
     if (args.isSet("-version")) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1720,10 +1720,10 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             _escalatedCommandMap.erase(commandIt);
         } else
             SWARN("Received ESCALATE_ABORTED for unescalated command " << message["ID"] << ", ignoring.");
-    } else if (SIEquals(message.methodLine, "CRASH_COMMAND")) {
+    } else if (SIEquals(message.methodLine, "CRASH_COMMAND") || SIEquals(message.methodLine, "BROADCAST_COMMAND")) {
         // Create a new Command and send to the server.
-        PINFO("Received CRASH_COMMAND command, forwarding to server.");
         SData messageCopy = message;
+        PINFO("Received " << message.methodLine << " command, forwarding to server.");
         _server.acceptCommand(SQLiteCommand(move(messageCopy)));
     } else {
         STHROW("unrecognized message");
@@ -1878,12 +1878,12 @@ void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly) {
     }
 }
 
-void SQLiteNode::emergencyBroadcast(const SData& message, Peer* peer) {
+void SQLiteNode::broadcast(const SData& message, Peer* peer) {
     if (peer) {
-        SALERT("Sending emergency broadcast: " << message.serialize() << " to peer: " << peer->name);
+        SINFO("Sending broadcast: " << message.serialize() << " to peer: " << peer->name);
         _sendToPeer(peer, message);
     } else {
-        SALERT("Sending emergency broadcast: " << message.serialize());
+        SINFO("Sending broadcast: " << message.serialize());
         _sendToAllPeers(message, false);
     }
 }

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -112,10 +112,8 @@ class SQLiteNode : public STCPNode {
     // 2. SQLite::g_commitLock
     shared_timed_mutex stateMutex;
 
-    // This allows the caller to immediately send a message to all peers that something horrible has happened,
-    // typically, we've segfaulted and are trying to warn other servers of a bad command before we finish crashing.
-    // This is not to be used as a general messaging mechanism.
-    void emergencyBroadcast(const SData& message, Peer* peer = nullptr);
+    // This will broadcast a message to all peers, or a specific peer.
+    void broadcast(const SData& message, Peer* peer = nullptr);
 
   private:
     // STCPNode API: Peer handling framework functions

--- a/test/clustertest/BedrockClusterTester.cpp
+++ b/test/clustertest/BedrockClusterTester.cpp
@@ -79,6 +79,7 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
             {"-nodeName",    nodeName},
             {"-peerList",    peerString},
             {"-plugins",     "db,cache," + string(cwd) + "/testplugin/testplugin.so"},
+            {"-overrideProcessName", "bedrock" + to_string(nodePort)},
         };
 
         for (auto& a : _args) {

--- a/test/clustertest/BedrockClusterTester.cpp
+++ b/test/clustertest/BedrockClusterTester.cpp
@@ -2,20 +2,32 @@
 
 list<BedrockClusterTester*> BedrockClusterTester::testers;
 
-BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize size, list<string> queries)
+BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize size, list<string> queries, int threadID, map<string, string> _args, list<string> uniquePorts)
 : _size(size)
 {
     cout << "Starting " << size << " node bedrock cluster." << endl;
     // Make sure we won't re-allocate.
     _cluster.reserve(size);
 
-    int nodePortBase = 9500;
-    // We'll need a list of each node's addresses, and each will need to know the addresses of the others.
+    // Each node gets three + uniquePorts ports. The lowest port we'll use is 11111. To make sure each thread gets it's
+    // own port space, we'll add enough to this base port.
+    int portCount = 3 + uniquePorts.size();
+    int nodePortBase = 11111 + (threadID * portCount * size);
 
+    // Each node gets three ports.
+    vector<vector<int>> ports;
+    for (int i = 0; i < size; i++) {
+        // This node gets three consecutive ports.
+        vector<int> nodePorts = {nodePortBase + (i * portCount), nodePortBase + (i * portCount) + 1, nodePortBase + (i * portCount) + 2};
+        ports.push_back(nodePorts);
+    }
+
+
+    // We'll need a list of each node's addresses, and each will need to know the addresses of the others.
     // We'll use this to create the 'peerList' argument for each node.
     vector<string> peers;
     for (size_t i = 0; i < size; i++) {
-        int nodePort = nodePortBase + i;
+        int nodePort = nodePortBase + 1;
         peers.push_back("127.0.0.1:" + to_string(nodePort));
     }
 
@@ -23,26 +35,34 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
 
     for (size_t i = 0; i < size; i++) {
 
+        int portOffset = 3;
+        for (auto& up : uniquePorts) {
+            _args[up] = "127.0.0.1:" + to_string(nodePortBase + (i * portCount) + portOffset);
+            portOffset++;
+        }
+
         // We need each node to listen on a different port which is sort of inconvenient, but since they're all running
         // on the same machine, they can't share a port.
-        int serverPort = 9000 + i;
-        int nodePort = nodePortBase + i;
-        int controlPort = 19999 + i;
+        int nodePort = ports[i][0];
+        int serverPort = ports[i][1];
+        int controlPort = ports[i][2];
 
         // Construct all the arguments for each server.
         string serverHost  = "127.0.0.1:" + to_string(serverPort);
         string nodeHost    = "127.0.0.1:" + to_string(nodePort);
         string controlHost = "127.0.0.1:" + to_string(controlPort);
-        string db          = BedrockTester::getTempFileName("cluster_node_" + to_string(i) + "_");
+        string db          = BedrockTester::getTempFileName("cluster_node_" + to_string(nodePort));
         string priority    = to_string(100 - (i * 10));
         string nodeName    = nodeNamePrefix + to_string(i);
 
         // Construct our list of peers.
+        int j = 0;
         list<string> peerList;
-        for (size_t j = 0; j < peers.size(); j++) {
-            if (j != i) {
-                peerList.push_back(peers[j] + "?nodeName=" + nodeNamePrefix + to_string(j));
+        for (auto p : ports) {
+            if (p[0] != nodePort) {
+                peerList.push_back("127.0.0.1:"s + to_string(p[0]) + "?nodeName=" + nodeNamePrefix + to_string(j));
             }
+            j++;
         }
         string peerString = SComposeList(peerList, ",");
 
@@ -60,6 +80,10 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
             {"-peerList",    peerString},
             {"-plugins",     "db,cache," + string(cwd) + "/testplugin/testplugin.so"},
         };
+
+        for (auto& a : _args) {
+            args[a.first] = a.second;
+        }
         _cluster.emplace_back(args, queries, false);
     }
     list<thread> threads;

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -14,7 +14,7 @@ class BedrockClusterTester {
 
     // Creates a cluster of the given size and brings up all the nodes. The nodes will have priority in the order of
     // their creation (i.e., node 0 is highest priority and will become master.
-    BedrockClusterTester(ClusterSize size, list<string> queries = {});
+    BedrockClusterTester(ClusterSize size, list<string> queries = {}, int threadID = 0, map<string, string> _args = {}, list<string> uniquePorts = {});
     ~BedrockClusterTester();
 
     // Returns the index of the node that's mastering. Returns a negative number on error:


### PR DESCRIPTION
These are the changes required to allow running billing on slaves. They really have no effect without the corresponding auth changes, but they do the following:

1. Expose more data so that plugins can see data about peers.
2. Make the `emergencyBroadcast` feature more generally useful (and rename it `broadcast`).
3. Update the test infrastructure so that it can works with multi-threaded test environments (like auth test).
