### PR TITLE
Rename GetJob(s) parameter from priority to jobPriority

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -98,7 +98,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
         //     - name - list of name patterns of jobs to match. If only one name is passed, you can use '*' to match any job.
         //     - numResults - (optional) Optional for GetJob, required for GetJobs. Maximum number of jobs to dequeue. 
         //     - connection - (optional) If "wait" will pause up to "timeout" for a match
-        //     - priority - (optional) Only check for jobs with this priority
+        //     - jobPriority - (optional) Only check for jobs with this priority
         //     - timeout - (optional) maximum time (in ms) to wait, default forever
         //
         //     Returns:
@@ -128,7 +128,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
         if (!db.read("SELECT 1 "
                      "FROM jobs "
                      "WHERE state in ('QUEUED', 'RUNQUEUED') "
-                        "AND " + (request.isSet("priority") ? "priority = " + SQ(request.calc("priority")) : "priority IN (0, 500, 1000)") + " "
+                        "AND " + (request.isSet("jobPriority") ? "priority = " + SQ(request.calc("jobPriority")) : "priority IN (0, 500, 1000)") + " "
                         "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                         "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " + 
                         string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
@@ -670,15 +670,14 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         SQResult result;
         const list<string> nameList = SParseList(request["name"]);
         string safeNumResults = SQ(max(request.calc("numResults"),1));
-        string safePriority = SQ(request.calc("priority"));
         bool mockRequest = command.request.isSet("mockRequest") || command.request.isSet("getMockedJobs");
         string selectQuery;
-        if (request.isSet("priority")) {
+        if (request.isSet("jobPriority")) {
             selectQuery =
                 "SELECT jobID, name, data, parentJobID, retryAfter, created, repeat, lastRun, nextRun "
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
-                    "AND priority=" + SQ(request.calc("priority")) + " "
+                    "AND priority=" + SQ(request.calc("jobPriority")) + " "
                     "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                     "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                     string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -623,31 +623,31 @@ struct GetJobTest : tpunit::TestFixture {
         // Low
         SData command("CreateJob");
         command["name"] = "low_5";
-        command["priority"] = "0";
+        command["jobPriority"] = "0";
         command["firstRun"] = firstRun;
         STable response = tester->executeWaitVerifyContentTable(command);
 
         // High
         command["name"] = "high_1";
-        command["priority"] = "1000";
+        command["jobPriority"] = "1000";
         command["firstRun"] = firstRun;
         response = tester->executeWaitVerifyContentTable(command);
 
         // Medium
         command["name"] = "medium_3";
-        command["priority"] = "500";
+        command["jobPriority"] = "500";
         command["firstRun"] = firstRun;
         response = tester->executeWaitVerifyContentTable(command);
 
         // High
         command["name"] = "high_2";
-        command["priority"] = "1000";
+        command["jobPriority"] = "1000";
         command["firstRun"] = firstRun;
         response = tester->executeWaitVerifyContentTable(command);
 
         // Medium
         command["name"] = "medium_4";
-        command["priority"] = "500";
+        command["jobPriority"] = "500";
         command["firstRun"] = firstRun;
         response = tester->executeWaitVerifyContentTable(command);
 
@@ -656,22 +656,22 @@ struct GetJobTest : tpunit::TestFixture {
         tester->readDB("SELECT DISTINCT nextRun FROM jobs;", result);
         ASSERT_EQUAL(result.size(), 1);
 
-        // Use GetJobs with priority = 0, then 500, then 1000 and confirm that the jobs are returned in reverse priority
+        // Use GetJobs with jobPriority = 0, then 500, then 1000 and confirm that the jobs are returned in reverse jobPriority
         command.clear();
         command.methodLine = "GetJobs";
         command["name"] = "*";
         command["numResults"] = "2";
 
-        // Get priority 0
-        command["priority"] = "0";
+        // Get jobPriority 0
+        command["jobPriority"] = "0";
         response = tester->executeWaitVerifyContentTable(command);
         list<string> jobList = SParseJSONArray(response["jobs"]);
         ASSERT_EQUAL(jobList.size(), 1);
         ASSERT_EQUAL(SParseJSONObject(jobList.front())["name"], "low_5");
 
-        // Get priority 500
+        // Get jobPriority 500
         // nextRun is the same for all the jobs, so we just want to confirm that a medium job was returned
-        command["priority"] = "500";
+        command["jobPriority"] = "500";
         response = tester->executeWaitVerifyContentTable(command);
         jobList = SParseJSONArray(response["jobs"]);
         ASSERT_EQUAL(jobList.size(), 2);
@@ -679,9 +679,9 @@ struct GetJobTest : tpunit::TestFixture {
         jobList.pop_front();
         ASSERT_NOT_EQUAL(SParseJSONObject(jobList.front())["name"].find("medium"), string::npos);
 
-        // Get priority 1000
+        // Get jobPriority 1000
         // nextRun is the same for all the jobs, so we just want to confirm that a high job was returned
-        command["priority"] = "1000";
+        command["jobPriority"] = "1000";
         response = tester->executeWaitVerifyContentTable(command);
         jobList = SParseJSONArray(response["jobs"]);
         ASSERT_EQUAL(jobList.size(), 2);


### PR DESCRIPTION
cc @iwiznia @tylerkaraszewski 
Fixes bug introduced in https://github.com/Expensify/Bedrock/pull/557/
We cannot use `priority` as parameter for `GetJob`/`GetJobs`, it's already a parameter on all Bedrock commands