### PR TITLE
Make conflict constants configurable by control command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -735,7 +735,7 @@ void BedrockServer::worker(SData& args,
             }
 
             // We'll retry on conflict up to this many times.
-            int retry = 3;
+            int retry = server._maxConflictRetries.load();
 
             // We check first, and allow this command to retry all three times, even if it becomes disallowed during
             // iteration.
@@ -997,7 +997,7 @@ BedrockServer::BedrockServer(const SData& args)
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),
     _syncThreadComplete(false), _syncNode(nullptr), _suppressMultiWrite(true), _shutdownState(RUNNING),
     _multiWriteEnabled(args.test("-enableMultiWrite")), _backupOnShutdown(false), _detach(args.isSet("-bootstrap")),
-    _controlPort(nullptr), _commandPort(nullptr)
+    _controlPort(nullptr), _commandPort(nullptr), _maxConflictRetries(3)
 {
     _version = SVERSION;
 
@@ -1709,6 +1709,7 @@ bool BedrockServer::_isControlCommand(BedrockCommand& command) {
         SIEquals(command.request.methodLine, "ClearCrashCommands")     ||
         SIEquals(command.request.methodLine, "Detach")                 ||
         SIEquals(command.request.methodLine, "Attach")                 ||
+        SIEquals(command.request.methodLine, "SetConflictParams")      ||
         SIEquals(command.request.methodLine, "SetCheckpointIntervals")
         ) {
         return true;
@@ -1743,6 +1744,21 @@ void BedrockServer::_control(BedrockCommand& command) {
         }
         if (command.request.isSet("fullCheckpointPageMin")) {
             SQLite::fullCheckpointPageMin.store(command.request.calc("fullCheckpointPageMin"));
+        }
+    } else if (SIEquals(command.request.methodLine, "SetConflictParams")) {
+        if (command.request.isSet("MaxConflictRetries")) {
+            int retries = command.request.calc("MaxConflictRetries");
+            if (retries > 0 && retries <= 100) {
+                SINFO("Updating _maxConflictRetries to: " << retries);
+                _maxConflictRetries.store(retries);
+            }
+        }
+        if (command.request.isSet("AutoBlacklistConflictFraction")) {
+            float fraction = SToFloat(command.request["AutoBlacklistConflictFraction"]);
+            if (fraction > 0.001 && fraction <= 1.0) {
+                SINFO("Updating BedrockConflictMetrics::fraction to: " << fraction);
+                BedrockConflictMetrics::setFraction(fraction);
+            }
         }
     }
 }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -381,6 +381,9 @@ class BedrockServer : public SQLiteServer {
     Port* _controlPort;
     Port* _commandPort;
 
+    // The maximum number of conflicts we'll accept before forwarding a command to the sync thread.
+    atomic<int> _maxConflictRetries;
+
     // This is a map of HTTPS requests to the commands that contain them. We use this to quickly look up commands when
     // their HTTPS requests finish and move them back to the main queue.
     map<SHTTPSManager::Transaction*, BedrockCommand> _outstandingHTTPSRequests;


### PR DESCRIPTION
Tested by looking at new logs, which seem fine.

This will let us increase these values before (or during) the next load test to see if we see better offload.