### PR TITLE
Demote log

### DIFF
--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -146,7 +146,7 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                     // peer->s->lastRecvTime is always set, it's initialized to STimeNow() at creation.
                     if (peer->s->lastRecvTime + recvTimeout < STimeNow()) {
                         // Reset and reconnect.
-                        SWARN("Connection with peer '" << peer->name << "' timed out.");
+                        SHMMM("Connection with peer '" << peer->name << "' timed out.");
                         STHROW("Timed Out!");
                     }
 


### PR DESCRIPTION
We warn first which creates a bug and then throw which creates another bug, which is totally unnecessary.

Fixes https://github.com/Expensify/Expensify/issues/73803
Fixes https://github.com/Expensify/Expensify/issues/73797
Fixes https://github.com/Expensify/Expensify/issues/73802