### PR TITLE
Make sure we generate a signal on assertions so we can trap bad commands

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -54,7 +54,6 @@ void SSetSignalHandlerDieFunc(function<void()>&& func);
     do {                                                                                                               \
         if (!(_LHS_)) {                                                                                                \
             SERROR("Assertion failed: (" << #_LHS_ << ") != true");                                                    \
-            abort();                                                                                                   \
         }                                                                                                              \
     } while (false)
 #define SASSERTEQUALS(_LHS_, _RHS_)                                                                                    \
@@ -347,7 +346,7 @@ void SLogStackTrace();
         SSYSLOG(LOG_ERR, "[eror] " << SLOGPREFIX << _MSG_);                                               \
         SLogStackTrace();                                                                                              \
         fflush(stdout);                                                                                                \
-        exit(1);                                                                                                       \
+        abort();                                                                                                       \
     } while (false)
 #define STRACE() SLOG("[trac] " << __FILE__ << "(" << __LINE__ << ") :" << __FUNCTION__)
 

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -74,6 +74,9 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
         int* i = 0;
         int x = *i;
         command.response["invalid"] = to_string(x);
+    } else if (SStartsWith(command.request.methodLine, "generateassertpeek")) {
+        SASSERT(0);
+        command.response["invalid"] = "nope";
     }
 
     return false;


### PR DESCRIPTION
fixes:
$ https://github.com/Expensify/Expensify/issues/77331

SERROR used to call `exit()` which doesn't generate a signal we can catch. Instead it now calls `abort()` which triggers the existing crash handling.

A new test is added to catch this case.