### PR TITLE
Enable SQL tracing for normalized queries.

### DIFF
--- a/libstuff/sqlite3.h
+++ b/libstuff/sqlite3.h
@@ -125,7 +125,7 @@ extern "C" {
 */
 #define SQLITE_VERSION        "3.26.0"
 #define SQLITE_VERSION_NUMBER 3026000
-#define SQLITE_SOURCE_ID      "2018-12-03 18:24:31 85fd92c71fd5b29bd45bb1717a5be761600fc23bed12eaff9eed708701a0fdf7"
+#define SQLITE_SOURCE_ID      "2018-12-05 13:49:23 342c9538d9c6a993ac0acaa6f74ad58886bcef7bb53783d053f9b24c131aec5d"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -231,7 +231,7 @@ void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg) {
 
 int SQLite::_sqliteTraceCallback(unsigned int traceCode, void* c, void* p, void* x) {
     if (enableTrace && traceCode == SQLITE_TRACE_STMT) {
-        SINFO("NORMALIZED_SQL:" << sqlite3_sql((sqlite3_stmt*)p));
+        SINFO("NORMALIZED_SQL:" << sqlite3_normalized_sql((sqlite3_stmt*)p));
     }
     return 0;
 }

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -183,6 +183,9 @@ class SQLite {
     // passive checkpoint. They're public, non-const, and atomic so that they can be configured on the fly.
     static atomic<int> passiveCheckpointPageMin;
     static atomic<int> fullCheckpointPageMin;
+
+    // Enable/disable SQL statement tracing.
+    static atomic<bool> enableTrace;
     
   private:
 
@@ -359,6 +362,9 @@ class SQLite {
 
     // Causes the current query to skip re-write checking if it's already a re-written query.
     bool _currentlyRunningRewritten;
+
+    // 
+    static int _sqliteTraceCallback(unsigned int traceCode, void* c, void* p, void* x);
 
     // Handles running checkpointing operations.
     static int _sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int pageCount);


### PR DESCRIPTION
This enables logging normalized SQL queries from sqlite.

To enable, send the following command to bedrock:
```
EnableSQLTracing
enable: true

```

This can be tested by watching logs for `NORMALIZED_SQL`.

With tracing disabled, this should not be seen. With it enabled, logs like this should be seen:
```
2018-12-05T15:02:01.878251+00:00 expensidev bedrock: pyXjVS (SQLite.cpp:234) _sqliteTraceCallback [worker1] [info] NORMALIZED_SQL:PRAGMA ?=?;
2018-12-05T15:02:01.878345+00:00 expensidev bedrock: pyXjVS (SQLite.cpp:234) _sqliteTraceCallback [worker1] [info] NORMALIZED_SQL:SELECT r.accountid,r.receiptid,r.filename,a.email,(SELECT ?.value FROM namevaluepairs AS ?WHERE ?.accountid=a.accountid AND ?.name=?)FROM receipts r INNER JOIN accounts a ON a.accountid=r.accountid WHERE state=?LIMIT?;
2018-12-05T15:02:01.880528+00:00 expensidev bedrock: pyXjVS (SQLite.cpp:234) _sqliteTraceCallback [worker1] [info] NORMALIZED_SQL:ROLLBACK;
```

Note that actual data from these queries has been removed.