### PR TITLE
Optimize CancelJob peek query

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -339,6 +339,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
                      "FROM jobs j "
                      "LEFT JOIN jobs jj ON jj.parentJobID = j.jobID "
                      "WHERE j.jobID=" + SQ(jobID) + " "
+                        "AND jj.parentJobID != 0 "
                      "GROUP BY j.jobID;",
                      result)) {
             STHROW("502 Select failed");


### PR DESCRIPTION
It was timing out for SSDos: 

$ https://github.com/Expensify/Expensify/issues/85542
$ https://github.com/Expensify/Expensify/issues/85541

Here is the old query plan:

```
ionatan@staging-www1.la:~$ sudo readdb.sh "explain query plan SELECT j.state, GROUP_CONCAT(jj.jobID), j.parentJobID FROM jobs j LEFT JOIN jobs jj ON jj.parentJobID = j.jobID WHERE j.jobID=726201773 GROUP BY j.jobID;"
QUERY PLAN
|--SEARCH TABLE jobs AS j USING INTEGER PRIMARY KEY (rowid=?)
`--SCAN TABLE jobs AS jj
```

As @iwiznia suggested, the solution is to add `parentJobID!=0`. I also simplified the whole query to make it more readable.

```
explain query plan SELECT j.state, j.parentJobID, (SELECT COUNT(1) FROM jobs WHERE parentJobID!=0 AND parentJobID=726201773) children FROM jobs j WHERE j.jobID=726201773;
selectid    order       from        detail                                                    
----------  ----------  ----------  ----------------------------------------------------------
0           0           0           SEARCH TABLE jobs AS j USING INTEGER PRIMARY KEY (rowid=?)
0           0           0           EXECUTE SCALAR SUBQUERY 1                                 
1           0           0           SEARCH TABLE jobs USING COVERING INDEX jobsParentJobIDStat

real    0m0.006s
user    0m0.004s
sys    0m0.000s
```

