### PR TITLE
Tyler race condition

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1247,23 +1247,25 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
             break;
             case STCPManager::Socket::CONNECTED:
             {
-                // If we're shutting down and past our lastChance timeout, we start killing these.
-                SAUTOLOCK(_socketIDMutex);
-                if (_shutdownState.load() != RUNNING && lastChance && lastChance < STimeNow() && _socketIDMap.find(s->id) == _socketIDMap.end()) {
-                    SINFO("Closing socket " << s->id << " with no data and no pending command: shutting down.");
-                    socketsToClose.push_back(s);
-                } else if (s->recvBuffer.empty()) {
-                    // If nothing's been received, break early.
-                    break;
-                } else {
-                    // Otherwise, we'll see if there's any activity on this socket. Currently, we don't handle clients
-                    // pipelining requests well. We process commands in no particular order, so we can't dequeue two
-                    // requests off the same socket at one time, or we don't guarantee their return order, thus we just
-                    // wait and will try again later.
+                {
                     SAUTOLOCK(_socketIDMutex);
-                    auto socketIt = _socketIDMap.find(s->id);
-                    if (socketIt != _socketIDMap.end()) {
+                    // If we're shutting down and past our lastChance timeout, we start killing these.
+                    if (_shutdownState.load() != RUNNING && lastChance && lastChance < STimeNow() && _socketIDMap.find(s->id) == _socketIDMap.end()) {
+                        SINFO("Closing socket " << s->id << " with no data and no pending command: shutting down.");
+                        socketsToClose.push_back(s);
+                    } else if (s->recvBuffer.empty()) {
+                        // If nothing's been received, break early.
                         break;
+                    } else {
+                        // Otherwise, we'll see if there's any activity on this socket. Currently, we don't handle clients
+                        // pipelining requests well. We process commands in no particular order, so we can't dequeue two
+                        // requests off the same socket at one time, or we don't guarantee their return order, thus we just
+                        // wait and will try again later.
+                        SAUTOLOCK(_socketIDMutex);
+                        auto socketIt = _socketIDMap.find(s->id);
+                        if (socketIt != _socketIDMap.end()) {
+                            break;
+                        }
                     }
                 }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1082,6 +1082,7 @@ BedrockServer::~BedrockServer() {
         SWARN("Still have " << _socketIDMap.size() << " entries in _socketIDMap.");
     }
 
+    SAUTOLOCK(_socketIDMutex);
     for (list<Socket*>::iterator socketIt = socketList.begin(); socketIt != socketList.end();) {
         // Shut it down and go to the next (because closeSocket will invalidate this iterator otherwise)
         Socket* s = *socketIt++;
@@ -1380,6 +1381,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
 
     // Now we can close any sockets that we need to.
     for (auto s: socketsToClose) {
+        SAUTOLOCK(_socketIDMutex);
         closeSocket(s);
     }
 
@@ -1851,6 +1853,7 @@ void BedrockServer::_finishPeerCommand(BedrockCommand& command) {
 void BedrockServer::_acceptSockets() {
     Socket* s = nullptr;
     Port* acceptPort = nullptr;
+    SAUTOLOCK(_socketIDMutex);
     while ((s = acceptSocket(acceptPort))) {
         if (SContains(_portPluginMap, acceptPort)) {
             BedrockPlugin* plugin = _portPluginMap[acceptPort];

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1239,6 +1239,10 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     // them, and we'll stop accepting any new sockets, but if existing sockets just sit around giving us nothing, we
     // need to figure out some way to handle them. We'll wait 5 seconds and then start killing them.
     static uint64_t lastChance = 0;
+
+    // We don't lock on this access to socketList, because we're sure that only `main` can modify it. How do we know
+    // that? Because we only modify socketList by closing sockets, or accepting them (BedrockServer never calls
+    // openSocket). closeSocket and acceptSocket are only called by the main thread, in this function.
     for (auto s : socketList) {
         switch (s->state.load()) {
             case STCPManager::Socket::CLOSED:

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1078,7 +1078,6 @@ BedrockServer::~BedrockServer() {
 
     // Close any sockets that are still open. We wait until the sync thread has completed to do this, as until it's
     // finished, it may keep writing to these sockets.
-    SAUTOLOCK(_socketIDMutex);
     if (_socketIDMap.size()) {
         SWARN("Still have " << _socketIDMap.size() << " entries in _socketIDMap.");
     }
@@ -1386,7 +1385,6 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
 
     // Now we can close any sockets that we need to.
     for (auto s: socketsToClose) {
-        SAUTOLOCK(_socketIDMutex);
         closeSocket(s);
     }
 
@@ -1858,7 +1856,6 @@ void BedrockServer::_finishPeerCommand(BedrockCommand& command) {
 void BedrockServer::_acceptSockets() {
     Socket* s = nullptr;
     Port* acceptPort = nullptr;
-    SAUTOLOCK(_socketIDMutex);
     while ((s = acceptSocket(acceptPort))) {
         if (SContains(_portPluginMap, acceptPort)) {
             BedrockPlugin* plugin = _portPluginMap[acceptPort];

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1256,6 +1256,8 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 // If we're shutting down and past our lastChance timeout, we start killing these.
                 if (_shutdownState.load() != RUNNING && lastChance && lastChance < STimeNow() && _socketIDMap.find(s->id) == _socketIDMap.end()) {
                     SINFO("Closing socket " << s->id << " with no data and no pending command: shutting down.");
+                    SAUTOLOCK(_socketIDMutex);
+                    _socketIDMap.erase(s->id);
                     socketsToClose.push_back(s);
                 } else if (s->recvBuffer.empty()) {
                     // If nothing's been received, break early.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1238,10 +1238,6 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     // them, and we'll stop accepting any new sockets, but if existing sockets just sit around giving us nothing, we
     // need to figure out some way to handle them. We'll wait 5 seconds and then start killing them.
     static uint64_t lastChance = 0;
-
-    // We don't lock on this access to socketList, because we're sure that only `main` can modify it. How do we know
-    // that? Because we only modify socketList by closing sockets, or accepting them (BedrockServer never calls
-    // openSocket). closeSocket and acceptSocket are only called by the main thread, in this function.
     for (auto s : socketList) {
         switch (s->state.load()) {
             case STCPManager::Socket::CLOSED:

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1261,7 +1261,6 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                         // pipelining requests well. We process commands in no particular order, so we can't dequeue two
                         // requests off the same socket at one time, or we don't guarantee their return order, thus we just
                         // wait and will try again later.
-                        SAUTOLOCK(_socketIDMutex);
                         auto socketIt = _socketIDMap.find(s->id);
                         if (socketIt != _socketIDMap.end()) {
                             break;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -222,6 +222,8 @@ class BedrockServer : public SQLiteServer {
     map <uint64_t, Socket*> _socketIDMap;
 
     // The above _socketIDMap is modified by multiple threads, so we lock this mutex around operations that modify it.
+    // We also lockthis any time we modify the base class's `socketList` to make sure we can't try to respond to a
+    // socket that's been closed and deleted by another thread.
     recursive_mutex _socketIDMutex;
 
     // This is the replication state of the sync node. It's updated after every SQLiteNode::update() iteration. A


### PR DESCRIPTION
@coleaeason 

Fixes:
$ https://github.com/Expensify/Expensify/issues/77615

This adds a missing lock around accessing `_socketIDMap`. I'm not sure that this could have caused the issue we saw, but it's the only clear issue I see here. We could have removed an item from the map while we were running `find` on it, though I would have expected this to cause the threads doing `find` to crash, not the thread doing the removal.

If it were possible for this case to cause `_socketIDMap.find(s->id) == _socketIDMap.end()` to appear true for a socket where it shouldn't be, then we could end up deleting a socket that someone else should reply to, which would have the behavior we observed, though whether that would be possible is up to the implementation of `map::find`.

In either case, this bug should get fixed. If the issue recurs in the future, we can look into it again.