### PR TITLE
Allow exiting from a detached state

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1110,6 +1110,9 @@ BedrockServer::~BedrockServer() {
 
 bool BedrockServer::shutdownComplete() {
     if (_detach) {
+        if (shutdownWhileDetached) {
+            return true;
+        }
         // We don't want main() to stop calling `poll` for us, we are listening on the control port.
         return false;
     }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -93,6 +93,10 @@ void BedrockServer::syncWrapper(SData& args,
             SINFO("Bedrock server entering detached state.");
             server._shutdownState.store(RUNNING);
             while (server._detach) {
+                if (server.shutdownWhileDetached) {
+                    SINFO("Bedrock server exiting from detached state.");
+                    return;
+                }
                 // Just wait until we're attached.
                 SINFO("Bedrock server sleeping in detached state.");
                 sleep(1);
@@ -995,7 +999,7 @@ void BedrockServer::_resetServer() {
 }
 
 BedrockServer::BedrockServer(const SData& args)
-  : SQLiteServer(""), _args(args), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
+  : SQLiteServer(""), shutdownWhileDetached(false), _args(args), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),
     _syncThreadComplete(false), _syncNode(nullptr), _suppressMultiWrite(true), _shutdownState(RUNNING),
     _multiWriteEnabled(args.test("-enableMultiWrite")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -210,6 +210,11 @@ class BedrockServer : public SQLiteServer {
     // Returns if we are detached and the sync thread has exited.
     bool isDetached();
 
+    // If you want to exit from the detached state, set this to true and the server will exit after the next loop.
+    // It has no effect when not detached (except that it will cause the server to exit immediately upon becoming
+    // detached), and shouldn't need to be reset, because the server exits immediately upon seeing this.
+    atomic<bool> shutdownWhileDetached;
+
   private:
     // The name of the sync thread.
     static constexpr auto _syncThreadName = "sync";

--- a/main.cpp
+++ b/main.cpp
@@ -322,6 +322,10 @@ int main(int argc, char* argv[]) {
             nextActivity = STimeNow() + STIME_US_PER_S; // 1s max period
             server.postPoll(fdm, nextActivity);
         }
+        if (server.shutdownWhileDetached) {
+            // We need to actually shut down here.
+            break;
+        }
     }
 
     // Log how much time we spent in our main mutex.

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -66,6 +66,8 @@ class BedrockTester {
     bool readDB(const string& query, SQResult& result);
     SQLite& getSQLiteDB();
 
+    int getServerPID() {return _serverPID; }
+
   protected:
     // Args passed on creation, which will be used to start the server if the `start` flag is set, or if `startServer`
     // is called later on with an empty args list.


### PR DESCRIPTION
This allows a plugin that's detached the server to exit instead of reattaching the DB. This is useful for debugging the backup manager.

Addresses https://github.com/Expensify/Expensify/issues/63008