### PR TITLE
Stop logging potentially sensitive data

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -91,7 +91,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
         _handleCommandException(command, e);
     } catch (...) {
         _db.read("PRAGMA query_only = false;");
-        SALERT("Unhandled exception typename: " << _getExceptionName() << ", command: " << command.request.serialize());
+        SALERT("Unhandled exception typename: " << _getExceptionName() << ", command: " << request.methodLine);
         command.response.methodLine = "500 Unhandled Exception";
     }
 
@@ -185,7 +185,7 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         _db.rollback();
         needsCommit = false;
     } catch(...) {
-        SALERT("Unhandled exception typename: " << _getExceptionName() << ", command: " << command.request.serialize());
+        SALERT("Unhandled exception typename: " << _getExceptionName() << ", command: " << request.methodLine);
         command.response.methodLine = "500 Unhandled Exception";
         _db.rollback();
         needsCommit = false;
@@ -203,8 +203,7 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
 }
 
 void BedrockCore::_handleCommandException(BedrockCommand& command, const SException& e) {
-    const string& msg = "Error processing command '" + command.request.methodLine + "' (" + e.what() + "), ignoring: " +
-                        command.request.serialize();
+    const string& msg = "Error processing command '" + command.request.methodLine + "' (" + e.what() + "), ignoring.";
     if (SContains(e.what(), "_ALERT_")) {
         SALERT(msg);
     } else if (SContains(e.what(), "_WARN_")) {


### PR DESCRIPTION
@tylerkaraszewski @nkuoch @coleaeason please review
cc @pecanoro @brandonhub @iwiznia, initially found in https://github.com/Expensify/Expensify/issues/76096

Ref: https://github.com/Expensify/Expensify/issues/76097

I initially thought we broke this in https://github.com/Expensify/Bedrock/pull/405/files, but I don't think so anymore -- anyhow, I'm making these logs stop logging the whole request, it should be the responsibility of each plugin to do that safely. 
As for what exactly is going on, I'm a bit confused, I'll take the discussion to the issue https://github.com/Expensify/Expensify/issues/76097