### PR TITLE
 Modify GetJob to support more than one job name

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -76,7 +76,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
         //     Atomically dequeues one or more jobs, if available.
         //
         //     Parameters:
-        //     - name - list of name pattern of jobs to match
+        //     - name - list of name patterns of jobs to match. If only one name is passed, you can use '*' to match any job.
         //     - numResults - maximum number of jobs to dequeue
         //     - connection - (optional) If "wait" will pause up to "timeout" for a match
         //     - timeout - (optional) maximum time (in ms) to wait, default forever
@@ -109,7 +109,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
                      "FROM jobs "
                      "WHERE state in ('QUEUED', 'RUNQUEUED') "
                         "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
-                        "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")": "GLOB " + SQ(request["name"])) + " "
+                        "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " "
                         "AND JSON_EXTRACT(data, '$.mockRequest') " + operation + " NULL "
                      "LIMIT 1;",
                      result)) {
@@ -633,7 +633,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                     "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                         "AND priority=1000 "
                         "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
-                        "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")": "GLOB " + SQ(request["name"])) + " "
+                        "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " "
                         "AND JSON_EXTRACT(data, '$.mockRequest') " + operation + " NULL "
                     "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
@@ -644,7 +644,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                     "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                         "AND priority=500 "
                         "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
-                        "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")": "GLOB " + SQ(request["name"])) + " "
+                        "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " "
                         "AND JSON_EXTRACT(data, '$.mockRequest') " + operation + " NULL "
                     "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
@@ -655,7 +655,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                     "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                         "AND priority=0 "
                         "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
-                        "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")": "GLOB " + SQ(request["name"])) + " "
+                        "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " "
                         "AND JSON_EXTRACT(data, '$.mockRequest') " + operation + " NULL "
                     "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -12,6 +12,7 @@ struct GetJobTest : tpunit::TestFixture {
                               TEST(GetJobTest::testPrioritiesWithDifferentNextRunTimes),
                               TEST(GetJobTest::testWithFinishedAndCancelledChildren),
                               TEST(GetJobTest::testPrioritiesWithRunQueued),
+                              TEST(GetJobTest::testMultipleNames),
                               AFTER(GetJobTest::tearDown),
                               AFTER_CLASS(GetJobTest::tearDownClass)) { }
 
@@ -478,6 +479,69 @@ struct GetJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(response["name"], "medium_4");
         response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(response["name"], "low_5");
+    }
+
+    // Get a job from a list of names and make sure the jobs are returned in the proper order by priorities
+    void testMultipleNames() {
+        // Create jobs of different priorities
+        // Low
+        SData command("CreateJob");
+        command["name"] = "low";
+        command["priority"] = "0";
+        tester->executeWaitVerifyContent(command);
+
+        // High
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "high";
+        command["priority"] = "1000";
+        tester->executeWaitVerifyContent(command);
+
+        // Medium
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "medium";
+        command["priority"] = "500";
+        tester->executeWaitVerifyContent(command);
+
+        // Medium
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "medium";
+        command["priority"] = "500";
+        tester->executeWaitVerifyContent(command);
+
+        // Get medium and high jobs
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "medium,high";
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm that high is in the RUNNING state
+        SQResult result;
+        tester->readDB("SELECT DISTINCT state FROM jobs WHERE name = 'high' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;", result);
+        ASSERT_EQUAL(result.size(), 1);
+        ASSERT_EQUAL(result[0][0], "RUNNING");
+
+        // Get any of the job names
+        command["name"] = "low,medium,high";
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm that medium is in the RUNNING state since there are no more high jobs
+        tester->readDB("SELECT COUNT(1) FROM jobs WHERE name = 'medium' AND state = 'RUNNING' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;", result);
+        ASSERT_EQUAL(result.size(), 1);
+        ASSERT_EQUAL(result[0][0], "1");
+
+        // Return 2 jobs and confirm that the jobs are returned in medium and low order
+        command.clear();
+        command.methodLine = "GetJobs";
+        command["name"] = "low,medium";
+        command["numResults"] = "2";
+
+        tester->readDB("SELECT COUNT(1) FROM jobs WHERE name = 'medium' AND state = 'RUNNING' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;", result);
+        STable response = tester->executeWaitVerifyContentTable(command);
+        list<string> jobList = SParseJSONArray(response["jobs"]);
+        ASSERT_EQUAL(jobList.size(), 2);
     }
 } __GetJobTest;
 


### PR DESCRIPTION
Now GetJob and GetJobs support passing more than one job name. Like I discussed with Ioni, we agree on passing a comma-separated list of names instead of an array, easier to parse. Everything else works as before, we return the oldest job with the highest priority. 

### Issues

$ https://github.com/Expensify/Expensify/issues/76437

### Tests

Automated.