### PR TITLE
Decrement counter on discarded command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -654,6 +654,7 @@ void BedrockServer::worker(SData& args,
                 if (server._shutdownState.load() != RUNNING) {
                     SWARN("Sync thread shut down while were waiting for it to come up. Discarding command '"
                           << command.request.methodLine << "'.");
+                    server._commandsInProgress--;
                     return;
                 }
 


### PR DESCRIPTION
@coleaeason please review

Fixes: https://github.com/Expensify/Expensify/issues/79218

Fixes a weird edge case where we discard a command that we would have processed because the server started shutting down from a non-mastering/slaving state but neglected to decrement the count of commands.