### PR TITLE
Fix partial index on jobsParentJobIDState

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -46,8 +46,7 @@ void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
     // These indexes are not used by the Bedrock::Jobs plugin, but provided for easy analysis
     // using the Bedrock::DB plugin.
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsName     ON jobs ( name     );"));
-    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsParentJobIDState ON jobs ( parentJobID, state ) WHERE parentJobID IS NOT NULL;"));
-    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsStatePriorityNextRunName ON jobs ( state, priority, nextRun, name );"));
+    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsParentJobIDState ON jobs ( parentJobID, state ) WHERE parentJobID != 0;"));
 
     SQResult nextIDResult;
     db.read("SELECT MAX(jobID) FROM jobs;", nextIDResult);

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -47,6 +47,7 @@ void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
     // using the Bedrock::DB plugin.
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsName     ON jobs ( name     );"));
     SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsParentJobIDState ON jobs ( parentJobID, state ) WHERE parentJobID != 0;"));
+    SASSERT(db.write("CREATE INDEX IF NOT EXISTS jobsStatePriorityNextRunName ON jobs ( state, priority, nextRun, name );"));
 
     SQResult nextIDResult;
     db.read("SELECT MAX(jobID) FROM jobs;", nextIDResult);

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -742,7 +742,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 // Only non-retryable jobs can have children so see if this job has any
                 // FINISHED/CANCELLED child jobs, indicating it is being resumed
                 SQResult childJobs;
-                if (!db.read("SELECT jobID, data, state FROM jobs WHERE parentJobID=" + result[c][0] + " AND state IN ('FINISHED', 'CANCELLED');", childJobs)) {
+                if (!db.read("SELECT jobID, data, state FROM jobs WHERE parentJobID != 0 AND parentJobID=" + result[c][0] + " AND state IN ('FINISHED', 'CANCELLED');", childJobs)) {
                     STHROW("502 Failed to select finished child jobs");
                 }
 
@@ -939,7 +939,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
 
         // Delete any FINISHED/CANCELLED child jobs, but leave any PAUSED children alone (as those will signal that
         // we just want to re-PAUSE this job so those new children can run)
-        if (!db.writeIdempotent("DELETE FROM jobs WHERE parentJobID=" + SQ(jobID) + " AND state IN ('FINISHED', 'CANCELLED');")) {
+        if (!db.writeIdempotent("DELETE FROM jobs WHERE parentJobID != 0 AND parentJobID=" + SQ(jobID) + " AND state IN ('FINISHED', 'CANCELLED');")) {
             STHROW("502 Failed deleting finished/cancelled child jobs");
         }
 
@@ -975,7 +975,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             // Also un-pause any child jobs such that they can run
             if (!db.writeIdempotent("UPDATE jobs SET state='QUEUED' "
                           "WHERE state='PAUSED' "
-                            "AND parentJobID=" + SQ(jobID) + ";")) {
+                            "AND parentJobID != 0 AND parentJobID=" + SQ(jobID) + ";")) {
                 STHROW("502 Child update failed");
             }
 
@@ -1050,7 +1050,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
 
                 // At this point, all child jobs should already be deleted, but
                 // let's double check.
-                if (!db.read("SELECT 1 FROM jobs WHERE parentJobID=" + SQ(jobID) + " LIMIT 1;").empty()) {
+                if (!db.read("SELECT 1 FROM jobs WHERE parentJobID != 0 AND parentJobID=" + SQ(jobID) + " LIMIT 1;").empty()) {
                     SWARN("Child jobs still exist when deleting parent job, ignoring.");
                 }
             }
@@ -1086,7 +1086,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         const string& safeParentJobID = SQ(result[0][0]);
         if (!db.read("SELECT count(1) "
                      "FROM jobs "
-                     "WHERE parentJobID=" + safeParentJobID + " AND "
+                     "WHERE parentJobID != 0 AND parentJobID=" + safeParentJobID + " AND "
                        "state IN ('QUEUED', 'RUNQUEUED', 'RUNNING');",
                      result)) {
             STHROW("502 Select failed");
@@ -1257,7 +1257,7 @@ bool BedrockPlugin_Jobs::_hasPendingChildJobs(SQLite& db, int64_t jobID) {
     SQResult result;
     if (!db.read("SELECT 1 "
                  "FROM jobs "
-                 "WHERE parentJobID = " + SQ(jobID) + " " +
+                 "WHERE parentJobID != 0 AND parentJobID = " + SQ(jobID) + " " +
                  " AND state IN ('QUEUED', 'RUNQUEUED', 'RUNNING', 'PAUSED') "
                  "LIMIT 1;",
                  result)) {

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -476,9 +476,9 @@ struct GetJobTest : tpunit::TestFixture {
         response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(response["name"], "high_2");
         response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_EQUAL(response["name"], "medium_4"); // Because we don't order by jobID, the order of these jobs depends on the table/index used to retrieve them
+        ASSERT_TRUE(response["name"] == "medium_4" || response["name"] == "medium_3"); // Because we don't order by jobID, the order of these jobs depends on the table/index used to retrieve them
         response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_EQUAL(response["name"], "medium_3");
+        ASSERT_TRUE(response["name"] == "medium_4" || response["name"] == "medium_3"); // Because we don't order by jobID, the order of these jobs depends on the table/index used to retrieve them
         response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(response["name"], "low_5");
     }

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -200,7 +200,8 @@ struct GetJobTest : tpunit::TestFixture {
         SData command("CreateJob");
         command["name"] = "low";
         command["priority"] = "0";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", STimeNow());
+        const uint64_t time = STimeNow();
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time);
         STable response = tester->executeWaitVerifyContentTable(command);
         list<string> jobList;
         jobList.push_back(response["jobID"]);
@@ -208,35 +209,35 @@ struct GetJobTest : tpunit::TestFixture {
         // Medium
         command["name"] = "medium";
         command["priority"] = "500";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", STimeNow() + 1'000'000);
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 1'000'000);
         response = tester->executeWaitVerifyContentTable(command);
         jobList.push_back(response["jobID"]);
 
         // High
         command["name"] = "high";
         command["priority"] = "1000";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", STimeNow() + 2'000'000);
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 2'000'000);
         response = tester->executeWaitVerifyContentTable(command);
         jobList.push_back(response["jobID"]);
 
         // High
         command["name"] = "high";
         command["priority"] = "1000";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", STimeNow() + 5'000'000);
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 5'000'000);
         response = tester->executeWaitVerifyContentTable(command);
         jobList.push_back(response["jobID"]);
 
         // Medium
         command["name"] = "medium";
         command["priority"] = "500";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", STimeNow() + 4'000'000);
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 4'000'000);
         response = tester->executeWaitVerifyContentTable(command);
         jobList.push_back(response["jobID"]);
 
         // Low
         command["name"] = "low";
         command["priority"] = "0";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", STimeNow() + 3'000'000);
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 3'000'000);
         response = tester->executeWaitVerifyContentTable(command);
         jobList.push_back(response["jobID"]);
 
@@ -408,7 +409,8 @@ struct GetJobTest : tpunit::TestFixture {
         SData command("CreateJob");
         command["name"] = "low_5";
         command["priority"] = "0";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", STimeNow()+2000000);
+        const uint64_t time = STimeNow();
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time+2000000);
         tester->executeWaitVerifyContent(command);
 
         // High
@@ -432,7 +434,7 @@ struct GetJobTest : tpunit::TestFixture {
         command.methodLine = "CreateJob";
         command["name"] = "high_2";
         command["priority"] = "1000";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", STimeNow()+2000000);
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time+2000000);
         tester->executeWaitVerifyContent(command);
 
         // Medium
@@ -440,7 +442,7 @@ struct GetJobTest : tpunit::TestFixture {
         command.methodLine = "CreateJob";
         command["name"] = "medium_3";
         command["priority"] = "500";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", STimeNow()+2000000);
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time+2000000);
         tester->executeWaitVerifyContent(command);
 
         // Get the two jobs with retryAfter set to put them in a RUNQUEUED state

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -474,9 +474,9 @@ struct GetJobTest : tpunit::TestFixture {
         response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(response["name"], "high_2");
         response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_EQUAL(response["name"], "medium_3"); // Because we don't order by jobID, QUEUED jobs will always run before RUNQUEUED when priority and nextRun are the same
+        ASSERT_EQUAL(response["name"], "medium_4"); // Because we don't order by jobID, the order of these jobs depends on the table/index used to retrieve them
         response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_EQUAL(response["name"], "medium_4");
+        ASSERT_EQUAL(response["name"], "medium_3");
         response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(response["name"], "low_5");
     }


### PR DESCRIPTION
@coleaeason please review. 

Needed for https://github.com/Expensify/Expensify/issues/84444 

Hopefully this will be lower (or throughput should increase):
![image](https://user-images.githubusercontent.com/521248/43471718-f2c348e6-94eb-11e8-9c99-38ab5a621344.png)

Tests:
- Restart bedrock
- Stop bedrock.
- Run the migration.
- Start bedrock.

Queries tests:
```
sqlite> explain query plan SELECT jobID, data, state FROM jobs WHERE parentJobID != 0 AND parentJobID = 1 AND state IN ('FINISHED', 'CANCELLED');
QUERY PLAN
`--SEARCH TABLE jobs USING INDEX jobsParentJobIDState (parentJobID=? AND state=?)

sqlite> explain query plan DELETE FROM jobs WHERE parentJobID != 0 AND parentJobID=1 AND state IN ('FINISHED', 'CANCELLED');
QUERY PLAN
`--SEARCH TABLE jobs USING INDEX jobsParentJobIDState (parentJobID=? AND state=?)

`--SEARCH TABLE jobs USING INDEX jobsParentJobIDState (parentJobID=? AND state=?)
sqlite> explain query plan UPDATE jobs SET state='QUEUED' WHERE state='PAUSED' AND parentJobID != 0 AND parentJobID=1;
QUERY PLAN
`--SEARCH TABLE jobs USING INDEX jobsParentJobIDState (parentJobID=? AND state=?)

sqlite> explain query plan SELECT 1 FROM jobs WHERE parentJobID != 0 AND parentJobID=1 LIMIT 1;
QUERY PLAN
`--SEARCH TABLE jobs USING COVERING INDEX jobsParentJobIDState (parentJobID=?)

sqlite> explain query plan SELECT count(1) FROM jobs WHERE parentJobID != 0 AND parentJobID = 1 AND state IN ('QUEUED', 'RUNQUEUED', 'RUNNING');
QUERY PLAN
`--SEARCH TABLE jobs USING COVERING INDEX jobsParentJobIDState (parentJobID=? AND state=?)

sqlite> explain query plan SELECT 1 FROM jobs WHERE parentJobID != 0 AND parentJobID = 1 AND state IN ('QUEUED', 'RUNQUEUED', 'RUNNING', 'PAUSED') LIMIT 1;
QUERY PLAN
`--SEARCH TABLE jobs USING COVERING INDEX jobsParentJobIDState (parentJobID=? AND state=?)
```

Query plans on the DBs without the new index created:
```
ionatan@staging-www1.la:~$ sudo readdb.sh "explain query plan SELECT jobID, data, state FROM jobs WHERE parentJobID != 0 AND parentJobID = 1 AND state IN ('FINISHED', 'CANCELLED');"
QUERY PLAN
`--SEARCH TABLE jobs USING INDEX jobsParentJobIDState (parentJobID=? AND state=?)
ionatan@staging-www1.la:~$ explain query plan DELETE FROM jobs WHERE parentJobID != 0 AND parentJobID=1 AND state IN ('FINISHED', 'CANCELLED');^C
ionatan@staging-www1.la:~$ sudo readdb.sh "explain query plan DELETE FROM jobs WHERE parentJobID != 0 AND parentJobID=1 AND state IN ('FINISHED', 'CANCELLED');"
QUERY PLAN
`--SEARCH TABLE jobs USING INDEX jobsParentJobIDState (parentJobID=? AND state=?)
ionatan@staging-www1.la:~$ sudo readdb.sh "explain query plan UPDATE jobs SET state='QUEUED' WHERE state='PAUSED' AND parentJobID != 0 AND parentJobID=1;"
QUERY PLAN
`--SEARCH TABLE jobs USING INDEX jobsParentJobIDState (parentJobID=? AND state=?)
ionatan@staging-www1.la:~$ sudo readdb.sh "explain query plan SELECT 1 FROM jobs WHERE parentJobID != 0 AND parentJobID=1 LIMIT 1;"
QUERY PLAN
`--SEARCH TABLE jobs USING COVERING INDEX jobsParentJobIDState (parentJobID=?)
ionatan@staging-www1.la:~$ sudo readdb.sh "explain query plan SELECT count(1) FROM jobs WHERE parentJobID != 0 AND parentJobID = 1 AND state IN ('QUEUED', 'RUNQUEUED', 'RUNNING');"
QUERY PLAN
`--SEARCH TABLE jobs USING COVERING INDEX jobsParentJobIDState (parentJobID=? AND state=?)
ionatan@staging-www1.la:~$ sudo readdb.sh "explain query plan SELECT 1 FROM jobs WHERE parentJobID != 0 AND parentJobID = 1 AND state IN ('QUEUED', 'RUNQUEUED', 'RUNNING', 'PAUSED') LIMIT 1;"
QUERY PLAN
`--SEARCH TABLE jobs USING COVERING INDEX jobsParentJobIDState (parentJobID=? AND state=?)
```