### PR TITLE
Use auto-decrementing object to manage _pendingCommitCount

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -962,10 +962,10 @@ void BedrockServer::worker(SData& args,
                                 } else {
                                     BedrockCore::AutoTimer(command, BedrockCommand::COMMIT_WORKER);
                                     commitSuccess = core.commit();
-
-                                    // The commit is done, decrement this as soon as possible.
-                                    pendingCommitIncrement.dec();
                                 }
+
+                                // The commit is done, decrement this as soon as possible.
+                                pendingCommitIncrement.dec();
                             }
                             if (commitSuccess) {
                                 SINFO("Successfully committed " << command.request.methodLine << " on worker thread in "

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -814,15 +814,16 @@ void BedrockServer::worker(SData& args,
                 db.waitForCheckpoint();
 
                 // We create this lock outside the `if` block so that it's scoped correctly, but we only lock it in
-                // blocking mode.
+                // blocking mode. The scoped increment works the same way, as the scoped locking.
                 unique_lock<decltype(server._syncThreadCommitMutex)> lock(server._syncThreadCommitMutex, defer_lock);
+                SWaitCounterScopedIncrement pendingCommitIncrement(server._pendingCommitCount, true);
                 if (retries) {
                     // We only wait for the number of pending commits in non-blocking mode. There's no point in waiting
                     // in blocking mode, since we have to get to the front of the line in order to lock the mutex.
                     server._pendingCommitCount.waitUntilLessThan(server._maxPendingCommits.load());
                 } else {
                     // No retries left, lock for blocking mode.
-                    ++server._pendingCommitCount;
+                    pendingCommitIncrement.inc();
                     SINFO("No retries left for command '" << command.request.methodLine << "', will complete in blocking mode.");
                     lock.lock();
                 }
@@ -921,16 +922,16 @@ void BedrockServer::worker(SData& args,
                                 // In blocking mode, we've already incremented _pendingCommitCount (at the end of the
                                 // last loop) and locked the mutex (at the top if this loop), so we only need to do
                                 // this in non-blocking mode.
+                                SWaitCounterScopedIncrement pendingCommitIncrement1(server._pendingCommitCount, true);
                                 if (retries) {
                                     // It's important this is incremented before the lock, since this counts the number
                                     // of threads waiting on the lock. There will only ever be one thread with the
                                     // lock.
-                                    int64_t newPendingCount =  ++server._pendingCommitCount;
+                                    int64_t newPendingCount = pendingCommitIncrement.inc();
                                     if (newPendingCount > server._maxPendingCommits.load()) {
                                         SINFO("Would have attempted commit, but have " << newPendingCount
                                               << " pending commits already, of max " << server._maxPendingCommits.load()
                                               << ", will retry later.");
-                                        --server._pendingCommitCount;
                                         core.rollback();
                                         continue;
                                     }
@@ -963,9 +964,6 @@ void BedrockServer::worker(SData& args,
                                     BedrockCore::AutoTimer(command, BedrockCommand::COMMIT_WORKER);
                                     commitSuccess = core.commit();
                                 }
-
-                                // And we're done with the commit, drop our count back down.
-                                server._pendingCommitCount--;
                             }
                             if (commitSuccess) {
                                 SINFO("Successfully committed " << command.request.methodLine << " on worker thread in "

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -927,7 +927,7 @@ void BedrockServer::worker(SData& args,
                                     // It's important this is incremented before the lock, since this counts the number
                                     // of threads waiting on the lock. There will only ever be one thread with the
                                     // lock.
-                                    int64_t newPendingCount = pendingCommitIncrement.inc();
+                                    int64_t newPendingCount = pendingCommitIncrement1.inc();
                                     if (newPendingCount > server._maxPendingCommits.load()) {
                                         SINFO("Would have attempted commit, but have " << newPendingCount
                                               << " pending commits already, of max " << server._maxPendingCommits.load()

--- a/libstuff/SWaitCounter.h
+++ b/libstuff/SWaitCounter.h
@@ -53,7 +53,17 @@ class SWaitCounterScopedIncrement {
     // Increments the counter if it wasn't already incremented.
     int64_t inc() {
         if (!_incremented) {
+            _incremented = true;
             return ++_counter;
+        }
+        return _counter.value();
+    }
+
+    // Increments the counter if it was already incremented.
+    int64_t dec() {
+        if (_incremented) {
+            _incremented = false;
+            return --_counter;
         }
         return _counter.value();
     }

--- a/libstuff/SWaitCounter.h
+++ b/libstuff/SWaitCounter.h
@@ -33,3 +33,32 @@ class SWaitCounter {
     mutex _m;
     condition_variable _cv;
 };
+
+// Increments the counter either at construction, or if deferred, when `inc()` is called.
+// Decrements the counter on destruction, if it was ever incremented.
+class SWaitCounterScopedIncrement {
+  public:
+    SWaitCounterScopedIncrement(SWaitCounter& counter, bool defer = false) : _counter(counter), _incremented(!defer) {
+        if (_incremented) {
+            ++_counter;
+        }
+    }
+
+    ~SWaitCounterScopedIncrement() {
+        if (_incremented) {
+            --_counter;
+        }
+    }
+
+    // Increments the counter if it wasn't already incremented.
+    int64_t inc() {
+        if (!_incremented) {
+            return ++_counter;
+        }
+        return _counter.value();
+    }
+
+  private:
+    SWaitCounter& _counter;
+    bool _incremented;
+};


### PR DESCRIPTION
In exceptional cases (cases where there was no commit to be done during blocking mode), we would exit our command processing loop without decrementing our counter.

This PR adds a class much like `unique_lock` with a `deferred` property, so that these counters will be decremented automatically whenever these objects go out of scope.

It works exactly like the standard lock objects, except with increment and decrement instead of lock and unlock. We manually increment these values, but let them auto-decrement on object destruction any time we exit early.

