### PR TITLE
Convert us timeouts to ms.

### DIFF
--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -5,7 +5,7 @@ class BedrockServer;
 
 class BedrockCore : public SQLiteCore {
   public:
-    const uint64_t DEFAULT_TIMEOUT = 30'000'000; // 30 seconds.
+    const uint64_t DEFAULT_TIMEOUT = 30'000; // 30 seconds.
     BedrockCore(SQLite& db, const BedrockServer& server);
 
     // Automatic timing class that records an entry corresponding to its lifespan.

--- a/test/clustertest/tests/TimeoutTest.cpp
+++ b/test/clustertest/tests/TimeoutTest.cpp
@@ -26,7 +26,7 @@ struct TimeoutTest : tpunit::TestFixture {
 
         // Run one long query.
         SData slow("slowquery");
-        slow["timeout"] = "5000000"; // 5s
+        slow["timeout"] = "5000"; // 5s
         brtester->executeWaitVerifyContent(slow, "555 Timeout peeking command");
 
         // And a bunch of faster ones.
@@ -42,7 +42,7 @@ struct TimeoutTest : tpunit::TestFixture {
 
         // Run one long query.
         SData slow("slowprocessquery");
-        slow["timeout"] = "500000"; // 0.5s
+        slow["timeout"] = "500"; // 0.5s
         slow["size"] = "1000000";
         slow["count"] = "1";
         brtester->executeWaitVerifyContent(slow, "555 Timeout processing command");


### PR DESCRIPTION
Fixes:
$ https://github.com/Expensify/Expensify/issues/77531

See also:
https://github.com/Expensify/Server-Expensify/pull/2644
https://github.com/Expensify/Web-Expensify/pull/20859

Only existing tests.