### PR TITLE
Cleaning up the top links on BedrockDB.com

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -523,7 +523,10 @@
             	font-family:Menlo,Consolas,"Bitstream Vera Sans Mono","DejaVu Sans Mono",Monaco,monospace;
             }
 
-
+            .content-card__inner > table td a {
+                display: inline-block;
+                margin: 0 10px 10px 0;
+            }
         </style>
     </head>
     <body>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-*Links: [Why](http://firstround.com/review/your-database-is-your-prison-heres-how-expensify-broke-free/) | [Code](https://github.com/Expensify/Bedrock) | [Install](http://bedrockdb.com#how-to-get-it) | [Use](http://bedrockdb.com#how-to-use-it) | [Jobs](http://bedrockdb.com/jobs.html) | [Cache](http://bedrockdb.com/cache.html) | [vs MySQL](http://bedrockdb.com/vs_mysql.html) | [Replication](http://bedrockdb.com/synchronization.html) | [Blockchain](http://bedrockdb.com/blockchain.html) | [Multizone](http://bedrockdb.com/multizone.html) | [Chat](https://gitter.im/Expensify-Bedrock/Lobby) | [Contact](http://bedrockdb.com#how-to-help-and-get-helped)*
+[Why](http://firstround.com/review/your-database-is-your-prison-heres-how-expensify-broke-free/) | [Code](https://github.com/Expensify/Bedrock) | [Install](http://bedrockdb.com#how-to-get-it) | [Use](http://bedrockdb.com#how-to-use-it) | [Jobs](http://bedrockdb.com/jobs.html) | [Cache](http://bedrockdb.com/cache.html) | [vs MySQL](http://bedrockdb.com/vs_mysql.html) | [Replication](http://bedrockdb.com/synchronization.html) | [Blockchain](http://bedrockdb.com/blockchain.html) | [Multizone](http://bedrockdb.com/multizone.html) | [Chat](https://gitter.im/Expensify-Bedrock/Lobby) | [Contact](http://bedrockdb.com#how-to-help-and-get-helped)
 
 # Bedrock -- Rock-solid distributed data
 Bedrock is a simple, modular, WAN-replicated, Blockchain-based data foundation for global-scale applications.  Taking each of those in turn:


### PR DESCRIPTION
@quinthar will you please review this? This is a quick fix to get the links at the top of BedrockDB.com looking nicer:

![image](https://user-images.githubusercontent.com/2319350/46128907-50d52000-c235-11e8-8fc5-975182b76130.png)

We should really add the capability to have a dynamic navigation in the future. I think I'd need a little help from someone more familiar with jekyll to help me out with that in the future. CC @Expensify/infra in case anyone wants to help me out for a quick rainy day project!


### Tests & QA
1. Pull a copy of this branch `shawn-docs` in `Bedrock`
1. Run `jekyl serve` from `Bedrock/docs`
1. Go to `http://localhost:4000/` and make sure the links look nice

