### PR TITLE
Improve Bedrock Tests

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -26,7 +26,7 @@
 
 // Initializations for static vars.
 const uint64_t SQLiteNode::SQL_NODE_DEFAULT_RECV_TIMEOUT = STIME_US_PER_M * 5;
-const uint64_t SQLiteNode::SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT = STIME_US_PER_M;
+const uint64_t SQLiteNode::SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT = STIME_US_PER_S * 30;
 atomic<bool> SQLiteNode::unsentTransactions(false);
 uint64_t SQLiteNode::_lastSentTransactionID = 0;
 
@@ -1369,7 +1369,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 }
 
                 // Also, extend our timeout so long as we're still alive
-                _stateTimeout = STimeNow() + SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT + SRandom::rand64() % STIME_US_PER_M * 5;
+                _stateTimeout = STimeNow() + SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT + SRandom::rand64() % STIME_US_PER_S * 5;
             }
         } catch (const SException& e) {
             // Transaction failed
@@ -1957,7 +1957,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
         } else if (newState == SEARCHING || newState == SUBSCRIBING) {
             timeout = SQL_NODE_DEFAULT_RECV_TIMEOUT + SRandom::rand64() % STIME_US_PER_S * 5;
         } else if (newState == SYNCHRONIZING) {
-            timeout = SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT + SRandom::rand64() % STIME_US_PER_M * 5;
+            timeout = SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT + SRandom::rand64() % STIME_US_PER_S * 5;
         } else {
             timeout = 0;
         }

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -57,7 +57,7 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
         arbitraryData["commandExecuteTime"] = command.request["commandExecuteTime"];
         arbitraryData["not_special"] = command.request["not_special"];
         return true;
-    } else if (SStartsWith(command.request.methodLine, "getboradcasttimeouts")) {
+    } else if (SStartsWith(command.request.methodLine, "getbroadcasttimeouts")) {
         // Finally, the caller can send this command to the peers to make sure they received the correct timeout data.
         lock_guard<mutex> lock(dataLock);
         command.response["stored_timeout"] = arbitraryData["timeout"];
@@ -112,7 +112,7 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
                 transaction->s->send(request.serialize());
             }).detach();
         }
-    } else if (SStartsWith(command.request.methodLine, "dieinpeek")) {
+    } else if (SStartsWith(command.request.methodLine, "exceptioninpeek")) {
         throw 1;
     } else if (SStartsWith(command.request.methodLine, "generatesegfaultpeek")) {
         int* i = 0;
@@ -224,7 +224,7 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
             query += ";";
             db.read(query, result);
         }
-    } else if (SStartsWith(command.request.methodLine, "dieinprocess")) {
+    } else if (SStartsWith(command.request.methodLine, "exceptioninprocess")) {
         throw 2;
     } else if (SStartsWith(command.request.methodLine, "generatesegfaultprocess")) {
         int* i = 0;

--- a/test/clustertest/tests/BroadcastTest.cpp
+++ b/test/clustertest/tests/BroadcastTest.cpp
@@ -28,13 +28,24 @@ struct BroadcastCommandTest : tpunit::TestFixture {
 
         // Make sure unhandled exceptions send the right response.
         SData cmd("broadcastwithtimeouts");
-        master->executeWaitVerifyContent(cmd);
+        try {
+            master->executeWaitVerifyContent(cmd);
+        } catch (...) {
+            cout << "Couldn't send broadcastwithtimeouts" << endl;
+            throw;
+        }
 
         // Now wait for the slave to have received and run the command.
         sleep(5);
 
-        SData cmd2("getboradcasttimeouts");
-        vector<SData> results = slave->executeWaitMultipleData({cmd2});
+        SData cmd2("getbroadcasttimeouts");
+        vector<SData> results;
+        try {
+            results = slave->executeWaitMultipleData({cmd2});
+        } catch (...) {
+            cout << "Couldn't send getbroadcasttimeouts" << endl;
+            throw;
+        }
 
         // The commandExecuteTime of the command should be between the time we stored as `now` above, and 3 seconds
         // after that

--- a/test/clustertest/tests/FutureExecutionTest.cpp
+++ b/test/clustertest/tests/FutureExecutionTest.cpp
@@ -43,9 +43,20 @@ struct FutureExecutionTest : tpunit::TestFixture {
         // Then sleep three more seconds, it *should* be there now.
         sleep(3);
 
-        // And now it should be there.
-        result = brtester->executeWaitVerifyContent(query);
-        ASSERT_TRUE(SContains(result, "50011"));
+        // And now it should be there, but we'll give it a couple tries.
+        int retries = 3;
+        bool success = false;
+        while (retries) {
+            result = brtester->executeWaitVerifyContent(query);
+            if (SContains(result, "50011")) {
+                success = true;
+                break;
+            } else {
+                sleep(1);
+                retries--;
+            }
+        }
+        ASSERT_TRUE(success);
     }
 
 } __FutureExecutionTest;

--- a/test/clustertest/tests/MasteringTest.cpp
+++ b/test/clustertest/tests/MasteringTest.cpp
@@ -133,7 +133,7 @@ struct MasteringTest : tpunit::TestFixture {
         tester->stopNode(1);
 
         // Create a bunch of commands.
-        vector<SData> requests(1000);
+        vector<SData> requests(5000);
         int count = 0;
         for (auto& request : requests) {
             if (!count) {
@@ -154,6 +154,7 @@ struct MasteringTest : tpunit::TestFixture {
 
         // Start the slave back up.
         bool wasSynchronizing = false;
+        bool wasSlaving = false;
         string startstatus = tester->startNodeDontWait(1);
         STable json = SParseJSONObject(startstatus);
         if (json["state"] == "SYNCHRONIZING") {
@@ -175,6 +176,9 @@ struct MasteringTest : tpunit::TestFixture {
                 }
             }
             if(json["state"] == "SLAVING") {
+                // Make sure it was slaving before it was synchronizing.
+                ASSERT_TRUE(wasSynchronizing);
+                wasSlaving = true;
                 break;
             }
             tries++;
@@ -184,6 +188,7 @@ struct MasteringTest : tpunit::TestFixture {
             usleep(10'000); // 1/100th of a second
         }
         ASSERT_TRUE(wasSynchronizing);
+        ASSERT_TRUE(wasSlaving);
     }
 
 } __MasteringTest;

--- a/test/clustertest/tests/TimeoutTest.cpp
+++ b/test/clustertest/tests/TimeoutTest.cpp
@@ -28,7 +28,7 @@ struct TimeoutTest : tpunit::TestFixture {
 
         // Run one long query.
         SData slow("slowquery");
-        slow["processTimeout"] = "5000"; // 5s
+        slow["processTimeout"] = "1000"; // 1s
         brtester->executeWaitVerifyContent(slow, "555 Timeout peeking command");
 
         // And a bunch of faster ones.

--- a/test/clustertest/tests/TimingTest.cpp
+++ b/test/clustertest/tests/TimingTest.cpp
@@ -28,8 +28,19 @@ struct TimingTest : tpunit::TestFixture {
             SData query("idcollision h");
             query["writeConsistency"] = "ASYNC";
             query["value"] = "default";
-            auto results = brtester->executeWaitMultipleData({query});
-            auto result = results[0];
+            int retries = 3;
+            SData result;
+            while (retries) {
+                auto results = brtester->executeWaitMultipleData({query});
+                result = results[0];
+                if (result.isSet("totalTime")) {
+                    break;
+                } else {
+                    sleep(1);
+                    retries--;
+                    continue;
+                }
+            }
             /* Uncomment for inspection.
             for (const auto& row : result.nameValueMap) {
                 cout << row.first << ":" << row.second << endl;
@@ -43,11 +54,25 @@ struct TimingTest : tpunit::TestFixture {
 
             // Only master is expected to have these set.
             if (i == 0) {
+                if (peekTime <= 0 || processTime <= 0) {
+                    cout << "peekTime: " << peekTime << endl;
+                    cout << "processTime: " << processTime << endl;
+                    cout << "totalTime: " << totalTime << endl;
+                    cout << result.serialize() << endl;
+                }
                 ASSERT_GREATER_THAN(peekTime, 0);
                 ASSERT_GREATER_THAN(processTime, 0);
             } else {
                 ASSERT_EQUAL(peekTime, 0);
                 ASSERT_EQUAL(processTime, 0);
+            }
+
+            if (peekTime + processTime >= totalTime) {
+                // These are just blank in the failure case.
+                cout << "peekTime: " << peekTime << endl;
+                cout << "processTime: " << processTime << endl;
+                cout << "totalTime: " << totalTime << endl;
+                cout << result.serialize() << endl;
             }
 
             ASSERT_LESS_THAN(peekTime + processTime, totalTime);

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -171,13 +171,13 @@ string BedrockTester::startServer(bool dontWait) {
 
         // Make sure the ports we need are free.
         int portsFree = 0;
-        portsFree |= waitForPort(serverPort());
-        portsFree |= waitForPort(nodePort());
-        portsFree |= waitForPort(controlPort());
+        portsFree |= waitForPort(getServerPort());
+        portsFree |= waitForPort(getNodePort());
+        portsFree |= waitForPort(getControlPort());
 
         if (portsFree) {
-            cout << "At least one port wasn't free (of: " << serverPort() << ", " << nodePort() << ", "
-                 << controlPort() << ") to start server, things will probably fail." << endl;
+            cout << "At least one port wasn't free (of: " << getServerPort() << ", " << getNodePort() << ", "
+                 << getControlPort() << ") to start server, things will probably fail." << endl;
         }
 
         // And then start the new server!
@@ -488,15 +488,15 @@ bool BedrockTester::readDB(const string& query, SQResult& result)
     return getSQLiteDB().read(query, result);
 }
 
-int BedrockTester::serverPort() {
+int BedrockTester::getServerPort() {
     return _serverPort;
 }
 
-int BedrockTester::nodePort() {
+int BedrockTester::getNodePort() {
     return _nodePort;
 }
 
-int BedrockTester::controlPort() {
+int BedrockTester::getControlPort() {
     return _controlPort;
 }
 
@@ -529,6 +529,7 @@ int BedrockTester::waitForPort(int port) {
 
     int result = 0;
     int count = 0;
+    uint64_t start = STimeNow();
     do {
         result = ::bind(sock, (sockaddr*)&addr, sizeof(addr));
         if (result) {
@@ -539,8 +540,8 @@ int BedrockTester::waitForPort(int port) {
             close(sock);
             return 0;
         }
-    // Wait up to 300 10ths of a second (30 seconds).
-    } while (result && count++ < 300);
+    // Wait up to 30 seconds.
+    } while (result && STimeNow() < start + 30'000'000);
 
     return 1;
 }

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -51,7 +51,7 @@ class BedrockTester {
     // Takes a list of requests, and returns a corresponding list of responses.
     // Uses `connections` parallel connections to the server to send the requests.
     // If `control` is set, sends the message to the control port.
-    vector<SData> executeWaitMultipleData(vector<SData> requests, int connections = 10, bool control = false, bool returnOnDisconnect = false);
+    vector<SData> executeWaitMultipleData(vector<SData> requests, int connections = 10, bool control = false, bool returnOnDisconnect = false, int* errorCode = nullptr);
 
     // Sends a single request, returning the response content.
     // If the response method line doesn't begin with the expected result, throws.
@@ -67,6 +67,19 @@ class BedrockTester {
     SQLite& getSQLiteDB();
 
     int getServerPID() { return _serverPID; }
+
+    // Expose the ports that the server is listening on.
+    int serverPort();
+    int nodePort();
+    int controlPort();
+
+    // Waits up to timeoutUS for the node to be in state `state`, returning true as soon as that state is reached, or
+    // false if the timeout is hit.
+    bool waitForState(string state, uint64_t timeoutUS = 60'000'000);
+
+    // Waits for a particular port to be free to bind to. This is useful when we've killed a server, because sometimes
+    // it takes the OS a few seconds to make the port available again.
+    static int waitForPort(int port);
 
   protected:
     // Args passed on creation, which will be used to start the server if the `start` flag is set, or if `startServer`
@@ -93,4 +106,9 @@ class BedrockTester {
 
     // For locking around changes to the _testers list.
     static mutex _testersMutex;
+
+    // The ports the server will listen on.
+    uint16_t _serverPort;
+    uint16_t _nodePort;
+    uint16_t _controlPort;
 };

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -69,9 +69,9 @@ class BedrockTester {
     int getServerPID() { return _serverPID; }
 
     // Expose the ports that the server is listening on.
-    int serverPort();
-    int nodePort();
-    int controlPort();
+    int getServerPort();
+    int getNodePort();
+    int getControlPort();
 
     // Waits up to timeoutUS for the node to be in state `state`, returning true as soon as that state is reached, or
     // false if the timeout is hit.

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -20,8 +20,6 @@ struct LibStuff : tpunit::TestFixture {
                                     TEST(LibStuff::testSData),
                                     TEST(LibStuff::testSTable),
                                     TEST(LibStuff::testFileIO),
-                                    TEST(LibStuff::testSTimeNow),
-                                    TEST(LibStuff::testCurrentTimestamp),
                                     TEST(LibStuff::testSQList),
                                     TEST(LibStuff::testRandom),
                                     TEST(LibStuff::testHexConversion),
@@ -430,36 +428,6 @@ struct LibStuff : tpunit::TestFixture {
 
         // The non-existent file's size is reported as zero
         ASSERT_EQUAL(SFileSize(path), 0);
-    }
-
-    void testSTimeNow() {
-        // This is a super-awful test.
-        uint64_t prev = STimeNow();
-        uint64_t next;
-        int failures = 0;
-        for (int i = 0; i < 10000; i++) {
-            next = STimeNow();
-            if (next < prev) {
-                failures++;
-            }
-            prev = next;
-        }
-        ASSERT_EQUAL(failures, 0);
-    }
-
-    void testCurrentTimestamp() {
-        // This is also a super-awful test.
-        string prev = SCURRENT_TIMESTAMP();
-        string next;
-        int failures = 0;
-        for (int i = 0; i < 10000; i++) {
-            next = SCURRENT_TIMESTAMP();
-            if (next < prev) {
-                failures++;
-            }
-            prev = next;
-        }
-        ASSERT_EQUAL(failures, 0);
     }
 
     void testSQList() {

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -34,7 +34,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         // This exposes just enough to test the peer selection logic.
         SQLite db(":memory:", 1000000, 100, 5000, -1, -1);
         TestServer server("");
-        SQLiteNode testNode(server, db, "test", "localhost:19999", "", 1, 1000000000, "1.0", 100);
+        SQLiteNode testNode(server, db, "test", "localhost:19998", "", 1, 1000000000, "1.0", 100);
 
         STable dummyParams;
         testNode.addPeer("peer1", "host1.fake:15555", dummyParams);

--- a/test/tests/WriteTest.cpp
+++ b/test/tests/WriteTest.cpp
@@ -51,7 +51,6 @@ struct WriteTest : tpunit::TestFixture {
     void parallelInsert() {
         vector<SData> requests;
         int numCommands = 50;
-        cout << "Testing with " << numCommands << " commands." << endl;
         for (int i = 0; i < numCommands; i++) {
             SData query("Query");
             query["writeConsistency"] = "ASYNC";

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -429,20 +429,22 @@ struct CreateJobTest : tpunit::TestFixture {
         }
 
         // This will fail with 404's until the job re-queues.
-        int retries = 100; // 100 tenths of a second.
-        while (retries) {
+        uint64_t start = STimeNow();
+        bool assertionsChecked = false;
+        while (STimeNow() < start + 10'000'000) {
             try {
                 response = tester->executeWaitVerifyContentTable(command);
             } catch (...) {
-                retries--;
                 usleep(100'000);
                 continue;
             }
             ASSERT_EQUAL(response["data"], "{}");
             ASSERT_EQUAL(response["jobID"], jobID);
             ASSERT_EQUAL(response["name"], jobName);
+            assertionsChecked = true;
             break;
         }
+        ASSERT_TRUE(assertionsChecked);
 
         // try again immediately and it should be not found.
         try {

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -269,7 +269,7 @@ struct CreateJobTest : tpunit::TestFixture {
         // Create a job with both retry and repeat
         SData command("CreateJob");
         string jobName = "testRetryable";
-        string retryValue = "+1 SECOND";
+        string retryValue = "+5 SECOND";
         string repeatValue = "SCHEDULED, +10 SECONDS";
         command["name"] = jobName;
         command["repeat"] = repeatValue;
@@ -308,20 +308,44 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(jobData[0][0], "RUNQUEUED");
         time_t nextRunTime = JobTestHelper::getTimestampForDateTimeString(jobData[0][1]);
         time_t lastRunTime = JobTestHelper::getTimestampForDateTimeString(jobData[0][2]);
-        ASSERT_EQUAL(difftime(nextRunTime, lastRunTime), 1);
+        ASSERT_EQUAL(difftime(nextRunTime, lastRunTime), 5);
 
         // Get the job, confirm error because 1 second hasn't passed
-        tester->executeWaitVerifyContent(command, "404 No job found");
+        try {
+            tester->executeWaitVerifyContent(command, "404 No job found");
+        } catch (...) {
+            cout << "retryRecurringJobs failed at point 1." << endl;
+            throw;
+        }
 
-        // Wait 1 second, get the job, confirm no error
-        sleep(1);
-        response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_EQUAL(response["data"], "{}");
-        ASSERT_EQUAL(response["jobID"], jobID);
-        ASSERT_EQUAL(response["name"], jobName);
+        // Try and get it repeatedly. Should fail a couple times and then succeed.
+        int retries = 9;
+        bool success = false;
+        while (retries-- > 0) {
+            try {
+                // Let it repeat until it works or we run out of retries.
+                response = tester->executeWaitVerifyContentTable(command);
+                ASSERT_EQUAL(response["data"], "{}");
+                ASSERT_EQUAL(response["jobID"], jobID);
+                ASSERT_EQUAL(response["name"], jobName);
+            } catch (...) {
+                sleep(1);
+                continue;
+            }
 
-        // Get the job, confirm error
-        tester->executeWaitVerifyContent(command, "404 No job found");
+            // Now it should fail again.
+            while (retries-- > 0) {
+                try {
+                    tester->executeWaitVerifyContent(command, "404 No job found");
+                    success = true;
+                    break;
+                } catch (...) {
+                    sleep(1);
+                    continue;
+                }
+            }
+        }
+        ASSERT_TRUE(success);
 
         // Finish the job
         command.clear();
@@ -334,7 +358,7 @@ struct CreateJobTest : tpunit::TestFixture {
         nextRunTime = JobTestHelper::getTimestampForDateTimeString(jobData[0][1]);
         lastRunTime = JobTestHelper::getTimestampForDateTimeString(jobData[0][2]);
         ASSERT_EQUAL(jobData[0][0], "QUEUED");
-        ASSERT_EQUAL(difftime(nextRunTime, lastRunTime), 11);
+        ASSERT_EQUAL(difftime(nextRunTime, lastRunTime), 15);
     }
 
     void retryWithMalformedValue() {
@@ -356,7 +380,7 @@ struct CreateJobTest : tpunit::TestFixture {
         // Create a retryable job
         SData command("CreateJob");
         string jobName = "testRetryable";
-        string retryValue = "+1 SECOND";
+        string retryValue = "+5 SECONDS";
         command["name"] = jobName;
         command["retryAfter"] = retryValue;
 
@@ -387,26 +411,46 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(response["jobID"], jobID);
         ASSERT_EQUAL(response["name"], jobName);
 
-        // Query the db and confirm that state, nextRun and lastRun are 1 second apart
+        // Query the db and confirm that state, nextRun and lastRun are 5 seconds apart
         SQResult jobData;
         tester->readDB("SELECT state, nextRun, lastRun FROM jobs WHERE jobID = " + jobID + ";", jobData);
         ASSERT_EQUAL(jobData[0][0], "RUNQUEUED");
         time_t nextRunTime = JobTestHelper::getTimestampForDateTimeString(jobData[0][1]);
         time_t lastRunTime = JobTestHelper::getTimestampForDateTimeString(jobData[0][2]);
-        ASSERT_EQUAL(difftime(nextRunTime, lastRunTime), 1);
+        ASSERT_EQUAL(difftime(nextRunTime, lastRunTime), 5);
 
         // Get the job, confirm error
-        tester->executeWaitVerifyContent(command, "404 No job found");
+        try {
+            // This needs to run less than 5 seconds after the first `GetJob` or it doesn't work.
+            tester->executeWaitVerifyContent(command, "404 No job found");
+        } catch (...) {
+            cout << "CreateJobTest failed at point 1." << endl;
+            throw;
+        }
 
-        // Wait 1 second, get the job, confirm no error
-        sleep(1);
-        response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_EQUAL(response["data"], "{}");
-        ASSERT_EQUAL(response["jobID"], jobID);
-        ASSERT_EQUAL(response["name"], jobName);
+        // This will fail with 404's until the job re-queues.
+        int retries = 100; // 100 tenths of a second.
+        while (retries) {
+            try {
+                response = tester->executeWaitVerifyContentTable(command);
+            } catch (...) {
+                retries--;
+                usleep(100'000);
+                continue;
+            }
+            ASSERT_EQUAL(response["data"], "{}");
+            ASSERT_EQUAL(response["jobID"], jobID);
+            ASSERT_EQUAL(response["name"], jobName);
+            break;
+        }
 
-        // Get the job, confirm error
-        tester->executeWaitVerifyContent(command, "404 No job found");
+        // try again immediately and it should be not found.
+        try {
+            tester->executeWaitVerifyContent(command, "404 No job found");
+        } catch (...) {
+            cout << "CreateJobTest failed at point 2." << endl;
+            throw;
+        }
 
         // Finish the job
         command.clear();

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -1,5 +1,25 @@
 #include <test/lib/BedrockTester.h>
 
+bool isBetweenSecondsInclusive(uint64_t startTimestamp, uint64_t endTimestamp, string timestampString) {
+    uint64_t testTime = startTimestamp;
+    while (true) {
+        string testTimeString = SComposeTime("%Y-%m-%d %H:%M:%S", testTime);
+        if (timestampString == testTimeString) {
+            return true;
+        }
+        if (testTime == endTimestamp) {
+            // We already tried everything.
+            break;
+        }
+        testTime += 1'000'000; // next second.
+        if (testTime > endTimestamp) {
+            // this is the last possible test.
+            testTime = endTimestamp;
+        }
+    }
+    return false;
+}
+
 struct GetJobTest : tpunit::TestFixture {
     GetJobTest()
         : tpunit::TestFixture("GetJob",
@@ -45,7 +65,9 @@ struct GetJobTest : tpunit::TestFixture {
         command.clear();
         command.methodLine = "GetJob";
         command["name"] = jobName;
+        uint64_t start = STimeNow();
         response = tester->executeWaitVerifyContentTable(command);
+        uint64_t end = STimeNow();
 
         ASSERT_EQUAL(response.size(), 4);
         ASSERT_EQUAL(response["jobID"], jobID);
@@ -61,7 +83,10 @@ struct GetJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(currentJob[0][2], "RUNNING");
         ASSERT_EQUAL(currentJob[0][3], jobName);
         ASSERT_EQUAL(currentJob[0][4], originalJob[0][4]);
-        ASSERT_EQUAL(currentJob[0][5], SComposeTime("%Y-%m-%d %H:%M:%S", STimeNow()));
+
+        // The lastRun time can be anything from start to end, inclusive.
+        ASSERT_TRUE(isBetweenSecondsInclusive(start, end, currentJob[0][5]));
+
         ASSERT_EQUAL(currentJob[0][6], originalJob[0][6]);
         ASSERT_EQUAL(currentJob[0][7], originalJob[0][7]);
         ASSERT_EQUAL(currentJob[0][8], originalJob[0][8]);
@@ -70,6 +95,7 @@ struct GetJobTest : tpunit::TestFixture {
 
     // Simple GetJob with Http
     void getJobWithHttp() {
+        uint64_t start = STimeNow();
         // Create the job
         SData command("CreateJob");
         string jobName = "job";
@@ -86,6 +112,8 @@ struct GetJobTest : tpunit::TestFixture {
         command["name"] = jobName;
         response = tester->executeWaitVerifyContentTable(command);
 
+        uint64_t end = STimeNow();
+
         ASSERT_EQUAL(response.size(), 4);
         ASSERT_EQUAL(response["jobID"], jobID);
         ASSERT_EQUAL(response["name"], jobName);
@@ -100,7 +128,10 @@ struct GetJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(currentJob[0][2], "RUNNING");
         ASSERT_EQUAL(currentJob[0][3], jobName);
         ASSERT_EQUAL(currentJob[0][4], originalJob[0][4]);
-        ASSERT_EQUAL(currentJob[0][5], SComposeTime("%Y-%m-%d %H:%M:%S", STimeNow()));
+
+        // The lastRun time can be anything from start to end, inclusive.
+        ASSERT_TRUE(isBetweenSecondsInclusive(start, end, currentJob[0][5]));
+
         ASSERT_EQUAL(currentJob[0][6], originalJob[0][6]);
         ASSERT_EQUAL(currentJob[0][7], originalJob[0][7]);
         ASSERT_EQUAL(currentJob[0][8], originalJob[0][8]);
@@ -191,40 +222,23 @@ struct GetJobTest : tpunit::TestFixture {
         response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(response["name"], "low_5");
     }
+
     // Create jobs in order of low, medium, high, high, medium, low
     // with nextRun times in order of now, now+1, now+2, now+5, now+4, now+3
     // Expect the jobs to be returned in order of low, medium, high, high, medium, low
     void testPrioritiesWithDifferentNextRunTimes() {
+
+        // We mark a `start at` time because timing is critical to this test.
+        uint64_t startAt = STimeNow();
         // Create jobs of different priorities
         // Low
         SData command("CreateJob");
         command["name"] = "low";
         command["priority"] = "0";
         const uint64_t time = STimeNow();
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time);
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 1'000'000);
         STable response = tester->executeWaitVerifyContentTable(command);
         list<string> jobList;
-        jobList.push_back(response["jobID"]);
-
-        // Medium
-        command["name"] = "medium";
-        command["priority"] = "500";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 1'000'000);
-        response = tester->executeWaitVerifyContentTable(command);
-        jobList.push_back(response["jobID"]);
-
-        // High
-        command["name"] = "high";
-        command["priority"] = "1000";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 2'000'000);
-        response = tester->executeWaitVerifyContentTable(command);
-        jobList.push_back(response["jobID"]);
-
-        // High
-        command["name"] = "high";
-        command["priority"] = "1000";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 5'000'000);
-        response = tester->executeWaitVerifyContentTable(command);
         jobList.push_back(response["jobID"]);
 
         // Medium
@@ -234,10 +248,31 @@ struct GetJobTest : tpunit::TestFixture {
         response = tester->executeWaitVerifyContentTable(command);
         jobList.push_back(response["jobID"]);
 
+        // High
+        command["name"] = "high";
+        command["priority"] = "1000";
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 7'000'000);
+        response = tester->executeWaitVerifyContentTable(command);
+        jobList.push_back(response["jobID"]);
+
+        // High
+        command["name"] = "high";
+        command["priority"] = "1000";
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 15'000'000);
+        response = tester->executeWaitVerifyContentTable(command);
+        jobList.push_back(response["jobID"]);
+
+        // Medium
+        command["name"] = "medium";
+        command["priority"] = "500";
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 13'000'000);
+        response = tester->executeWaitVerifyContentTable(command);
+        jobList.push_back(response["jobID"]);
+
         // Low
         command["name"] = "low";
         command["priority"] = "0";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 3'000'000);
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", time + 10'000'000);
         response = tester->executeWaitVerifyContentTable(command);
         jobList.push_back(response["jobID"]);
 
@@ -246,18 +281,27 @@ struct GetJobTest : tpunit::TestFixture {
         tester->readDB("SELECT DISTINCT nextRun FROM jobs WHERE jobID IN (" + SComposeList(jobList) + ");", result);
         ASSERT_EQUAL(result.size(), 6);
 
+        // Make sure we finished this fast enough that we can still dequeue commands in the order we expect.
+        // We require the above to have finished in 2 seconds or less.
+        uint64_t createdBy = STimeNow();
+        ASSERT_LESS_THAN(createdBy, startAt + 3'500'000);
+
         // Get jobs in the order they become available. Make sure the first three we get are in the order low, medium,
         // high, as that's when they were scheduled to run. This test can fail if timing is off, as we expect
         // everything to happen correctly over 1-second intervals.
         vector<string> names;
-        uint64_t timeout = STimeNow() + 10'000'000;
+
+        // Now we allow 20 seconds to get all the commands, giving us a margin.
+        uint64_t timeout = STimeNow() + 20'000'000;
         command.clear();
         command.methodLine = "GetJob";
         command["name"] = "*";
+        list<STable> responses;
         while (true) {
             try {
                 response = tester->executeWaitVerifyContentTable(command);
                 names.push_back(response["name"]);
+                responses.push_back(response);
                 if (names.size() == 3) {
                     // Done, did all three.
                     break;
@@ -266,7 +310,7 @@ struct GetJobTest : tpunit::TestFixture {
                     // Took too long.
                     break;
                 }
-                // Wait a second and try again.
+                // Wait 50 ms and try again.
                 usleep(50'000);
             } catch (const SException& e) {
                 if (SContains(e.what(), "404 No job found")) {
@@ -279,12 +323,22 @@ struct GetJobTest : tpunit::TestFixture {
 
         // Now we should have three responses verify they're correct.
         ASSERT_EQUAL(names.size(), 3);
+
+        if (names[0] != "low" || names[1] != "medium" || names[2] != "high") {
+            cout << "Will fail:" << endl;
+            for (auto& a : responses) {
+                for (auto&p : a) {
+                    cout << p.first << ": " << p.second << endl;
+                }
+                cout << endl;
+            }
+        }
         ASSERT_EQUAL(names[0], "low");
         ASSERT_EQUAL(names[1], "medium");
         ASSERT_EQUAL(names[2], "high");
 
         // GetJob and confirm that the last 3 jobs are returned in priority order since now is past nextRun for all of them
-        sleep(5);
+        sleep(11);
         response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(response["name"], "high");
         response = tester->executeWaitVerifyContentTable(command);
@@ -418,7 +472,7 @@ struct GetJobTest : tpunit::TestFixture {
         command.methodLine = "CreateJob";
         command["name"] = "high_1";
         command["priority"] = "1000";
-        command["retryAfter"] = "+1 SECONDS";
+        command["retryAfter"] = "+2 SECONDS";
         tester->executeWaitVerifyContent(command);
 
         // Medium
@@ -449,9 +503,13 @@ struct GetJobTest : tpunit::TestFixture {
         command.clear();
         command.methodLine = "GetJob";
         command["name"] = "high_1";
-        tester->executeWaitVerifyContent(command);
+        uint64_t start = STimeNow();
+        STable data1 = tester->executeWaitVerifyContentTable(command);
+        uint64_t jobID1 = stoull(data1["jobID"]);
         command["name"] = "medium_4";
-        tester->executeWaitVerifyContent(command);
+        STable data2 = tester->executeWaitVerifyContentTable(command);
+        uint64_t jobID2 = stoull(data2["jobID"]);
+        uint64_t end = STimeNow();
 
         // Confirm they are in the RUNQUEUED state
         SQResult result;
@@ -459,27 +517,37 @@ struct GetJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(result.size(), 1);
         ASSERT_EQUAL(result[0][0], "RUNQUEUED");
 
-        // Sleep for two seconds and then confirm that all jobs but high_1 have the same nextRun time
-        sleep(2);
-        tester->readDB("SELECT DISTINCT nextRun, GROUP_CONCAT(name) FROM jobs WHERE JSON_EXTRACT(data, '$.mockRequest') IS NULL GROUP BY nextRun;", result);
+
+        // What we need to confirm is that the next run time of the two jobs we got above is correct.
+        tester->readDB("SELECT nextRun, jobID FROM jobs WHERE JSON_EXTRACT(data, '$.mockRequest') IS NULL AND jobID IN (" + SQ(jobID1) + ", " + SQ(jobID2) + ")", result);
         ASSERT_EQUAL(result.size(), 2);
-        ASSERT_EQUAL(SParseList(result[0][1]).size(), 1);
-        ASSERT_EQUAL(result[0][1], "high_1");
-        ASSERT_EQUAL(SParseList(result[1][1]).size(), 4);
+
+        // Make sure both run times are in the allowable range.
+        ASSERT_TRUE(isBetweenSecondsInclusive(start + 2'000'000, end + 2'000'000, result[0][0]));
+        ASSERT_TRUE(isBetweenSecondsInclusive(start + 2'000'000, end + 2'000'000, result[1][0]));
+
+        // This should push us past the time when high_1 and medium_4 are re-queued.
+        sleep(3);
 
         // GetJob and confirm that the jobs are returned in high, medium, low order
         command.clear();
         command.methodLine = "GetJob";
         command["name"] = "*";
         STable response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_EQUAL(response["name"], "high_1");
+        ASSERT_TRUE(response["name"] == "high_1" || response["name"] == "high_2");
         response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_EQUAL(response["name"], "high_2");
-        response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_TRUE(response["name"] == "medium_4" || response["name"] == "medium_3"); // Because we don't order by jobID, the order of these jobs depends on the table/index used to retrieve them
+        ASSERT_TRUE(response["name"] == "high_1" || response["name"] == "high_2");
         response = tester->executeWaitVerifyContentTable(command);
         ASSERT_TRUE(response["name"] == "medium_4" || response["name"] == "medium_3"); // Because we don't order by jobID, the order of these jobs depends on the table/index used to retrieve them
         response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_TRUE(response["name"] == "medium_4" || response["name"] == "medium_3"); // Because we don't order by jobID, the order of these jobs depends on the table/index used to retrieve them
+        response = tester->executeWaitVerifyContentTable(command);
+        if (response["name"] != "low_5") {
+            cout << "This will fail:" << endl;
+            for (auto& row : response) {
+                cout << row.first << ": '" << row.second << "'." << endl;
+            }
+        }
         ASSERT_EQUAL(response["name"], "low_5");
     }
 


### PR DESCRIPTION
This is a squashed version of this PR: https://github.com/Expensify/Bedrock/pull/525 because I didn't feel like merging hundreds of commits that all did nothing except cause Travis to run.

Fixes: https://github.com/Expensify/Expensify/issues/92130

This is my attempt to fix the flaky tests we currently have for bedrock. As you can see from the above-referenced PR, it's still not perfect, but the current state is bad enough I'd be happy to accept this in the meantime and come back to it again later.

Here are the highlights:

* Fixes a bug where the "jitter" assigned to synchronization timeouts was up to *5 minutes* instead of 5 seconds (and makes the default timeout 30s instead of 60). This is the only change that's not to the tests.
* Changes this line: https://github.com/Expensify/Bedrock/compare/tyler-improve-tests?expand=1#diff-b2e502599c037776a6c5aabc2002fcfcR37 so that we don't use a port that conflicts with other default ports (this causes a *ton* of failures when they happen to overlap).
* Changes a bunch of timing, and checks around timing, to be less strict.
* Refactors some tests.
* Adds more logging around failures that occasionally happen in tests
* Refactors `BedrockTester` to handle disconnections better.

*Note:* I also built Auth tests against this branch and ran them successfully to make sure they still work.