### PR TITLE
Use random JobIDs

### DIFF
--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -17,7 +17,7 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     virtual void handleFailedReply(const BedrockCommand& command);
 
   private:
-    atomic<uint64_t> lastJobID;
+    static int64_t getNextID(SQLite& db);
 
     // Helper functions
     string _constructNextRunDATETIME(const string& lastScheduled, const string& lastRun, const string& repeat);

--- a/test/clustertest/tests/JobIDTest.cpp
+++ b/test/clustertest/tests/JobIDTest.cpp
@@ -27,7 +27,6 @@ struct JobIDTest : tpunit::TestFixture {
         SData createCmd("CreateJob");
         createCmd["name"] = "TestJob";
         STable response = master->executeWaitVerifyContentTable(createCmd);
-        const int jobID = SToInt(response["jobID"]);
 
         // Restart slave. This is a regression test, before we only re-initialized the lastID if it was !=0 which made
         // these tests pass (because the first ID is 0) but fail in the real life. So here we make sure that when a slave
@@ -56,9 +55,8 @@ struct JobIDTest : tpunit::TestFixture {
         // make sure it actually succeeded.
         ASSERT_TRUE(success);
 
-        // Create a job in the slave and check the ID returned is the next one
+        // Create a job in the slave
         response = slave->executeWaitVerifyContentTable(createCmd, "200");
-        ASSERT_EQUAL(jobID + 1, SToInt(response["jobID"]));
 
         // Restart master
         tester->startNode(0);
@@ -78,9 +76,8 @@ struct JobIDTest : tpunit::TestFixture {
             sleep(1);
         }
 
-        // Create a new job in master and check the ID is the next one
+        // Create a new job in master.
         response = master->executeWaitVerifyContentTable(createCmd);
-        ASSERT_EQUAL(jobID + 2, SToInt(response["jobID"]));
 
         // Get the 3 jobs to leave the db clean
         SData getCmd("GetJobs");

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -41,7 +41,7 @@ struct CreateJobTest : tpunit::TestFixture {
         string jobName = "testCreate";
         command["name"] = jobName;
         STable response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_GREATER_THAN(SToInt(response["jobID"]), 0);
+        ASSERT_GREATER_THAN(stol(response["jobID"]), 0);
 
         SQResult originalJob;
         tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", originalJob);
@@ -55,8 +55,8 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], "{}");
-        ASSERT_EQUAL(SToInt(originalJob[0][8]), 500);
-        ASSERT_EQUAL(SToInt(originalJob[0][9]), 0);
+        ASSERT_EQUAL(stol(originalJob[0][8]), 500);
+        ASSERT_EQUAL(stol(originalJob[0][9]), 0);
     }
 
     void createWithHttp() {
@@ -64,7 +64,7 @@ struct CreateJobTest : tpunit::TestFixture {
         string jobName = "testCreate";
         command["name"] = jobName;
         STable response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_GREATER_THAN(SToInt(response["jobID"]), 0);
+        ASSERT_GREATER_THAN(stol(response["jobID"]), 0);
 
         SQResult originalJob;
         tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", originalJob);
@@ -78,8 +78,8 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], "{}");
-        ASSERT_EQUAL(SToInt(originalJob[0][8]), 500);
-        ASSERT_EQUAL(SToInt(originalJob[0][9]), 0);
+        ASSERT_EQUAL(stol(originalJob[0][8]), 500);
+        ASSERT_EQUAL(stol(originalJob[0][9]), 0);
     }
 
     void createWithPriority() {
@@ -89,7 +89,7 @@ struct CreateJobTest : tpunit::TestFixture {
         command["name"] = jobName;
         command["priority"] = priority;
         STable response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_GREATER_THAN(SToInt(response["jobID"]), 0);
+        ASSERT_GREATER_THAN(stol(response["jobID"]), 0);
 
         SQResult originalJob;
         tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", originalJob);
@@ -104,7 +104,7 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], "{}");
         ASSERT_EQUAL(originalJob[0][8], priority);
-        ASSERT_EQUAL(SToInt(originalJob[0][9]), 0);
+        ASSERT_EQUAL(stol(originalJob[0][9]), 0);
     }
 
     void createWithData() {
@@ -114,7 +114,7 @@ struct CreateJobTest : tpunit::TestFixture {
         command["name"] = jobName;
         command["data"] = data;
         STable response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_GREATER_THAN(SToInt(response["jobID"]), 0);
+        ASSERT_GREATER_THAN(stol(response["jobID"]), 0);
 
         SQResult originalJob;
         tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", originalJob);
@@ -128,8 +128,8 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], data);
-        ASSERT_EQUAL(SToInt(originalJob[0][8]), 500);
-        ASSERT_EQUAL(SToInt(originalJob[0][9]), 0);
+        ASSERT_EQUAL(stol(originalJob[0][8]), 500);
+        ASSERT_EQUAL(stol(originalJob[0][9]), 0);
     }
 
     void createWithRepeat() {
@@ -139,7 +139,7 @@ struct CreateJobTest : tpunit::TestFixture {
         command["name"] = jobName;
         command["repeat"] = repeat;
         STable response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_GREATER_THAN(SToInt(response["jobID"]), 0);
+        ASSERT_GREATER_THAN(stol(response["jobID"]), 0);
 
         SQResult originalJob;
         tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", originalJob);
@@ -153,8 +153,8 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], repeat);
         ASSERT_EQUAL(originalJob[0][7], "{}");
-        ASSERT_EQUAL(SToInt(originalJob[0][8]), 500);
-        ASSERT_EQUAL(SToInt(originalJob[0][9]), 0);
+        ASSERT_EQUAL(stol(originalJob[0][8]), 500);
+        ASSERT_EQUAL(stol(originalJob[0][9]), 0);
     }
 
     // Create a unique job
@@ -167,7 +167,7 @@ struct CreateJobTest : tpunit::TestFixture {
         command["name"] = jobName;
         command["unique"] = "true";
         STable response = tester->executeWaitVerifyContentTable(command);
-        int jobID = SToInt(response["jobID"]);
+        int64_t jobID = stol(response["jobID"]);
         ASSERT_GREATER_THAN(jobID, 0);
 
         SQResult originalJob;
@@ -175,13 +175,13 @@ struct CreateJobTest : tpunit::TestFixture {
 
         // Try to recreate the job with the same data.
         response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_EQUAL(SToInt(response["jobID"]), jobID);
+        ASSERT_EQUAL(stol(response["jobID"]), jobID);
 
         // Try to recreate the job with new data, it should get updated.
         string data = "{\"blabla\":\"test\"}";
         command["data"] = data;
         response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_EQUAL(SToInt(response["jobID"]), jobID);
+        ASSERT_EQUAL(stol(response["jobID"]), jobID);
 
         SQResult updatedJob;
         tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", updatedJob);
@@ -288,8 +288,8 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], repeatValue);
         ASSERT_EQUAL(originalJob[0][7], "{}");
-        ASSERT_EQUAL(SToInt(originalJob[0][8]), 500);
-        ASSERT_EQUAL(SToInt(originalJob[0][9]), 0);
+        ASSERT_EQUAL(stol(originalJob[0][8]), 500);
+        ASSERT_EQUAL(stol(originalJob[0][9]), 0);
         ASSERT_EQUAL(originalJob[0][10], retryValue);
 
         // Get the job
@@ -397,8 +397,8 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], "{}");
-        ASSERT_EQUAL(SToInt(originalJob[0][8]), 500);
-        ASSERT_EQUAL(SToInt(originalJob[0][9]), 0);
+        ASSERT_EQUAL(stol(originalJob[0][8]), 500);
+        ASSERT_EQUAL(stol(originalJob[0][9]), 0);
         ASSERT_EQUAL(originalJob[0][10], retryValue);
 
         // Get the job

--- a/test/tests/jobs/CreateJobsTest.cpp
+++ b/test/tests/jobs/CreateJobsTest.cpp
@@ -159,7 +159,7 @@ struct CreateJobsTest : tpunit::TestFixture {
         command["name"] = "createWithParentMocked_child1";
         command["mockRequest"] = "true";
         STable response2 = tester->executeWaitVerifyContentTable(command);
-        int child1ID = stoi(response2["jobID"]);
+        int64_t child1ID = stol(response2["jobID"]);
         responseJSON = SParseJSONObject(response2["data"]);
         ASSERT_TRUE(responseJSON.find("mockRequest") != responseJSON.end());
 
@@ -168,7 +168,7 @@ struct CreateJobsTest : tpunit::TestFixture {
         command["name"] = "createWithParentMocked_child2";
         command["mockRequest"] = "true";
         response2 = tester->executeWaitVerifyContentTable(command);
-        int child2ID = stoi(response2["jobID"]);
+        int64_t child2ID = stol(response2["jobID"]);
         responseJSON = SParseJSONObject(response2["data"]);
         ASSERT_TRUE(responseJSON.find("mockRequest") != responseJSON.end());
 
@@ -186,7 +186,7 @@ struct CreateJobsTest : tpunit::TestFixture {
         response = tester->executeWaitVerifyContent(command);
 
         // Now make sure these are gone.
-        list<int> jobIDs = {child1ID, child2ID, stoi(parentID)};
+        list<int64_t> jobIDs = {child1ID, child2ID, stol(parentID)};
         SQResult result;
         string query = "SELECT jobID, state FROM jobs WHERE jobID in (" + SQList(jobIDs) + ");";
         tester->readDB(query, result);

--- a/test/tests/jobs/FinishJobTest.cpp
+++ b/test/tests/jobs/FinishJobTest.cpp
@@ -249,14 +249,19 @@ struct FinishJobTest : tpunit::TestFixture {
         // Confirm that the parent is in the PAUSED state and the children are in the QUEUED state
         SQResult result;
         list<string> ids = {parentID, finishedChildID, cancelledChildID};
-        tester->readDB("SELECT jobID, state FROM jobs WHERE jobID IN(" + SComposeList(ids) + ") ORDER BY jobID;", result);
+        tester->readDB("SELECT jobID, state FROM jobs WHERE jobID IN(" + SComposeList(ids) + ");", result);
         ASSERT_EQUAL(result.rows.size(), 3);
-        ASSERT_EQUAL(result[0][0], parentID);
-        ASSERT_EQUAL(result[0][1], "PAUSED");
-        ASSERT_EQUAL(result[1][0], finishedChildID);
-        ASSERT_EQUAL(result[1][1], "QUEUED");
-        ASSERT_EQUAL(result[2][0], cancelledChildID);
-        ASSERT_EQUAL(result[2][1], "QUEUED");
+        for (auto& row : result.rows) {
+            if (row[0] == parentID) {
+                ASSERT_EQUAL(row[1], "PAUSED");
+            } else if (row[0] == finishedChildID) {
+                ASSERT_EQUAL(row[1], "QUEUED");
+            } else if (row[0] == cancelledChildID) {
+                ASSERT_EQUAL(row[1], "QUEUED");
+            } else { 
+                ASSERT_TRUE(false);
+            }
+        }
     }
 
     void deleteFinishedJobWithNoChildren() {

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -57,7 +57,7 @@ struct GetJobTest : tpunit::TestFixture {
         command["name"] = jobName;
         STable response = tester->executeWaitVerifyContentTable(command);
         string jobID = response["jobID"];
-        ASSERT_GREATER_THAN(SToInt(jobID), 0);
+        ASSERT_GREATER_THAN(stol(jobID), 0);
         SQResult originalJob;
         tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + jobID + ";", originalJob);
 
@@ -102,7 +102,7 @@ struct GetJobTest : tpunit::TestFixture {
         command["name"] = jobName;
         STable response = tester->executeWaitVerifyContentTable(command);
         string jobID = response["jobID"];
-        ASSERT_GREATER_THAN(SToInt(jobID), 0);
+        ASSERT_GREATER_THAN(stol(jobID), 0);
         SQResult originalJob;
         tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + jobID + ";", originalJob);
 

--- a/test/tests/jobs/QueryJobTest.cpp
+++ b/test/tests/jobs/QueryJobTest.cpp
@@ -32,7 +32,7 @@ struct QueryJobTest : tpunit::TestFixture {
         command["priority"] = "1000";
         STable response = tester->executeWaitVerifyContentTable(command);
         string jobID = response["jobID"];
-        ASSERT_GREATER_THAN(SToInt(jobID), 0);
+        ASSERT_GREATER_THAN(stol(jobID), 0);
 
         command.clear();
         command.methodLine = "QueryJob";


### PR DESCRIPTION
This siwtches Jobs to use random positive signed 64-bit numbers for IDs.

The algorithm for generating IDs is identical to the new one for receipts in Auth.