### PR TITLE
Remove unnecessary indexes

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -45,6 +45,8 @@ void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsName     ON jobs ( name     );"));
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsNextRun  ON jobs ( nextRun  );"));
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsLastRun  ON jobs ( lastRun  );"));
+    SASSERT(db.write("CREATE INDEX jobsStateNextRunName ON jobs ( state, nextRun, name );"));
+    SASSERT(db.write("CREATE INDEX jobsStateNamePrefixNextRun ON jobs ( state, SUBSTR(name, 1, INSTR(name, '/')), nextRun );"));
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsPriority ON jobs ( priority );"));
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsParentJobIDState ON jobs ( parentJobID, state );"));
 

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -41,18 +41,9 @@ void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
 
     // These indexes are not used by the Bedrock::Jobs plugin, but provided for easy analysis
     // using the Bedrock::DB plugin.
-    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsState    ON jobs ( state    );"));
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsName     ON jobs ( name     );"));
-    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsNextRun  ON jobs ( nextRun  );"));
-    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsLastRun  ON jobs ( lastRun  );"));
-    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsStateNextRunName ON jobs ( state, nextRun, name );"));
-    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsStateNamePrefixNextRun ON jobs ( state, SUBSTR(name, 1, INSTR(name, '/')), nextRun );"));
-    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsPriority ON jobs ( priority );"));
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsParentJobIDState ON jobs ( parentJobID, state );"));
-
-    // This index is used to optimize the Bedrock::Jobs::GetJob call.
-    SASSERT(db.write(
-        "CREATE INDEX IF NOT EXISTS jobsStatePriorityNextRunName ON jobs ( state, priority, nextRun, name );"));
+    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsStatePriorityNextRunName ON jobs ( state, priority, nextRun, name );"));
 
     if (!lastJobID) {
         SQResult nextIDResult;
@@ -110,6 +101,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
         if (!db.read("SELECT 1 "
                      "FROM jobs "
                      "WHERE state in ('QUEUED', 'RUNQUEUED') "
+                     "  AND priority IN (0, 500, 1000) "
                      "  AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                      "  AND name GLOB " + SQ(name) + " "
                      "  AND JSON_EXTRACT(data, '$.mockRequest') " + operation + " NULL "

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -45,8 +45,8 @@ void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsName     ON jobs ( name     );"));
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsNextRun  ON jobs ( nextRun  );"));
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsLastRun  ON jobs ( lastRun  );"));
-    SASSERT(db.write("CREATE INDEX jobsStateNextRunName ON jobs ( state, nextRun, name );"));
-    SASSERT(db.write("CREATE INDEX jobsStateNamePrefixNextRun ON jobs ( state, SUBSTR(name, 1, INSTR(name, '/')), nextRun );"));
+    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsStateNextRunName ON jobs ( state, nextRun, name );"));
+    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsStateNamePrefixNextRun ON jobs ( state, SUBSTR(name, 1, INSTR(name, '/')), nextRun );"));
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsPriority ON jobs ( priority );"));
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsParentJobIDState ON jobs ( parentJobID, state );"));
 


### PR DESCRIPTION
Tests listed in https://github.com/Expensify/Expensify/issues/67103

# Timing
(first 3 are the old query, second 3 are the new query)
```
ionatan@staging-www1:~$ sudo readdb.sh -t "select 1 from jobs where state in ('QUEUED', 'RUNQUEUED') and '2018-04-10 02:00:00' >= nextRun AND name GLOB 'www-prod/*' AND json_extract(data, '$.mockRequest') IS NOT NULL;"

real	0m0.016s
user	0m0.008s
sys	0m0.004s
ionatan@staging-www1:~$ sudo readdb.sh -t "select 1 from jobs where state in ('QUEUED', 'RUNQUEUED') and '2018-04-10 02:00:00' >= nextRun AND name GLOB 'www-prod/*' AND json_extract(data, '$.mockRequest') IS NOT NULL;"

real	0m0.012s
user	0m0.004s
sys	0m0.004s
ionatan@staging-www1:~$ sudo readdb.sh -t "select 1 from jobs where state in ('QUEUED', 'RUNQUEUED') and '2018-04-10 02:00:00' >= nextRun AND name GLOB 'www-prod/*' AND json_extract(data, '$.mockRequest') IS NOT NULL;"

real	0m0.012s
user	0m0.008s
sys	0m0.000s
ionatan@staging-www1:~$ sudo readdb.sh -t "select 1 from jobs where state in ('QUEUED', 'RUNQUEUED') and '2018-04-10 02:00:00' >= nextRun AND priority in (0,500,1000) AND name GLOB 'www-prod/*' AND json_extract(data, '$.mockRequest') IS NOT NULL;"

real	0m0.012s
user	0m0.008s
sys	0m0.000s
ionatan@staging-www1:~$ sudo readdb.sh -t "select 1 from jobs where state in ('QUEUED', 'RUNQUEUED') and '2018-04-10 02:00:00' >= nextRun AND priority in (0,500,1000) AND name GLOB 'www-prod/*' AND json_extract(data, '$.mockRequest') IS NOT NULL;"

real	0m0.012s
user	0m0.008s
sys	0m0.000s
ionatan@staging-www1:~$ sudo readdb.sh -t "select 1 from jobs where state in ('QUEUED', 'RUNQUEUED') and '2018-04-10 02:00:00' >= nextRun AND priority in (0,500,1000) AND name GLOB 'www-prod/*' AND json_extract(data, '$.mockRequest') IS NOT NULL;"

real	0m0.013s
user	0m0.012s
sys	0m0.000s
```
Same but with IS NULL:
```
ionatan@staging-www1:~$ sudo readdb.sh -t "select 1 from jobs where state in ('QUEUED', 'RUNQUEUED') and '2018-04-10 02:00:00' >= nextRun AND name GLOB 'www-prod/*' AND json_extract(data, '$.mockRequest') IS  NULL;"

real	0m0.018s
user	0m0.016s
sys	0m0.000s
ionatan@staging-www1:~$ sudo readdb.sh -t "select 1 from jobs where state in ('QUEUED', 'RUNQUEUED') and '2018-04-10 02:00:00' >= nextRun AND name GLOB 'www-prod/*' AND json_extract(data, '$.mockRequest') IS  NULL;"

real	0m0.011s
user	0m0.008s
sys	0m0.004s
ionatan@staging-www1:~$ sudo readdb.sh -t "select 1 from jobs where state in ('QUEUED', 'RUNQUEUED') and '2018-04-10 02:00:00' >= nextRun AND name GLOB 'www-prod/*' AND json_extract(data, '$.mockRequest') IS  NULL;"

real	0m0.011s
user	0m0.012s
sys	0m0.000s
ionatan@staging-www1:~$ sudo readdb.sh -t "select 1 from jobs where state in ('QUEUED', 'RUNQUEUED') and '2018-04-10 02:00:00' >= nextRun AND priority in (0,500,1000) AND name GLOB 'www-prod/*' AND json_extract(data, '$.mockRequest') IS NULL;"

real	0m0.012s
user	0m0.008s
sys	0m0.000s
ionatan@staging-www1:~$ sudo readdb.sh -t "select 1 from jobs where state in ('QUEUED', 'RUNQUEUED') and '2018-04-10 02:00:00' >= nextRun AND priority in (0,500,1000) AND name GLOB 'www-prod/*' AND json_extract(data, '$.mockRequest') IS NULL;"

real	0m0.014s
user	0m0.004s
sys	0m0.008s
ionatan@staging-www1:~$ sudo readdb.sh -t "select 1 from jobs where state in ('QUEUED', 'RUNQUEUED') and '2018-04-10 02:00:00' >= nextRun AND priority in (0,500,1000) AND name GLOB 'www-prod/*' AND json_extract(data, '$.mockRequest') IS NULL;"

real	0m0.012s
user	0m0.008s
sys	0m0.000s
```