### PR TITLE
 Removed case which prevented a retryAfter for unique jobs

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -249,11 +249,6 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
                 STHROW("402 Malformed retryAfter");
             }
 
-            // Throw if retryAfter was passed for unique job
-            if (SContains(job, "retryAfter") && job["retryAfter"] != "" && SContains(job, "unique") && job["unique"] == "true") {
-                STHROW("405 Unique jobs can't be retried");
-            }
-
             // Validate that the parentJobID exists and is in the right state if one was passed.
             // Also verify that the parent job doesn't have a retryAfter set.
             int64_t parentJobID = SContains(job, "parentJobID") ? SToInt(job["parentJobID"]) : 0;

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -17,7 +17,6 @@ struct CreateJobTest : tpunit::TestFixture {
                               TEST(CreateJobTest::createChildWithRunningGrandparent),
                               TEST(CreateJobTest::retryRecurringJobs),
                               TEST(CreateJobTest::retryWithMalformedValue),
-                              TEST(CreateJobTest::retryUnique),
                               TEST(CreateJobTest::retryLifecycle),
                               TEST(CreateJobTest::retryWithChildren),
                               AFTER(CreateJobTest::tearDown),
@@ -278,14 +277,6 @@ struct CreateJobTest : tpunit::TestFixture {
         command["name"] = "test";
         command["retryAfter"] = "10";
         tester->executeWaitVerifyContent(command, "402 Malformed retryAfter");
-    }
-
-    void retryUnique() {
-        SData command("CreateJob");
-        command["name"] = "test";
-        command["retryAfter"] = "+10 HOUR";
-        command["unique"] = "true";
-        tester->executeWaitVerifyContent(command, "405 Unique jobs can't be retried");
     }
 
     void retryLifecycle() {

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -17,6 +17,7 @@ struct CreateJobTest : tpunit::TestFixture {
                               TEST(CreateJobTest::createChildWithRunningGrandparent),
                               TEST(CreateJobTest::retryRecurringJobs),
                               TEST(CreateJobTest::retryWithMalformedValue),
+                              TEST(CreateJobTest::retryUnique),
                               TEST(CreateJobTest::retryLifecycle),
                               TEST(CreateJobTest::retryWithChildren),
                               AFTER(CreateJobTest::tearDown),
@@ -277,6 +278,14 @@ struct CreateJobTest : tpunit::TestFixture {
         command["name"] = "test";
         command["retryAfter"] = "10";
         tester->executeWaitVerifyContent(command, "402 Malformed retryAfter");
+    }
+
+    void retryUnique() {
+        SData command("CreateJob");
+        command["name"] = "test";
+        command["retryAfter"] = "+10 HOUR";
+        command["unique"] = "true";
+        tester->executeWaitVerifyContent(command, "200 OK");
     }
 
     void retryLifecycle() {


### PR DESCRIPTION
PR to remove the case which prevents a retryAfter for unique jobs, which we decided to do in [this github issue](https://github.com/Expensify/Expensify/issues/84654) and concluded in [this github conversation](https://github.com/Expensify/Expensify/issues/84654#issuecomment-424258389).