### PR TITLE
Re-shuffle commands on conflict

### DIFF
--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -97,6 +97,14 @@ void BedrockCommandQueue::push(BedrockCommand&& item) {
     _queueCondition.notify_one();
 }
 
+void BedrockCommandQueue::requeue(BedrockCommand&& item) {
+    SAUTOLOCK(_queueMutex);
+    auto& queue = _commandQueue[item.priority];
+    item.startTiming(BedrockCommand::QUEUE_WORKER);
+    queue.emplace(STimeNow(), move(item));
+    _queueCondition.notify_one();
+}
+
 // This function currently never gets called. It's actually completely untested, so if you ever make any changes that
 // cause it to actually get called, you'll want to do that testing.
 bool BedrockCommandQueue::removeByID(const string& id) {

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -33,6 +33,9 @@ class BedrockCommandQueue {
     // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
     void push(BedrockCommand&& item);
 
+    // Like push, but assumes we want to use the current time rather than the original time for scheduling.
+    void requeue(BedrockCommand&& item);
+
     // Looks for a command with the given ID and removes it.
     // This will inspect every command in the case the command does not exist.
     bool removeByID(const string& id);


### PR DESCRIPTION
This re-queues commands in the main command queue after they've conflicted. The idea is to re-order a large command list so that conflicting commands are less likely to run in the same set of commands that caused them to conflict in the first place.

View with whitespace ignored.