### PR TITLE
Do not fail on empty data object

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -234,7 +234,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
             }
 
             // Throw if data is not a valid JSON object, otherwise UPDATE query will fail.
-            if (SContains(job, "data") && SParseJSONObject(job["data"]).empty()) {
+            if (SContains(job, "data") && SParseJSONObject(job["data"]).empty() && job["data"] != "{}") {
                 STHROW("402 Data is not a valid JSON Object");
             }
 


### PR DESCRIPTION
Related to https://github.com/Expensify/Web-Expensify/pull/22695
Kind of needed for https://github.com/Expensify/Expensify/issues/88302

This allows the clients to send `{}` as the data.
In my tests of https://github.com/Expensify/Expensify/issues/88302 I tested with no data (null) and some data, but not an empty array... either that or I fucked up my tests before.