### PR TITLE
[WIP] Make timed out responses return reasonably quickly after timing out.

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -42,12 +42,14 @@ BedrockCommand::BedrockCommand() :
 }
 
 BedrockCommand::~BedrockCommand() {
+    // Lock before doing any cleanup, this way if timing out occurs right at destruction, there's no ambiguity as to
+    // who cleaned this up.
+    lock_guard<mutex> lock(timeoutMutex);
     for (auto request : httpsRequests) {
         request->owner.closeTransaction(request);
     }
 
     // Remove in timeout info.
-    lock_guard<mutex> lock(timeoutMutex);
     auto items = commandTimeouts.equal_range(_timeout);
 
     int count = 0;

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -158,6 +158,7 @@ BedrockCommand& BedrockCommand::operator=(BedrockCommand&& from) {
         crashIdentifyingValues = move(from.crashIdentifyingValues);
         dead.store(from.dead.load());
         _inProgressTiming = from._inProgressTiming;
+        _timeout = from._timeout;
 
         // And call the base class's move constructor as well.
         SQLiteCommand::operator=(move(from));

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -29,41 +29,29 @@ class AutoScopeRewrite {
     bool (*_handler)(int, const char*, string&);
 };
 
-uint64_t BedrockCore::_getTimeout(const SData& request) {
+uint64_t BedrockCore::_getRemainingTime(const BedrockCommand& command) {
+    int64_t timeout = command.timeout();
+    int64_t now = STimeNow();
 
-    // Timeout is the default, unless explicitly supplied, or if Connection: forget is set.
-    uint64_t timeout =  DEFAULT_TIMEOUT;
-    if (request.isSet("timeout")) {
-        timeout = request.calc("timeout");
-    } else if (SIEquals(request["connection"], "forget")) {
-        timeout = DEFAULT_TIMEOUT_FORGET;
-    }
+    // This is what's left for the "absolute" time. If it's negative, we've already timed out.
+    int64_t adjustedTimeout = timeout - now;
 
     // We also want to know the processTimeout, because we'll return early if we get stuck processing for too long.
-    int64_t processTimeout = request.isSet("processTimeout") ? request.calc("processTimeout") : DEFAULT_PROCESS_TIMEOUT;
+    int64_t processTimeout = command.request.isSet("processTimeout") ? (command.request.calc("processTimeout")) : BedrockCommand::DEFAULT_PROCESS_TIMEOUT;
 
-    // See when the command was scheduled to run. The timeout is from *this* start time, not from when the command
-    // starts executing.
-    try {
-        int64_t adjustedTimeout = (int64_t)timeout - (int64_t)((STimeNow() - stoull(request["commandExecuteTime"])) / 1000);
+    // Since timeouts are specified in ms, we convert to us.
+    processTimeout *= 1000;
 
-        // If this is negative, we're *already* past the timeout, just return early.
-        if (adjustedTimeout <= 0 || processTimeout <= 0) {
-            SALERT("Command " << request.methodLine << " timed out after " << (timeout - adjustedTimeout) << "ms.");
-            STHROW("555 Timeout");
-        } else {
-            // Otherwise, we can return the shorter of our two timeouts.
-            return min(adjustedTimeout, processTimeout);
-        }
-    } catch (const invalid_argument& e) {
-        SWARN("Couldn't parse commandExecuteTime: " << request["commandExecuteTime"] << "'.");
-    } catch (const out_of_range& e) {
-        SWARN("Invalid commandExecuteTime: " << request["commandExecuteTime"] << "'.");
+    // Already expired.
+    if (adjustedTimeout <= 0 || processTimeout <= 0) {
+        SALERT("Command " << command.request.methodLine << " timed out after " << (timeout - adjustedTimeout) << "ms.");
+        STHROW("555 Timeout");
     }
-
-    // This only happens if we hit the catch blocks above. Default to a low value.
-    return min(DEFAULT_TIMEOUT, DEFAULT_PROCESS_TIMEOUT);
+     
+    // Both of these are positive, return the lowest remaining.
+    return min(processTimeout, adjustedTimeout);
 }
+
 bool BedrockCore::peekCommand(BedrockCommand& command) {
     AutoTimer timer(command, BedrockCommand::PEEK);
     // Convenience references to commonly used properties.
@@ -74,10 +62,10 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
     // We catch any exception and handle in `_handleCommandException`.
     try {
         SDEBUG("Peeking at '" << request.methodLine << "' with priority: " << command.priority);
-        uint64_t timeout = _getTimeout(request);
+        uint64_t timeout = _getRemainingTime(command);
         command.peekCount++;
 
-        _db.startTiming(timeout * 1000);
+        _db.startTiming(timeout);
         // We start a transaction in `peekCommand` because we want to support having atomic transactions from peek
         // through process. This allows for consistency through this two-phase process. I.e., anything checked in
         // peek is guaranteed to still be valid in process, because they're done together as one transaction.
@@ -179,11 +167,11 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
     bool needsCommit = false;
     try {
         SDEBUG("Processing '" << request.methodLine << "'");
-        uint64_t timeout = _getTimeout(request);
+        uint64_t timeout = _getRemainingTime(command);
         command.processCount++;
 
         // Time in US.
-        _db.startTiming(timeout * 1000);
+        _db.startTiming(timeout);
         // If a transaction was already begun in `peek`, then this is a no-op. We call it here to support the case where
         // peek created a httpsRequest and closed it's first transaction until the httpsRequest was complete, in which
         // case we need to open a new transaction.

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -5,9 +5,6 @@ class BedrockServer;
 
 class BedrockCore : public SQLiteCore {
   public:
-    const uint64_t DEFAULT_TIMEOUT = 290'000; // 290 seconds, so clients can have a 5 minute timeout.
-    const uint64_t DEFAULT_TIMEOUT_FORGET = 60'000 * 60; // 1 hour for `connection: forget` commands.
-    const uint64_t DEFAULT_PROCESS_TIMEOUT = 30'000; // 30 seconds.
     BedrockCore(SQLite& db, const BedrockServer& server);
 
     // Automatic timing class that records an entry corresponding to its lifespan.
@@ -52,7 +49,8 @@ class BedrockCore : public SQLiteCore {
     // Gets the amount of time remaining until this command times out. This is the difference between the command's
     // 'timeout' value (or the default timeout, if not set) and the time the command was initially scheduled to run. If
     // this time is already expired, this throws `555 Timeout`
-    uint64_t _getTimeout(const SData& request);
+    uint64_t _getRemainingTime(const BedrockCommand& command);
+
     void _handleCommandException(BedrockCommand& command, const SException& e);
     const BedrockServer& _server;
 };


### PR DESCRIPTION
So far, this adds a map that we can query for commands that have timed out, but doesn't actually do anything with those commands. There are concurrency difficulties to work out, as well.

Issue:
https://github.com/Expensify/Expensify/issues/90591