### PR TITLE
Return retryAfter in queryJob command

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -172,7 +172,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
 
         // Verify there is a job like this
         SQResult result;
-        if (!db.read("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data "
+        if (!db.read("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, retryAfter "
                      "FROM jobs "
                      "WHERE jobID=" + SQ(request.calc64("jobID")) + ";",
                      result)) {
@@ -189,6 +189,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
         content["lastRun"] = result[0][5];
         content["repeat"] = result[0][6];
         content["data"] = result[0][7];
+        content["retryAfter"] = result[0][8];
         return true; // Successfully processed
     }
 

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -172,7 +172,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
 
         // Verify there is a job like this
         SQResult result;
-        if (!db.read("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, retryAfter "
+        if (!db.read("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, retryAfter, priority "
                      "FROM jobs "
                      "WHERE jobID=" + SQ(request.calc64("jobID")) + ";",
                      result)) {
@@ -190,6 +190,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
         content["repeat"] = result[0][6];
         content["data"] = result[0][7];
         content["retryAfter"] = result[0][8];
+        content["priority"] = result[0][9];
         return true; // Successfully processed
     }
 

--- a/test/tests/jobs/QueryJobTest.cpp
+++ b/test/tests/jobs/QueryJobTest.cpp
@@ -1,0 +1,51 @@
+#include <test/lib/BedrockTester.h>
+
+struct QueryJobTest : tpunit::TestFixture {
+    QueryJobTest()
+        : tpunit::TestFixture("QueryJob",
+                              BEFORE_CLASS(QueryJobTest::setupClass),
+                              TEST(QueryJobTest::queryJob),
+                              AFTER(QueryJobTest::tearDown),
+                              AFTER_CLASS(QueryJobTest::tearDownClass)) { }
+
+    BedrockTester* tester;
+
+    void setupClass() { tester = new BedrockTester(_threadID, {{"-plugins", "Jobs,DB"}}, {});}
+
+    // Reset the jobs table
+    void tearDown() {
+        SData command("Query");
+        command["query"] = "DELETE FROM jobs WHERE jobID > 0;";
+        tester->executeWaitVerifyContent(command);
+    }
+
+    void tearDownClass() { delete tester; }
+
+    void queryJob() {
+        // Create the job
+        SData command("CreateJob");
+        string jobName = "job";
+        command["name"] = jobName;
+        command["firstRun"] = "2042-04-02 00:42:42";
+        command["repeat"] = "FINISHED, +1 DAY";
+        command["data"] = "{\"something\":1}";
+        command["priority"] = "1000";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+        ASSERT_GREATER_THAN(SToInt(jobID), 0);
+
+        command.clear();
+        command.methodLine = "QueryJob";
+        command["jobID"] = jobID;
+        response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_EQUAL(response.size(), 10);
+        ASSERT_EQUAL(response["jobID"], jobID);
+        ASSERT_EQUAL(response["name"], jobName);
+        ASSERT_EQUAL(response["nextRun"], "2042-04-02 00:42:42");
+        ASSERT_EQUAL(response["repeat"], "FINISHED, +1 DAY");
+        ASSERT_EQUAL(response["data"], "{\"something\":1}");
+        ASSERT_EQUAL(response["priority"], "1000");
+        SASSERT(!response["created"].empty());
+    }
+} __QueryJobTest;
+


### PR DESCRIPTION
@pecanoro please review.
 
Related to https://github.com/Expensify/Expensify/issues/90258
Used in https://github.com/Expensify/Web-Expensify/pull/22982

Tests:
Called queryJob and check retryAfter was returned.