### PR TITLE
Calculate timeout from command scheduled execution time

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -58,12 +58,13 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
     SData& request = command.request;
     SData& response = command.response;
     STable& content = command.jsonContent;
-    SDEBUG("Peeking at '" << request.methodLine << "' with priority: " << command.priority);
-    command.peekCount++;
-    uint64_t timeout = _getTimeout(request);
 
     // We catch any exception and handle in `_handleCommandException`.
     try {
+        SDEBUG("Peeking at '" << request.methodLine << "' with priority: " << command.priority);
+        uint64_t timeout = _getTimeout(request);
+        command.peekCount++;
+
         _db.startTiming(timeout * 1000);
         // We start a transaction in `peekCommand` because we want to support having atomic transactions from peek
         // through process. This allows for consistency through this two-phase process. I.e., anything checked in
@@ -160,13 +161,14 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
     SData& request = command.request;
     SData& response = command.response;
     STable& content = command.jsonContent;
-    SDEBUG("Processing '" << request.methodLine << "'");
-    command.processCount++;
-    uint64_t timeout = _getTimeout(request);
 
     // Keep track of whether we've modified the database and need to perform a `commit`.
     bool needsCommit = false;
     try {
+        SDEBUG("Processing '" << request.methodLine << "'");
+        uint64_t timeout = _getTimeout(request);
+        command.processCount++;
+
         // Time in US.
         _db.startTiming(timeout * 1000);
         // If a transaction was already begun in `peek`, then this is a no-op. We call it here to support the case where

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -31,12 +31,6 @@ class AutoScopeRewrite {
 uint64_t BedrockCore::_getTimeout(const SData& request) {
     uint64_t timeout = request.isSet("timeout") ? request.calc("timeout") : DEFAULT_TIMEOUT;
 
-    if (timeout > 2'000'000) {
-        // Old microsecond timeout. Update caller to use milliseconds. Remove this line once we no longer see this.
-        SWARN("[TYLER] old-style timeout found for command: " << request.methodLine);
-        timeout /= 1000;
-    }
-
     // See when the command was scheduled to run. The timeout is from *this* start time, not from when the command
     // starts executing.
     try {
@@ -44,7 +38,7 @@ uint64_t BedrockCore::_getTimeout(const SData& request) {
 
         // If this is negative, we're *already* past the timeout, just return early.
         if (adjustedTimeout <= 0) {
-            STHROW("555 Timeout peeking command");
+            STHROW("555 Timeout");
         } else {
             // Otherwise, we can return.
             return adjustedTimeout;

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -46,6 +46,7 @@ class BedrockCore : public SQLiteCore {
   private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.
     string _getExceptionName();
+    uint64_t _getTimeout(const SData& request);
     void _handleCommandException(BedrockCommand& command, const SException& e);
     const BedrockServer& _server;
 };

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -46,6 +46,10 @@ class BedrockCore : public SQLiteCore {
   private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.
     string _getExceptionName();
+
+    // Gets the amount of time remaining until this command times out. This is the difference between the command's
+    // 'timeout' value (or the default timeout, if not set) and the time the command was initially scheduled to run. If
+    // this time is already expired, this throws `555 Timeout`
     uint64_t _getTimeout(const SData& request);
     void _handleCommandException(BedrockCommand& command, const SException& e);
     const BedrockServer& _server;


### PR DESCRIPTION
@mea36 please review.

This changes the timeout for commands to be from the time they were scheduled to run, rather than from the time they started running.

Addresses:
https://github.com/Expensify/Expensify/issues/85100#issuecomment-415108959

I didn't add any new tests for this. I will if someone bothers me too.