### PR TITLE
Don't overwrite 'request' and its execution time

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -17,7 +17,7 @@ int64_t BedrockCommand::_getTimeout(const SData& request) {
     if (request.isSet("commandExecuteTime")) {
         start = request.calc64("commandExecuteTime");
     } else {
-        SWARN("BedrockCommand created with no commandExecuteTime, should be done in base constructor!");
+        SWARN("BedrockCommand '" + request.methodLine + "' created with no commandExecuteTime, should be done in base constructor!");
         start = STimeNow();
     }
     return timeout + start;


### PR DESCRIPTION
@flodnv 

Fixes: https://github.com/Expensify/Expensify/issues/92305

What was happening here is we were assigning the `request` of a SQLiteCommand over the one created in the constructor, which could delete its `commandExecuteTime`.

This creates the command from the completed `request`, allowing it to set (and keep) this value.

This should have no real practical effect except to silence this warning.

Note to self for other issue (https://github.com/Expensify/Expensify/issues/92130)  - the tests for this needed to be restarted 2 times before succeeding. Ignore this line unless you care about me fixing the tests.