### PR TITLE
Defer lock till after setting up socket

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -56,8 +56,7 @@ int SHTTPSManager::getHTTPResponseCode(const string& methodLine) {
 
 SHTTPSManager::Socket* SHTTPSManager::openSocket(const string& host, SX509* x509) {
     // Just call the base class function but in a thread-safe way.
-    SAUTOLOCK(_listMutex);
-    return STCPManager::openSocket(host, x509);
+    return STCPManager::openSocket(host, x509, &_listMutex);
 }
 
 void SHTTPSManager::closeSocket(Socket* socket) {

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -52,7 +52,7 @@ struct STCPManager {
     void postPoll(fd_map& fdm);
 
     // Opens outgoing socket
-    Socket* openSocket(const string& host, SX509* x509 = nullptr);
+    Socket* openSocket(const string& host, SX509* x509 = nullptr, recursive_mutex* listMutexPtr = nullptr);
 
     // Gracefully shuts down a socket
     void shutdownSocket(Socket* socket, int how = SHUT_RDWR);


### PR DESCRIPTION
Defers locking the transaction list until *after* we've set up the required socket. This includes a DNS lookup and a `connect` which is SUPER SLOW.

Tests: only existing tests.