### PR TITLE
Don't use BedrockCommand default constructor

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -23,19 +23,6 @@ int64_t BedrockCommand::_getTimeout(const SData& request) {
     return timeout + start;
 }
 
-BedrockCommand::BedrockCommand() :
-    SQLiteCommand(),
-    priority(PRIORITY_NORMAL),
-    peekCount(0),
-    processCount(0),
-    peekedBy(nullptr),
-    processedBy(nullptr),
-    onlyProcessOnSyncThread(false),
-    _inProgressTiming(INVALID, 0, 0),
-    _timeout(_getTimeout(request))
-{
-}
-
 BedrockCommand::~BedrockCommand() {
     for (auto request : httpsRequests) {
         request->owner.closeTransaction(request);

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -28,9 +28,6 @@ class BedrockCommand : public SQLiteCommand {
     static const uint64_t DEFAULT_TIMEOUT_FORGET = 60'000 * 60; // 1 hour for `connection: forget` commands.
     static const uint64_t DEFAULT_PROCESS_TIMEOUT = 30'000; // 30 seconds.
 
-    // Constructor to make an empty object.
-    BedrockCommand();
-
     // Constructor to convert from an existing SQLiteCommand (by move).
     BedrockCommand(SQLiteCommand&& from);
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -173,7 +173,7 @@ void BedrockServer::sync(SData& args,
 
     // Now we jump into our main command processing loop.
     uint64_t nextActivity = STimeNow();
-    BedrockCommand command;
+    BedrockCommand command(move(SQLiteCommand(SData())));
     bool committingCommand = false;
 
     // We hold a lock here around all operations on `syncNode`, because `SQLiteNode` isn't thread-safe, but we need
@@ -646,7 +646,7 @@ void BedrockServer::worker(SData& args,
     BedrockCore core(db, server);
 
     // Command to work on. This default command is replaced when we find work to do.
-    BedrockCommand command;
+    BedrockCommand command(move(SQLiteCommand(SData())));
 
     // We just run this loop looking for commands to process forever. There's a check for appropriate exit conditions
     // at the bottom, which will cause our loop and thus this thread to exit when that becomes true.


### PR DESCRIPTION
@iwiznia 
cc @coleaeason 

Fixes:
https://github.com/Expensify/Expensify/issues/93330

The default `BedrockCommand` constructor throws a warning, to keep us from using it, because we don't get basic information initialized in it (like when the command is supposed to run).

We created one default command for each thread, so we'd see these warnings at startup. After those default, empty commands, we'd never create new default commands, so this generally only happened when deploying auth.

This change removes that default constructor, so we can't call it in this way. We replace the calls to it with ones that explicitly construct an `SQLiteCommand` object with a `commandExecuteTime`.
