### PR TITLE
Respond to peers from wokers

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -943,8 +943,8 @@ void BedrockServer::worker(SData& args,
                 // a conflict, and we'll retry.
                 if (command.complete) {
                     if (command.initiatingPeerID) {
-                        // Escalated command. Give it back to the sync thread to respond.
-                        syncNodeCompletedCommands.push(move(command));
+                        // Escalated command. Send it back to the peer.
+                        server._finishPeerCommand(command);
                     } else {
                         server._reply(command);
                     }


### PR DESCRIPTION
@coleaeason 

This is minor but should be a small win for pulling work off the sync thread. We had this at some point, but we must have broken it.

This lets workers respond directly to peers, rather than queuing their responses to go through the sync thread. All if the infrastructure for this already existed, so it should work fine.