### PR TITLE
Temporarily remove usage of getNextID

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -71,6 +71,8 @@ void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
 
     SQResult nextIDResult;
     db.read("SELECT MAX(jobID) FROM jobs;", nextIDResult);
+    lastJobID = nextIDResult.empty() ? 1 : SToInt64(nextIDResult[0][0]);
+    SINFO("Initializing jobs plugin, last jobID used is " << SToStr(lastJobID));
 }
 
 // ==========================================================================
@@ -622,7 +624,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 const string& safeRetryAfter = SContains(job, "retryAfter") && !job["retryAfter"].empty() ? SQ(job["retryAfter"]) : SQ("");
 
                 // Create this new job with a new generated ID
-                const int64_t jobIDToUse = getNextID(db);
+                const int64_t jobIDToUse = ++lastJobID;
                 SINFO("Next jobID to be used " << jobIDToUse);
                 if (!db.writeIdempotent("INSERT INTO jobs ( jobID, created, state, name, nextRun, repeat, data, priority, parentJobID, retryAfter ) "
                          "VALUES( " +

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -17,6 +17,7 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     virtual void handleFailedReply(const BedrockCommand& command);
 
   private:
+    atomic<uint64_t> lastJobID;
     static int64_t getNextID(SQLite& db);
 
     // Helper functions


### PR DESCRIPTION
@swhi3635 @iwiznia 
cc @tylerkaraszewski 

As agreed in Slack, we'll deploy this first, then the revert of this. 

# Tests

Confirmed I see `Initializing jobs plugin, last jobID used is ` and that subsequently created jobIDs are sequential