### PR TITLE
For fire-and-forget commands, don't require master to respond to slaves

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1872,7 +1872,7 @@ void BedrockServer::_finishPeerCommand(BedrockCommand& command) {
     bool forget = it != command.request.nameValueMap.end() && SIEquals(it->second, "forget");
     command.finalizeTimingInfo();
     if (forget) {
-        SINFO("Not responding to 'forget' command '" << command.request.methodLine << "' to slave.");
+        SINFO("Not responding to 'forget' command '" << command.request.methodLine << "' from slave.");
     } else {
         auto _syncNodeCopy = _syncNode;
         if (_syncNodeCopy) {

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -87,7 +87,8 @@ class SQLiteNode : public STCPNode {
     // If we have a command that can't be handled on a slave, we can escalate it to the master node. The SQLiteNode
     // takes ownership of the command until it receives a response from the slave. When the command completes, it will
     // be re-queued in the SQLiteServer (_server), but its `complete` field will be set to true.
-    void escalateCommand(SQLiteCommand&& command);
+    // If the 'forget' flag is set, we will not expect a response from master for this command.
+    void escalateCommand(SQLiteCommand&& command, bool forget = false);
 
     // This takes a completed command and sends the response back to the originating peer. If we're not the master
     // node, or if this command doesn't have an `initiatingPeerID`, then calling this function is an error.

--- a/test/clustertest/tests/l_GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/l_GracefulFailoverTest.cpp
@@ -28,6 +28,11 @@ struct l_GracefulFailoverTest : tpunit::TestFixture {
                         if (i % 10 == 0) {
                             if (j % 5 == 0) {
                                 SData query("sendrequest" + randCommand);
+                                if (j % 15 == 0) {
+                                    // In this case, let's make them `Connection: forget` to make sure they're
+                                    // forgotten.
+                                    query["Connection"] = "forget";
+                                }
                                 query["writeConsistency"] = "ASYNC";
                                 query["senttonode"] = to_string(currentNodeIndex);
                                 query["clientID"] = to_string(i);


### PR DESCRIPTION
@coleaeason 

We fire-and-forget commands that we don't care about responses to (for instance, and especially `ScrapeCard`). We want the database to get updated with new data, but we don't need to give anything back to the client (we immediately a return a 202 in these cases).

However, when one of these commands is sent to a slave, it still follows the normal procedure of escalating it to master and waiting for master's response to it. This change extends the "fire and forget" behavior to escalations as well. I.e., a slave forgets about one of these commands once it's sent to master, and does not wait for a response. Correspondingly, master does not bother sending these responses back to slaves.

This is intended to fix a problem where shutting down a slave can timeout, because we're waiting on responses to slow commands (typically `ScrapeCard`) that we don't even care about. Master should already handle these slow commands, as it reduces all HTTPS timeouts to 5s when shutting down.

Tests were updated to send commands like this, and logs were watched to verify that we see the new loglines, while the tests still pass.