### PR TITLE
Reconnecting doesn't deserve a warning.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2203,7 +2203,7 @@ void SQLiteNode::_reconnectPeer(Peer* peer) {
     // If we're connected, just kill the connection
     if (peer->s) {
         // Reset
-        SWARN("Reconnecting to '" << peer->name << "'");
+        SHMMM("Reconnecting to '" << peer->name << "'");
         shutdownSocket(peer->s);
         (*peer)["LoggedIn"] = "false";
     }


### PR DESCRIPTION
@coleaeason 

Normal networking events don't constitute warnings.

Fixes:
$ https://github.com/Expensify/Expensify/issues/77544