### PR TITLE
Remove incorrect state check

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -327,11 +327,6 @@ void BedrockServer::sync(SData& args,
         // If we started a commit, and one's not in progress, then we've finished it and we'll take that command and
         // stick it back in the appropriate queue.
         if (committingCommand && !server._syncNode->commitInProgress()) {
-            // It should be impossible to get here if we're not mastering or standing down.
-            if (nodeState != SQLiteNode::MASTERING && nodeState != SQLiteNode::STANDINGDOWN) {
-                SERROR("Committing command but node state is " << SQLiteNode::stateNames[nodeState]);
-            }
-
             // Record the time spent.
             command.stopTiming(BedrockCommand::COMMIT_SYNC);
 


### PR DESCRIPTION
@coleaeason 

Fixes:
$ https://github.com/Expensify/Expensify/issues/77656

This just removes a check for MASTERING or STANDINGDOWN when we have finished committing a transaction. It's actually possible, if the last update loop as we're standing down finishes the transaction, that the next time we hit this code path, the node has actually switched to SLAVING, but we should still send the last response from when we were mastering.