### PR TITLE
Do auto-QUORUM based on time

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -147,7 +147,7 @@ void BedrockServer::sync(SData& args,
     // Initialize the shared pointer to our sync node object.
     server._syncNode = make_shared<SQLiteNode>(server, db, args["-nodeName"], args["-nodeHost"],
                                                args["-peerList"], args.calc("-priority"), firstTimeout,
-                                               server._version, args.calc("-quorumCheckpoint"));
+                                               server._version, (args.isSet("-quorumCheckpointSeconds") ? args.calc("-quorumCheckpointSeconds") : 60));
 
     // We keep a queue of completed commands that workers will insert into when they've successfully finished a command
     // that just needs to be returned to a peer.

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -49,7 +49,7 @@ class SQLiteNode : public STCPNode {
 
     // Constructor/Destructor
     SQLiteNode(SQLiteServer& server, SQLite& db, const string& name, const string& host, const string& peerList,
-               int priority, uint64_t firstTimeout, const string& version, int quorumCheckpoint = 0);
+               int priority, uint64_t firstTimeout, const string& version, int quorumCheckpointSeconds = 0);
     ~SQLiteNode();
 
     // Simple Getters. See property definitions for details.
@@ -168,12 +168,12 @@ class SQLiteNode : public STCPNode {
     // Master's version string.
     string _masterVersion;
 
-    // The maximum number of commits we'll allow before we force a quorum commit. This can be violated when commits
+    // The maximum number of seconds we'll allow before we force a quorum commit. This can be violated when commits
     // are performed outside of SQLiteNode, but we'll catch up the next time we do a commit.
-    int _quorumCheckpoint;
+    int _quorumCheckpointSeconds;
 
-    // The number of commits we've actually done since the last quorum command.
-    int _commitsSinceCheckpoint;
+    // The timestamp of the (end of) the last quorum commit.
+    uint64_t _lastQuorumTime;
 
     // Helper methods
     void _sendToPeer(Peer* peer, const SData& message);


### PR DESCRIPTION
@coleaeason 

As the sync thread backs up, we end up doing more and more quorum commits (because we only do quorum commits on the sync thread, and we do one every N commits). 

During performance testing yesterday, the sync thread spent approximately 2% of it's time waiting for QUORUM responses, doing roughly 20 QUORUM commits per minute.

This changes the behavior to do quorums on a time, rather than count, based metric, with a default of requiring a QUORUM commit once per minute.