### PR TITLE
retryAfter for repeatable jobs

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -656,9 +656,9 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         string safeNumResults = SQ(max(request.calc("numResults"),1));
         bool mockRequest = command.request.isSet("mockRequest") || command.request.isSet("getMockedJobs");
         string selectQuery =
-            "SELECT jobID, name, data, parentJobID, retryAfter, created FROM ( "
+            "SELECT jobID, name, data, parentJobID, retryAfter, created, repeat FROM ( "
                 "SELECT * FROM ("
-                    "SELECT jobID, name, data, priority, parentJobID, retryAfter, created "
+                    "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat "
                     "FROM jobs "
                     "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                         "AND priority=1000 "
@@ -669,7 +669,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 ") "
             "UNION ALL "
                 "SELECT * FROM ("
-                    "SELECT jobID, name, data, priority, parentJobID, retryAfter, created "
+                    "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat "
                     "FROM jobs "
                     "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                         "AND priority=500 "
@@ -680,7 +680,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 ") "
             "UNION ALL "
                 "SELECT * FROM ("
-                    "SELECT jobID, name, data, priority, parentJobID, retryAfter, created "
+                    "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat "
                     "FROM jobs "
                     "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                         "AND priority=0 "
@@ -715,7 +715,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         list<STable> retriableJobs;
         list<string> jobList;
         for (size_t c=0; c<result.size(); ++c) {
-            SASSERT(result[c].size() == 6); // jobID, name, data, parentJobID, retryAfter, created
+            SASSERT(result[c].size() == 7); // jobID, name, data, parentJobID, retryAfter, created, repeat
 
             // Add this object to our output
             STable job;
@@ -735,6 +735,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             // Add jobID to the respective list depending on if retryAfter is set
             if (result[c][4] != "") {
                 job["retryAfter"] = result[c][4];
+                job["repeat"] = result[c][6];
                 retriableJobs.push_back(job);
             } else {
                 nonRetriableJobs.push_back(result[c][0]);
@@ -788,7 +789,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 string updateQuery = "UPDATE jobs "
                                      "SET state='RUNQUEUED', "
                                          "lastRun=" + SCURRENT_TIMESTAMP() + ", "
-                                         "nextRun=DATETIME(" + SCURRENT_TIMESTAMP() + ", " + SQ(job["retryAfter"]) + ") "
+                                         "nextRun=MIN(DATETIME(" + SCURRENT_TIMESTAMP() + ", " + SQ(job["retryAfter"]) + "), " + _constructNextRunDATETIME(job["nextRun"], job["lastRun"], job["repeat"]) + ") "
                                      "WHERE jobID = " + SQ(job["jobID"]) + ";";
                 if (!db.writeIdempotent(updateQuery)) {
                     STHROW("502 Update failed");

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -238,12 +238,6 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
                 STHROW("402 Data is not a valid JSON Object");
             }
 
-            // Recurring auto-retrying jobs open the doors to a whole new world of potential bugs
-            // so we're intentionally not adding support for them them yet
-            if (SContains(job, "repeat") && SContains(job, "retryAfter")) {
-                STHROW("402 Recurring auto-retrying jobs are not supported");
-            }
-
             // Validate retryAfter
             if (SContains(job, "retryAfter") && job["retryAfter"] != "" && !_isValidSQLiteDateModifier(job["retryAfter"])){
                 STHROW("402 Malformed retryAfter");

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -793,7 +793,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 string updateQuery = "UPDATE jobs "
                                      "SET state='RUNQUEUED', "
                                          "lastRun=" + currentTime + ", "
-                                         "nextRun=MIN(DATETIME(" + currentTime + ", " + SQ(job["retryAfter"]) + "), COALESCE(NULLIF(" + (nextRunDateTime != "" ? nextRunDateTime : "''") + ", ''), 'z'))" + " "
+                                         "nextRun=MIN(DATETIME(" + currentTime + ", " + SQ(job["retryAfter"]) + "), COALESCE(" + (nextRunDateTime != "" ? nextRunDateTime : "NULL") + ", 'z'))" + " "
                                      "WHERE jobID = " + SQ(job["jobID"]) + ";";
                 if (!db.writeIdempotent(updateQuery)) {
                     STHROW("502 Update failed");


### PR DESCRIPTION
We're adding the ability to have retryAfter with repeatable jobs. The functionality will be that if you have retryAfter and a repeat and a job gets stuck, we'll pick whichever is sooner, the retryAfter or the repeat. If the retryAfter ends up running, it will offset any jobs that are done relative to queue or finish of the last run (and not beginning of the day) to be offset by the retryAfter time. Shouldn't be a big deal, just need to be aware.

# Tests
1. CreateJob with retryAfter `+5 SECONDS` and repeat `FINISHED, +10 SECONDS`
2. GetJob, confirm that nextRun is 5 seconds after lastRun.
3. FinishJob, confirm that nextRun is 10 seconds after you finished the job.

Also added some automated tests.