### PR TITLE
Add better logging for DNS issues.

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1579,14 +1579,10 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking) {
             // There was a problem.
             if (result || !resolved) {
                 freeaddrinfo(resolved);
-                STHROW("can't resolve host error:" << strerror(result));
+                STHROW("can't resolve host error no#" + result);
             }
 
-            // Note if this seems slow.
-            uint64_t elapsed = STimeNow() - start;
-            if (elapsed > 100 * 1000) {
-                SWARN("Slow DNS lookup. " << elapsed / 1000 << "ms for '" << domain << "'.");
-            }
+            SINFO("DNS lookup took " << STimeNow() - start / 1000 << "ms for '" << domain << "'.");
 
             // Grab the resolved address.
             sockaddr_in* addr = (sockaddr_in*)resolved->ai_addr;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1579,7 +1579,7 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking) {
             // There was a problem.
             if (result || !resolved) {
                 freeaddrinfo(resolved);
-                STHROW("can't resolve host");
+                STHROW("can't resolve host error:" << strerror(result));
             }
 
             // Note if this seems slow.

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1575,15 +1575,13 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking) {
 
             // Do the initialization.
             int result = getaddrinfo(domain.c_str(), to_string(port).c_str(), &hints, &resolved);
+            SINFO("DNS lookup took " << STimeNow() - start / 1000 << "ms for '" << domain << "'.");
 
             // There was a problem.
             if (result || !resolved) {
                 freeaddrinfo(resolved);
                 STHROW("can't resolve host error no#" + result);
             }
-
-            SINFO("DNS lookup took " << STimeNow() - start / 1000 << "ms for '" << domain << "'.");
-
             // Grab the resolved address.
             sockaddr_in* addr = (sockaddr_in*)resolved->ai_addr;
             ip = addr->sin_addr.s_addr;


### PR DESCRIPTION
@tylerkaraszewski please review. Adds logging of the error returned when we fail a DNS look up, and always logs the time taken to do a dns look up instead of just when it's slow. 