### PR TITLE
Allow processing transactions in the future

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -89,11 +89,11 @@ void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSMan
         // Did we get any responses?
         list<Transaction*>::iterator activeIt = nextIt++;
         Transaction* active = *activeIt;
-        uint64_t sentTime = 0;
-        if (active->isDelayedSend) {
+        if (active->isDelayedSend && !sentTime) {
             // This transaction was created, queued, and then meant to be sent later.
             // As such we'll use STimeNow() as it's "created" time for time.
-            sentTime = STimeNow();
+            SINFO("Transaction is marked for delayed sending, setting sentTime for timeout.");
+            active->sentTime = STimeNow();
         }
         uint64_t now = STimeNow();
         uint64_t elapsed =  now - (sentTime ? sentTime : active->created);
@@ -145,6 +145,7 @@ SHTTPSManager::Transaction::Transaction(SHTTPSManager& owner_) :
     s(nullptr),
     created(STimeNow()),
     finished(0),
+    sentTime(0),
     response(0),
     owner(owner_),
     isDelayedSend(false)

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -83,20 +83,21 @@ void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSMan
     STCPManager::postPoll(fdm);
 
     // Update each of the active requests
+    uint64_t now = STimeNow();
     uint64_t timeout = timeoutMS * 1000;
     list<Transaction*>::iterator nextIt = _activeTransactionList.begin();
     while (nextIt != _activeTransactionList.end()) {
         // Did we get any responses?
         list<Transaction*>::iterator activeIt = nextIt++;
         Transaction* active = *activeIt;
-        if (active->isDelayedSend && !sentTime) {
-            // This transaction was created, queued, and then meant to be sent later.
-            // As such we'll use STimeNow() as it's "created" time for time.
-            SINFO("Transaction is marked for delayed sending, setting sentTime for timeout.");
-            active->sentTime = STimeNow();
-        }
-        uint64_t now = STimeNow();
-        uint64_t elapsed =  now - (sentTime ? sentTime : active->created);
+        // if (active->isDelayedSend && !active->sentTime) {
+        //     // This transaction was created, queued, and then meant to be sent later.
+        //     // As such we'll use STimeNow() as it's "created" time for time.
+        //     SINFO("Transaction is marked for delayed sending, setting sentTime for timeout.");
+        //     active->sentTime = STimeNow();
+        // }
+        //uint64_t timeoutFromTime = active->sentTime ? active->sentTime : active->created;
+        uint64_t elapsed = now - active->created;
         int size = active->fullResponse.deserialize(active->s->recvBuffer);
         if (size) {
             // Consume how much we read.
@@ -145,10 +146,10 @@ SHTTPSManager::Transaction::Transaction(SHTTPSManager& owner_) :
     s(nullptr),
     created(STimeNow()),
     finished(0),
-    sentTime(0),
+    //sentTime(0),
     response(0),
-    owner(owner_),
-    isDelayedSend(false)
+    owner(owner_)
+    //isDelayedSend(false)
 { }
 
 SHTTPSManager::Transaction::~Transaction() {

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -83,21 +83,21 @@ void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSMan
     STCPManager::postPoll(fdm);
 
     // Update each of the active requests
-    uint64_t now = STimeNow();
     uint64_t timeout = timeoutMS * 1000;
     list<Transaction*>::iterator nextIt = _activeTransactionList.begin();
     while (nextIt != _activeTransactionList.end()) {
         // Did we get any responses?
         list<Transaction*>::iterator activeIt = nextIt++;
         Transaction* active = *activeIt;
-        // if (active->isDelayedSend && !active->sentTime) {
-        //     // This transaction was created, queued, and then meant to be sent later.
-        //     // As such we'll use STimeNow() as it's "created" time for time.
-        //     SINFO("Transaction is marked for delayed sending, setting sentTime for timeout.");
-        //     active->sentTime = STimeNow();
-        // }
-        //uint64_t timeoutFromTime = active->sentTime ? active->sentTime : active->created;
-        uint64_t elapsed = now - active->created;
+        if (active->isDelayedSend && !active->sentTime) {
+            // This transaction was created, queued, and then meant to be sent later.
+            // As such we'll use STimeNow() as it's "created" time for time.
+            SINFO("Transaction is marked for delayed sending, setting sentTime for timeout.");
+            active->sentTime = STimeNow();
+        }
+        uint64_t timeoutFromTime = active->sentTime ? active->sentTime : active->created;
+        uint64_t now = STimeNow();
+        uint64_t elapsed = now - timeoutFromTime;
         int size = active->fullResponse.deserialize(active->s->recvBuffer);
         if (size) {
             // Consume how much we read.
@@ -127,7 +127,7 @@ void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSMan
             }
         } else {
             // Haven't timed out yet, let the caller know how long until we do.
-            nextActivity = min(nextActivity, active->created + timeout);
+            nextActivity = min(nextActivity, timeoutFromTime + timeout);
         }
 
         // If we're done, remove from the active and add to completed
@@ -146,10 +146,10 @@ SHTTPSManager::Transaction::Transaction(SHTTPSManager& owner_) :
     s(nullptr),
     created(STimeNow()),
     finished(0),
-    //sentTime(0),
     response(0),
-    owner(owner_)
-    //isDelayedSend(false)
+    owner(owner_),
+    isDelayedSend(0),
+    sentTime(0)
 { }
 
 SHTTPSManager::Transaction::~Transaction() {

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -11,13 +11,13 @@ class SHTTPSManager : public STCPManager {
         STCPManager::Socket* s;
         uint64_t created;
         uint64_t finished;
-        //uint64_t sentTime;
         SData fullRequest;
         SData fullResponse;
         int response;
         STable values;
         SHTTPSManager& owner;
-        //bool isDelayedSend;
+        bool isDelayedSend;
+        uint64_t sentTime;
     };
 
     // Constructor/Destructor

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -16,6 +16,7 @@ class SHTTPSManager : public STCPManager {
         int response;
         STable values;
         SHTTPSManager& owner;
+        bool isDelayedSend;
     };
 
     // Constructor/Destructor

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -11,13 +11,13 @@ class SHTTPSManager : public STCPManager {
         STCPManager::Socket* s;
         uint64_t created;
         uint64_t finished;
-        uint64_t sentTime;
+        //uint64_t sentTime;
         SData fullRequest;
         SData fullResponse;
         int response;
         STable values;
         SHTTPSManager& owner;
-        bool isDelayedSend;
+        //bool isDelayedSend;
     };
 
     // Constructor/Destructor

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -11,6 +11,7 @@ class SHTTPSManager : public STCPManager {
         STCPManager::Socket* s;
         uint64_t created;
         uint64_t finished;
+        uint64_t sentTime;
         SData fullRequest;
         SData fullResponse;
         int response;


### PR DESCRIPTION
@johnmlee101 Please review. This works in conjunction with our new billing rate limit code. This allows us to set a transaction as being allowed to process in the future, this means we will not use the created timestamp to check for timeouts, but instead start the timeout when we first interact with the transaction. This should prevent immediately timing out transactions that were made more than five minutes ago.