### PR TITLE
Throw when trying to delete parent with children

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1059,7 +1059,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 // At this point, all child jobs should already be deleted, but
                 // let's double check.
                 if (!db.read("SELECT 1 FROM jobs WHERE parentJobID != 0 AND parentJobID=" + SQ(jobID) + " LIMIT 1;").empty()) {
-                    SWARN("Child jobs still exist when deleting parent job, ignoring.");
+                    STHROW("405 Failed to delete a job with outstanding children");
                 }
             }
         }


### PR DESCRIPTION
This can actually happen when one of the children fails and honestly, we don't want to just warn and move o, the parent should fail as well.

## Issues 

https://github.com/Expensify/Expensify/issues/94073