### PR TITLE
Add onRecv to HTTPSManager base class

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -191,3 +191,9 @@ SHTTPSManager::Transaction* SHTTPSManager::_httpsSend(const string& url, const S
     _activeTransactionList.push_front(transaction);
     return transaction;
 }
+
+bool SHTTPSManager::_onRecv(Transaction* transaction)
+{
+    transaction->response = getHTTPResponseCode(transaction->fullResponse.methodLine);
+    return false;
+}

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -47,7 +47,7 @@ class SHTTPSManager : public STCPManager {
     // Methods
     Transaction* _httpsSend(const string& url, const SData& request);
     Transaction* _createErrorTransaction();
-    virtual bool _onRecv(Transaction* transaction) = 0;
+    virtual bool _onRecv(Transaction* transaction);
 
     list<Transaction*> _activeTransactionList;
     list<Transaction*> _completedTransactionList;


### PR DESCRIPTION
@tylerkaraszewski resolves https://github.com/Expensify/Server-Expensify/pull/2263#discussion_r186614034. Instead of repeating this code in every SHTTPSManager we can just have the base class do it. 