### PR TITLE
Add getHTTPResponseCode function

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -37,6 +37,23 @@ void SHTTPSManager::closeTransaction(Transaction* transaction) {
     delete transaction;
 }
 
+int SHTTPSManager::getHTTPResponseCode(const string& methodLine) {
+    // This code looks for the first space in the methodLine, and then for the first non-space
+    // after that, and *then* parses the response code. If we fail to find such a code, or can't parse it as an
+    // integer, we default to 400.
+    size_t offset = methodLine.find_first_of(' ', 0);
+    offset = methodLine.find_first_not_of(' ', offset);
+    if (offset != string::npos) {
+        int status = SToInt(methodLine.substr(offset));
+        if (status) {
+            return status;
+        }
+    }
+
+    // Default case, return 400
+    return 400;
+}
+
 SHTTPSManager::Socket* SHTTPSManager::openSocket(const string& host, SX509* x509) {
     // Just call the base class function but in a thread-safe way.
     SAUTOLOCK(_listMutex);

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -33,7 +33,7 @@ class SHTTPSManager : public STCPManager {
     // Close a transaction and remove it from our internal lists.
     void closeTransaction(Transaction* transaction);
 
-    int getHTTPResponseCode(const string& methodLine);
+    static int getHTTPResponseCode(const string& methodLine);
 
   protected: // Child API
 

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -33,6 +33,8 @@ class SHTTPSManager : public STCPManager {
     // Close a transaction and remove it from our internal lists.
     void closeTransaction(Transaction* transaction);
 
+    int getHTTPResponseCode(const string& methodLine);
+
   protected: // Child API
 
     // Used to create the signing certificate.


### PR DESCRIPTION
Needed for https://github.com/Expensify/Server-Expensify/pull/2593 to DRY up a few repeated times of this code. 

### Description
Basic functionality of this code is described in the comment, but this parses a method line for HTTP status code. 

### Tests
Auth tests should cover this and verify it works as intended