### PR TITLE
Sync thread should also wait for checkpointing

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -263,7 +263,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
         string filename = object->_filename;
         string dbNameCopy = dbName;
         int alreadyCheckpointing = object->_checkpointThreadBusy.fetch_add(1);
-        if (alreadyCheckpointing != 1) {
+        if (alreadyCheckpointing) {
             SINFO("[checkpoint] Not starting checkpoint thread. It's already running.");
             return SQLITE_OK;
         }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -272,7 +272,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
             uint64_t start = STimeNow();
 
             // Lock the mutex that keeps anyone from starting a new transaction.
-            object->_sharedData->blockNewTransactionsMutex.lock();
+            lock_guard<decltype(object->_sharedData->blockNewTransactionsMutex)> transactionLock(object->_sharedData->blockNewTransactionsMutex);
 
             while (1) {
                 // Lock first, this prevents anyone from updating the count while we're operating here.
@@ -310,8 +310,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
                           << framesCheckpointed << " of " << walSizeFrames
                           << " in " << ((STimeNow() - checkpointStart) / 1000) << "ms.");
 
-                    // We're done. Unlock and anyone can start a new transaction.
-                    object->_sharedData->blockNewTransactionsMutex.unlock();
+                    // We're done. Anyone can start a new transaction.
                     break;
                 }
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -413,4 +413,7 @@ class SQLite {
 
     // Will be set to false while running a non-deterministic query to prevent it's result being cached.
     bool _isDeterministicQuery;
+
+    // Used as a flag to prevent starting multiple checkpoint threads simultaneously.
+    atomic<int> _checkpointThreadBusy;
 };

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1460,6 +1460,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         if (_db.getCommitCount() + 1 != message.calcU64("NewCount")) {
             STHROW("commit count mismatch. Expected: " + message["NewCount"] + ", but would actually be: " + to_string(_db.getCommitCount() + 1));
         }
+        _db.waitForCheckpoint();
         if (!_db.beginTransaction()) {
             STHROW("failed to begin transaction");
         }
@@ -2116,6 +2117,7 @@ void SQLiteNode::_recvSynchronize(Peer* peer, const SData& message) {
             SALERT("Synchronized blank query");
         if (commit.calcU64("CommitIndex") != _db.getCommitCount() + 1)
             STHROW("commit index mismatch");
+        _db.waitForCheckpoint();
         if (!_db.beginTransaction())
             STHROW("failed to begin transaction");
         try {


### PR DESCRIPTION
The sync thread should wait for checkpointing to complete before starting the next DB transaction, just like worker threads.

What can happen in the existing code, is we hit the point where we're supposed to start a complete checkpoint. The checkpoint thread waits for all existing transactions to complete, but the sync thread, while slaving, keeps committing new replicated transactions, so it takes a while for the checkpoint thread to actually begin it's checkpoint.

That's not too bad, but what happens in addition is that each new transaction spawns a new checkpoint thread, each waiting for the previous one to finish, so we can end up doing several checkpoints in a row.