### PR TITLE
Do not warn if repeat is empty

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1235,7 +1235,9 @@ string BedrockPlugin_Jobs::_constructNextRunDATETIME(const string& lastScheduled
     // Not canned, split the advanced repeat into its parts
     list<string> parts = SParseList(SToUpper(repeat));
     if (parts.size() < 2) {
-        SWARN("Syntax error, failed parsing repeat '" << repeat << "': too short.");
+        if (repeat != "") {
+            SWARN("Syntax error, failed parsing repeat '" << repeat << "': too short.");
+        }
         return "";
     }
 

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1224,6 +1224,10 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
 // ==========================================================================
 string BedrockPlugin_Jobs::_constructNextRunDATETIME(const string& lastScheduled, const string& lastRun,
                                                      const string& repeat) {
+    if (repeat.empty()) {
+        return "";
+    }
+
     // Some "canned" times for convenience
     if (SIEquals(repeat, "HOURLY"))
         return "STRFTIME( '%Y-%m-%d %H:00:00', DATETIME( " + SCURRENT_TIMESTAMP() + ", '+1 HOUR' ) )";
@@ -1235,9 +1239,7 @@ string BedrockPlugin_Jobs::_constructNextRunDATETIME(const string& lastScheduled
     // Not canned, split the advanced repeat into its parts
     list<string> parts = SParseList(SToUpper(repeat));
     if (parts.size() < 2) {
-        if (repeat != "") {
-            SWARN("Syntax error, failed parsing repeat '" << repeat << "': too short.");
-        }
+        SWARN("Syntax error, failed parsing repeat '" << repeat << "': too short.");
         return "";
     }
 


### PR DESCRIPTION
@flodnv 

Tests:
1. Insert a job in RUNQUEUED state and with a retryAfter
1. Get it with GetJob
1. Check logs:
```
2018-11-28T13:49:12.838394+00:00 expensidev php: 3fA3zk /home/vagrant/.config/composer/vendor/bin/psysh we@dont.know !script! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'GetJob' clusterName: 'webrock' headers: '[name: 'caca' commitCount: '4601' requestID: '3fA3zk' lastIP: '73.95.137.73' writeConsistency: 'ASYNC' priority: '250' timeout: '290000']'
2018-11-28T13:49:12.838540+00:00 expensidev php: 3fA3zk /home/vagrant/.config/composer/vendor/bin/psysh we@dont.know !script! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'localhost'
2018-11-28T13:49:12.838774+00:00 expensidev php: 3fA3zk /home/vagrant/.config/composer/vendor/bin/psysh we@dont.know !script! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'localhost']'
2018-11-28T13:49:12.838905+00:00 expensidev php: 3fA3zk /home/vagrant/.config/composer/vendor/bin/psysh we@dont.know !script! ?api? [info] Bedrock\Client - Reusing socket ~~ host: 'localhost' cluster: 'webrock' pid: '3038'
2018-11-28T13:49:12.839025+00:00 expensidev bedrock: 3fA3zk (BedrockServer.cpp:1407) postPoll [main] [info] Waiting for 'GetJob' to complete.
2018-11-28T13:49:12.839215+00:00 expensidev bedrock: 3fA3zk (BedrockServer.cpp:1446) postPoll [main] [info] Queued new 'GetJob' command from local client, with 0 commands already queued.
2018-11-28T13:49:12.839547+00:00 expensidev bedrock: 3fA3zk (BedrockServer.cpp:668) worker [worker2] [info] Dequeued command GetJob in worker, 0 commands in queue.
2018-11-28T13:49:12.840880+00:00 expensidev bedrock: 3fA3zk (BedrockCore.cpp:65) peekCommand [worker2] [dbug] Peeking at 'GetJob' with priority: 250
2018-11-28T13:49:12.841099+00:00 expensidev bedrock: 3fA3zk (SQLite.cpp:396) beginConcurrentTransaction [worker2] [dbug] [concurrent] Beginning transaction
2018-11-28T13:49:12.841225+00:00 expensidev bedrock: 3fA3zk (libstuff.cpp:2355) SQuery [worker2] [dbug] BEGIN CONCURRENT
2018-11-28T13:49:12.841391+00:00 expensidev bedrock: 3fA3zk (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA query_only = true;
2018-11-28T13:49:12.841575+00:00 expensidev bedrock: 3fA3zk (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT 1 FROM jobs WHERE state in ('QUEUED', 'RUNQUEUED') AND priority IN (0, 500, 1000) AND '2018-11-28 13:49:12'>=nextRun AND name GLOB 'caca'  AND JSON_EXTRACT(data, '$.mockRequest') IS NULL LIMIT 1;
2018-11-28T13:49:12.843058+00:00 expensidev bedrock: 3fA3zk (Jobs.cpp:146) peekCommand [worker2] [info] {Jobs} Found results, but waiting for processCommand to update
2018-11-28T13:49:12.843294+00:00 expensidev bedrock: 3fA3zk (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA query_only = false;
2018-11-28T13:49:12.843481+00:00 expensidev bedrock: 3fA3zk (BedrockCore.cpp:112) peekCommand [worker2] [info] Command 'GetJob' is not peekable, queuing for processing.
2018-11-28T13:49:12.843670+00:00 expensidev bedrock: 3fA3zk (BedrockCore.cpp:170) processCommand [worker2] [dbug] Processing 'GetJob'
2018-11-28T13:49:12.843849+00:00 expensidev bedrock: 3fA3zk (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT jobID, name, data, parentJobID, retryAfter, created, repeat, lastRun, nextRun FROM ( SELECT * FROM (SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun FROM jobs WHERE state IN ('QUEUED', 'RUNQUEUED') AND priority=1000 AND '2018-11-28 13:49:12'>=nextRun AND name GLOB 'caca'  AND JSON_EXTRACT(data, '$.mockRequest') IS NULL ORDER BY nextRun ASC LIMIT 1) UNION ALL SELECT * FROM (SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun FROM jobs WHERE state IN ('QUEUED', 'RUNQUEUED') AND priority=500 AND '2018-11-28 13:49:12'>=nextRun AND name GLOB 'caca'  AND JSON_EXTRACT(data, '$.mockRequest') IS NULL ORDER BY nextRun ASC LIMIT 1) UNION ALL SELECT * FROM (SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun FROM jobs WHERE state IN ('QUEUED', 'RUNQUEUED') AND priority=0 AND '2018-11-28 13:49:12'>=nextRun AND name GLOB 'caca'  AND JSON_EXTRACT(data, '$.mockRequest') IS NULL ORDER BY nextRun ASC LIMIT 1) ) ORDER BY priority DESC LIMIT 1;
2018-11-28T13:49:12.844258+00:00 expensidev bedrock: 3fA3zk (Jobs.cpp:720) processCommand [worker2] [info] {Jobs} Returning jobID 54 from GetJob
2018-11-28T13:49:12.844803+00:00 expensidev bedrock: 3fA3zk (Jobs.cpp:787) processCommand [worker2] [info] {Jobs} Updating jobs with retryAfter
2018-11-28T13:49:12.845233+00:00 expensidev bedrock: 3fA3zk (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-11-28T13:49:12.845775+00:00 expensidev bedrock: 3fA3zk (libstuff.cpp:2355) SQuery [worker2] [dbug] UPDATE jobs SET state='RUNQUEUED', lastRun='2018-11-28 13:49:12', nextRun=DATETIME('2018-11-28 13:49:12', '+1 SECONDS') WHERE jobID = '54';
2018-11-28T13:49:12.846135+00:00 expensidev bedrock: 3fA3zk (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-11-28T13:49:12.846589+00:00 expensidev bedrock: 3fA3zk (BedrockCore.cpp:195) processCommand [worker2] [info] Plugin 'Jobs' processed command 'GetJob'
2018-11-28T13:49:12.846957+00:00 expensidev bedrock: 3fA3zk (BedrockCore.cpp:225) processCommand [worker2] [info] Processed '200 OK' for 'GetJob'.
2018-11-28T13:49:12.847364+00:00 expensidev bedrock: 3fA3zk (BedrockServer.cpp:903) worker [worker2] [info] _syncThreadCommitMutex acquired in worker in 0ms.
2018-11-28T13:49:12.848557+00:00 expensidev bedrock: 3fA3zk (libstuff.cpp:2355) SQuery [worker2] [dbug] INSERT INTO journal0002 VALUES (4602, 'UPDATE jobs SET state=''RUNQUEUED'', lastRun=''2018-11-28 13:49:12'', nextRun=DATETIME(''2018-11-28 13:49:12'', ''+1 SECONDS'') WHERE jobID = ''54'';', 'BD7A6533E73AFE87C41FA5B53091D51A6849B0A7' )
2018-11-28T13:49:12.848877+00:00 expensidev bedrock: 3fA3zk (SQLite.cpp:620) prepare [worker2] [dbug] Prepared transaction
2018-11-28T13:49:12.849122+00:00 expensidev bedrock: 3fA3zk (SQLite.cpp:654) commit [worker2] [dbug] Committing transaction
2018-11-28T13:49:12.849385+00:00 expensidev bedrock: 3fA3zk (libstuff.cpp:2355) SQuery [worker2] [dbug] COMMIT
2018-11-28T13:49:12.851566+00:00 expensidev bedrock: 3fA3zk (SQLite.cpp:234) _sqliteWALCallback [worker2] [info] [checkpoint] skipping checkpoint with 19 pages in WAL file (checkpoint every 2500 pages).
2018-11-28T13:49:12.851860+00:00 expensidev bedrock: 3fA3zk (SQLite.cpp:663) commit [worker2] [info] SQuery 'COMMIT' took 3ms.
2018-11-28T13:49:12.852121+00:00 expensidev bedrock: 3fA3zk (SQLite.cpp:676) commit [worker2] [info] COMMIT operation wrote 4 pages. WAL file size is 78312 bytes.
2018-11-28T13:49:12.852326+00:00 expensidev bedrock: 3fA3zk (SQLite.cpp:686) commit [worker2] [dbug] Commit successful (4602), releasing commitLock.
2018-11-28T13:49:12.852620+00:00 expensidev bedrock: 3fA3zk (SQLite.cpp:699) commit [worker2] [info] Transaction commit with 5 queries attempted, 0 served from cache for 'GetJob'.
2018-11-28T13:49:12.852832+00:00 expensidev bedrock: 3fA3zk (BedrockServer.cpp:929) worker [worker2] [info] Successfully committed GetJob on worker thread.
2018-11-28T13:49:12.853035+00:00 expensidev bedrock: 3fA3zk (BedrockCommand.cpp:284) finalizeTimingInfo [worker2] [info] command 'GetJob' timing info (ms): 4 (1), 2 (1), 0, 0, 0, 0, 13, 5, 0. Upstream: 0, 0, 0, 0.
2018-11-28T13:49:12.853238+00:00 expensidev php: 3fA3zk /home/vagrant/.config/composer/vendor/bin/psysh we@dont.know !script! ?api? [info] Bedrock\Client - Request finished ~~ host: 'localhost' command: 'GetJob' jsonCode: '200 OK' duration: '0.014' net: '-13125.986' wait: '10321' proc: '2805' commitCount: '4602'
```