### PR TITLE
Update to enable compilation on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ testplugin:
 # Set up our precompiled header. This makes building *way* faster (roughly twice as fast).
 # Including it here causes it to be generated.
 # Depends on one of our mbedtls files, to make sure the submodule gets pulled and built.
-UNAME_S := $(shell uname -s)
 PRECOMPILE_D =libstuff/libstuff.d
 PRECOMPILE_INCLUDE =-include libstuff/libstuff.h
 libstuff/libstuff.h.gch libstuff/libstuff.d: libstuff/libstuff.h mbedtls/library/libmbedcrypto.a

--- a/Makefile
+++ b/Makefile
@@ -45,16 +45,13 @@ testplugin:
 # Set up our precompiled header. This makes building *way* faster (roughly twice as fast).
 # Including it here causes it to be generated.
 # Depends on one of our mbedtls files, to make sure the submodule gets pulled and built.
-# Currently disabled on OS X.
 UNAME_S := $(shell uname -s)
-ifneq ($(UNAME_S),Darwin)
 PRECOMPILE_D =libstuff/libstuff.d
 PRECOMPILE_INCLUDE =-include libstuff/libstuff.h
 libstuff/libstuff.h.gch libstuff/libstuff.d: libstuff/libstuff.h mbedtls/library/libmbedcrypto.a
 	$(GXX) $(CXXFLAGS) -MMD -MF libstuff/libstuff.d -MT libstuff/libstuff.h.gch -c libstuff/libstuff.h
 ifneq ($(MAKECMDGOALS),clean)
 -include  libstuff/libstuff.d
-endif
 endif
 
 clean:

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,16 @@ You can build from scratch as follows:
     # Install some dependencies with Brew (see: https://brew.sh/)
     brew update
     brew install gcc@6
-    brew install pcre
+    
+    # Configure PCRE to use C++17 and compile from source
+    brew uninstall --ignore-dependencies pcre
+    brew edit pcre
+    # Add these to the end of the `system "./configure"` command:
+    #     "--enable-cpp",
+    #     "--enable-pcre64",
+    #     "CXX=/usr/local/bin/g++-6",
+    #     "CXXFLAGS=--std=gnu++14"
+    brew install --build-from-source pcre
     
     # Build it
     cd Bedrock

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,34 @@ Copy/paste this command into your terminal:
 
 This will tansparently download the latest version from GitHub, compile it, package it up, and install it.
 
+### MacOSX
+You can build from scratch as follows:
+
+    # Clone out this repo:
+    git clone https://github.com/Expensify/Bedrock.git
+    
+    # Install some dependencies with Brew (see: https://brew.sh/)
+    brew update
+    brew install gcc@6
+    brew install pcre
+    
+    # Build it
+    cd Bedrock
+    make
+    
+    # Create an empty database (See: https://github.com/Expensify/Bedrock/issues/489)
+    touch bedrock.db
+    
+    # Run it (press Ctrl^C to quit, or use -fork to make it run in the backgroud)
+    ./bedrock
+    
+    # Connect to it in a different terminal using netcat
+    nc localhost 8888
+    
+    # Type "Status" and then enter twice to verify it's working
+    # See here to use the default DB plugin: http://bedrockdb.com/db.html
+
+
 ## How to use it
 Bedrock is so easy to use, you'll think you're missing something.  Once installed, Bedrock listens on `localhost` port 8888, and stores its database in `/var/lib/bedrock`.  The easiest way to talk with Bedrock is using `netcat` as follows:
 

--- a/test/clustertest/testplugin/Makefile
+++ b/test/clustertest/testplugin/Makefile
@@ -51,11 +51,15 @@ ifneq ($(MAKECMDGOALS),clean)
 -include $(DEP)
 endif
 
-LIBRARIES =-lpcrecpp -lbedrock -lstuff -ldl -lpthread -lmbedtls -lmbedx509 -lmbedcrypto -lz
+# OSX needs to re-link the libraries for some reason
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+LIBRARIES = -L../../../ -L../../../mbedtls/library -rdynamic -lpcrecpp -lbedrock -lstuff -ldl -lpthread -lmbedtls -lmbedx509 -lmbedcrypto -lz
+endif
 
 # The main library depends on all the .o files.
 testplugin.so: $(OBJ)
-	$(GXX) $(CXXFLAGS) -shared -o $@ $(OBJ) -lpcrecpp -L../../../ -L../../../mbedtls/library -rdynamic $(LIBRARIES)
+	$(GXX) $(CXXFLAGS) -shared -o $@ $(OBJ) $(LIBRARIES)
 
 # Make dependency files from cpp files, putting them in $INTERMEDIATEDIR.
 # This is the same as making the object files, both dependencies and object files are built together. The only

--- a/test/clustertest/testplugin/Makefile
+++ b/test/clustertest/testplugin/Makefile
@@ -51,9 +51,11 @@ ifneq ($(MAKECMDGOALS),clean)
 -include $(DEP)
 endif
 
+LIBRARIES =-lpcrecpp -lbedrock -lstuff -ldl -lpthread -lmbedtls -lmbedx509 -lmbedcrypto -lz
+
 # The main library depends on all the .o files.
 testplugin.so: $(OBJ)
-	$(GXX) $(CXXFLAGS) -shared -o $@ $(OBJ)
+	$(GXX) $(CXXFLAGS) -shared -o $@ $(OBJ) -L/usr/local/Cellar/pcre/8.42/lib -lpcrecpp -L../../../ -L../../../mbedtls/library -rdynamic $(LIBRARIES)
 
 # Make dependency files from cpp files, putting them in $INTERMEDIATEDIR.
 # This is the same as making the object files, both dependencies and object files are built together. The only

--- a/test/clustertest/testplugin/Makefile
+++ b/test/clustertest/testplugin/Makefile
@@ -55,7 +55,7 @@ LIBRARIES =-lpcrecpp -lbedrock -lstuff -ldl -lpthread -lmbedtls -lmbedx509 -lmbe
 
 # The main library depends on all the .o files.
 testplugin.so: $(OBJ)
-	$(GXX) $(CXXFLAGS) -shared -o $@ $(OBJ) -L/usr/local/Cellar/pcre/8.42/lib -lpcrecpp -L../../../ -L../../../mbedtls/library -rdynamic $(LIBRARIES)
+	$(GXX) $(CXXFLAGS) -shared -o $@ $(OBJ) -lpcrecpp -L../../../ -L../../../mbedtls/library -rdynamic $(LIBRARIES)
 
 # Make dependency files from cpp files, putting them in $INTERMEDIATEDIR.
 # This is the same as making the object files, both dependencies and object files are built together. The only


### PR DESCRIPTION
Problem:
====
Bedrock doesn't compile on OSX.  Fixes https://github.com/Expensify/Bedrock/issues/509

Solution:
====
Fixes to make it compile!

Tests:
====
Compiled under both Ubuntu and OSX