### PR TITLE
Revert using a simplified query for GetJobs if jobPriority is set

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -98,7 +98,6 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
         //     - name - list of name patterns of jobs to match. If only one name is passed, you can use '*' to match any job.
         //     - numResults - (optional) Optional for GetJob, required for GetJobs. Maximum number of jobs to dequeue.
         //     - connection - (optional) If "wait" will pause up to "timeout" for a match
-        //     - jobPriority - (optional) Only check for jobs with this priority
         //     - timeout - (optional) maximum time (in ms) to wait, default forever
         //
         //     Returns:
@@ -125,24 +124,13 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
         SQResult result;
         const list<string> nameList = SParseList(request["name"]);
         bool mockRequest = command.request.isSet("mockRequest") || command.request.isSet("getMockedJobs");
-        string priorityCondition = "priority IN (0, 500, 1000)";
-        string nameColumn = "name";
-        if (request.isSet("jobPriority")) {
-            int64_t priority = request.calc64("jobPriority");
-            if (priority != 0 && priority != 500 && priority != 1000) {
-                STHROW("402 Invalid priority value");
-            }
-
-            priorityCondition = "priority = " + SQ(priority);
-            nameColumn = "+name";
-        }
 
         if (!db.read("SELECT 1 "
                      "FROM jobs "
                      "WHERE state in ('QUEUED', 'RUNQUEUED') "
-                        "AND " + priorityCondition + " "
+                        "AND priority IN (0, 500, 1000) "
                         "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
-                        "AND " + nameColumn + " " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
+                        "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                         string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                      "LIMIT 1;",
                      result)) {
@@ -684,55 +672,43 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         string safeNumResults = SQ(max(request.calc("numResults"),1));
         bool mockRequest = command.request.isSet("mockRequest") || command.request.isSet("getMockedJobs");
         string selectQuery;
-        if (request.isSet("jobPriority")) {
-            selectQuery =
-                "SELECT jobID, name, data, parentJobID, retryAfter, created, repeat, lastRun, nextRun "
-                "FROM jobs "
-                "WHERE state IN ('QUEUED', 'RUNQUEUED') "
-                    "AND priority=" + SQ(request.calc("jobPriority")) + " "
-                    "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
-                    "AND +name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                    string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
-                "ORDER BY nextRun ASC LIMIT " + safeNumResults + ";";
-        } else {
-            selectQuery =
-                "SELECT jobID, name, data, parentJobID, retryAfter, created, repeat, lastRun, nextRun FROM ( "
-                    "SELECT * FROM ("
-                        "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun "
-                        "FROM jobs "
-                        "WHERE state IN ('QUEUED', 'RUNQUEUED') "
-                            "AND priority=1000 "
-                            "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
-                            "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                            string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
-                        "ORDER BY nextRun ASC LIMIT " + safeNumResults +
-                    ") "
-                "UNION ALL "
-                    "SELECT * FROM ("
-                        "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun "
-                        "FROM jobs "
-                        "WHERE state IN ('QUEUED', 'RUNQUEUED') "
-                            "AND priority=500 "
-                            "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
-                            "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                            string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
-                        "ORDER BY nextRun ASC LIMIT " + safeNumResults +
-                    ") "
-                "UNION ALL "
-                    "SELECT * FROM ("
-                        "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun "
-                        "FROM jobs "
-                        "WHERE state IN ('QUEUED', 'RUNQUEUED') "
-                            "AND priority=0 "
-                            "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
-                            "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                            string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
-                        "ORDER BY nextRun ASC LIMIT " + safeNumResults +
-                    ") "
+        selectQuery =
+            "SELECT jobID, name, data, parentJobID, retryAfter, created, repeat, lastRun, nextRun FROM ( "
+                "SELECT * FROM ("
+                    "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun "
+                    "FROM jobs "
+                    "WHERE state IN ('QUEUED', 'RUNQUEUED') "
+                        "AND priority=1000 "
+                        "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                        "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
+                        string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                    "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
-                "ORDER BY priority DESC "
-                "LIMIT " + safeNumResults + ";";
-        }
+            "UNION ALL "
+                "SELECT * FROM ("
+                    "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun "
+                    "FROM jobs "
+                    "WHERE state IN ('QUEUED', 'RUNQUEUED') "
+                        "AND priority=500 "
+                        "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                        "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
+                        string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                    "ORDER BY nextRun ASC LIMIT " + safeNumResults +
+                ") "
+            "UNION ALL "
+                "SELECT * FROM ("
+                    "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun "
+                    "FROM jobs "
+                    "WHERE state IN ('QUEUED', 'RUNQUEUED') "
+                        "AND priority=0 "
+                        "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                        "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
+                        string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                    "ORDER BY nextRun ASC LIMIT " + safeNumResults +
+                ") "
+            ") "
+            "ORDER BY priority DESC "
+            "LIMIT " + safeNumResults + ";";
         if (!db.read(selectQuery, result)) {
             STHROW("502 Query failed");
         }


### PR DESCRIPTION
Reverts 
1.  https://github.com/Expensify/Bedrock/pull/557/ - Using a simplified query for `GetJob(s)` when `priority` was set
1. https://github.com/Expensify/Bedrock/pull/558/ - Oops! Can't use `priority`, use `jobPriority` instead
1.  https://github.com/Expensify/Bedrock/pull/559/ - Adds unary `+` to the simplified query