### PR TITLE
This was overlooked in previous PR

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -44,8 +44,8 @@ uint64_t BedrockCore::_getRemainingTime(const BedrockCommand& command) {
 
     // Already expired.
     if (adjustedTimeout <= 0 || processTimeout <= 0) {
-        // TODO: The actual timeout number in this line is wrong.
-        SALERT("Command " << command.request.methodLine << " timed out after " << (timeout - adjustedTimeout) << "ms.");
+        SALERT("Command " << command.request.methodLine << " timed out after "
+               << ((now - command.request.calc64("commandExecuteTime")) / 1000) << "ms.");
         STHROW("555 Timeout");
     }
 


### PR DESCRIPTION
@iwiznia 

This is why that timestamp was wrong. Doesn't fix anything else except an inaccurate log line.