### PR TITLE
Let Auth alert command timeout instead of bedrock

### DIFF
--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -60,7 +60,9 @@ bool BedrockPlugin::peekCommand(SQLite& db, BedrockCommand& command) {
 bool BedrockPlugin::processCommand(SQLite& db, BedrockCommand& command) {
     return false;
 }
-
+bool BedrockPlugin::shouldSuppressTimeoutWarnings() {
+    return false;
+}
 void BedrockPlugin::timerFired(SStopwatch* timer) {}
 
 void BedrockPlugin::upgradeDatabase(SQLite& db) {}

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -79,6 +79,9 @@ class BedrockPlugin {
     // s        Optional socket from which this request was received
     virtual void onPortRequestComplete(const BedrockCommand& command, STCPManager::Socket* s) { }
 
+    // Set to true if we don't want to log timeout alerts, and let the caller deal with it.
+    virtual bool shouldSuppressTimeoutWarnings();
+
   public:
     // A global static list of all registered plugins.
     static list<BedrockPlugin*>* g_registeredPluginList;


### PR DESCRIPTION
@tylerkaraszewski cc @flodnv 

Linked with https://github.com/Expensify/Server-Expensify/pull/2583

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/72389

# Tests
See in https://github.com/Expensify/Server-Expensify/pull/2583