### PR TITLE
Fix segfault, give up when no socket in tests.

### DIFF
--- a/libstuff/STCPServer.h
+++ b/libstuff/STCPServer.h
@@ -35,4 +35,7 @@ struct STCPServer : public STCPManager {
 
     // Attributes
     list<Port> portList;
+
+    // Protect access to to the port list when multiple threads insert and delete from it.
+    mutex portListMutex;
 };

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -184,15 +184,14 @@ string BedrockTester::startServer(bool dontWait) {
             }
 
             // We've successfully opened a socket, so let's try and send a command.
-            try {
-                SData status("Status");
-                auto result = executeWaitMultipleData({status}, 10, dontWait);
+            SData status("Status");
+            auto result = executeWaitMultipleData({status}, 1, dontWait);
+            if (result[0].methodLine == "200 OK") {
                 return result[0].content;
-            } catch (...) {
-                // This will happen if the server's not up yet. We'll just try again.
-                usleep(100000); // 0.1 seconds.
-                continue;
             }
+            // This will happen if the server's not up yet. We'll just try again.
+            usleep(100000); // 0.1 seconds.
+            continue;
         }
     }
     return "";
@@ -262,6 +261,14 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
                 size_t count = 1;
                 if (mockRequestMode > 1) {
                     count = mockRequestMode;
+                }
+
+                // If the socket failed to open, don't bother trying with it.
+                if (socket == -1) {
+                    SAUTOLOCK(listLock);
+                    SData responseData("002 Socket Failed");
+                    results[myIndex] = move(responseData);
+                    continue;
                 }
 
                 for (size_t mockCount = 0; mockCount < count; mockCount++) {


### PR DESCRIPTION
@coleaeason 
cc @flodnv 

Partially fixes: https://github.com/Expensify/Expensify/issues/76060

Since the auth tests now open and close the command port when they run billing, I found a race condition where we could try and read from the command port while we were closing it (and then deleting it) in another thread. This could result in a segfault. This change synchronizes the list of ports to avoid that.

Also, if we failed to open a socket to bedrock, we'd wait the entire time for the timeout before returning. This change now returns a failure immediately in this case (since we don't retry connecting anyway).