### PR TITLE
Fix underflow in DNS logging

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1575,7 +1575,7 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking) {
 
             // Do the initialization.
             int result = getaddrinfo(domain.c_str(), to_string(port).c_str(), &hints, &resolved);
-            SINFO("DNS lookup took " << STimeNow() - start / 1000 << "ms for '" << domain << "'.");
+            SINFO("DNS lookup took " << STimeNow() - start << "us for '" << domain << "'.");
 
             // There was a problem.
             if (result || !resolved) {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1575,7 +1575,7 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking) {
 
             // Do the initialization.
             int result = getaddrinfo(domain.c_str(), to_string(port).c_str(), &hints, &resolved);
-            SINFO("DNS lookup took " << STimeNow() - start << "us for '" << domain << "'.");
+            SINFO("DNS lookup took " << (STimeNow() - start) / 1000 << "ms for '" << domain << "'.");
 
             // There was a problem.
             if (result || !resolved) {


### PR DESCRIPTION
@tylerkaraszewski please review. this is underflowing creating weird log lines like this:
```
2018-06-19T23:19:15.204766+00:00 db3.la bedrock: xxxxxx (libstuff.cpp:1578) S_socket [downloadWorker65] [info] DNS lookup took 1527920904849521ms for 's3.amazonaws.com'.
```