### PR TITLE
Only warn that we failed to process a message if we have a message

### DIFF
--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -186,9 +186,12 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                         }
                     }
                 } catch (const SException& e) {
-                    // Error -- reconnect
-                    PWARN("Error processing message '" << message.methodLine << "' (" << e.what()
-                                                       << "), reconnecting:" << message.serialize());
+                    // Warn if the message is set. Otherwise, the error is that we got no message (we timed out), just
+                    // reconnect without complaining about it.
+                    if (message.methodLine.size()) {
+                        PWARN("Error processing message '" << message.methodLine << "' (" << e.what()
+                                                           << "), reconnecting:" << message.serialize());
+                    }
                     SData reconnect("RECONNECT");
                     reconnect["Reason"] = e.what();
                     peer->s->send(reconnect.serialize());


### PR DESCRIPTION
Fixes:
$ https://github.com/Expensify/Expensify/issues/73804
$ https://github.com/Expensify/Expensify/issues/73801
$ https://github.com/Expensify/Expensify/issues/73796


When we timeout talking to a peer, we get no message. All this indicates is that either the peer is down, or the network is down. Don't warn.