### PR TITLE
Remove auto increment from jobs table

### DIFF
--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -11,6 +11,8 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     virtual bool processCommand(SQLite& db, BedrockCommand& command);
 
   private:
+    int64_t lastJobID;
+
     // Helper functions
     string _constructNextRunDATETIME(const string& lastScheduled, const string& lastRun, const string& repeat);
     bool _validateRepeat(const string& repeat) { return !_constructNextRunDATETIME("", "", repeat).empty(); }

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -11,7 +11,7 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     virtual bool processCommand(SQLite& db, BedrockCommand& command);
 
   private:
-    int64_t lastJobID;
+    atomic<uint64_t> lastJobID;
 
     // Helper functions
     string _constructNextRunDATETIME(const string& lastScheduled, const string& lastRun, const string& repeat);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -410,7 +410,7 @@ bool SQLite::verifyTable(const string& tableName, const string& sql, bool& creat
             return true;
         } else {
             // Not right -- need to upgrade?
-            SHMMM("'" << tableName << "' has incorrect schema, need to upgrade? Is '" << collapsedResult << "'");
+            SHMMM("'" << tableName << "' has incorrect schema, need to upgrade? Is '" << collapsedResult << "' expected  '" << collapsedSQL << "'");
             return false;
         }
     }

--- a/test/clustertest/BedrockClusterTester.cpp
+++ b/test/clustertest/BedrockClusterTester.cpp
@@ -58,7 +58,7 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
             {"-priority",    priority},
             {"-nodeName",    nodeName},
             {"-peerList",    peerString},
-            {"-plugins",     "db,cache," + string(cwd) + "/testplugin/testplugin.so"},
+            {"-plugins",     "db,cache,jobs," + string(cwd) + "/testplugin/testplugin.so"},
         };
         _cluster.emplace_back(args, queries, false);
     }

--- a/test/clustertest/tests/k_JobIDTest.cpp
+++ b/test/clustertest/tests/k_JobIDTest.cpp
@@ -15,15 +15,22 @@ struct k_JobIDTest : tpunit::TestFixture {
         BedrockTester* slave = tester->getBedrockTester(1);
 
         // Create a job
-        SData cmd("CreateJob");
-        cmd["name"] = "TestJob";
-        STable response = master->executeWaitVerifyContentTable(cmd);
+        SData createCmd("CreateJob");
+        createCmd["name"] = "TestJob";
+        STable response = master->executeWaitVerifyContentTable(createCmd);
         const int jobID = SToInt(response["jobID"]);
 
         // Stop master
         tester->stopNode(0);
-        response = slave->executeWaitVerifyContentTable(cmd, "200");
+        response = slave->executeWaitVerifyContentTable(createCmd, "200");
         ASSERT_EQUAL(jobID + 1, SToInt(response["jobID"]));
+
+        // Get the 2 jobs to leave the db clean.
+        SData getCmd("GetJob");
+        getCmd["name"] = "TestJob";
+        getCmd["name"] = "*";
+        slave->executeWaitVerifyContentTable(getCmd, "200");
+        slave->executeWaitVerifyContentTable(getCmd, "200");
     }
 
 } __k_JobIDTest;

--- a/test/clustertest/tests/k_JobIDTest.cpp
+++ b/test/clustertest/tests/k_JobIDTest.cpp
@@ -1,0 +1,29 @@
+#include "../BedrockClusterTester.h"
+
+struct k_JobIDTest : tpunit::TestFixture {
+    k_JobIDTest()
+        : tpunit::TestFixture("k_jobID",
+                              TEST(k_JobIDTest::test)
+                             ) { }
+
+    BedrockClusterTester* tester;
+
+    void test()
+    {
+        tester = BedrockClusterTester::testers.front();
+        BedrockTester* master = tester->getBedrockTester(0);
+        BedrockTester* slave = tester->getBedrockTester(1);
+
+        // Create a job
+        SData cmd("CreateJob");
+        cmd["name"] = "TestJob";
+        STable response = master->executeWaitVerifyContentTable(cmd);
+        const int jobID = SToInt(response["jobID"]);
+
+        // Stop master
+        tester->stopNode(0);
+        response = slave->executeWaitVerifyContentTable(cmd, "200");
+        ASSERT_EQUAL(jobID + 1, SToInt(response["jobID"]));
+    }
+
+} __k_JobIDTest;

--- a/test/clustertest/tests/k_JobIDTest.cpp
+++ b/test/clustertest/tests/k_JobIDTest.cpp
@@ -14,7 +14,7 @@ struct k_JobIDTest : tpunit::TestFixture {
         BedrockTester* master = tester->getBedrockTester(0);
         BedrockTester* slave = tester->getBedrockTester(1);
 
-        // Create a job
+        // Create a job in master
         SData createCmd("CreateJob");
         createCmd["name"] = "TestJob";
         STable response = master->executeWaitVerifyContentTable(createCmd);
@@ -22,18 +22,23 @@ struct k_JobIDTest : tpunit::TestFixture {
 
         // Stop master
         tester->stopNode(0);
+
+        // Create a job in the slave and check the ID returned is the next one
         response = slave->executeWaitVerifyContentTable(createCmd, "200");
         ASSERT_EQUAL(jobID + 1, SToInt(response["jobID"]));
 
-        // Get the 2 jobs to leave the db clean.
-        SData getCmd("GetJob");
-        getCmd["name"] = "TestJob";
-        getCmd["name"] = "*";
-        slave->executeWaitVerifyContentTable(getCmd, "200");
-        slave->executeWaitVerifyContentTable(getCmd, "200");
-
-        // Restart master so rest of tests can use it.
+        // Restart master
         tester->startNode(0);
+
+        // Create a new job in master and check the ID is the next one
+        response = master->executeWaitVerifyContentTable(createCmd);
+        ASSERT_EQUAL(jobID + 2, SToInt(response["jobID"]));
+
+        // Get the 3 jobs to leave the db clean
+        SData getCmd("GetJobs");
+        getCmd["name"] = "*";
+        getCmd["numResults"] = 3;
+        slave->executeWaitVerifyContentTable(getCmd, "200");
     }
 
 } __k_JobIDTest;

--- a/test/clustertest/tests/k_JobIDTest.cpp
+++ b/test/clustertest/tests/k_JobIDTest.cpp
@@ -31,6 +31,9 @@ struct k_JobIDTest : tpunit::TestFixture {
         getCmd["name"] = "*";
         slave->executeWaitVerifyContentTable(getCmd, "200");
         slave->executeWaitVerifyContentTable(getCmd, "200");
+
+        // Restart master so rest of tests can use it.
+        tester->startNode(0);
     }
 
 } __k_JobIDTest;


### PR DESCRIPTION
@tylerkaraszewski, @mea36 please review.

Part of https://github.com/Expensify/Expensify/issues/75339

Tests:
- Start bedrock with this changes.
- Run [this migration](https://github.com/Expensify/Expensify/issues/75339#issuecomment-374274942).
- Start bedrock.
- Create some jobs, check the IDs returned (on new DB or a one with an empty jobs table it starts at 1).
- Restart bedrock.
- Create another job, check it uses the correct ID

