### PR TITLE
Allow an https manager to not have a transactions timeout list

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -77,6 +77,11 @@ void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     postPoll(fdm, nextActivity, completedRequests, transactionTimeouts);
 }
 
+void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSManager::Transaction*>& completedRequests) {
+    map<Transaction*, uint64_t> transactionTimeouts;
+    postPoll(fdm, nextActivity, completedRequests, transactionTimeouts);
+}
+
 void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSManager::Transaction*>& completedRequests, map<Transaction*, uint64_t>& transactionTimeouts, uint64_t timeoutMS) {
     SAUTOLOCK(_listMutex);
 

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -28,6 +28,8 @@ class SHTTPSManager : public STCPManager {
     // STCPServer API. Except for postPoll, these are just threadsafe wrappers around base class functions.
     void prePoll(fd_map& fdm);
     void postPoll(fd_map& fdm, uint64_t& nextActivity);
+    void postPoll(fd_map& fdm, uint64_t& nextActivity, list<Transaction*>& completedRequests);
+
 
     // Default timeout for HTTPS requests is 5 minutes.This can be changed on any call to postPoll.
     void postPoll(fd_map& fdm, uint64_t& nextActivity, list<Transaction*>& completedRequests, map<Transaction*, uint64_t>& transactionTimeouts, uint64_t timeoutMS = (5 * 60 * 1000));


### PR DESCRIPTION
@swhi3635 please review, the recent time out change changed the postPoll APIs available for HTTPSManagers under the assumption that every HTTPSManager is polled through BedrockServer, but that's not true for the backup manager which uses it's own out of band polling thread because there is no BedrockServer object available to do the polling while it's doing it's work.

Tests:
Compiled EBM against this version of bedrock, ran the test suite.
```
expensidev->expensifyBackupManager/test (master) > ./expensifyBackupManagerTest
[--------------]
[ RUN          ] BackupTest::upload
[       PASSED ] BackupTest::upload
[ RUN          ] BackupTest::download
[       PASSED ] BackupTest::download
[--------------]

[==============]
[ TEST RESULTS ] Passed: 2, Failed: 0
[==============]
```