### PR TITLE
Demote warning. This just indicates a client disconnected

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1488,7 +1488,7 @@ void BedrockServer::_reply(BedrockCommand& command) {
         _socketIDMap.erase(socketIt);
     }
     else if (!SIEquals(command.request["Connection"], "forget")) {
-        SWARN("No socket to reply for: '" << command.request.methodLine << "' #" << command.initiatingClientID);
+        SINFO("No socket to reply for: '" << command.request.methodLine << "' #" << command.initiatingClientID);
     }
     _commandsInProgress--;
 }


### PR DESCRIPTION
This is normal and happens if a client disconnects from bedrock while we're processing their command.

fixes: https://github.com/Expensify/Expensify/issues/76078