### PR TITLE
[WIP] use a special worker for blocking commits.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -994,7 +994,6 @@ void BedrockServer::worker(SData& args,
             // No commands to process after 1 second.
             // If the sync node has shut down, we can return now, there will be no more work to do.
             if  (server._shutdownState.load() == DONE) {
-                // This does weird things in the blocking queue.
                 SINFO("No commands found in queue and DONE.");
                 return;
             }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -222,6 +222,9 @@ class BedrockServer : public SQLiteServer {
     // Commands that aren't currently being processed are kept here.
     BedrockCommandQueue _commandQueue;
 
+    // These are commands that will be processed in a blacking fashion.
+    BedrockCommandQueue _blockingCommandQueue;
+
     // Each time we read a new request from a client, we give it a unique ID.
     uint64_t _requestCount;
 


### PR DESCRIPTION
This change makes worker 0 special - in that it does blocking commits and no other worker does blocking commits (the sync thread still does blocking commits for quorum commands).

This is designed to replicate the old behavior of a single bottleneck for blocking commits (which previously existed in the sync thread), without potentially blocking *every* worker, as they could all be waiting on the same exclusive lock. Now all workers except worker 0 will move on to the next command, queuing their conflicting commands for worker 0.

This separates responsibilities of doing networking and synchronization (sync thread tasks) from doing blocking commits, hopefully allowing a higher total throughput of blocking commits on worker 0 than on the sync thread.