### PR TITLE
Make sure mocked jobs do not repeat

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -452,6 +452,9 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             // If this is a mock request, we insert that into the data.
             string originalData = job["data"];
             if (command.request.isSet("mockRequest")) {
+                // Mocked jobs should never repeat.
+                job.erase("repeat");
+
                 if (job["data"].empty()) {
                     job["data"] = "{\"mockRequest\":true}";
                 } else {


### PR DESCRIPTION
@iwiznia will you please review?

Ensure that mocked jobs do not repeat.

### Tests
- Turned LOAD_TEST on in dev config.
- Enabled Auto Sync for one of my xero connections.
- Checked that 2 jobs were created, one mocked and one regular, but that the mocked one did not have a `repeat` set:
<img width="992" alt="screen shot 2018-11-30 at 2 04 42 pm" src="https://user-images.githubusercontent.com/4741899/49317411-39224e00-f4a9-11e8-8478-a2b45466dc5d.png">
<img width="966" alt="screen shot 2018-11-30 at 2 04 48 pm" src="https://user-images.githubusercontent.com/4741899/49317414-3a537b00-f4a9-11e8-90e9-addc95d10b2f.png">

