### PR TITLE
Stop logging full serialized messages, they can contain sensitive params

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1742,7 +1742,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             _server.acceptCommand(move(command), false);
             _escalatedCommandMap.erase(commandIt);
         } else {
-            SHMMM("Received ESCALATE_RESPONSE for unknown command ID '" << message["ID"] << "', ignoring. " << command.request.methodLine);
+            SHMMM("Received ESCALATE_RESPONSE for unknown command ID '" << message["ID"] << "', ignoring. ");
         }
     } else if (SIEquals(message.methodLine, "ESCALATE_ABORTED")) {
         // ESCALATE_RESPONSE: Sent when the master aborts processing an escalated command. Re-submit to the new master.

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -814,7 +814,7 @@ bool SQLiteNode::update() {
                     SData commit("COMMIT_TRANSACTION");
                     commit.set("ID", _lastSentTransactionID + 1);
                     _sendToAllPeers(commit, true); // true: Only to subscribed peers.
-                    
+
                     // clear the unsent transactions, we've sent them all (including this one);
                     _db.getCommittedTransactions();
 
@@ -1742,7 +1742,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             _server.acceptCommand(move(command), false);
             _escalatedCommandMap.erase(commandIt);
         } else {
-            SHMMM("Received ESCALATE_RESPONSE for unknown command ID '" << message["ID"] << "', ignoring. " << message.serialize());
+            SHMMM("Received ESCALATE_RESPONSE for unknown command ID '" << message["ID"] << "', ignoring. " << command.request.methodLine);
         }
     } else if (SIEquals(message.methodLine, "ESCALATE_ABORTED")) {
         // ESCALATE_RESPONSE: Sent when the master aborts processing an escalated command. Re-submit to the new master.
@@ -2185,7 +2185,7 @@ void SQLiteNode::_updateSyncPeer()
             newSyncPeer = peer;
         }
     }
-    
+
     // Log that we've changed peers.
     if (_syncPeer != newSyncPeer) {
         string from, to;


### PR DESCRIPTION
@expensifyrandomdrake or @cead22 please review, serializing this message is causing us to log sensitive params. Not sure why we are hitting this log line, will make an issue for @tylerkaraszewski  for that. 

Fixes https://github.com/Expensify/Expensify/issues/93322