### PR TITLE
Allow repeating tests to more easily diagnose intermittent failures

### DIFF
--- a/test/clustertest/main.cpp
+++ b/test/clustertest/main.cpp
@@ -36,11 +36,16 @@ int main(int argc, char* argv[]) {
     list<string> before;
     list<string> after;
     int threads = 1;
+    int repeatCount = 1;
 
     if (args.isSet("-duplicateRequests")) {
         // Duplicate every request N times.
         cout << "Setting load testing to: " << SToInt(args["-duplicateRequests"]) << endl;
         BedrockTester::mockRequestMode = SToInt(args["-duplicateRequests"]);
+    }
+
+    if (args.isSet("-repeatCount")) {
+        repeatCount = max(1, SToInt(args["-repeatCount"]));
     }
 
     if (args.isSet("-only")) {
@@ -75,11 +80,13 @@ int main(int argc, char* argv[]) {
 
     int retval = 0;
     {
-        try {
-            retval = tpunit::Tests::run(include, exclude, before, after, threads);
-        } catch (...) {
-            cout << "Unhandled exception running tests!" << endl;
-            retval = 1;
+        for (int i = 0; i < repeatCount; i++) {
+            try {
+                retval = tpunit::Tests::run(include, exclude, before, after, threads);
+            } catch (...) {
+                cout << "Unhandled exception running tests!" << endl;
+                retval = 1;
+            }
         }
     }
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -29,6 +29,11 @@ int main(int argc, char* argv[]) {
     list<string> before;
     list<string> after;
     int threads = 1;
+    int repeatCount = 1;
+
+    if (args.isSet("-repeatCount")) {
+        repeatCount = max(1, SToInt(args["-repeatCount"]));
+    }
 
     if (args.isSet("-only")) {
         list<string> includeList = SParseList(args["-only"]);
@@ -82,11 +87,13 @@ int main(int argc, char* argv[]) {
     }
 
     int retval = 0;
-    try {
-        retval = tpunit::Tests::run(include, exclude, before, after, threads);
-    } catch (...) {
-        cout << "Unhandled exception running tests!" << endl;
-        retval = 1;
+    for (int i = 0; i < repeatCount; i++) {
+        try {
+            retval = tpunit::Tests::run(include, exclude, before, after, threads);
+        } catch (...) {
+            cout << "Unhandled exception running tests!" << endl;
+            retval = 1;
+        }
     }
 
     return retval;


### PR DESCRIPTION
The main point of this change is to be able to do:

```
gdb ./test
br SomethingTest.cpp:123
run -only Something -repeatCount 50
```

And the test will just repeat over and over again until an intermittent failure actually occurs and you hit your breakpoint.