### PR TITLE
Figure out what workers are doing when they should shut down.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -897,7 +897,7 @@ void BedrockServer::worker(SData& args,
         // Even if the sync thread is shut down, we still have work to do here, so we'll try another loop until we
         // don't find any commands to process, or we hit the timeout.
         if (server._shutdownState.load() == DONE) {
-            if (_gracefulShutdownTimeout.ringing()) {
+            if (server._gracefulShutdownTimeout.ringing()) {
                 SINFO("_shutdownState is DONE and we've timed out, exiting worker.");
                 return;
             } else {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -540,9 +540,6 @@ void BedrockServer::sync(SData& args,
         workerThread.join();
     }
 
-    // At this point, everything is done.
-    server._shutdownState.store(DONE);
-
     // If there's anything left in the command queue here, we'll discard it, because we have no way of processing it.
     if (server._commandQueue.size()) {
         SWARN("Sync thread shut down with " << server._commandQueue.size() << " queued commands. Commands were: "
@@ -890,11 +887,22 @@ void BedrockServer::worker(SData& args,
             }
         } catch (const BedrockCommandQueue::timeout_error& e) {
             // No commands to process after 1 second.
+
+            // If the sync node has shut down, we can return now, there will be no more work to do.
+            if  (server._shutdownState.load() == DONE) {
+                break;
+            }
         }
 
-        // If the sync node has shut down, we can return now, there will be no more work to do.
-        if  (server._shutdownState.load() == DONE) {
-            break;
+        // Even if the sync thread is shut down, we still have work to do here, so we'll try another loop until we
+        // don't find any commands to process, or we hit the timeout.
+        if (server._shutdownState.load() == DONE) {
+            if (_gracefulShutdownTimeout.ringing()) {
+                SINFO("_shutdownState is DONE and we've timed out, exiting worker.");
+                return;
+            } else {
+                SINFO("_shutdownState is DONE, but still have work, waiting for timeout.");
+            }
         }
     }
 }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -142,6 +142,8 @@ bool SQLiteNode::shutdownComplete() {
     if (_gracefulShutdownTimeout.ringing()) {
         // Timing out
         SWARN("Graceful shutdown timed out, killing non gracefully.");
+        // Force this.
+        _changeState(SEARCHING);
         return true;
     }
 


### PR DESCRIPTION
Remove redundant `_shutdownState.store(DONE);` [See this line.](https://github.com/Expensify/Bedrock/blob/4dd874fb433a2f8c81208bdcb8b42173d5cf29c5/BedrockServer.cpp#L519)

Only return from worker without logging if there's actually no work left for it.

If there *is* work left for it, log and only return if the timeout is ringing.

make the sync node set itself SEARCHING when timing out.