### PR TITLE
Add a SHA256 hash function

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -8,6 +8,7 @@
 #include <mbedtls/aes.h>
 #include <mbedtls/base64.h>
 #include <mbedtls/sha1.h>
+#include <mbedtls/sha256.h>
 
 // Additional headers
 #include <netdb.h>
@@ -2133,6 +2134,13 @@ string SHashSHA1(const string& buffer) {
     return result;
 }
 
+string SHashSHA256(const string& buffer) {
+    string result;
+    result.resize(32);
+    mbedtls_sha256((unsigned char*)buffer.c_str(), (int)buffer.size(), (unsigned char*)&result[0], 0);
+    return result;
+}
+
 // --------------------------------------------------------------------------
 
 string SEncodeBase64(const unsigned char* buffer, int size) {
@@ -2184,6 +2192,19 @@ string SHMACSHA1(const string& key, const string& buffer) {
     // Then use it to make the hashes
     const string& innerHash = SHashSHA1(ipadSecret + buffer);
     const string& outerHash = SHashSHA1(opadSecret + innerHash);
+    return outerHash;
+}
+
+string SHMACSHA256(const string& key, const string& buffer) {
+    int BLOCK_SIZE = 64;
+    string ipadSecret(BLOCK_SIZE, 0x36), opadSecret(BLOCK_SIZE, 0x5c);
+    for (int c = 0; c < (int)key.size(); ++c) {
+        ipadSecret[c] ^= key[c];
+        opadSecret[c] ^= key[c];
+    }
+
+    const string& innerHash = SHashSHA256(ipadSecret + buffer);
+    const string& outerHash = SHashSHA256(opadSecret + innerHash);
     return outerHash;
 }
 

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -712,6 +712,7 @@ uint64_t SFileSize(const string& path);
 // --------------------------------------------------------------------------
 // Various hashing functions
 string SHashSHA1(const string& buffer);
+string SHashSHA256(const string& buffer);
 
 // Various encoding/decoding functions
 string SEncodeBase64(const unsigned char* buffer, const int size);
@@ -721,6 +722,7 @@ string SDecodeBase64(const string& buffer);
 
 // HMAC (for use with Amazon S3)
 string SHMACSHA1(const string& key, const string& buffer);
+string SHMACSHA256(const string& key, const string& buffer);
 
 // Encryption/Decryption
 #define SAES_KEY_SIZE 32 // AES256 32 bytes = 256 bits

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -5,6 +5,7 @@ struct LibStuff : tpunit::TestFixture {
     LibStuff() : tpunit::TestFixture("LibStuff",
                                     TEST(LibStuff::testEncryptDecrpyt),
                                     TEST(LibStuff::testSHMACSHA1),
+                                    TEST(LibStuff::testSHMACSHA256),
                                     TEST(LibStuff::testJSONDecode),
                                     TEST(LibStuff::testJSON),
                                     TEST(LibStuff::testEscapeUnescape),
@@ -41,6 +42,11 @@ struct LibStuff : tpunit::TestFixture {
         ASSERT_EQUAL(SToHex(SHMACSHA1("", "")), "FBDB1D1B18AA6C08324B7D64B71FB76370690E1D");
         ASSERT_EQUAL(SToHex(SHMACSHA1("key", "The quick brown fox jumps over the lazy dog")),
                      "DE7C9B85B8B78AA6BC8A7A36F70A90701C9DB4D9");
+    }
+
+    void testSHMACSHA256() {
+        ASSERT_EQUAL(SToHex(SHMACSHA256("", "")), "B613679A0814D9EC772F95D778C35FC5FF1697C493715653C6C712144292C5AD");
+        ASSERT_EQUAL(SToHex(SHMACSHA256("key", "Only a Sith deals in absolutes")), "524C9B1C0B6E9F47F10041A429FCB2C880129F940DC9E41F31267E0909D46845");
     }
 
     void testJSONDecode() {


### PR DESCRIPTION
@flodnv @coleaeason   Please review
cc @tylerkaraszewski 

**Issue:**
We need to authenticate a webhook response from Stripe, and Cole and Flo wanted it to be done so in Auth. However, we only have methods in place for SHA1 hash functions.

**Solution:**
We already had a mbed_sha256 hash function already available, so I just created a wrapper method that uses that so that we can have a SHA256 hash function.

Overview (more for myself than you guys as a lot of this was self taught tonight)
- Block size is set to 64 bytes
- Inner padding is byte 0x36
- Outer padding is byte 0x5
- Output is 256bits/8bit = 32

