### PR TITLE
Make the BedrockServer object long lived, fix attach/detach

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1569,10 +1569,6 @@ void BedrockServer::setDetach(bool detach) {
     }
 }
 
-void BedrockServer::resetBackupOnShutdown() {
-    _backupOnShutdown = false;
-}
-
 void BedrockServer::_status(BedrockCommand& command) {
     SData& request  = command.request;
     SData& response = command.response;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1565,10 +1565,6 @@ void BedrockServer::setDetach(bool detach) {
     if (detach) {
         _beginShutdown("Detach", true);
     } else {
-        // When the sync thread exits it sets this to true. However, since we
-        // aren't destroying the BedrockServer object anymore we need to make sure we reset it
-        // or else we will go into a shutdown loop we cannot get out of.
-        _syncThreadComplete.store(false);
         _detach = false;
     }
 }
@@ -1758,10 +1754,6 @@ void BedrockServer::_control(BedrockCommand& command) {
         _beginShutdown("Detach", true);
     } else if (SIEquals(command.request.methodLine, "Attach")) {
         response.methodLine = "204 ATTACHING";
-        // When the sync thread exits it sets this to true. However, since we
-        // aren't destroying the BedrockServer object anymore we need to make sure we reset it
-        // or else we will go into a shutdown loop we cannot get out of.
-        _syncThreadComplete.store(false);
         _detach = false;
     } else if (SIEquals(command.request.methodLine, "SetCheckpointIntervals")) {
         response["passiveCheckpointPageMin"] = to_string(SQLite::passiveCheckpointPageMin.load());

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -193,8 +193,8 @@ class BedrockServer : public SQLiteServer {
     // SQLiteNode in a STANDINGDOWN state to know that it can switch to searching.
     virtual bool canStandDown();
 
-    // Returns whether or not this server was configured to backup when it completed shutdown.
-    bool backupOnShutdown();
+    // Returns whether or not this server was configured to backup.
+    bool shouldBackup();
 
     // Returns a copy of the internal state of the sync node's peers. This can be empty if there are no peers, or no
     // sync node.
@@ -206,6 +206,9 @@ class BedrockServer : public SQLiteServer {
     // Set the detach state of the server. Setting to true will cause the server to detach from the database and go
     // into a sleep loop until this is called again with false
     void setDetach(bool detach);
+
+    // Returns if we are detached and the sync thread has exited.
+    bool isDetached();
 
   private:
     // The name of the sync thread.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -276,6 +276,9 @@ class BedrockServer : public SQLiteServer {
     void _prePollPlugins(fd_map& fdm);
     void _postPollPlugins(fd_map& fdm, uint64_t nextActivity);
 
+    // Resets the server state so when the sync node restarts it is as if the BedrockServer object was just created.
+    void _resetServer();
+
     // This is the function that launches the sync thread, which will bring up the SQLiteNode for this server, and then
     // start the worker threads.
     static void sync(SData& args,

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -207,9 +207,6 @@ class BedrockServer : public SQLiteServer {
     // into a sleep loop until this is called again with false
     void setDetach(bool detach);
 
-    // Reset the backup on shutdown variable back to false.
-    void resetBackupOnShutdown();
-
   private:
     // The name of the sync thread.
     static constexpr auto _syncThreadName = "sync";

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -207,6 +207,9 @@ class BedrockServer : public SQLiteServer {
     // into a sleep loop until this is called again with false
     void setDetach(bool detach);
 
+    // Reset the backup on shutdown variable back to false.
+    void resetBackupOnShutdown();
+
   private:
     // The name of the sync thread.
     static constexpr auto _syncThreadName = "sync";

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -379,8 +379,8 @@ class BedrockServer : public SQLiteServer {
     // Flag indicating whether multi-write is enabled.
     atomic<bool> _multiWriteEnabled;
 
-    // Set this to cause a backup to run when the server shuts down.
-    bool _backupOnShutdown;
+    // Set this to cause a backup to run in detached mode
+    bool _shouldBackup;
     atomic<bool> _detach;
 
     // Pointers to the ports on which we accept commands.

--- a/main.cpp
+++ b/main.cpp
@@ -310,7 +310,7 @@ int main(int argc, char* argv[]) {
 
         uint64_t nextActivity = STimeNow();
         while (!server.shutdownComplete()) {
-            if (server.backupOnShutdown()) {
+            if (server.shouldBackup() && server.isDetached()) {
                 BackupDB(args["-db"]);
                 server.setDetach(false);
             }

--- a/main.cpp
+++ b/main.cpp
@@ -297,6 +297,7 @@ int main(int argc, char* argv[]) {
 
     // Create our BedrockServer object so we can keep it for the life of the
     // program.
+    SINFO("Starting bedrock server");
     BedrockServer server(args);
 
     // Keep going until someone kills it (either via TERM or Control^C)
@@ -307,13 +308,11 @@ int main(int argc, char* argv[]) {
             SClearSignals();
         }
 
-        SINFO("Starting bedrock server");
         uint64_t nextActivity = STimeNow();
         while (!server.shutdownComplete()) {
             if (server.backupOnShutdown()) {
                 BackupDB(args["-db"]);
                 server.setDetach(false);
-                server.resetBackupOnShutdown();
             }
             // Wait and process
             fd_map fdm;
@@ -323,7 +322,6 @@ int main(int argc, char* argv[]) {
             nextActivity = STimeNow() + STIME_US_PER_S; // 1s max period
             server.postPoll(fdm, nextActivity);
         }
-        SINFO("Graceful bedrock shutdown complete");
         // Backup the main database on HUP signal.
         if (SGetSignal(SIGHUP)) {
             server.setDetach(true);

--- a/main.cpp
+++ b/main.cpp
@@ -322,12 +322,6 @@ int main(int argc, char* argv[]) {
             nextActivity = STimeNow() + STIME_US_PER_S; // 1s max period
             server.postPoll(fdm, nextActivity);
         }
-        // Backup the main database on HUP signal.
-        if (SGetSignal(SIGHUP)) {
-            server.setDetach(true);
-            BackupDB(args["-db"]);
-            server.setDetach(false);
-        }
     }
 
     // Log how much time we spent in our main mutex.


### PR DESCRIPTION
@tylerkaraszewski Please review. This PR makes it so that the BedrockServer object isn't destroyed until the binary terminates. This allows us to ensure the server object never goes away while a plugin is depending on it. It also fixes attach/detach, which is currently broken and only works because after we hit the remainder of the 60 second gracefulshutdown timeout we destroy and recreate the bedrock server. 

## Tests
Tested `BeginBackup`, `Detach`,`Attach`, and shutdown, all function as expected. 
