### PR TITLE
Add `processTimeout`

### DIFF
--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -5,7 +5,9 @@ class BedrockServer;
 
 class BedrockCore : public SQLiteCore {
   public:
-    const uint64_t DEFAULT_TIMEOUT = 30'000; // 30 seconds.
+    const uint64_t DEFAULT_TIMEOUT = 290'000; // 290 seconds, so clients can have a 5 minute timeout.
+    const uint64_t DEFAULT_TIMEOUT_FORGET = 60'000 * 60; // 1 hour for `connection: forget` commands.
+    const uint64_t DEFAULT_PROCESS_TIMEOUT = 30'000; // 30 seconds.
     BedrockCore(SQLite& db, const BedrockServer& server);
 
     // Automatic timing class that records an entry corresponding to its lifespan.

--- a/test/clustertest/tests/TimeoutTest.cpp
+++ b/test/clustertest/tests/TimeoutTest.cpp
@@ -7,7 +7,8 @@ struct TimeoutTest : tpunit::TestFixture {
                               BEFORE_CLASS(TimeoutTest::setup),
                               AFTER_CLASS(TimeoutTest::teardown),
                               TEST(TimeoutTest::test),
-                              TEST(TimeoutTest::testprocess)) { }
+                              TEST(TimeoutTest::testprocess),
+                              TEST(TimeoutTest::totalTimeout)) { }
 
     BedrockClusterTester* tester;
 
@@ -26,7 +27,7 @@ struct TimeoutTest : tpunit::TestFixture {
 
         // Run one long query.
         SData slow("slowquery");
-        slow["timeout"] = "5000"; // 5s
+        slow["processTimeout"] = "5000"; // 5s
         brtester->executeWaitVerifyContent(slow, "555 Timeout peeking command");
 
         // And a bunch of faster ones.
@@ -42,7 +43,7 @@ struct TimeoutTest : tpunit::TestFixture {
 
         // Run one long query.
         SData slow("slowprocessquery");
-        slow["timeout"] = "500"; // 0.5s
+        slow["processTimeout"] = "500"; // 0.5s
         slow["size"] = "1000000";
         slow["count"] = "1";
         brtester->executeWaitVerifyContent(slow, "555 Timeout processing command");
@@ -51,6 +52,15 @@ struct TimeoutTest : tpunit::TestFixture {
         slow["size"] = "100";
         slow["count"] = "10000";
         brtester->executeWaitVerifyContent(slow, "555 Timeout processing command");
+    }
+
+    void totalTimeout() {
+        // Test total timeout, not process timeout.
+        BedrockTester* brtester = tester->getBedrockTester(0);
+
+        SData https("httpstimeout");
+        https["timeout"] = "5000"; // 5s.
+        brtester->executeWaitVerifyContent(https, "555 Timeout");
     }
 } __TimeoutTest;
 


### PR DESCRIPTION
cc @coleaeason @flodnv @iwiznia 

[HOLD] for https://github.com/Expensify/Server-Expensify/pull/3094

2 of 2 for:
$ Expensify/Expensify#90656

Adds a second timeout value called `processTimeout`, so commands time out after 30s in `peek` or `process` OR after the total timeout has elapsed since they were supposed to run.

New test added. Hold on change to billing in auth.