### PR TITLE
[HOLD] Add stack counter for command port closures

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -7,6 +7,7 @@
 
 set<string>BedrockServer::_blacklistedParallelCommands;
 recursive_mutex BedrockServer::_blacklistedParallelCommandMutex;
+recursive_mutex BedrockServer::_commandPortMutex;
 
 void BedrockServer::acceptCommand(SQLiteCommand&& command, bool isNew) {
     // If the sync node tells us that a command causes a crash, we immediately save that.
@@ -1188,8 +1189,8 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     }
     if (!_suppressCommandPort && (state == SQLiteNode::MASTERING || state == SQLiteNode::SLAVING) &&
         _shutdownState.load() == RUNNING) {
-        // Open the port if we don't have one and we've had as many opens as we have closures.
-        if (!_commandPort) {
+        // Open the port if we don't have one and we are the only thread trying to open it.
+        if (!_commandPort && _commandPortMutex.try_lock()) {
             SINFO("Ready to process commands, opening command port on '" << _args["-serverHost"] << "'");
             _commandPort = openPort(_args["-serverHost"]);
         }
@@ -1534,7 +1535,7 @@ void BedrockServer::suppressCommandPort(const string& reason, bool suppress, boo
         // Clearing past suppression, but don't reopen (It's always safe to close, but not always safe to open).
         SHMMM("Clearing command port suppression");
         closures = _commandPortClosures.fetch_sub(1);
-        if (closures == 1) {
+        if (closures == 1 && _commandPortMutex.try_lock()) {
             SINFO("Removing a command port closure.");
             _commandPort = openPort(_args["-serverHost"]);
         } else if (closures <= 0) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -992,6 +992,7 @@ void BedrockServer::_resetServer() {
     _upgradeInProgress = false;
     _suppressCommandPort = false;
     _suppressCommandPortManualOverride = false;
+    _commandPortClosures = 0;
     _syncThreadComplete = false;
     _syncNode = nullptr;
     _suppressMultiWrite = true;
@@ -1004,9 +1005,9 @@ void BedrockServer::_resetServer() {
 BedrockServer::BedrockServer(const SData& args)
   : SQLiteServer(""), shutdownWhileDetached(false), _args(args), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),
-    _syncThreadComplete(false), _syncNode(nullptr), _suppressMultiWrite(true), _shutdownState(RUNNING),
-    _multiWriteEnabled(args.test("-enableMultiWrite")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),
-    _controlPort(nullptr), _commandPort(nullptr), _maxConflictRetries(3)
+    _commandPortClosures(0), _syncThreadComplete(false), _syncNode(nullptr), _suppressMultiWrite(true),
+    _shutdownState(RUNNING), _multiWriteEnabled(args.test("-enableMultiWrite")), _shouldBackup(false),
+    _detach(args.isSet("-bootstrap")), _controlPort(nullptr), _commandPort(nullptr), _maxConflictRetries(3)
 {
     _version = SVERSION;
 
@@ -1188,7 +1189,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     }
     if (!_suppressCommandPort && (state == SQLiteNode::MASTERING || state == SQLiteNode::SLAVING) &&
         _shutdownState.load() == RUNNING) {
-        // Open the port if we don't have one and we are the only thread trying to open it.
+        // Open the port if we don't have one and we've had as many opens as we have closures.
         if (!_commandPort && _commandPortMutex.try_lock()) {
             SINFO("Ready to process commands, opening command port on '" << _args["-serverHost"] << "'");
             _commandPort = openPort(_args["-serverHost"]);
@@ -1520,10 +1521,12 @@ void BedrockServer::suppressCommandPort(const string& reason, bool suppress, boo
     }
     // Process accordingly
     _suppressCommandPort = suppress;
+    int closures;
     if (suppress) {
-        // Close the command port, and all plugin's ports. Won't reopen.
-        SHMMM("Suppressing command port");
-        if (!portList.empty()) {
+        closures = _commandPortClosures.fetch_add(1);
+        if (!portList.empty() && !closures) {
+            // Close the command port, and all plugin's ports. Won't reopen.
+            SHMMM("Suppressing command port");
             closePorts({_controlPort});
             _portPluginMap.clear();
             _commandPort = nullptr;
@@ -1632,7 +1635,8 @@ void BedrockServer::_status(BedrockCommand& command) {
         content["state"]    = SQLiteNode::stateNames[state];
         content["version"]  = _version;
         content["host"]     = _args["-nodeHost"];
-
+        content["commandPortOpen"] = _commandPort ? "true" : "false";
+        content["CommandPortClosures"] = to_string(_commandPortClosures);
         {
             // Make it known if anything is known to cause crashes.
             shared_lock<decltype(_crashCommandMutex)> lock(_crashCommandMutex);
@@ -1750,6 +1754,10 @@ void BedrockServer::_control(BedrockCommand& command) {
         suppressCommandPort("SuppressCommandPort", true, true);
     } else if (SIEquals(command.request.methodLine, "ClearCommandPort")) {
         suppressCommandPort("ClearCommandPort", false, true);
+        int closures = _commandPortClosures.load();
+        if (closures >= 1) {
+            response.methodLine = "201 Not opening port, " + to_string(closures) + " closures reamining";
+        }
     } else if (SIEquals(command.request.methodLine, "ClearCrashCommands")) {
         unique_lock<decltype(_crashCommandMutex)> lock(_crashCommandMutex);
         _crashCommands.clear();

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -262,6 +262,7 @@ class BedrockServer : public SQLiteServer {
     // These control whether or not the command port is currently opened.
     bool _suppressCommandPort;
     bool _suppressCommandPortManualOverride;
+    atomic<int> _commandPortClosures;
 
     // Controls whether or not you can call openPort on the command port.
     static recursive_mutex _commandPortMutex;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -264,6 +264,9 @@ class BedrockServer : public SQLiteServer {
     bool _suppressCommandPortManualOverride;
     atomic<int> _commandPortClosures;
 
+    // Controls whether or not you can call openPort on the command port.
+    static recursive_mutex _commandPortMutex;
+
     // This is a map of open listening ports to the plugin objects that created them.
     map<Port*, BedrockPlugin*> _portPluginMap;
 

--- a/libstuff/STCPServer.cpp
+++ b/libstuff/STCPServer.cpp
@@ -33,7 +33,7 @@ void STCPServer::closePorts(list<Port*> except) {
         while (it != portList.end()) {
             if  (find(except.begin(), except.end(), &(*it)) == except.end()) {
                 // Close this port
-                ::close(it->s);
+                close(it->s);
                 SINFO("Close ports closing " << it->host << ".");
                 it = portList.erase(it);
             } else {

--- a/test/clustertest/tests/ControlCommandTest.cpp
+++ b/test/clustertest/tests/ControlCommandTest.cpp
@@ -3,10 +3,11 @@
 
 struct ControlCommandTest : tpunit::TestFixture {
     ControlCommandTest()
-        : tpunit::TestFixture("ControlCommandTest",
+        : tpunit::TestFixture("ControlCommand",
                               BEFORE_CLASS(ControlCommandTest::setup),
                               AFTER_CLASS(ControlCommandTest::teardown),
-                              TEST(ControlCommandTest::testPreventAttach)) { }
+                              TEST(ControlCommandTest::testPreventAttach),
+                              TEST(ControlCommandTest::testSuppressCommandPort)) { }
 
     BedrockClusterTester* tester;
 
@@ -33,6 +34,7 @@ struct ControlCommandTest : tpunit::TestFixture {
 
         // Wait for it to detach
         sleep(3);
+
         // Try to attach
         SData attachCommand("attach");
         slave->executeWaitVerifyContent(attachCommand, "401 Attaching prevented by TestPlugin", true);
@@ -42,6 +44,80 @@ struct ControlCommandTest : tpunit::TestFixture {
         // Try to attach again, should be allowed now that the sleep in the plugin
         // has passed.
         slave->executeWaitVerifyContent(attachCommand, "204", true);
+    }
+
+    void testSuppressCommandPort()
+    {
+        // Pick a slave to test on
+        BedrockTester* slave = tester->getBedrockTester(1);
+
+        // The three commands we'll need for this test
+        SData suppress("SuppressCommandPort");
+        SData clear("ClearCommandPort");
+        SData status("Status");
+
+        // Basic case, open then close it.
+        slave->executeWaitVerifyContent(suppress, "200", true);
+        slave->executeWaitVerifyContent(clear, "200", true);
+
+        // Failure case 1, more suppressions than clears
+        slave->executeWaitVerifyContent(suppress, "200", true);
+        slave->executeWaitVerifyContent(suppress, "200", true);
+        slave->executeWaitVerifyContent(clear, "201", true);
+
+        // Ensure the port is actually closed.
+        slave->executeWaitVerifyContent(status, "002");
+
+        // Send one more clear to get the counter back to 0
+        slave->executeWaitVerifyContent(clear, "200", true);
+
+        // Ensure the port was reopened
+        int count = 0;
+        bool success = false;
+        while (count++ < 50) {
+            try {
+                string response = slave->executeWaitVerifyContent(status);
+                STable json = SParseJSONObject(response);
+                if (json["state"] == "SLAVING") {
+                    success = true;
+                    break;
+                }
+            } catch (const SException& e) {
+                // just try again
+            }
+
+            // Give it another second...
+            sleep(1);
+        }
+
+        ASSERT_TRUE(success);
+
+        // Failure case 2, more clears than suppressions
+        slave->executeWaitVerifyContent(suppress, "200", true);
+        slave->executeWaitVerifyContent(clear, "200", true);
+        slave->executeWaitVerifyContent(clear, "200", true);
+
+        // Ensure the port is actually opened, and counter didn't go below 0
+        count = 0;
+        success = false;
+        while (count++ < 50) {
+            try {
+                string response = slave->executeWaitVerifyContent(status);
+                STable json = SParseJSONObject(response);
+                if (json["state"] == "SLAVING") {
+                    ASSERT_EQUAL(json["CommandPortClosures"], "0");
+                    success = true;
+                    break;
+                }
+            } catch (const SException& e) {
+                // just try again
+            }
+
+            // Give it another second...
+            sleep(1);
+        }
+
+        ASSERT_TRUE(success);
     }
 
 } __ControlCommandTest;

--- a/test/clustertest/tests/MasteringTest.cpp
+++ b/test/clustertest/tests/MasteringTest.cpp
@@ -60,12 +60,16 @@ struct MasteringTest : tpunit::TestFixture {
         int count = 0;
         bool success = false;
         while (count++ < 50) {
-            SData cmd("Status");
-            string response = newMaster->executeWaitVerifyContent(cmd);
-            STable json = SParseJSONObject(response);
-            if (json["state"] == "MASTERING") {
-                success = true;
-                break;
+            try {
+                SData cmd("Status");
+                string response = newMaster->executeWaitVerifyContent(cmd);
+                STable json = SParseJSONObject(response);
+                if (json["state"] == "MASTERING") {
+                    success = true;
+                    break;
+                }
+            } catch (const SException& e) {
+                    // just try again
             }
 
             // Give it another second...
@@ -116,8 +120,8 @@ struct MasteringTest : tpunit::TestFixture {
             STable json1 = SParseJSONObject(responses[1]);
             STable json2 = SParseJSONObject(responses[2]);
 
-            if (json0["state"] == "MASTERING" && 
-                json1["state"] == "SLAVING" && 
+            if (json0["state"] == "MASTERING" &&
+                json1["state"] == "SLAVING" &&
                 json2["state"] == "SLAVING") {
 
                 break;


### PR DESCRIPTION
@tylerkaraszewski try two, this one has a mutex around opening a command port to prevent two threads for both trying to open one at the same time. Ran the auth tests several times with no failures, before all billing tests failed. Ran the bedrock tests with no failures.