### PR TITLE
Add command line parameter, make control command return current values

### DIFF
--- a/BedrockConflictMetrics.cpp
+++ b/BedrockConflictMetrics.cpp
@@ -1,10 +1,11 @@
 #include "BedrockConflictMetrics.h"
 
 // Initialize non-const static variables.
+const double DEFAULT_FRAC = 0.10;
 recursive_mutex BedrockConflictMetrics::_mutex;
 map<string, BedrockConflictMetrics> BedrockConflictMetrics::_conflictInfoMap;
-double BedrockConflictMetrics::_fraction = 0.10;
-int BedrockConflictMetrics::_threshold = _fraction * COMMAND_COUNT;
+atomic<double> BedrockConflictMetrics::_fraction(DEFAULT_FRAC);
+atomic<int> BedrockConflictMetrics::_threshold(DEFAULT_FRAC * COMMAND_COUNT);
 
 BedrockConflictMetrics::BedrockConflictMetrics(const string& commandName) :
 _commandName(commandName)
@@ -116,4 +117,8 @@ void BedrockConflictMetrics::setFraction(double fraction) {
         _threshold = _fraction * COMMAND_COUNT;
         SINFO("Multi-write conflict limit fraction set to " << _fraction << ".");
     }
+}
+
+double BedrockConflictMetrics::getFraction() {
+    return _fraction;
 }

--- a/BedrockConflictMetrics.h
+++ b/BedrockConflictMetrics.h
@@ -33,6 +33,9 @@ public:
     // Change the fraction of commands required to decide that multiWriteOK will return false.
     static void setFraction(double fraction);
 
+    // Return the current value of _fraction;
+    static double getFraction();
+
 private:
     // The number of most recent commands to keep track of the results from.
     static constexpr int COMMAND_COUNT = 100;
@@ -63,9 +66,9 @@ private:
 
     // The fraction of commands of a given name that are allowed to conflict before we decide the sync thread will
     // process them all.
-    static double _fraction;
+    static atomic<double> _fraction;
 
     // The count of conflicts of the last BedrockConflictMetrics::COMMAND_COUNT commands that we'll allow to have failed
     // before we decide that this command needs to be executed on the sync thread.
-    static int _threshold;
+    static atomic<int> _threshold;
 };

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1047,6 +1047,11 @@ BedrockServer::BedrockServer(const SData& args)
         _version = SComposeList(versionStrings, ":");
     }
 
+    // Allow setting a blacklist fraction at startup.
+    if (args.isSet("-autoBlacklistConflictFraction")) {
+        BedrockConflictMetrics::setFraction(stod(args["-autoBlacklistConflictFraction"]));
+    }
+
     // Check for commands that will be forced to use QUORUM write consistency.
     if (args.isSet("-synchronousCommands")) {
         list<string> syncCommands;
@@ -1782,6 +1787,9 @@ void BedrockServer::_control(BedrockCommand& command) {
                 BedrockConflictMetrics::setFraction(fraction);
             }
         }
+
+        command.response["AutoBlacklistConflictFraction"] = to_string(BedrockConflictMetrics::getFraction());
+        command.response["MaxConflictRetries"] = to_string(_maxConflictRetries.load());
     }
 }
 


### PR DESCRIPTION
This adds a new command line parameter for the conflict auto-blacklist fraction.

Tested by starting bedrock with the new parameter and sending it this command:
```
SetConflictParams

200 OK
AutoBlacklistConflictFraction: 0.990000
MaxConflictRetries: 3
nodeName: bedrock
totalTime: 48
unaccountedTime: 48
Content-Length: 0
```

This also adds `AutoBlacklistConflictFraction` and `MaxConflictRetries` to the output of SetConflictParams.