### PR TITLE
Add error checking and logging for strange mockRequest cases

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -504,7 +504,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             int64_t parentJobID = SContains(job, "parentJobID") ? SToInt(job["parentJobID"]) : 0;
             if (parentJobID) {
                 SQResult result;
-                if (!db.read("SELECT state, parentJobID FROM jobs WHERE jobID=" + SQ(parentJobID) + ";", result)) {
+                if (!db.read("SELECT state, parentJobID, data FROM jobs WHERE jobID=" + SQ(parentJobID) + ";", result)) {
                     STHROW("502 Select failed");
                 }
                 if (result.empty()) {
@@ -513,6 +513,12 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 if (!SIEquals(result[0][0], "RUNNING") && !SIEquals(result[0][0], "PAUSED")) {
                     SWARN("Trying to create child job with parent jobID#" << parentJobID << ", but parent isn't RUNNING or PAUSED (" << result[0][0] << ")");
                     STHROW("405 Can only create child job when parent is RUNNING or PAUSED");
+                }
+
+                // Verify that the parent and child job have the same `mockRequest` setting.
+                STable parentData = SParseJSONObject(result[0][2]);
+                if (command.request.isSet("mockRequest") != (parentData.find("mockRequest") != parentData.end())) {
+                    STHROW("405 Parent and child jobs must have matching mockRequest setting");
                 }
 
                 // Prevent jobs from creating grandchildren
@@ -861,7 +867,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
 
         // Verify there is a job like this and it's running
         SQResult result;
-        if (!db.read("SELECT state, nextRun, lastRun, repeat, parentJobID, json_extract(data, '$.mockRequest') "
+        if (!db.read("SELECT state, nextRun, lastRun, repeat, parentJobID, json_extract(data, '$.mockRequest'), data "
                      "FROM jobs "
                      "WHERE jobID=" + SQ(jobID) + ";",
                      result)) {
@@ -877,6 +883,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         string repeat = result[0][3];
         int64_t parentJobID = SToInt(result[0][4]);
         bool mockRequest = result[0][5] == "1";
+        const string& existingData = result[0][6];
 
         // Make sure we're finishing a job that's actually running
         if (state != "RUNNING" && state != "RUNQUEUED" && !mockRequest) {
@@ -904,6 +911,32 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         // If we've been asked to update the data, let's do that
         auto data = request["data"];
         if (!data.empty()) {
+
+            // See if the existing data was from a mockRequest.
+            STable oldData;
+            bool oldMocked = false;
+            if (!existingData.empty()) {
+                oldData = SParseJSONObject(existingData);
+                oldMocked = oldData.find("mockRequest") != oldData.end();
+            }
+
+            // And the new data.
+            STable newData = SParseJSONObject(data);
+            bool newMocked = newData.find("mockRequest") != newData.end();
+
+            // Make sure these match each other and the request object or don't do an update.
+            if (oldMocked != newMocked) {
+                SWARN("Not updating mockRequest field of job data.");
+                STHROW("500 Mock Mismatch");
+            }
+            if (newMocked != command.request.isSet("mockRequest")) {
+                SWARN("mockRequest field in job data does not match request header.");
+                STHROW("500 Mock Mismatch");
+            }
+
+            // Note that if `mockRequest` is set for this request, the following is a noop, so it would be impossible
+            // to corrupt this value with `mockRequest` set. To make any changes, we'd have to hit this code on a
+            // non-mock request.
             if (!db.writeIdempotent("UPDATE jobs SET data=" + SQ(data) + " WHERE jobID=" + SQ(jobID) + ";")) {
                 STHROW("502 Failed to update job data");
             }


### PR DESCRIPTION
@iwiznia please review.

This is to try and address:
https://github.com/Expensify/Expensify/issues/78304

This will prevent us adding child jobs to a parent job unless they have the same `mockRequest` state, and will prevent updating the job `data` if the `mockRequest` state doesn't match the existing one.

It may not fix the issue, but should at least help narrow it down if it is actually related to mockRequest, and if so, may prevent it from causing further problems, and let us diagnose the underlying cause. Once that's figured out, we can probably revert this change.