### PR TITLE
Revert "Add stack counter to supporessCommandPort"

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -991,7 +991,6 @@ void BedrockServer::_resetServer() {
     _upgradeInProgress = false;
     _suppressCommandPort = false;
     _suppressCommandPortManualOverride = false;
-    _commandPortClosures = 0;
     _syncThreadComplete = false;
     _syncNode = nullptr;
     _suppressMultiWrite = true;
@@ -1004,9 +1003,9 @@ void BedrockServer::_resetServer() {
 BedrockServer::BedrockServer(const SData& args)
   : SQLiteServer(""), shutdownWhileDetached(false), _args(args), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),
-    _commandPortClosures(0), _syncThreadComplete(false), _syncNode(nullptr), _suppressMultiWrite(true),
-    _shutdownState(RUNNING), _multiWriteEnabled(args.test("-enableMultiWrite")), _shouldBackup(false),
-    _detach(args.isSet("-bootstrap")), _controlPort(nullptr), _commandPort(nullptr), _maxConflictRetries(3)
+    _syncThreadComplete(false), _syncNode(nullptr), _suppressMultiWrite(true), _shutdownState(RUNNING),
+    _multiWriteEnabled(args.test("-enableMultiWrite")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),
+    _controlPort(nullptr), _commandPort(nullptr), _maxConflictRetries(3)
 {
     _version = SVERSION;
 
@@ -1188,7 +1187,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     }
     if (!_suppressCommandPort && (state == SQLiteNode::MASTERING || state == SQLiteNode::SLAVING) &&
         _shutdownState.load() == RUNNING) {
-        // Open the port if we don't have one and we've had as many opens as we have closures.
+        // Open the port
         if (!_commandPort) {
             SINFO("Ready to process commands, opening command port on '" << _args["-serverHost"] << "'");
             _commandPort = openPort(_args["-serverHost"]);
@@ -1520,12 +1519,10 @@ void BedrockServer::suppressCommandPort(const string& reason, bool suppress, boo
     }
     // Process accordingly
     _suppressCommandPort = suppress;
-    int closures;
     if (suppress) {
-        closures = _commandPortClosures.fetch_add(1);
-        if (!portList.empty() && !closures) {
-            // Close the command port, and all plugin's ports. Won't reopen.
-            SHMMM("Suppressing command port");
+        // Close the command port, and all plugin's ports. Won't reopen.
+        SHMMM("Suppressing command port");
+        if (!portList.empty()) {
             closePorts({_controlPort});
             _portPluginMap.clear();
             _commandPort = nullptr;
@@ -1533,15 +1530,6 @@ void BedrockServer::suppressCommandPort(const string& reason, bool suppress, boo
     } else {
         // Clearing past suppression, but don't reopen (It's always safe to close, but not always safe to open).
         SHMMM("Clearing command port suppression");
-        closures = _commandPortClosures.fetch_sub(1);
-        if (closures == 1) {
-            SINFO("Removing a command port closure.");
-            _commandPort = openPort(_args["-serverHost"]);
-        } else if (closures <= 0) {
-            SWARN("Trying to decrement command port closures past 0, incrementing it back.");
-            _commandPortClosures.fetch_add(1);
-        }
-
     }
 }
 
@@ -1634,8 +1622,7 @@ void BedrockServer::_status(BedrockCommand& command) {
         content["state"]    = SQLiteNode::stateNames[state];
         content["version"]  = _version;
         content["host"]     = _args["-nodeHost"];
-        content["commandPortOpen"] = _commandPort ? "true" : "false";
-        content["CommandPortClosures"] = to_string(_commandPortClosures);
+
         {
             // Make it known if anything is known to cause crashes.
             shared_lock<decltype(_crashCommandMutex)> lock(_crashCommandMutex);
@@ -1753,10 +1740,6 @@ void BedrockServer::_control(BedrockCommand& command) {
         suppressCommandPort("SuppressCommandPort", true, true);
     } else if (SIEquals(command.request.methodLine, "ClearCommandPort")) {
         suppressCommandPort("ClearCommandPort", false, true);
-        int closures = _commandPortClosures.load();
-        if (closures >= 1) {
-            response.methodLine = "201 Not opening port, " + to_string(closures) + " closures reamining";
-        }
     } else if (SIEquals(command.request.methodLine, "ClearCrashCommands")) {
         unique_lock<decltype(_crashCommandMutex)> lock(_crashCommandMutex);
         _crashCommands.clear();
@@ -1984,7 +1967,7 @@ int BedrockServer::finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& comp
                 commandsCompleted++;
             }
         }
-
+        
         // Now we can erase the transaction, as it's no longer outstanding.
         _outstandingHTTPSRequests.erase(transactionIt);
     }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -262,7 +262,6 @@ class BedrockServer : public SQLiteServer {
     // These control whether or not the command port is currently opened.
     bool _suppressCommandPort;
     bool _suppressCommandPortManualOverride;
-    atomic<int> _commandPortClosures;
 
     // This is a map of open listening ports to the plugin objects that created them.
     map<Port*, BedrockPlugin*> _portPluginMap;

--- a/test/clustertest/tests/ControlCommandTest.cpp
+++ b/test/clustertest/tests/ControlCommandTest.cpp
@@ -3,11 +3,10 @@
 
 struct ControlCommandTest : tpunit::TestFixture {
     ControlCommandTest()
-        : tpunit::TestFixture("ControlCommand",
+        : tpunit::TestFixture("ControlCommandTest",
                               BEFORE_CLASS(ControlCommandTest::setup),
                               AFTER_CLASS(ControlCommandTest::teardown),
-                              TEST(ControlCommandTest::testPreventAttach),
-                              TEST(ControlCommandTest::testSuppressCommandPort)) { }
+                              TEST(ControlCommandTest::testPreventAttach)) { }
 
     BedrockClusterTester* tester;
 
@@ -34,7 +33,6 @@ struct ControlCommandTest : tpunit::TestFixture {
 
         // Wait for it to detach
         sleep(3);
-
         // Try to attach
         SData attachCommand("attach");
         slave->executeWaitVerifyContent(attachCommand, "401 Attaching prevented by TestPlugin", true);
@@ -44,80 +42,6 @@ struct ControlCommandTest : tpunit::TestFixture {
         // Try to attach again, should be allowed now that the sleep in the plugin
         // has passed.
         slave->executeWaitVerifyContent(attachCommand, "204", true);
-    }
-
-    void testSuppressCommandPort()
-    {
-        // Pick a slave to test on
-        BedrockTester* slave = tester->getBedrockTester(1);
-
-        // The three commands we'll need for this test
-        SData suppress("SuppressCommandPort");
-        SData clear("ClearCommandPort");
-        SData status("Status");
-
-        // Basic case, open then close it.
-        slave->executeWaitVerifyContent(suppress, "200", true);
-        slave->executeWaitVerifyContent(clear, "200", true);
-
-        // Failure case 1, more suppressions than clears
-        slave->executeWaitVerifyContent(suppress, "200", true);
-        slave->executeWaitVerifyContent(suppress, "200", true);
-        slave->executeWaitVerifyContent(clear, "201", true);
-
-        // Ensure the port is actually closed.
-        slave->executeWaitVerifyContent(status, "002");
-
-        // Send one more clear to get the counter back to 0
-        slave->executeWaitVerifyContent(clear, "200", true);
-
-        // Ensure the port was reopened
-        int count = 0;
-        bool success = false;
-        while (count++ < 50) {
-            try {
-                string response = slave->executeWaitVerifyContent(status);
-                STable json = SParseJSONObject(response);
-                if (json["state"] == "SLAVING") {
-                    success = true;
-                    break;
-                }
-            } catch (const SException& e) {
-                // just try again
-            }
-
-            // Give it another second...
-            sleep(1);
-        }
-
-        ASSERT_TRUE(success);
-
-        // Failure case 2, more clears than suppressions
-        slave->executeWaitVerifyContent(suppress, "200", true);
-        slave->executeWaitVerifyContent(clear, "200", true);
-        slave->executeWaitVerifyContent(clear, "200", true);
-
-        // Ensure the port is actually opened, and counter didn't go below 0
-        count = 0;
-        success = false;
-        while (count++ < 50) {
-            try {
-                string response = slave->executeWaitVerifyContent(status);
-                STable json = SParseJSONObject(response);
-                if (json["state"] == "SLAVING") {
-                    ASSERT_EQUAL(json["CommandPortClosures"], "0");
-                    success = true;
-                    break;
-                }
-            } catch (const SException& e) {
-                // just try again
-            }
-
-            // Give it another second...
-            sleep(1);
-        }
-
-        ASSERT_TRUE(success);
     }
 
 } __ControlCommandTest;

--- a/test/clustertest/tests/MasteringTest.cpp
+++ b/test/clustertest/tests/MasteringTest.cpp
@@ -60,16 +60,12 @@ struct MasteringTest : tpunit::TestFixture {
         int count = 0;
         bool success = false;
         while (count++ < 50) {
-            try {
-                SData cmd("Status");
-                string response = newMaster->executeWaitVerifyContent(cmd);
-                STable json = SParseJSONObject(response);
-                if (json["state"] == "MASTERING") {
-                    success = true;
-                    break;
-                }
-            } catch (const SException& e) {
-                    // just try again
+            SData cmd("Status");
+            string response = newMaster->executeWaitVerifyContent(cmd);
+            STable json = SParseJSONObject(response);
+            if (json["state"] == "MASTERING") {
+                success = true;
+                break;
             }
 
             // Give it another second...
@@ -120,8 +116,8 @@ struct MasteringTest : tpunit::TestFixture {
             STable json1 = SParseJSONObject(responses[1]);
             STable json2 = SParseJSONObject(responses[2]);
 
-            if (json0["state"] == "MASTERING" &&
-                json1["state"] == "SLAVING" &&
+            if (json0["state"] == "MASTERING" && 
+                json1["state"] == "SLAVING" && 
                 json2["state"] == "SLAVING") {
 
                 break;


### PR DESCRIPTION
Reverts Expensify/Bedrock#459

@anyone this broke our internal billing tests because sometimes we fail to close the port before we reopen it. I'll look at a fix tomorrow, but this revert will fix tests. 