### PR TITLE
Further Shutdown Improvements

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1394,8 +1394,8 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
         if (!lastChance) {
             lastChance = STimeNow() + 5 * 1'000'000; // 5 seconds from now.
         }
-        // If we've run out of sockets or hit a timeout, we'll increment _shutdownState.
-        if ((lastChance && lastChance < STimeNow()) || _gracefulShutdownTimeout.ringing() || socketList.empty()) {
+        // If we've run out of sockets or hit our timeout, we'll increment _shutdownState.
+        if (socketList.empty() || _gracefulShutdownTimeout.ringing()) {
             lastChance = 0;
             _shutdownState.store(CLIENTS_RESPONDED);
         }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -907,8 +907,7 @@ void BedrockServer::worker(SData& args,
             }
         }
 
-        // Even if the sync thread is shut down, we still have work to do here, so we'll try another loop until we
-        // don't find any commands to process, or we hit the timeout.
+        // If we hit the timeout, doesn't matter if we've got work to do. Exit.
         if (server._gracefulShutdownTimeout.ringing()) {
             SINFO("_shutdownState is DONE and we've timed out, exiting worker.");
             return;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -94,9 +94,10 @@ class BedrockServer : public SQLiteServer {
     //
     // Notes on timing out a shutdown.
     // Here's how timing out a shutdown works:
-    // 1. When beginShutdown() is called, it sets a one minute timer. It proceeds to shut down the node as normal.
+    // 1. When _beginShutdown() is called, it sets a one minute timer. It proceeds to shut down the node as normal.
     // 2. When shutdown progresses far enough that we can shut down the sync node, we set the timeout for the sync node
-    // to whatever portion of our minute is remaining (minus 5 seconds, to allow for final cleanup afterward).
+    // to whatever portion of our minute is remaining (minus 5 seconds, to allow for final cleanup afterward - also, we
+    // make sure this value stays positive, so will always be at least 1us).
     // 3. The sync node should finish with at least 5 seconds left, and we should finish any final cleanup or responses
     // and shut down cleanly.
     //

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -208,6 +208,7 @@ class BedrockServer : public SQLiteServer {
 
     // The actual thread object for the sync thread.
     thread _syncThread;
+    atomic<bool> _syncThreadComplete;
 
     // Give all of our plugins a chance to verify and/or modify the database schema. This will run every time this node
     // becomes master. It will return true if the DB has changed and needs to be committed.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -91,6 +91,49 @@ class BedrockServer : public SQLiteServer {
     // can do about these, except not shut down. If we're standing down, we could keep them, but they break our
     // checking against whether the main command queue is empty, and fall into the same category of us being unable to
     // distinguish them from commands that may have already started.
+    //
+    // Notes on timing out a shutdown.
+    // Here's how timing out a shutdown works:
+    // 1. When beginShutdown() is called, it sets a one minute timer. It proceeds to shut down the node as normal.
+    // 2. When shutdown progresses far enough that we can shut down the sync node, we set the timeout for the sync node
+    // to whatever portion of our minute is remaining (minus 5 seconds, to allow for final cleanup afterward).
+    // 3. The sync node should finish with at least 5 seconds left, and we should finish any final cleanup or responses
+    // and shut down cleanly.
+    //
+    // However, if we do get to the end of our 1 minute timer, everything just starts exiting. Worker threads return,
+    // whether there's more work to do or not. The sync thread drops out of it's main loop and starts joining workers.
+    // This leaves us in a potentially broken state, and hitting the timeout should count as an error condition, but we
+    // need to support it for now. Here's the case that should look catastrophic, but is actually quite common, and what
+    // we should eventually do about it:
+    // 
+    // A slave begins shutdown, and sets a 60 second timeout. It has escalated commands to master. It wants to wait for
+    // the responses to these commands before it finishes shutting down, but *there is no timeout on escalated
+    // commands*. Normally, we won't try to shut down the sync node until we've responded to all connected clients.
+    // Because there will always be connected clients waiting for these responses to escalated commands, we'll wait the
+    // full 60 seconds, and then we'll just die with no responses. Effectively, the sever `kill -9`'s itself here,
+    // leaving clients hanging with no cleanup.
+    //
+    // On master, this state could be catastrophic, though master doesn't need to worry about a lack of timeouts on
+    // escalations, so let's look at a different case - a command running a custom query that takes longer than our 60
+    // second timeout. There will be a local client waiting for the response to this command, so the same criteria
+    // breaks - we can't shut down the sync thread until it's complete, but the command it's waiting for doesn't return
+    // until after our timeout. This is *after* everything just starts exiting, which is to say the sync node could
+    // have shut down due to hitting the timeout before a worker thread shut down performing a write command. This
+    // write will be orphaned, as the sync node will not be able to send it out, and this database is then forked.
+    //
+    // We can't safely start shutting down the sync node until we know that all possible writes are complete for this
+    // reason, but if we're going to enforce a timeout, then we need to.
+    //
+    // The only way to make this timeout safe is to make sure no individual command can live longer than our shutdown
+    // timeout, which would require time-stamping commands pre-escalation and giving up on them if we failed to receive
+    // a response in time, as well as making sure that commands always return in less time than that (they currently,
+    // usually will, as long as the default command timeout is less than one minute, but they can still block in system
+    // calls like sleep(), and the timeout is configurable). Certainly, no "normal" command (i.e., a programmatically
+    // generated command, as opposed to something like a CustomQuery command) should have a timeout longer than the
+    // shutdown timeout, or it can cause a non-graceful shutdown.
+    //
+    // Of course, if nothing can take longer than the shutdown timeout, then we should never hit that timeout, and all
+    // our failures should be limited to individual commands rather than the entire server shutting down.
 
     // Shutdown states.
     enum SHUTDOWN_STATE {

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -71,7 +71,8 @@ class SQLiteNode : public STCPNode {
     bool commitSucceeded() { return _commitState == CommitState::SUCCESS; }
 
     // Call this if you want to shut down the node.
-    void beginShutdown();
+    // Default timeout is 30 seconds.
+    void beginShutdown(uint64_t usToWait = 30'000'000);
 
     // Call this to check if the node's completed shutting down.
     bool shutdownComplete();

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -71,8 +71,7 @@ class SQLiteNode : public STCPNode {
     bool commitSucceeded() { return _commitState == CommitState::SUCCESS; }
 
     // Call this if you want to shut down the node.
-    // Default timeout is 30 seconds.
-    void beginShutdown(uint64_t usToWait = 30'000'000);
+    void beginShutdown(uint64_t usToWait);
 
     // Call this to check if the node's completed shutting down.
     bool shutdownComplete();

--- a/test/clustertest/tests/l_GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/l_GracefulFailoverTest.cpp
@@ -100,11 +100,15 @@ struct l_GracefulFailoverTest : tpunit::TestFixture {
         int success = false;
         while (count++ < 50) {
             SData cmd("Status");
-            string response = node->executeWaitVerifyContent(cmd);
-            STable json = SParseJSONObject(response);
-            if (json["state"] == state) {
-                success = true;
-                break;
+            try {
+                string response = node->executeWaitVerifyContent(cmd);
+                STable json = SParseJSONObject(response);
+                if (json["state"] == state) {
+                    success = true;
+                    break;
+                }
+            } catch (const SException& e) {
+                // Just try again.
             }
 
             // Give it another second...
@@ -117,11 +121,14 @@ struct l_GracefulFailoverTest : tpunit::TestFixture {
         BedrockTester* node = tester->getBedrockTester(nodeNumber);
         int count = 0;
         while (count++ < 50) {
-            SData cmd("Status");
-            string response = node->executeWaitVerifyContent(cmd);
-            STable json = SParseJSONObject(response);
-            return json[propName];
-
+            try {
+                SData cmd("Status");
+                string response = node->executeWaitVerifyContent(cmd);
+                STable json = SParseJSONObject(response);
+                return json[propName];
+            } catch (const SException& e) {
+                // Just try again.
+            }
             // Give it another second...
             sleep(1);
         }


### PR DESCRIPTION
This further cleans up bedrock's shutdown procedure and tries to make it more consistent. There are fewer different criteria and timers keeping track of a variety of different things.

1. `_gracefulShutdownTimeout` is the canonical timer for killing bedrock. If it times out, bedrock should stop.
2. The sync node's shutdown timeout is based on `_gracefulShutdownTimeout`. When we start shutting down the sync node, it's timeout is the remainder of `_gracefulShutdownTimeout`'s time left, minus five seconds for final cleanup.
3. The criteria for a `BedrockServer` having finished shutdown is that the sync thread has completed, not a complicated combination of other conditions.
4. `_gracefulShutdownTimeout`, now that it encompasses all other timers, has a 60s timeout.
5. When a slave sync node times out, it returns all escalated commands to the BedrockServer as `500 Abandoned` so that the server can accurately count the number of commands in progress.
6. The test were tweaked to provide more variety and reliability.
7. Another giant comment explaining timeouts was added. Essentially, timing out a shutdown is an error case and we should take steps to make it never happen.