### PR TITLE
Don't do writes in 'Query' in noopUpdateMode

### DIFF
--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -109,6 +109,10 @@ bool BedrockPlugin_DB::processCommand(SQLite& db, BedrockCommand& command) {
 
     // ----------------------------------------------------------------------
     if (SIEquals(request.getVerb(), "Query")) {
+        if (db.getUpdateNoopMode()) {
+            SINFO("Query run in mocked request, just ignoring.");
+            return true;
+        }
         // - Query( query )
         //
         //     Executes a simple read/write query


### PR DESCRIPTION
Just skip these when using mocked requests.

fixes: https://github.com/Expensify/Expensify/issues/76409