### PR TITLE
Do Blocking Commits in Workers

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -6,7 +6,7 @@
 #include <iomanip>
 
 set<string>BedrockServer::_blacklistedParallelCommands;
-recursive_mutex BedrockServer::_blacklistedParallelCommandMutex;
+shared_timed_mutex BedrockServer::_blacklistedParallelCommandMutex;
 
 void BedrockServer::acceptCommand(SQLiteCommand&& command, bool isNew) {
     // If the sync node tells us that a command causes a crash, we immediately save that.
@@ -803,6 +803,22 @@ void BedrockServer::worker(SData& args,
                 SINFO("mockRequest set for command '" << command.request.methodLine << "'.");
             }
 
+            // See if this is a feasible command to write parallel. If not, then be ready to forward it to the sync
+            // thread, if it doesn't finish in peek.
+            bool canWriteParallel = server._multiWriteEnabled.load();
+            if (canWriteParallel) {
+                // If multi-write is enabled, then we need to make sure the command isn't blacklisted.
+                shared_lock<decltype(_blacklistedParallelCommandMutex)> lock(_blacklistedParallelCommandMutex);
+                canWriteParallel =
+                    (_blacklistedParallelCommands.find(command.request.methodLine) == _blacklistedParallelCommands.end());
+            }
+
+            // More checks for parallel writing.
+            canWriteParallel = canWriteParallel && !server._suppressMultiWrite.load();
+            canWriteParallel = canWriteParallel && SQLiteNode::MASTERING;
+            canWriteParallel = canWriteParallel && !command.onlyProcessOnSyncThread;
+            canWriteParallel = canWriteParallel && (command.writeConsistency == SQLiteNode::ASYNC);
+
             // We'll retry on conflict up to this many times.
             int retry = server._maxConflictRetries.load();
             bool forceCommit = false;
@@ -861,24 +877,9 @@ void BedrockServer::worker(SData& args,
                             break;
                         }
                     }
-                    // Peek wasn't enough to handle this command. Now we need to decide if we should try and process
-                    // it, or if we should send it off to the sync node.
-                    bool canWriteParallel = server._multiWriteEnabled.load();
-                    if (canWriteParallel) {
-                        // If multi-write is enabled, then we need to make sure the command isn't blacklisted.
-                        SAUTOLOCK(_blacklistedParallelCommandMutex);
-                        canWriteParallel =
-                            (_blacklistedParallelCommands.find(command.request.methodLine) == _blacklistedParallelCommands.end());
-                    }
 
-                    // We need to have multi-write enabled, the command needs to not be explicitly blacklisted, and it
-                    // needs to not be automatically blacklisted.
-                    if (!canWriteParallel                 ||
-                        server._suppressMultiWrite.load() ||
-                        state != SQLiteNode::MASTERING    ||
-                        command.onlyProcessOnSyncThread   ||
-                        command.writeConsistency != SQLiteNode::ASYNC)
-                    {
+                    // Peek wasn't enough to handle this command. See if we think it should be writable in parallel.
+                    if (!canWriteParallel) {
                         // Roll back the transaction, it'll get re-run in the sync thread.
                         core.rollback();
 
@@ -888,66 +889,65 @@ void BedrockServer::worker(SData& args,
                               << " queued commands.");
                         syncNodeQueuedCommands.push(move(command));
 
-                        // We'll break out of our retry loop here, as we don't need to do anything else, we can just
-                        // look for another command to work on.
+                        // Done with this command, look for the next one.
                         break;
-                    } else {
-                        // In this case, there's nothing blocking us from processing this in a worker, so let's try it.
-                        if (core.processCommand(command)) {
-                            // If processCommand returned true, then we need to do a commit. Otherwise, the command is
-                            // done, and we just need to respond. Before we commit, we need to grab the sync thread
-                            // lock. Because the sync thread grabs an exclusive lock on this wrapping any transactions
-                            // that it performs, we'll get this lock while the sync thread isn't in the process of
-                            // handling a transaction, thus guaranteeing that we can't commit and cause a conflict on
-                            // the sync thread. We can still get conflicts here, as the sync thread might have
-                            // performed a transaction after we called `processCommand` and before we call `commit`,
-                            // or we could conflict with another worker thread, but the sync thread will never see a
-                            // conflict as long as we don't commit while it's performing a transaction. This is scoped
-                            // to the minimum time required.
-                            bool commitSuccess = false;
-                            {
-                                shared_lock<decltype(server._syncThreadCommitMutex)> lock1(server._syncThreadCommitMutex, defer_lock);
-                                if (!forceCommit) {
-                                    uint64_t preLockTime = STimeNow();
-                                    lock1.lock();
-                                    SINFO("_syncThreadCommitMutex (shared) acquired in worker in " << fixed << setprecision(2)
-                                          << ((STimeNow() - preLockTime)/1000) << "ms.");
-                                }
+                    }
 
-                                // This is the first place we get really particular with the state of the node from a
-                                // worker thread. We only want to do this commit if we're *SURE* we're mastering, and
-                                // not allow the state of the node to change while we're committing. If it turns out
-                                // we've changed states, we'll roll this command back, so we lock the node's state
-                                // until we complete.
-                                //
-                                // IMPORTANT: If we acquire both _syncThreadCommitMutex and stateMutex, they always
-                                // need to be locked in that order. The reason for this is that it's possible for the
-                                // sync thread to to change states mid-commit, meaning that it needs to acquire these
-                                // locks in the same order. Always acquiring the locks in the same order prevents the
-                                // deadlocks.
-                                shared_lock<decltype(server._syncNode->stateMutex)> lock2(server._syncNode->stateMutex);
-                                if (replicationState.load() != SQLiteNode::MASTERING &&
-                                    replicationState.load() != SQLiteNode::STANDINGDOWN) {
-                                    SALERT("Node State changed from MASTERING to "
-                                           << SQLiteNode::stateNames[replicationState.load()]
-                                           << " during worker commit. Rolling back transaction!");
-                                    core.rollback();
-                                } else {
-                                    BedrockCore::AutoTimer(command, BedrockCommand::COMMIT_WORKER);
-                                    commitSuccess = core.commit();
-                                }
+                    // In this case, there's nothing blocking us from processing this in a worker, so let's try it.
+                    if (core.processCommand(command)) {
+                        // If processCommand returned true, then we need to do a commit. Otherwise, the command is
+                        // done, and we just need to respond. Before we commit, we need to grab the sync thread
+                        // lock. Because the sync thread grabs an exclusive lock on this wrapping any transactions
+                        // that it performs, we'll get this lock while the sync thread isn't in the process of
+                        // handling a transaction, thus guaranteeing that we can't commit and cause a conflict on
+                        // the sync thread. We can still get conflicts here, as the sync thread might have
+                        // performed a transaction after we called `processCommand` and before we call `commit`,
+                        // or we could conflict with another worker thread, but the sync thread will never see a
+                        // conflict as long as we don't commit while it's performing a transaction. This is scoped
+                        // to the minimum time required.
+                        bool commitSuccess = false;
+                        {
+                            shared_lock<decltype(server._syncThreadCommitMutex)> lock1(server._syncThreadCommitMutex, defer_lock);
+                            if (!forceCommit) {
+                                uint64_t preLockTime = STimeNow();
+                                lock1.lock();
+                                SINFO("_syncThreadCommitMutex (shared) acquired in worker in " << fixed << setprecision(2)
+                                      << ((STimeNow() - preLockTime)/1000) << "ms.");
                             }
-                            if (commitSuccess) {
-                                SINFO("Successfully committed " << command.request.methodLine << " on worker thread. forceCommit: "
-                                      << (forceCommit ? "true" : "false"));
-                                // So we must still be mastering, and at this point our commit has succeeded, let's
-                                // mark it as complete. We add the currentCommit count here as well.
-                                command.response["commitCount"] = to_string(db.getCommitCount());
-                                command.complete = true;
+
+                            // This is the first place we get really particular with the state of the node from a
+                            // worker thread. We only want to do this commit if we're *SURE* we're mastering, and
+                            // not allow the state of the node to change while we're committing. If it turns out
+                            // we've changed states, we'll roll this command back, so we lock the node's state
+                            // until we complete.
+                            //
+                            // IMPORTANT: If we acquire both _syncThreadCommitMutex and stateMutex, they always
+                            // need to be locked in that order. The reason for this is that it's possible for the
+                            // sync thread to to change states mid-commit, meaning that it needs to acquire these
+                            // locks in the same order. Always acquiring the locks in the same order prevents the
+                            // deadlocks.
+                            shared_lock<decltype(server._syncNode->stateMutex)> lock2(server._syncNode->stateMutex);
+                            if (replicationState.load() != SQLiteNode::MASTERING &&
+                                replicationState.load() != SQLiteNode::STANDINGDOWN) {
+                                SALERT("Node State changed from MASTERING to "
+                                       << SQLiteNode::stateNames[replicationState.load()]
+                                       << " during worker commit. Rolling back transaction!");
+                                core.rollback();
                             } else {
-                                SINFO("Conflict or state change committing " << command.request.methodLine
-                                      << " on worker thread with " << retry << " retries remaining.");
+                                BedrockCore::AutoTimer(command, BedrockCommand::COMMIT_WORKER);
+                                commitSuccess = core.commit();
                             }
+                        }
+                        if (commitSuccess) {
+                            SINFO("Successfully committed " << command.request.methodLine << " on worker thread. forceCommit: "
+                                  << (forceCommit ? "true" : "false"));
+                            // So we must still be mastering, and at this point our commit has succeeded, let's
+                            // mark it as complete. We add the currentCommit count here as well.
+                            command.response["commitCount"] = to_string(db.getCommitCount());
+                            command.complete = true;
+                        } else {
+                            SINFO("Conflict or state change committing " << command.request.methodLine
+                                  << " on worker thread with " << retry << " retries remaining.");
                         }
                     }
                 }
@@ -1133,7 +1133,7 @@ BedrockServer::BedrockServer(const SData& args)
 
     // Check for commands that can't be written by workers.
     if (args.isSet("-blacklistedParallelCommands")) {
-        SAUTOLOCK(_blacklistedParallelCommandMutex);
+        unique_lock<decltype(_blacklistedParallelCommandMutex)> lock(_blacklistedParallelCommandMutex);
         list<string> parallelCommands;
         SParseList(args["-blacklistedParallelCommands"], parallelCommands);
         for (auto& command : parallelCommands) {
@@ -1772,7 +1772,7 @@ void BedrockServer::_status(BedrockCommand& command) {
     }
 
     else if (SIEquals(request.methodLine, STATUS_BLACKLIST)) {
-        SAUTOLOCK(_blacklistedParallelCommandMutex);
+        unique_lock<decltype(_blacklistedParallelCommandMutex)> lock(_blacklistedParallelCommandMutex);
 
         // Return the old list. We can check the list by not passing the "Commands" param.
         STable content;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -373,7 +373,7 @@ class BedrockServer : public SQLiteServer {
 
     // This is a list of command names than can be processed and committed in worker threads.
     static set<string> _blacklistedParallelCommands;
-    static recursive_mutex  _blacklistedParallelCommandMutex;
+    static shared_timed_mutex _blacklistedParallelCommandMutex;
 
     // Stopwatch to track if we're going to give up on gracefully shutting down and force it.
     SStopwatch _gracefulShutdownTimeout;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1298,8 +1298,10 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             SINFO("Got STANDUP_RESPONSE but not STANDINGUP. Probably a late message, ignoring.");
         }
     } else if (SIEquals(message.methodLine, "SYNCHRONIZE")) {
-        // If we're MASTERING or SLAVING, we'll let worker threads handle SYNCHRONIZATION messages.
-        if (_state == MASTERING || _state == SLAVING) {
+        // If we're SLAVING, we'll let worker threads handle SYNCHRONIZATION messages. We don't on master, because if
+        // there's a backlog of commands, these can get stale, and by the time they reach the slave, it's already
+        // behind, thus never catching up.
+        if (_state == SLAVING) {
             // Attach all of the state required to populate a SYNCHRONIZE_RESPONSE to this message. All of this is
             // processed asynchronously, but that is fine, the final `SUBSCRIBE` message and its response will be
             // processed synchronously.


### PR DESCRIPTION
@coleaeason @flodnv @quinthar 

review this with whitespace changes hidden.

This re-adds a part of this reverted commit: https://github.com/Expensify/Bedrock/pull/534

That change tried to limit the number of pending commits, and it didn't help at all. When we upped the limit back towards the number of threads, performance improved back towards the baseline.

This change does away with limiting the number of pending commits and *only* adds the blocking commits in workers. In theory, this is identical to the existing behavior where the sync thread grabs an exclusive lock, runs through a transaction and a commit, and unlocks, allowing workers to go back to parallel writing, except it's a worker that grabs the exclusive lock.

The difference is that in the sync thread, this actually looks like:

```
lock();
update();
postPoll();
write();
commit();
```

The stuff in and around `update()` and `postPoll()` is not horribly expensive, but does take some time. It seems that about 15% of our total time is spent there. This change is intended to have the exact same properties for committing and blocking as when the sync thread does it, but:

1. Allow the sync thread to do those other things like updating state machines and reading from the network while someone else is writing.
2. Have the writer *not* do those things, to keep the overall write (and thus, time with the lock held) as short as possible.

This change also moves some checks for whether or not parallel writing is possible up out of the main transaction loop, which won't make a huge difference but can't hurt. It also replaces an exclusive mutex for checking for blacklisted commands with a shared one, which can't hurt either.

I would like to performance test this change by itself, because the previous incarnation of it turned out pretty bad, but I'm hoping this version improves things by ~15% instead.