### PR TITLE
Log request email

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -34,8 +34,8 @@ void BedrockServer::acceptCommand(SQLiteCommand&& command, bool isNew) {
             newCommand.initiatingPeerID = 0;
         }
         // Add a request ID if one was missing.
-        _addRequestID(newCommand.request);
-        SAUTOPREFIX(newCommand.request["requestID"]);
+        _addRequestIDAndEmail(newCommand.request);
+        SAUTOPREFIX(newCommand.request["requestID"] + " " + newCommand.request["requestEmail"]);
         if (newCommand.writeConsistency != SQLiteNode::QUORUM
             && _syncCommands.find(newCommand.request.methodLine) != _syncCommands.end()) {
 
@@ -192,7 +192,7 @@ void BedrockServer::sync(SData& args,
     do {
 
         // Make sure the existing command prefix is still valid since they're reset when SAUTOPREFIX goes out of scope.
-        SAUTOPREFIX(command.request["requestID"]);
+        SAUTOPREFIX(command.request["requestID"] + " " + command.request["requestEmail"]);
 
         // If there were commands waiting on our commit count to come up-to-date, we'll move them back to the main
         // command queue here. There's no place in particular that's best to do this, so we do it at the top of this
@@ -303,7 +303,7 @@ void BedrockServer::sync(SData& args,
         // Process any network traffic that happened. Scope this so that we can change the log prefix and have it
         // auto-revert when we're finished.
         {
-            SAUTOPREFIX("xxxxxx");
+            SAUTOPREFIX("xxxxxx we@dont.know");
 
             // Process any activity in our plugins.
             server._postPollPlugins(fdm, nextActivity);
@@ -447,7 +447,7 @@ void BedrockServer::sync(SData& args,
             try {
                 while (true) {
                     BedrockCommand completedCommand = completedCommands.pop();
-                    SAUTOPREFIX(completedCommand.request["requestID"]);
+                    SAUTOPREFIX(completedCommand.request["requestID"] + " " + completedCommand.request["requestEmail"]);
                     SASSERT(completedCommand.complete);
                     SASSERT(completedCommand.initiatingPeerID);
                     SASSERT(!completedCommand.initiatingClientID);
@@ -466,7 +466,7 @@ void BedrockServer::sync(SData& args,
             command = syncNodeQueuedCommands.pop();
 
             // We got a command to work on! Set our log prefix to the request ID.
-            SAUTOPREFIX(command.request["requestID"]);
+            SAUTOPREFIX(command.request["requestID"] + " " + command.request["requestEmail"]);
             SINFO("Sync thread dequeued command " << command.request.methodLine << ". Sync thread has "
                   << syncNodeQueuedCommands.size() << " queued commands.");
 
@@ -681,7 +681,7 @@ void BedrockServer::worker(SData& args,
             // count wrong while we wait.
             command = commandQueue.getSynchronized(1000000, server._commandsInProgress);
 
-            SAUTOPREFIX(command.request["requestID"]);
+            SAUTOPREFIX(command.request["requestID"] + " " + command.request["requestEmail"]);
             SINFO("Dequeued command " << command.request.methodLine << " in worker, "
                   << commandQueue.size() << " commands in " << (threadId ? "" : "blocking") << " queue.");
 
@@ -1428,8 +1428,8 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 // command.
                 if (!request.empty()) {
                     // If there's no ID for this request, let's add one.
-                    _addRequestID(request);
-                    SAUTOPREFIX(request["requestID"]);
+                    _addRequestIDAndEmail(request);
+                    SAUTOPREFIX(request["requestID"] + " " + request["requestEmail"]);
                     deserializedRequests++;
                     // Either shut down the socket or store it so we can eventually sync out the response.
                     if (SIEquals(request["Connection"], "forget") ||
@@ -2114,7 +2114,7 @@ int BedrockServer::finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& comp
     return commandsCompleted;
 }
 
-void BedrockServer::_addRequestID(SData& request) {
+void BedrockServer::_addRequestIDAndEmail(SData& request) {
     if (!request.isSet("requestID")) {
         string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
         string requestID;
@@ -2122,5 +2122,8 @@ void BedrockServer::_addRequestID(SData& request) {
             requestID += chars[SRandom::rand64() % chars.size()];
         }
         request["requestID"] = requestID;
+    }
+    if (!request.isSet("requestEmail")) {
+        request["requestEmail"] = "we@dont.know";
     }
 }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -454,5 +454,5 @@ class BedrockServer : public SQLiteServer {
     // Generate a CRASH_COMMAND command for a given bad command.
     static SData _generateCrashMessage(const BedrockCommand* command);
 
-    static void _addRequestIDAndEmail(SData& request);
+    static void _addRequestID(SData& request);
 };

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -454,5 +454,5 @@ class BedrockServer : public SQLiteServer {
     // Generate a CRASH_COMMAND command for a given bad command.
     static SData _generateCrashMessage(const BedrockCommand* command);
 
-    static void _addRequestID(SData& request);
+    static void _addRequestIDAndEmail(SData& request);
 };


### PR DESCRIPTION
@tylerkaraszewski please review. /cc @flodnv 

# Fixes 
https://github.com/Expensify/Expensify/issues/93741

# Tests
Checked the logs:
Auth request `Auth::call('SetNameValuePair', ['name' => 'caca', 'value' => 'caca', 'requestEmail' => 'ionatan@expensify.com', 'authToken' => authToken()])`:
```
2018-12-21T14:25:13.779799+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (BedrockServer.cpp:1452) postPoll [main] [info] Waiting for 'SetNameValuePair' to complete.
2018-12-21T14:25:13.780233+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (BedrockServer.cpp:1491) postPoll [main] [info] Queued new 'SetNameValuePair' command from local client, with 0 commands already queued.
2018-12-21T14:25:13.781034+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (BedrockServer.cpp:686) worker [worker2] [info] Dequeued command SetNameValuePair in worker, 0 commands in  queue.
2018-12-21T14:25:13.781317+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (BedrockCore.cpp:65) peekCommand [worker2] [dbug] Peeking at 'SetNameValuePair' with priority: 500
2018-12-21T14:25:13.781507+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (SQLite.cpp:417) beginConcurrentTransaction [worker2] [dbug] [concurrent] Beginning transaction
2018-12-21T14:25:13.782253+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] BEGIN CONCURRENT
2018-12-21T14:25:13.782574+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA query_only = true;
2018-12-21T14:25:13.783439+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (Auth.cpp:658) peekCommand [worker2] [dbug] {:Auth} Peeking at 'SetNameValuePair'
2018-12-21T14:25:13.783934+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT value FROM nameValuePairs WHERE accountID=1 AND name='private_minimumAuthTokenIssueTime';
2018-12-21T14:25:13.786007+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT email FROM accounts WHERE accountID=1;
2018-12-21T14:25:13.786341+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT partnerName FROM partners WHERE partnerID=1;
2018-12-21T14:25:13.786611+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT validated FROM accounts WHERE accountID=1;
2018-12-21T14:25:13.786938+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (Auth.cpp:826) peekCommand [worker2] [info] {:Auth} Processing 'SetNameValuePair' for account 'ionatan@expensify.com' (#1) by partner 'expensify.com' (#1), type=
2018-12-21T14:25:13.787433+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT value FROM nameValuePairs WHERE accountID=1 AND name='caca';
2018-12-21T14:25:13.788270+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (AuthCommand.cpp:8) ~AuthCommand [worker2] [dbug] Destroying AuthCommand
2018-12-21T14:25:13.788742+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA query_only = false;
2018-12-21T14:25:13.789322+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (BedrockCore.cpp:112) peekCommand [worker2] [info] Command 'SetNameValuePair' is not peekable, queuing for processing.
2018-12-21T14:25:13.789758+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (BedrockCore.cpp:170) processCommand [worker2] [dbug] Processing 'SetNameValuePair'
2018-12-21T14:25:13.789975+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (Auth.cpp:891) processCommand [worker2] [dbug] {:Auth} Received 'SetNameValuePair'
2018-12-21T14:25:13.790293+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT value FROM nameValuePairs WHERE accountID=0 AND name='private_minimumAuthTokenIssueTime';
2018-12-21T14:25:13.790510+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (SetNameValuePair.cpp:232) process [worker2] [info] accountID=1: setting NVP 'caca'
2018-12-21T14:25:13.790813+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-12-21T14:25:13.791029+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] UPDATE nameValuePairs SET value='caca' WHERE accountID=1 AND name='caca';
2018-12-21T14:25:13.791234+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-12-21T14:25:13.791693+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT email FROM accounts WHERE accountID=1;
2018-12-21T14:25:13.792185+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT validated FROM accounts WHERE accountID=1;
2018-12-21T14:25:13.792446+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (AuthCommand.cpp:8) ~AuthCommand [worker2] [dbug] Destroying AuthCommand
2018-12-21T14:25:13.792695+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (Auth.cpp:968) processCommand [worker2] [info] {:Auth} Responding '' to 'SetNameValuePair'.
2018-12-21T14:25:13.792911+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (BedrockCore.cpp:195) processCommand [worker2] [info] Plugin 'Auth' processed command 'SetNameValuePair'
2018-12-21T14:25:13.793241+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (BedrockCore.cpp:225) processCommand [worker2] [info] Processed '200 OK' for 'SetNameValuePair'.
2018-12-21T14:25:13.793508+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (BedrockServer.cpp:934) worker [worker2] [info] _syncThreadCommitMutex (shared) acquired in worker in 0ms.
2018-12-21T14:25:13.793737+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] INSERT INTO journal0002 VALUES (12974, 'UPDATE nameValuePairs SET value=''caca'' WHERE accountID=1 AND name=''caca'';', 'A1CEEA87AAF3D97A733B60187A313919C52BDCAA' )
2018-12-21T14:25:13.793927+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (SQLite.cpp:641) prepare [worker2] [dbug] Prepared transaction
2018-12-21T14:25:13.794120+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (SQLite.cpp:675) commit [worker2] [dbug] Committing transaction
2018-12-21T14:25:13.794588+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (libstuff.cpp:2355) SQuery [worker2] [dbug] COMMIT
2018-12-21T14:25:13.796039+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (SQLite.cpp:248) _sqliteWALCallback [worker2] [info] [checkpoint] skipping checkpoint with 18 pages in WAL file (checkpoint every 2500 pages).
2018-12-21T14:25:13.796245+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (SQLite.cpp:684) commit [worker2] [info] SQuery 'COMMIT' took 6ms.
2018-12-21T14:25:13.796385+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (SQLite.cpp:697) commit [worker2] [info] COMMIT operation wrote 2 pages. WAL file size is 74192 bytes.
2018-12-21T14:25:13.796509+00:00 expensidev bedrock: xK6shX ionatan@expensify.com (SQLite.cpp:707) commit [worker2] [dbug] Commit successful (12974), releasing commitLock.
```
Bedrock jobs request:
```
2018-12-21T14:26:29.971115+00:00 expensidev bedrock: xxxxxx (STCPServer.cpp:62) acceptSocket [main] [dbug] Accepting socket from '127.0.0.1:54272' on port '0.0.0.0:8888'
2018-12-21T14:26:29.971445+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (BedrockServer.cpp:1452) postPoll [main] [info] Waiting for 'CreateJob' to complete.
2018-12-21T14:26:29.971630+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (BedrockServer.cpp:1491) postPoll [main] [info] Queued new 'CreateJob' command from local client, with 0 commands already queued.
2018-12-21T14:26:29.971882+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (BedrockServer.cpp:686) worker [worker2] [info] Dequeued command CreateJob in worker, 0 commands in  queue.
2018-12-21T14:26:29.972069+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (BedrockCore.cpp:65) peekCommand [worker2] [dbug] Peeking at 'CreateJob' with priority: 250
2018-12-21T14:26:29.972440+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (SQLite.cpp:417) beginConcurrentTransaction [worker2] [dbug] [concurrent] Beginning transaction
2018-12-21T14:26:29.972809+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (libstuff.cpp:2355) SQuery [worker2] [dbug] BEGIN CONCURRENT
2018-12-21T14:26:29.973077+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA query_only = true;
2018-12-21T14:26:29.973245+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (libstuff.cpp:1296) _SParseJSONObject [worker2] [dbug] Parsed: '_commitCounts':'{"auth":12974}'
2018-12-21T14:26:29.973386+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA query_only = false;
2018-12-21T14:26:29.973565+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (BedrockCore.cpp:112) peekCommand [worker2] [info] Command 'CreateJob' is not peekable, queuing for processing.
2018-12-21T14:26:29.973691+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (BedrockCore.cpp:170) processCommand [worker2] [dbug] Processing 'CreateJob'
2018-12-21T14:26:29.973810+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (Jobs.cpp:490) processCommand [worker2] [info] {Jobs} Job has no run time, can be scheduled immediately.
2018-12-21T14:26:29.973927+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT jobID FROM jobs WHERE jobID = 4851817544638375366;
2018-12-21T14:26:29.982847+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (Jobs.cpp:593) processCommand [worker2] [info] {Jobs} Next jobID to be used 4851817544638375366
2018-12-21T14:26:29.983322+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-12-21T14:26:29.984116+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (libstuff.cpp:2355) SQuery [worker2] [dbug] INSERT INTO jobs ( jobID, created, state, name, nextRun, repeat, data, priority, parentJobID, retryAfter ) VALUES( 4851817544638375366, '2018-12-21 14:26:29', 'QUEUED', 'www-prod/caca', '2018-12-21 14:26:29', '', '{"_commitCounts":{"auth":12974}}', 500, 0, ''  );
2018-12-21T14:26:29.984567+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-12-21T14:26:29.984934+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (BedrockCore.cpp:195) processCommand [worker2] [info] Plugin 'Jobs' processed command 'CreateJob'
2018-12-21T14:26:29.985165+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (BedrockCore.cpp:225) processCommand [worker2] [info] Processed '200 OK' for 'CreateJob'.
2018-12-21T14:26:29.985568+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (BedrockServer.cpp:934) worker [worker2] [info] _syncThreadCommitMutex (shared) acquired in worker in 0ms.
2018-12-21T14:26:29.985840+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (libstuff.cpp:2355) SQuery [worker2] [dbug] INSERT INTO journal0002 VALUES (5821, 'INSERT INTO jobs ( jobID, created, state, name, nextRun, repeat, data, priority, parentJobID, retryAfter ) VALUES( 4851817544638375366, ''2018-12-21 14:26:29'', ''QUEUED'', ''www-prod/caca'', ''2018-12-21 14:26:29'', '''', ''{"_commitCounts":{"auth":12974}}'', 500, 0, ''''  );', '7EF9E724462AFB3192FE9E339C6BE6F062B4D537' )
2018-12-21T14:26:29.986038+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (SQLite.cpp:641) prepare [worker2] [dbug] Prepared transaction
2018-12-21T14:26:29.986295+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (SQLite.cpp:675) commit [worker2] [dbug] Committing transaction
2018-12-21T14:26:29.986686+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (libstuff.cpp:2355) SQuery [worker2] [dbug] COMMIT
2018-12-21T14:26:29.995782+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (SQLite.cpp:248) _sqliteWALCallback [worker2] [info] [checkpoint] skipping checkpoint with 1881 pages in WAL file (checkpoint every 2500 pages).
2018-12-21T14:26:29.996111+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (SQLite.cpp:684) commit [worker2] [info] SQuery 'COMMIT' took 10ms.
2018-12-21T14:26:29.996242+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (SQLite.cpp:697) commit [worker2] [info] COMMIT operation wrote 5 pages. WAL file size is 10378312 bytes.
2018-12-21T14:26:29.996367+00:00 expensidev bedrock: xK6shX cacaca@asdaa.com (SQLite.cpp:707) commit [worker2] [dbug] Commit successful (5821), releasing commitLock.
```
With no email passed:
```
2018-12-21T14:27:00.893214+00:00 expensidev bedrock: 3gBv9Q we@dont.know (BedrockServer.cpp:1452) postPoll [main] [info] Waiting for 'RetryJob' to complete.
2018-12-21T14:27:00.893379+00:00 expensidev bedrock: 3gBv9Q we@dont.know (BedrockServer.cpp:1491) postPoll [main] [info] Queued new 'RetryJob' command from local client, with 0 commands already queued.
2018-12-21T14:27:00.893744+00:00 expensidev bedrock: 3gBv9Q we@dont.know (BedrockServer.cpp:686) worker [worker2] [info] Dequeued command RetryJob in worker, 0 commands in  queue.
2018-12-21T14:27:00.893909+00:00 expensidev bedrock: 3gBv9Q we@dont.know (BedrockCore.cpp:65) peekCommand [worker2] [dbug] Peeking at 'RetryJob' with priority: 500
2018-12-21T14:27:00.894061+00:00 expensidev bedrock: 3gBv9Q we@dont.know (SQLite.cpp:417) beginConcurrentTransaction [worker2] [dbug] [concurrent] Beginning transaction
2018-12-21T14:27:00.894215+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] BEGIN CONCURRENT
2018-12-21T14:27:00.894638+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA query_only = true;
2018-12-21T14:27:00.894813+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA query_only = false;
2018-12-21T14:27:00.894969+00:00 expensidev bedrock: 3gBv9Q we@dont.know (BedrockCore.cpp:112) peekCommand [worker2] [info] Command 'RetryJob' is not peekable, queuing for processing.
2018-12-21T14:27:00.895116+00:00 expensidev bedrock: 3gBv9Q we@dont.know (BedrockCore.cpp:170) processCommand [worker2] [dbug] Processing 'RetryJob'
2018-12-21T14:27:00.895269+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT state, nextRun, lastRun, repeat, parentJobID, json_extract(data, '$.mockRequest') FROM jobs WHERE jobID=7282397822179112622;
2018-12-21T14:27:00.895422+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] SELECT state FROM jobs WHERE jobID=6852468813438866520;
2018-12-21T14:27:00.895573+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-12-21T14:27:00.895718+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] DELETE FROM jobs WHERE parentJobID != 0 AND parentJobID=7282397822179112622 AND state IN ('FINISHED', 'CANCELLED');
2018-12-21T14:27:00.895874+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-12-21T14:27:00.896112+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:1296) _SParseJSONObject [worker2] [dbug] Parsed: 'receiptID':'204'
2018-12-21T14:27:00.896264+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:1296) _SParseJSONObject [worker2] [dbug] Parsed: 'filename':'u_864d34191ed191c23a6afbed867ef7c201fe0ad7.png'
2018-12-21T14:27:00.896422+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:1296) _SParseJSONObject [worker2] [dbug] Parsed: 'defaultCurrency':'USD'
2018-12-21T14:27:00.896571+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:1296) _SParseJSONObject [worker2] [dbug] Parsed: 'defaultDateFormat':'MM/DD/YYYY'
2018-12-21T14:27:00.896725+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:1296) _SParseJSONObject [worker2] [dbug] Parsed: '_commitCounts':'{"webrock":5588,"auth":12954}'
2018-12-21T14:27:00.896883+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-12-21T14:27:00.897036+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] UPDATE jobs SET data='{"receiptID":204,"filename":"u_864d34191ed191c23a6afbed867ef7c201fe0ad7.png","defaultCurrency":"USD","defaultDateFormat":"MM\/DD\/YYYY","_commitCounts":{"webrock":5588,"auth":12954}}' WHERE jobID=7282397822179112622;
2018-12-21T14:27:00.897182+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-12-21T14:27:00.897329+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-12-21T14:27:00.897487+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] UPDATE jobs SET name='manual/SmartScanMerchantAndCategory?receiptID=204' WHERE jobID=7282397822179112622;
2018-12-21T14:27:00.897639+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-12-21T14:27:00.897782+00:00 expensidev bedrock: 3gBv9Q we@dont.know (Jobs.cpp:1027) processCommand [worker2] [info] {Jobs} Rescheduling job#7282397822179112622: '2018-12-20 17:11:23'
2018-12-21T14:27:00.897935+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-12-21T14:27:00.898089+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] UPDATE jobs SET nextRun='2018-12-20 17:11:23', state='QUEUED' WHERE jobID=7282397822179112622;
2018-12-21T14:27:00.898234+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] PRAGMA schema_version;
2018-12-21T14:27:00.898378+00:00 expensidev bedrock: 3gBv9Q we@dont.know (BedrockCore.cpp:195) processCommand [worker2] [info] Plugin 'Jobs' processed command 'RetryJob'
2018-12-21T14:27:00.898534+00:00 expensidev bedrock: 3gBv9Q we@dont.know (BedrockCore.cpp:225) processCommand [worker2] [info] Processed '200 OK' for 'RetryJob'.
2018-12-21T14:27:00.898691+00:00 expensidev bedrock: 3gBv9Q we@dont.know (BedrockServer.cpp:934) worker [worker2] [info] _syncThreadCommitMutex (shared) acquired in worker in 0ms.
2018-12-21T14:27:00.898846+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] INSERT INTO journal0002 VALUES (5831, 'UPDATE jobs SET data=''{"receiptID":204,"filename":"u_864d34191ed191c23a6afbed867ef7c201fe0ad7.png","defaultCurrency":"USD","defaultDateFormat":"MM\/DD\/YYYY","_commitCounts":{"webrock":5588,"auth":12954}}'' WHERE jobID=7282397822179112622;UPDATE jobs SET name=''manual/SmartScanMerchantAndCategory?receiptID=204'' WHERE jobID=7282397822179112622;UPDATE jobs SET nextRun=''2018-12-20 17:11:23'', state=''QUEUED'' WHERE jobID=7282397822179112622;', '1AF4627794500308E3E942C44406711E6DF299E0' )
2018-12-21T14:27:00.899213+00:00 expensidev bedrock: 3gBv9Q we@dont.know (SQLite.cpp:641) prepare [worker2] [dbug] Prepared transaction
2018-12-21T14:27:00.899370+00:00 expensidev bedrock: 3gBv9Q we@dont.know (SQLite.cpp:675) commit [worker2] [dbug] Committing transaction
2018-12-21T14:27:00.899518+00:00 expensidev bedrock: 3gBv9Q we@dont.know (libstuff.cpp:2355) SQuery [worker2] [dbug] COMMIT
2018-12-21T14:27:00.899673+00:00 expensidev bedrock: 3gBv9Q we@dont.know (SQLite.cpp:248) _sqliteWALCallback [worker2] [info] [checkpoint] skipping checkpoint with 1953 pages in WAL file (checkpoint every 2500 pages).
2018-12-21T14:27:00.900251+00:00 expensidev bedrock: 3gBv9Q we@dont.know (SQLite.cpp:684) commit [worker2] [info] SQuery 'COMMIT' took 10ms.
2018-12-21T14:27:00.902120+00:00 expensidev bedrock: 3gBv9Q we@dont.know (SQLite.cpp:697) commit [worker2] [info] COMMIT operation wrote 7 pages. WAL file size is 10378312 bytes.
2018-12-21T14:27:00.902359+00:00 expensidev bedrock: 3gBv9Q we@dont.know (SQLite.cpp:707) commit [worker2] [dbug] Commit successful (5831), releasing commitLock.
2018-12-21T14:27:00.903501+00:00 expensidev bedrock: 3gBv9Q we@dont.know (SQLite.cpp:720) commit [worker2] [info] Transaction commit with 8 queries attempted, 0 served from cache for 'RetryJob'.
2018-12-21T14:27:00.903679+00:00 expensidev bedrock: 3gBv9Q we@dont.know (BedrockServer.cpp:962) worker [worker2] [info] Successfully committed RetryJob on worker thread. blocking: false
2018-12-21T14:27:00.903836+00:00 expensidev bedrock: 3gBv9Q we@dont.know (BedrockCommand.cpp:271) finalizeTimingInfo [worker2] [info] command 'RetryJob' timing info (ms): 0 (1), 7 (1), 0, 0, 0, 0, 19, 12, 0. Upstream: 0, 0, 0, 0.
```