### PR TITLE
Allow setting blacklist conflict rate via command line.

### DIFF
--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -89,19 +89,11 @@ list<string> BedrockCommandQueue::getRequestMethodLines() {
     return returnVal;
 }
 
-void BedrockCommandQueue::push(BedrockCommand&& item) {
+void BedrockCommandQueue::push(BedrockCommand&& item, bool useCurrentTime) {
     SAUTOLOCK(_queueMutex);
     auto& queue = _commandQueue[item.priority];
     item.startTiming(BedrockCommand::QUEUE_WORKER);
-    queue.emplace(item.request.calcU64("commandExecuteTime"), move(item));
-    _queueCondition.notify_one();
-}
-
-void BedrockCommandQueue::requeue(BedrockCommand&& item) {
-    SAUTOLOCK(_queueMutex);
-    auto& queue = _commandQueue[item.priority];
-    item.startTiming(BedrockCommand::QUEUE_WORKER);
-    queue.emplace(STimeNow(), move(item));
+    queue.emplace(useCurrentTime ? STimeNow() : item.request.calcU64("commandExecuteTime"), move(item));
     _queueCondition.notify_one();
 }
 

--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -97,6 +97,14 @@ void BedrockCommandQueue::push(BedrockCommand&& item) {
     _queueCondition.notify_one();
 }
 
+void BedrockCommandQueue::requeue(BedrockCommand&& item) {
+    SAUTOLOCK(_queueMutex);
+    auto& queue = _commandQueue[item.priority];
+    item.startTiming(BedrockCommand::QUEUE_WORKER);
+    queue.emplace(STimeNow(), move(item));
+    _queueCondition.notify_one();
+}
+
 // This function currently never gets called. It's actually completely untested, so if you ever make any changes that
 // cause it to actually get called, you'll want to do that testing.
 bool BedrockCommandQueue::removeByID(const string& id) {

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -32,7 +32,7 @@ class BedrockCommandQueue {
 
     // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
     // useCurrentTime will schedule the command for now, instead of for when it was originally created. This is useful
-    // for res-scheduling conflciting commands without pushing them to the front of the queue.
+    // for re-scheduling conflicting commands without pushing them to the front of the queue.
     void push(BedrockCommand&& item, bool useCurrentTime = false);
 
     // Looks for a command with the given ID and removes it.

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -31,10 +31,9 @@ class BedrockCommandQueue {
     list<string> getRequestMethodLines();
 
     // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
-    void push(BedrockCommand&& item);
-
-    // Like push, but assumes we want to use the current time rather than the original time for scheduling.
-    void requeue(BedrockCommand&& item);
+    // useCurrentTime will schedule the command for now, instead of for when it was originally created. This is useful
+    // for res-scheduling conflciting commands without pushing them to the front of the queue.
+    void push(BedrockCommand&& item, bool useCurrentTime = false);
 
     // Looks for a command with the given ID and removes it.
     // This will inspect every command in the case the command does not exist.

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -33,6 +33,9 @@ class BedrockCommandQueue {
     // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
     void push(BedrockCommand&& item);
 
+    // Like push, but assumes we want to use the current time rather than the original time for scheduling.
+    void requeue(BedrockCommand&& item);
+
     // Looks for a command with the given ID and removes it.
     // This will inspect every command in the case the command does not exist.
     bool removeByID(const string& id);

--- a/BedrockConflictMetrics.cpp
+++ b/BedrockConflictMetrics.cpp
@@ -1,10 +1,11 @@
 #include "BedrockConflictMetrics.h"
 
 // Initialize non-const static variables.
+const double DEFAULT_FRAC = 0.10;
 recursive_mutex BedrockConflictMetrics::_mutex;
 map<string, BedrockConflictMetrics> BedrockConflictMetrics::_conflictInfoMap;
-double BedrockConflictMetrics::_fraction = 0.10;
-int BedrockConflictMetrics::_threshold = _fraction * COMMAND_COUNT;
+atomic<double> BedrockConflictMetrics::_fraction(DEFAULT_FRAC);
+atomic<int> BedrockConflictMetrics::_threshold(DEFAULT_FRAC * COMMAND_COUNT);
 
 BedrockConflictMetrics::BedrockConflictMetrics(const string& commandName) :
 _commandName(commandName)
@@ -116,4 +117,8 @@ void BedrockConflictMetrics::setFraction(double fraction) {
         _threshold = _fraction * COMMAND_COUNT;
         SINFO("Multi-write conflict limit fraction set to " << _fraction << ".");
     }
+}
+
+double BedrockConflictMetrics::getFraction() {
+    return _fraction;
 }

--- a/BedrockConflictMetrics.h
+++ b/BedrockConflictMetrics.h
@@ -33,6 +33,9 @@ public:
     // Change the fraction of commands required to decide that multiWriteOK will return false.
     static void setFraction(double fraction);
 
+    // Return the current value of _fraction;
+    static double getFraction();
+
 private:
     // The number of most recent commands to keep track of the results from.
     static constexpr int COMMAND_COUNT = 100;
@@ -63,9 +66,9 @@ private:
 
     // The fraction of commands of a given name that are allowed to conflict before we decide the sync thread will
     // process them all.
-    static double _fraction;
+    static atomic<double> _fraction;
 
     // The count of conflicts of the last BedrockConflictMetrics::COMMAND_COUNT commands that we'll allow to have failed
     // before we decide that this command needs to be executed on the sync thread.
-    static int _threshold;
+    static atomic<int> _threshold;
 };

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1038,6 +1038,11 @@ BedrockServer::BedrockServer(const SData& args)
         _version = SComposeList(versionStrings, ":");
     }
 
+    // Allow setting a blacklist fraction at startup.
+    if (args.isSet("-autoBlacklistConflictFraction")) {
+        BedrockConflictMetrics::setFraction(stod(args["-autoBlacklistConflictFraction"]));
+    }
+
     // Check for commands that will be forced to use QUORUM write consistency.
     if (args.isSet("-synchronousCommands")) {
         list<string> syncCommands;
@@ -1773,6 +1778,9 @@ void BedrockServer::_control(BedrockCommand& command) {
                 BedrockConflictMetrics::setFraction(fraction);
             }
         }
+
+        command.response["AutoBlacklistConflictFraction"] = to_string(BedrockConflictMetrics::getFraction());
+        command.response["MaxConflictRetries"] = to_string(_maxConflictRetries.load());
     }
 }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -891,7 +891,7 @@ void BedrockServer::worker(SData& args,
             } else if (command.processCount < server._maxConflictRetries.load()) {
                 SINFO("requeueing command " << command.request.methodLine << " in main queue with "
                       << server._commandQueue.size() << " commands.");
-                server._commandQueue.requeue(move(command));
+                server._commandQueue.push(move(command), true);
             } else {
                 BedrockConflictMetrics::recordConflict(command.request.methodLine);
                 SINFO("[performance] Max retries hit in worker, forwarding command " << command.request.methodLine

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -737,6 +737,9 @@ void BedrockServer::worker(SData& args,
             // iteration.
             bool multiWriteOK = BedrockConflictMetrics::multiWriteOK(command.request.methodLine);
 
+            // Block if a checkpoint is happening so we don't interrupt it.
+            db.waitForCheckpoint();
+
             // If the command doesn't already have an httpsRequest from a previous peek attempt, try peeking it
             // now. We don't duplicate peeks for commands that make https requests.
             // If peek succeeds, then it's finished, and all we need to do is respond to the command at the bottom.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -762,6 +762,7 @@ void BedrockServer::worker(SData& args,
                         command.response.methodLine = "500 STANDDOWN TIMEOUT";
                         server._reply(command);
                         core.rollback();
+                        continue;
                     }
 
                     // If the command isn't complete, we'll move it into our map of outstanding HTTPS requests.


### PR DESCRIPTION
This adds a new command line parameter for the conflict auto-blacklist fraction.

Tested by starting bedrock with the new parameter and sending it this command:
```
SetConflictParams

200 OK
AutoBlacklistConflictFraction: 0.990000
MaxConflictRetries: 3
nodeName: bedrock
totalTime: 48
unaccountedTime: 48
Content-Length: 0
```

This also adds `AutoBlacklistConflictFraction` and `MaxConflictRetries` to the output of SetConflictParams.