### PR TITLE
Number state changes to check for stale message responses.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1172,7 +1172,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 // **FIXME**: Should it also deny if it knows of a higher priority peer?
                 SData response("STANDUP_RESPONSE");
                 // Parrot back the node's attempt count so that it can differentiate stale responses.
-                response["AttemptCount"] = message["AttemptCount"];
+                response["StandupAttemptCount"] = message["StandupAttemptCount"];
                 if (peer->params["Permaslave"] == "true") {
                     // We think it's a permaslave, deny
                     PHMMM("Permaslave trying to stand up, denying.");
@@ -1271,8 +1271,8 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             // We only verify this if it's present, which allows us to still receive valid STANDUP_RESPONSE
             // messages from peers on older versions. Once all nodes have been upgraded past the first version that
             // supports this, we can enforce that this count is present.
-            if (message.isSet("AttemptCount") && message.calc("AttemptCount") != _standupAttempt) {
-                SHMMM("Received STANDUP_RESPONSE for old standup attempt (" << message.calc("AttemptCount") << "), ignoring.");
+            if (message.isSet("StandupAttemptCount") && message.calc("StandupAttemptCount") != _standupAttempt) {
+                SHMMM("Received STANDUP_RESPONSE for old standup attempt (" << message.calc("StandupAttemptCount") << "), ignoring.");
                 return;
             }
             if (!message.isSet("Response")) {
@@ -1998,7 +1998,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
         SData state("STATE");
         if (_state == STANDINGUP) {
             // If we're standing up, peers will need to know which attempt we're on.
-            state["AttemptCount"] = to_string(++_standupAttempt);
+            state["StandupAttemptCount"] = to_string(++_standupAttempt);
         }
         state["State"] = stateNames[_state];
         state["Priority"] = SToStr(_priority);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -201,4 +201,9 @@ class SQLiteNode : public STCPNode {
 
     // The server object to which we'll pass incoming escalated commands.
     SQLiteServer& _server;
+
+    // An integer indicating the sequential standup attempt for this node (i.e., 1 the first time this node tries to
+    // stand up as master). This is used to clarify standup responses and make sure they apply to the current attempt,
+    // rather than as late responses to old attempts to stand up.
+    int _standupAttempt;
 };

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -202,8 +202,8 @@ class SQLiteNode : public STCPNode {
     // The server object to which we'll pass incoming escalated commands.
     SQLiteServer& _server;
 
-    // An integer indicating the sequential standup attempt for this node (i.e., 1 the first time this node tries to
-    // stand up as master). This is used to clarify standup responses and make sure they apply to the current attempt,
-    // rather than as late responses to old attempts to stand up.
-    int _standupAttempt;
+    // This is an integer that increments every time we change states. This is useful for responses to state changes
+    // (i.e., approving standup) to verify that the messages we're receiving are relevant to the current state change,
+    // and not stale reponses to old changes.
+    int _stateChangeCount;
 };


### PR DESCRIPTION
@coleaeason 

This fixes the attached issue by number state messages so we can detect (and ignore) stale messages. The current code can actually use the wrong response to approve or deny STANDINGUP, which sounds dangerous (though doesn't seem common in practice).

Fixes:
$ https://github.com/Expensify/Expensify/issues/76039