### PR TITLE
Store the jobID as soon as we increment it so it can't change in the meantime

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -574,7 +574,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 const string& safeRetryAfter = SContains(job, "retryAfter") && !job["retryAfter"].empty() ? SQ(job["retryAfter"]) : SQ("");
 
                 // Create this new job with a new generated ID
-                const int jobIDToUse = lastJobID++;
+                const int jobIDToUse = ++lastJobID;
                 SINFO("Next jobID to be used" << jobIDToUse);
                 if (!db.writeIdempotent("INSERT INTO jobs ( jobID, created, state, name, nextRun, repeat, data, priority, parentJobID, retryAfter ) "
                          "VALUES( " +

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -574,11 +574,11 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 const string& safeRetryAfter = SContains(job, "retryAfter") && !job["retryAfter"].empty() ? SQ(job["retryAfter"]) : SQ("");
 
                 // Create this new job with a new generated ID
-                lastJobID++;
-                SINFO("Next jobID to be used" << lastJobID);
+                const int jobIDToUse = lastJobID++;
+                SINFO("Next jobID to be used" << jobIDToUse);
                 if (!db.writeIdempotent("INSERT INTO jobs ( jobID, created, state, name, nextRun, repeat, data, priority, parentJobID, retryAfter ) "
                          "VALUES( " +
-                            SQ(lastJobID) + ", " +
+                            SQ(jobIDToUse) + ", " +
                             SCURRENT_TIMESTAMP() + ", " +
                             SQ(initialState) + ", " +
                             SQ(job["name"]) + ", " +
@@ -594,12 +594,12 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 }
 
                 if (SIEquals(requestVerb, "CreateJob")) {
-                    content["jobID"] = SToStr(lastJobID);
+                    content["jobID"] = SToStr(jobIDToUse);
                     return true;
                 }
 
                 // Append new jobID to list of created jobs.
-                jobIDs.push_back(SToStr(lastJobID));
+                jobIDs.push_back(SToStr(jobIDToUse));
             }
         }
 


### PR DESCRIPTION
@tylerkaraszewski @pecanoro please review.

Fixes https://github.com/Expensify/Expensify/issues/77007

This was wrong, we need to save the ID when we increment it or any other thread could've modified in the middle... 

Tests: kind of impossible to test... I created several jobs and checked the ID returned was correct.