### PR TITLE
Automatically add requestIDs to commands that lack them

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -437,4 +437,6 @@ class BedrockServer : public SQLiteServer {
 
     // Generate a CRASH_COMMAND command for a given bad command.
     static SData _generateCrashMessage(const BedrockCommand* command);
+
+    static void _addRequestID(SData& request);
 };


### PR DESCRIPTION
@flodnv 

Adds requestIDs to any commands that don't have one, for easier tracking in the logs.

Tested by watching logs for the `BillCustomers` command, which historically would not set this value.