### PR TITLE
Fix broken deserialization of broadcast commands

### DIFF
--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -27,4 +27,10 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
     TestHTTPSMananager httpsManager;
     BedrockServer* _server;
     bool shouldPreventAttach = false;
+
+    // This is a hack, but it lets one command store data for another command to read. This lets us inspect the output
+    // of one command from another, even if the first command never sends a response.
+    static mutex dataLock;
+    static map<string, string> arbitraryData;
+
 };

--- a/test/clustertest/tests/BroadcastTest.cpp
+++ b/test/clustertest/tests/BroadcastTest.cpp
@@ -1,0 +1,50 @@
+#include "../BedrockClusterTester.h"
+
+struct BroadcastCommandTest : tpunit::TestFixture {
+    BroadcastCommandTest()
+        : tpunit::TestFixture("BroadcastCommand",
+                              BEFORE_CLASS(BroadcastCommandTest::setup),
+                              AFTER_CLASS(BroadcastCommandTest::teardown),
+                              TEST(BroadcastCommandTest::test)
+                             ) { }
+
+    BedrockClusterTester* tester;
+
+    void setup() {
+        tester = new BedrockClusterTester(_threadID, "");
+    }
+
+    void teardown() {
+        delete tester;
+    }
+
+    void test()
+    {
+        BedrockTester* master = tester->getBedrockTester(0);
+        BedrockTester* slave = tester->getBedrockTester(1);
+
+        // We want to test when this command runs.
+        uint64_t now = STimeNow();
+
+        // Make sure unhandled exceptions send the right response.
+        SData cmd("broadcastwithtimeouts");
+        master->executeWaitVerifyContent(cmd);
+
+        // Now wait for the slave to have received and run the command.
+        sleep(5);
+
+        SData cmd2("getboradcasttimeouts");
+        vector<SData> results = slave->executeWaitMultipleData({cmd2});
+
+        // The commandExecuteTime of the command should be between the time we stored as `now` above, and 3 seconds
+        // after that
+        ASSERT_GREATER_THAN(now + 3'000'000, stoull(results[0]["stored_commandExecuteTime"]));
+        ASSERT_LESS_THAN(now, stoull(results[0]["stored_commandExecuteTime"]));
+
+        // Other values should just match what's in the testplugin code.
+        ASSERT_EQUAL(5001, stoll(results[0]["stored_processTimeout"]));
+        ASSERT_EQUAL(5002, stoll(results[0]["stored_timeout"]));
+        ASSERT_EQUAL("whatever", results[0]["stored_not_special"]);
+    }
+
+} __BroadcastCommandTest;


### PR DESCRIPTION
Copied comment from here https://github.com/Expensify/Server-Expensify/pull/3116#issuecomment-434997032 :

Fixes: https://github.com/Expensify/Expensify/issues/91751

Ok, here's what happens with the `BeginAutomatedBilling` timeout:

We do this:
https://github.com/Expensify/Bedrock/blob/master/sqlitecluster/SQLiteNode.cpp#L1766

```
 _server.acceptCommand(SQLiteCommand(move(messageCopy)), true);
```

When we send a `BROADCAST_COMMAND` to BedrockServer. Note that messageCopy is a `BROADCAST_COMMAND`, not whatever command it's going to broadcast. This means that the SQLiteContructor gets run for the `BROADCAST_COMMAND` command, which has no timeout information, thus receiving the defaults.

Then `acceptCommand` does this check:

https://github.com/Expensify/Bedrock/blob/master/BedrockServer.cpp#L28-L34
```
if (SIEquals(command.request.methodLine, "BROADCAST_COMMAND")) {
    SData newRequest;
    newRequest.deserialize(command.request.content);
    command.request = newRequest;
    command.initiatingClientID = -1;
    command.initiatingPeerID = 0;
}
```

The line of note being `newRequest.deserialize(command.request.content)`. We create a new request object, and assign it over the old object *inside* the existing command. This erases `commandExecuteTime`, which was set in the constructor, and is never restored.

Tests have been added.