### PR TITLE
Allow plugins to prevent attaching

### DIFF
--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -61,12 +61,19 @@ void BedrockPlugin::initialize(const SData& args, BedrockServer& server) {}
 bool BedrockPlugin::peekCommand(SQLite& db, BedrockCommand& command) {
     return false;
 }
+
 bool BedrockPlugin::processCommand(SQLite& db, BedrockCommand& command) {
     return false;
 }
+
 bool BedrockPlugin::shouldSuppressTimeoutWarnings() {
     return false;
 }
+
+bool BedrockPlugin::preventAttach() {
+    return false;
+}
+
 void BedrockPlugin::timerFired(SStopwatch* timer) {}
 
 void BedrockPlugin::upgradeDatabase(SQLite& db) {}

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -87,6 +87,8 @@ class BedrockPlugin {
     // Set to true if we don't want to log timeout alerts, and let the caller deal with it.
     virtual bool shouldSuppressTimeoutWarnings();
 
+    virtual bool preventAttach();
+
   public:
     // A global static list of all registered plugins.
     static list<BedrockPlugin*>* g_registeredPluginList;

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -16,6 +16,10 @@ void BedrockPlugin_TestPlugin::initialize(const SData& args, BedrockServer& serv
     _server = &server;
 }
 
+bool BedrockPlugin_TestPlugin::preventAttach() {
+    return shouldPreventAttach;
+}
+
 bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) {
     if (command.request.calc("PeekSleep")) {
         usleep(command.request.calc("PeekSleep") * 1000);
@@ -77,6 +81,21 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
     } else if (SStartsWith(command.request.methodLine, "generateassertpeek")) {
         SASSERT(0);
         command.response["invalid"] = "nope";
+    } else if (SStartsWith(command.request.methodLine, "preventattach")) {
+        // We do all of this work in a thread because plugins don't poll in detached
+        // mode, so the tester will send this command to the plugin, then detach BedrockServer,
+        // then the tester will try to attach, sleep, then try again.
+        thread([this](){
+            // Have this plugin block attaching
+            shouldPreventAttach = true;
+
+            // Wait for the tester to try to attach
+            sleep(5);
+
+            // Reset so the tester can attach this time.
+            shouldPreventAttach = false;
+        }).detach();
+        return true;
     }
 
     return false;

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -18,6 +18,7 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
     BedrockPlugin_TestPlugin();
     void upgradeDatabase(SQLite& db);
     virtual string getName() { return "TestPlugin"; }
+    virtual bool preventAttach();
     void initialize(const SData& args, BedrockServer& server);
     bool peekCommand(SQLite& db, BedrockCommand& command);
     bool processCommand(SQLite& db, BedrockCommand& command);
@@ -25,4 +26,5 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
   private:
     TestHTTPSMananager httpsManager;
     BedrockServer* _server;
+    bool shouldPreventAttach = false;
 };


### PR DESCRIPTION
@tylerkaraszewski Please review. Allows plugins to prevent from reattacing to the db. This is needed to prevent race conditions inside of the new backup plugin, as well as to prevent callers from reattaching to a malformed database that is in the process of being restored, as well as modifying one that is being backed up.