### PR TITLE
Tyler log exception names

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -91,7 +91,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
         _handleCommandException(command, e);
     } catch (...) {
         _db.read("PRAGMA query_only = false;");
-        SALERT("Unhandled exception typename: " << _getExceptionName() << ", command: " << request.methodLine);
+        SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
         command.response.methodLine = "500 Unhandled Exception";
     }
 
@@ -185,7 +185,7 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         _db.rollback();
         needsCommit = false;
     } catch(...) {
-        SALERT("Unhandled exception typename: " << _getExceptionName() << ", command: " << request.methodLine);
+        SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
         command.response.methodLine = "500 Unhandled Exception";
         _db.rollback();
         needsCommit = false;
@@ -229,23 +229,4 @@ void BedrockCore::_handleCommandException(BedrockCommand& command, const SExcept
 
     // Add the commitCount header to the response.
     command.response["commitCount"] = to_string(_db.getCommitCount());
-}
-string BedrockCore::_getExceptionName()
-{
-    // __cxa_demangle takes all its parameters by reference, so we create a buffer where it can demangle the current
-    // exception name.
-    int status = 0;
-    size_t length = 1000;
-    char buffer[length] = {0};
-
-    // Demangle the name of the current exception.
-    // See: https://libcxxabi.llvm.org/spec.html for details on this ABI interface.
-    abi::__cxa_demangle(abi::__cxa_current_exception_type()->name(), buffer, &length, &status);
-    string exceptionName = buffer;
-
-    // If it failed, use the original name instead.
-    if (status) {
-        exceptionName = "(mangled) "s + abi::__cxa_current_exception_type()->name();
-    }
-    return exceptionName;
 }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2369,3 +2369,32 @@ bool SQVerifyTableExists(sqlite3* db, const string& tableName) {
     SASSERT(!SQuery(db, "SQVerifyTable", "SELECT * FROM sqlite_master WHERE tbl_name=" + SQ(tableName), result));
     return !result.empty();
 }
+
+string SGetCurrentExceptionName()
+{
+    // __cxa_demangle takes all its parameters by reference, so we create a buffer where it can demangle the current
+    // exception name.
+    int status = 0;
+    size_t length = 1000;
+    char buffer[length] = {0};
+
+    // Demangle the name of the current exception.
+    // See: https://libcxxabi.llvm.org/spec.html for details on this ABI interface.
+    abi::__cxa_demangle(abi::__cxa_current_exception_type()->name(), buffer, &length, &status);
+    string exceptionName = buffer;
+
+    // If it failed, use the original name instead.
+    if (status) {
+        exceptionName = "(mangled) "s + abi::__cxa_current_exception_type()->name();
+    }
+    return exceptionName;
+}
+
+
+void STerminateHandler(void) {
+    // Alert.
+    SALERT("Terminating with uncaught exception '" << SGetCurrentExceptionName() << "'.");
+
+    // And we're out.
+    abort();
+}

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2390,7 +2390,6 @@ string SGetCurrentExceptionName()
     return exceptionName;
 }
 
-
 void STerminateHandler(void) {
     // Alert.
     SALERT("Terminating with uncaught exception '" << SGetCurrentExceptionName() << "'.");

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -299,6 +299,10 @@ string SGetSignalDescription();
 // Clear all outstanding signals.
 void SClearSignals();
 
+// And also exception stuff.
+string SGetCurrentExceptionName();
+void STerminateHandler(void);
+
 // --------------------------------------------------------------------------
 // Log stuff
 // --------------------------------------------------------------------------

--- a/main.cpp
+++ b/main.cpp
@@ -289,6 +289,9 @@ int main(int argc, char* argv[]) {
         SASSERT(SFileExists(args["-db"]));
     }
 
+    // Log stack traces if we have unhandled exceptions.
+    set_terminate(STerminateHandler);
+
     // Keep going until someone kills it (either via TERM or Control^C)
     while (!(SGetSignal(SIGTERM) || SGetSignal(SIGINT))) {
         if (SGetSignals()) {


### PR DESCRIPTION
This will log the name of an exception before exiting. The standard terminate handler does this, but prints it to STDERR, which we don't capture.