### PR TITLE
Automatically Cache Query Results

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -76,7 +76,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
         bool shouldSuppressTimeoutWarnings = false;
 
         try {
-            if (!_db.beginConcurrentTransaction()) {
+            if (!_db.beginConcurrentTransaction(true, command.request.methodLine)) {
                 STHROW("501 Failed to begin concurrent transaction");
             }
 
@@ -176,7 +176,7 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         // If a transaction was already begun in `peek`, then this is a no-op. We call it here to support the case where
         // peek created a httpsRequest and closed it's first transaction until the httpsRequest was complete, in which
         // case we need to open a new transaction.
-        if (!_db.insideTransaction() && !_db.beginConcurrentTransaction()) {
+        if (!_db.insideTransaction() && !_db.beginConcurrentTransaction(true, command.request.methodLine)) {
             STHROW("501 Failed to begin concurrent transaction");
         }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -35,7 +35,7 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints
     _queryCount(0),
     _cacheHits(0),
     _useCache(false),
-    _deterministicQuery(false)
+    _isDeterministicQuery(false)
 {
     // Perform sanity checks.
     SASSERT(!filename.empty());
@@ -480,9 +480,9 @@ bool SQLite::read(const string& query, SQResult& result) {
             return true;
         }
     }
-    _deterministicQuery = true;
+    _isDeterministicQuery = true;
     bool queryResult = !SQuery(_db, "read only query", query, result);
-    if (_useCache && _deterministicQuery && queryResult) {
+    if (_useCache && _isDeterministicQuery && queryResult) {
         _queryCache.emplace(make_pair(query, result));
     }
     _checkTiming("timeout in SQLite::read"s);
@@ -892,7 +892,7 @@ int SQLite::_authorize(int actionCode, const char* detail1, const char* detail2,
             !strcmp(detail2, "last_insert_rowid") ||
             !strcmp(detail2, "sqlite3_version")
         ) {
-            _deterministicQuery = false;
+            _isDeterministicQuery = false;
         }
     }
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -406,5 +406,5 @@ class SQLite {
     string _transactionName;
 
     // Will be set to false while running a non-deterministic query to prevent it's result being cached.
-    bool _deterministicQuery;
+    bool _isDeterministicQuery;
 };

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -51,10 +51,10 @@ class SQLite {
     string read(const string& query);
 
     // Begins a new transaction. Returns true on success.
-    bool beginTransaction();
+    bool beginTransaction(bool useCache = false, const string& note = "");
 
     // Begins a new concurrent transaction. Returns true on success.
-    bool beginConcurrentTransaction();
+    bool beginConcurrentTransaction(bool useCache = false, const string& note = "");
 
     // Verifies a table exists and has a particular definition. If the database is left with the right schema, it
     // returns true. If it had to create a new table (ie, the table was missing), it also sets created to true. If the
@@ -383,4 +383,10 @@ class SQLite {
     bool _noopUpdateMode;
 
     bool _enableFullCheckpoints;
+
+    map<string, SQResult> _queryCache;
+    int64_t _queryCount;
+    int64_t _cacheHits;
+    bool _useCache;
+    string _note;
 };

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -370,7 +370,7 @@ class SQLite {
     void _checkTiming(const string& error);
 
     // Called internally by _sqliteAuthorizerCallback to authorize columns for a query.
-    int _authorize(int actionCode, const char* table, const char* column);
+    int _authorize(int actionCode, const char* detail1, const char* detail2, const char* detail3, const char* detail4);
 
     // It's possible for certain transactions (namely, timing out a write operation, see here:
     // https://sqlite.org/c3ref/interrupt.html) to cause a transaction to be automatically rolled back. If this
@@ -389,4 +389,5 @@ class SQLite {
     int64_t _cacheHits;
     bool _useCache;
     string _note;
+    bool _deterministic;
 };

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -90,7 +90,7 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
             count = SToInt(command.request["count"]);
         }
         for (int i = 0; i < count; i++) {
-            string query = "WITH RECURSIVE cnt(x) AS ( SELECT 1 UNION ALL SELECT x+1 FROM cnt LIMIT " + SQ(size) + ") SELECT MAX(x) FROM cnt;";
+            string query = "WITH RECURSIVE cnt(x) AS ( SELECT random() UNION ALL SELECT x+1 FROM cnt LIMIT " + SQ(size) + ") SELECT MAX(x) FROM cnt;";
             SQResult result;
             db.read(query, result);
         }


### PR DESCRIPTION
This was an idea that grew out of optimizing the `ReimburseReport` command. The command calls library functions that perform relatively expensive queries, and can call them multiple times. Rather than passing a flag or a cached result set down the stack to every possible place that could call one of these queries (and keeping track of where those places were), it seemed easier and more beneficial to implement this in a general manner.

Instead of keeping a query cache for `ReimburseReport` commands, we decided we could keep a cache for every transaction, which was actually simpler to implement and would benefit (every* command that might make the same query twice.

This works by the following:

* Whenever we do a read query, we first look to see if we've already cached results for an identical query. If so, we just return those.
* We used the authorizer callback to check for non-deterministic functions being called in a read query (i.e., `random()`, `datetime()`). If a query uses these, its results will not be cached.
* We reset the cache on any `commit`, `rollback` or write query.
* The cache can be bypassed entirely if you do not pass `true` to `beginTransaction` or `beginConcurrentTransaction`. This is the default case so that we only use the cache for `peek` and `process` in command handling (and not for DB upgrades and such).

When running against the auth test suite, this saves us about 11% of our queries. Specifically for `ReimburseReport`, is saves roughly 30%.

We'll see exactly how much this helps in production, but 10% is worthwhile for a relatively small change.