### PR TITLE
Actually check to see if we got any data.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1357,6 +1357,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                         }
                     }
                 } else {
+                    SAUTOLOCK(_socketIDMutex);
                     // If we weren't able to deserialize a complete request, and we're shutting down, give up.
                     if (_shutdownState.load() != RUNNING && lastChance && lastChance < STimeNow() && _socketIDMap.find(s->id) == _socketIDMap.end()) {
                         SINFO("Closing socket " << s->id << " with incomplete data and no pending command: shutting down.");


### PR DESCRIPTION
Fixes:
$ https://github.com/Expensify/Expensify/issues/78033
$ https://github.com/Expensify/Expensify/issues/78166

As the comment says:
```
SINFO("Closing socket " << s->id << " with no data and no pending command: shutting down.");
```

We're supposed to close sockets where we have no pending command and *no data received*, but we're not actually checking to see if we've received any data.

So, what would happen, is we'd hit this timeout code *with* new data, and we'd close the socket, but there was no `break` after closing the socket, so we'd proceed through the rest of the code, and create and queue a command from this, but the socket it would refer to would have been deleted, so when the command finished, it's try to reply to a deleted socket.

This change makes this only happen when there's no new data. It also adds handling for the case that there's *some* new data, but not enough to deserialize into a complete command.

However, this makes me think that we need to discard any commands that are late enough here. What happens if we deserialize a new write command after the sync node is shut down? I'll add handling for that as well.