### PR TITLE
Add logging around probable deadlock in sqlite destructor

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -314,7 +314,9 @@ string SQLite::_getJournalTableName(int journalTableID) {
 
 SQLite::~SQLite() {
     // Lock around changes to the global shared list.
+    SINFO("Locking g_commitLock in destructor.");
     SQLITE_COMMIT_AUTOLOCK;
+    SINFO("g_commitLock acquired in destructor.");
     
     // Remove ourself from the list of valid objects.
     _sharedData->validObjects.erase(this);
@@ -329,7 +331,9 @@ SQLite::~SQLite() {
     // Now we can clean up our own data.
     // First, rollback any incomplete transaction.
     if (!_uncommittedQuery.empty()) {
+        SINFO("Rolling back in destructor.");
         rollback();
+        SINFO("Rollback in destructor complete.");
     }
 
     // Finally, Close the DB.


### PR DESCRIPTION
This is an attempt to get more information about what's going on for this issue:
https://github.com/Expensify/Expensify/issues/82643

Just adds logging.