### PR TITLE
Each jobs command is unique, so if the command causes a crash, we'll identify it on a unique random number

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -44,6 +44,10 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
     STable& content = command.jsonContent;
     const string& requestVerb = request.getVerb();
 
+    // Each command is unique, so if the command causes a crash, we'll identify it on a unique random number.
+    command.request["crashID"] = to_string(SRandom::rand64());
+    command.crashIdentifyingValues.insert("crashID");
+
     // Reset the content object. It could have been written by a previous call to this function that conflicted in
     // multi-write.
     content.clear();

--- a/test/clustertest/BedrockClusterTester.cpp
+++ b/test/clustertest/BedrockClusterTester.cpp
@@ -1,9 +1,9 @@
 #include "BedrockClusterTester.h"
 
-BedrockClusterTester::BedrockClusterTester(int threadID)
-  : BedrockClusterTester(THREE_NODE_CLUSTER, {"CREATE TABLE test (id INTEGER NOT NULL PRIMARY KEY, value TEXT NOT NULL)"}, threadID, {}, {}) {}
+BedrockClusterTester::BedrockClusterTester(int threadID, string pluginsToLoad)
+  : BedrockClusterTester(THREE_NODE_CLUSTER, {"CREATE TABLE test (id INTEGER NOT NULL PRIMARY KEY, value TEXT NOT NULL)"}, threadID, {}, {}, pluginsToLoad) {}
 
-BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize size, list<string> queries, int threadID, map<string, string> _args, list<string> uniquePorts)
+BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize size, list<string> queries, int threadID, map<string, string> _args, list<string> uniquePorts, string pluginsToLoad)
 : _size(size)
 {
     // Make sure we won't re-allocate.
@@ -77,7 +77,7 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
             {"-priority",    priority},
             {"-nodeName",    nodeName},
             {"-peerList",    peerString},
-            {"-plugins",     "db,cache,jobs," + string(cwd) + "/testplugin/testplugin.so"},
+            {"-plugins",     pluginsToLoad + "," + string(cwd) + "/testplugin/testplugin.so"},
             {"-overrideProcessName", "bedrock" + to_string(nodePort)},
         };
 

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -10,8 +10,9 @@ class BedrockClusterTester {
 
     // Creates a cluster of the given size and brings up all the nodes. The nodes will have priority in the order of
     // their creation (i.e., node 0 is highest priority and will become master.
-    BedrockClusterTester(ClusterSize size, list<string> queries = {}, int threadID = 0, map<string, string> _args = {}, list<string> uniquePorts = {});
-    BedrockClusterTester(int threadID);
+    // You can also specify plugins to load if for some reason you need to override the default configuration.
+    BedrockClusterTester(ClusterSize size, list<string> queries = {}, int threadID = 0, map<string, string> _args = {}, list<string> uniquePorts = {}, string pluginsToLoad = "db,cache,jobs");
+    BedrockClusterTester(int threadID, string pluginsToLoad = "db,cache,jobs");
     ~BedrockClusterTester();
 
     // Returns the index of the node that's mastering. Returns a negative number on error:

--- a/test/clustertest/tests/BadCommandTest.cpp
+++ b/test/clustertest/tests/BadCommandTest.cpp
@@ -11,7 +11,7 @@ struct BadCommandTest : tpunit::TestFixture {
     BedrockClusterTester* tester;
 
     void setup() {
-        tester = new BedrockClusterTester(_threadID);
+        tester = new BedrockClusterTester(_threadID, "");
     }
 
     void teardown() {


### PR DESCRIPTION
@tylerkaraszewski please review

$ https://github.com/Expensify/Expensify/issues/78808

Not tested 