### PR TITLE
Fix replacing content in peek

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -46,6 +46,11 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
     STable& content = command.jsonContent;
     const string& requestVerb = request.getVerb();
 
+    // Reset the content object. It could have been written by a previous call to this function that conflicted in
+    // multi-write.
+    content.clear();
+    response.clear();
+
     // ----------------------------------------------------------------------
     if (SIEquals(requestVerb, "GetJob") || SIEquals(requestVerb, "GetJobs")) {
         // - GetJob( name )


### PR DESCRIPTION
@tylerkaraszewski please review. Resolves https://github.com/Expensify/Expensify/issues/76126, which I found tailing the logs during the webrock deploy today and then realized there was an issue for it. We're only clearing the content when we recall process, but not when we recall peek. For CreateJob we insert the jobID into the content in peek, and if we call peek a second time we end up replacing this content. 

## Tests
Existing