### PR TITLE
Refactor command queue to generic base class for use in SQLiteNode

### DIFF
--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -1,127 +1,26 @@
-#include <libstuff/libstuff.h>
-#include "BedrockCommand.h"
-#include "BedrockCommandQueue.h"
+#include <BedrockCommandQueue.h>
 
-void BedrockCommandQueue::clear()  {
-    SAUTOLOCK(_queueMutex);
-    _commandQueue.clear();
+void BedrockCommandQueue::startTiming(BedrockCommand& command) {
+    command.startTiming(BedrockCommand::QUEUE_WORKER);
 }
 
-bool BedrockCommandQueue::empty()  {
-    SAUTOLOCK(_queueMutex);
-    return _commandQueue.empty();
+void BedrockCommandQueue::stopTiming(BedrockCommand& command) {
+    command.stopTiming(BedrockCommand::QUEUE_WORKER);
 }
 
-size_t BedrockCommandQueue::size()  {
-    SAUTOLOCK(_queueMutex);
-    size_t size = 0;
-    for (const auto& queue : _commandQueue) {
-        size += queue.second.size();
-    }
-    return size;
-}
-
-BedrockCommand BedrockCommandQueue::get(uint64_t timeoutUS) {
-    atomic<int> temp;
-    return getSynchronized(timeoutUS, temp);
-}
-
-BedrockCommand BedrockCommandQueue::getSynchronized(uint64_t timeoutUS, atomic<int>& incrementBeforeDequeue) {
-    unique_lock<mutex> queueLock(_queueMutex);
-
-    // NOTE:
-    // Possible future improvement: Say there's work in the queue, but it's not ready yet (i.e., it's scheduled in the
-    // future). Someone calls `get(1000000)`, and nothing gets added to the queue during that second (which would wake
-    // someone up to process whatever is next, which isn't necessarily the same thing that was added). BUT, some work
-    // in the queue comes due during that wait (i.e., it's timestamp is no longer in the future). Currently, we won't
-    // wake up here, we'll wait out our full second and force the caller to retry. This is fine for the current
-    // (03-2017) use case, where we interrupt every second and only really use scheduling at 1-second granularity.
-    //
-    // What we could do, is truncate the timeout to not be farther in the future than the next timestamp in the list.
-
-    // If there's already work in the queue, just return some.
-    try {
-        return _dequeue(incrementBeforeDequeue);
-    } catch (const out_of_range& e) {
-        // Nothing available.
-    }
-
-    // Otherwise, we'll wait for some.
-    if (timeoutUS) {
-        auto timeout = chrono::steady_clock::now() + chrono::microseconds(timeoutUS);
-        while (true) {
-            // Wait until we hit our timeout, or someone gives us some work.
-            _queueCondition.wait_until(queueLock, timeout);
-            
-            // If we got any work, return it.
-            try {
-                return _dequeue(incrementBeforeDequeue);
-            } catch (const out_of_range& e) {
-                // Still nothing available.
-            }
-
-            // Did we go past our timeout? If so, we give up. Otherwise, we awoke spuriously, and will retry.
-            if (chrono::steady_clock::now() > timeout) {
-                throw timeout_error();
-            }
-        }
-    } else {
-        // Wait indefinitely.
-        while (true) {
-            _queueCondition.wait(queueLock);
-            try {
-                return _dequeue(incrementBeforeDequeue);
-            } catch (const out_of_range& e) {
-                // Nothing yet, loop again.
-            }
-        }
-    }
-}
+BedrockCommandQueue::BedrockCommandQueue() :
+  SScheduledPriorityQueue<BedrockCommand>(function<void(BedrockCommand&)>(startTiming), function<void(BedrockCommand&)>(stopTiming))
+{ }
 
 list<string> BedrockCommandQueue::getRequestMethodLines() {
     list<string> returnVal;
     SAUTOLOCK(_queueMutex);
-    for (auto& queue : _commandQueue) {
+    for (auto& queue : _queue) {
         for (auto& entry : queue.second) {
-            returnVal.push_back(entry.second.request.methodLine);
+            returnVal.push_back(entry.second.item.request.methodLine);
         }
     }
     return returnVal;
-}
-
-void BedrockCommandQueue::push(BedrockCommand&& item) {
-    SAUTOLOCK(_queueMutex);
-    auto& queue = _commandQueue[item.priority];
-    item.startTiming(BedrockCommand::QUEUE_WORKER);
-    uint64_t executeTime = item.request.calcU64("commandExecuteTime");
-    _lookupByTimeout.insert(make_pair(item.timeout(), make_pair(item.priority, executeTime)));
-    queue.emplace(executeTime, move(item));
-    _queueCondition.notify_one();
-}
-
-// This function currently never gets called. It's actually completely untested, so if you ever make any changes that
-// cause it to actually get called, you'll want to do that testing.
-bool BedrockCommandQueue::removeByID(const string& id) {
-    SAUTOLOCK(_queueMutex);
-    bool retVal = false;
-    for (auto queueIt = _commandQueue.begin(); queueIt != _commandQueue.end(); queueIt++) {
-        auto& queue = queueIt->second;
-        auto it = queue.begin();
-        while (it != queue.end()) {
-            if (it->second.id == id) {
-                // Found it!
-                queue.erase(it);
-                retVal = true;
-                break;
-            }
-            it++;
-        }
-        if (retVal) {
-            _commandQueue.erase(queueIt);
-            break;
-        }
-    }
-    return retVal;
 }
 
 void BedrockCommandQueue::abandonFutureCommands(int msInFuture) {
@@ -134,8 +33,8 @@ void BedrockCommandQueue::abandonFutureCommands(int msInFuture) {
     // We're going to look at each queue by priority. It's possible we'll end up removing *everything* from multiple
     // queues. In that case, we need to remove the queues themselves, so we keep a list of queues to delete when we're
     // done operating on each of them (so that we don't delete them while iterating over them).
-    list<decltype(_commandQueue)::iterator> toDelete;
-    for (decltype(_commandQueue)::iterator queueMapIt = _commandQueue.begin(); queueMapIt != _commandQueue.end(); ++queueMapIt) {
+    list<typename decltype(_queue)::iterator> toDelete;
+    for (typename decltype(_queue)::iterator queueMapIt = _queue.begin(); queueMapIt != _queue.end(); ++queueMapIt) {
         // Starting from the first item, skip any items that have a valid scheduled time.
         auto commandMapIt = queueMapIt->second.begin();
         while (commandMapIt != queueMapIt->second.end() && commandMapIt->first < timeLimit) {
@@ -161,90 +60,13 @@ void BedrockCommandQueue::abandonFutureCommands(int msInFuture) {
 
     // Delete any empty queues.
     for (auto& it : toDelete) {
-        _commandQueue.erase(it);
+        _queue.erase(it);
     }
 }
 
-BedrockCommand BedrockCommandQueue::_dequeue(atomic<int>& incrementBeforeDequeue) {
-    // NOTE: We don't grab a mutex here on purpose - we use a non-recursive mutex to work with condition_variable, so
-    // we need to only lock it once, which we've already done in whichever function is calling this one (since this is
-    // private).
-
-    // We check to see if a command is going to occur in the future, if so, we won't dequeue it yet.
-    uint64_t now = STimeNow();
-
-    // If anything has timed out, pull that out of the queue, and return that first.
-    if (_lookupByTimeout.size()) {
-        auto timeoutIt = _lookupByTimeout.begin();
-        uint64_t timeout = timeoutIt->first;
-        if (timeout < now) {
-            //this command has timed out.
-            int priority = timeoutIt->second.first;
-            uint64_t executeTime = timeoutIt->second.second;
-
-            auto individualQueueIt = _commandQueue.find(priority);
-            if (individualQueueIt != _commandQueue.end()) {
-                auto itPair = individualQueueIt->second.equal_range(executeTime);
-                for (auto it = itPair.first; it != itPair.second; it++) {
-                    if (it->second.timeout() == timeout) {
-                        // This is the command that timed out.
-                        BedrockCommand command = move(it->second);
-                        individualQueueIt->second.erase(it);
-                        if (individualQueueIt->second.empty()) {
-                            _commandQueue.erase(individualQueueIt);
-                        }
-                        _lookupByTimeout.erase(timeoutIt);
-                        command.stopTiming(BedrockCommand::QUEUE_WORKER);
-                        return command;
-                    }
-                }
-            }
-
-            // We shouldn't have gotten here.
-            SWARN("Timeout (" << timeout << ") before now, but couldn't find a command for it?");
-            _lookupByTimeout.erase(timeoutIt);
-        }
-    }
-
-    // Look at each priority queue, starting from the highest priority.
-    for (auto queueMapIt = _commandQueue.rbegin(); queueMapIt != _commandQueue.rend(); ++queueMapIt) {
-        
-        // Look at the first item in the list, this is the one with the lowest timestamp. If this one isn't suitable,
-        // none of the others will be, either.
-        auto commandMapIt = queueMapIt->second.begin();
-        if (commandMapIt->first <= now) {
-            // Pull out the command we want to return.
-            BedrockCommand command = move(commandMapIt->second);
-
-            // Make sure we increment this counter before we actually dequeue, so this commands will never be not in
-            // the queue and also not counted by the counter.
-            incrementBeforeDequeue++;
-
-            // And delete the entry in the queue.
-            queueMapIt->second.erase(commandMapIt);
-
-            // If the whole queue is empty, delete that too.
-            if (queueMapIt->second.empty()) {
-                // The odd syntax in the argument converts a reverse to forward iterator.
-                _commandQueue.erase(next(queueMapIt).base());
-            }
-
-            // Remove from the timing map, too.
-            uint64_t executeTime = command.request.calcU64("commandExecuteTime");
-            auto itPair = _lookupByTimeout.equal_range(command.timeout());
-            for (auto it = itPair.first; it != itPair.second; it++) {
-                if (it->second.first == command.priority && it->second.second == executeTime) {
-                    _lookupByTimeout.erase(it);
-                    break;
-                }
-            }
-
-            // Done!
-            command.stopTiming(BedrockCommand::QUEUE_WORKER);
-            return command;
-        }
-    }
-
-    // No command suitable to process.
-    throw out_of_range("No command found.");
+void BedrockCommandQueue::push(BedrockCommand&& command) {
+    BedrockCommand::Priority priority = command.priority;
+    uint64_t executionTime = command.request.calcU64("commandExecuteTime");
+    uint64_t timeout = command.timeout();
+    SScheduledPriorityQueue<BedrockCommand>::push(move(command), priority, executionTime, timeout);
 }

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -1,63 +1,23 @@
 #pragma once
-class BedrockCommand;
+#include <libstuff/libstuff.h>
+#include <libstuff/SScheduledPriorityQueue.h>
+#include "BedrockCommand.h"
 
-class BedrockCommandQueue {
+class BedrockCommandQueue : public SScheduledPriorityQueue<BedrockCommand> {
   public:
-    class timeout_error : exception {
-      public:
-        const char* what() const noexcept {
-            return "timeout";
-        }
-    };
+    BedrockCommandQueue();
 
-    // Remove all items from the queue.
-    void clear();
-
-    // Returns true if there are no queued commands.
-    bool empty();
-
-    // Returns the size of the queue.
-    size_t size();
-
-    // Get an item from the queue. Optionally, a timeout can be specified.
-    // If timeout is non-zero, an exception will be thrown after timeoutUS microseconds, if no work was available.
-    BedrockCommand get(uint64_t timeoutUS = 0);
-
-    // Get a command from the queue, and pass it a counter to be incremented just before dequeuing a found command.
-    BedrockCommand getSynchronized(uint64_t timeoutUS, atomic<int>& incrementBeforeDequeue);
-
+    // Functions to start and stop timing on the commands when they're inserted/removed from the queue.
+    static void startTiming(BedrockCommand& command);
+    static void stopTiming(BedrockCommand& command);
+    
     // Returns a list of all the method lines for all the requests currently queued. This function exists for state
     // reporting, and is called by BedrockServer when we receive a `Status` command.
     list<string> getRequestMethodLines();
 
-    // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
-    void push(BedrockCommand&& item);
-
-    // Looks for a command with the given ID and removes it.
-    // This will inspect every command in the case the command does not exist.
-    bool removeByID(const string& id);
-
     // Discards all commands scheduled more than msInFuture milliseconds after right now.
     void abandonFutureCommands(int msInFuture);
 
-  private:
-    // Removes and returns the first workable command in the queue. A command is workable if it's executeTimestamp is
-    // not in the future.
-    //
-    // "First" means: Of all workable commands, the one in the highest priority queue, with the lowest timestamp of any
-    //                command *in that priority queue* - i.e., priority trumps timestamp.
-    //
-    // This function throws an exception if no workable commands are available.
-    BedrockCommand _dequeue(atomic<int>& incrementBeforeDequeue);
-
-    // Synchronization primitives for managing access to the queue.
-    mutex _queueMutex;
-    condition_variable _queueCondition;
-
-    // The priority queue in which we store commands. This is a map of integer priorities to their respective maps.
-    // Each of those maps maps timestamps to commands.
-    map<int, multimap<uint64_t, BedrockCommand>> _commandQueue;
-
-    // This is a map of timeouts to the queue/timestamp we'll need to find the command with this timestamp.
-    multimap<uint64_t, pair<int, uint64_t>> _lookupByTimeout;
+    // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
+    void push(BedrockCommand&& command);
 };

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -63,7 +63,7 @@ void BedrockServer::acceptCommand(SQLiteCommand&& command, bool isNew) {
 }
 
 void BedrockServer::cancelCommand(const string& commandID) {
-    _commandQueue.removeByID(commandID);
+    // TODO: Unimplemented (but never called, anyway)
 }
 
 bool BedrockServer::canStandDown() {
@@ -672,14 +672,14 @@ void BedrockServer::worker(SData& args,
         try {
             // Set a signal handler function that we can call even if we die early with no command.
             SSetSignalHandlerDieFunc([&](){
-                SWARN("Die function called early with no command, probably died in `getSynchronized`.");
+                SWARN("Die function called early with no command, probably died in `commandQueue.get`.");
             });
 
             // If we can't find any work to do, this will throw. If we can, this will increment _commandsInProgress for
             // us before returning the command that it is dequeuing. We don't update _commandsInProgress before calling
             // this, as it can spend up to a second finding out that there is no command to dequeue, which makes our
             // count wrong while we wait.
-            command = commandQueue.getSynchronized(1000000, server._commandsInProgress);
+            command = commandQueue.get(1000000, server._commandsInProgress);
 
             SAUTOPREFIX(command.request["requestID"]);
             SINFO("Dequeued command " << command.request.methodLine << " in worker, "

--- a/libstuff/SScheduledPriorityQueue.h
+++ b/libstuff/SScheduledPriorityQueue.h
@@ -1,0 +1,315 @@
+#pragma once
+#include <libstuff/libstuff.h>
+
+// A scheduled priority queue does the following:
+// Enqueues items with a scheduled time, a priority, and a timeout.
+// Both the scheduled time and timeout are epoch times in microseconds.
+//
+// Once queued, a caller can call "get" to retrieve the next item in the queue.
+//
+// What counts as the next item:
+//
+// If any item has timed out, it is the timed out item (if multiple items have timed out, it is the one with the oldest
+// timeout timestamp. If multiple items have identical timeout timestamps, which if those items is returned is
+// unspecified).
+//
+// If no items have timed out, the items are returned in order of priority, but only if they're scheduled before now.
+//
+// I.e., if two items are scheduled at the same timestamp, and that timestamp is before now, the one with the higher
+// priority is returned.
+//
+// If two items have the same priority, the one with the older scheduled timestamp is returned.
+//
+// Items scheduled in the future are never returned (unless they've timed out).
+template<typename T>
+class SScheduledPriorityQueue {
+  public:
+
+    // Typedefs are here for legibility's sake.
+    typedef int Priority;
+    typedef uint64_t Timeout; 
+    typedef uint64_t Scheduled;
+
+    // If nothing becomes available to dequeue while waiting, a timeout_error exception is thrown.
+    class timeout_error : exception {
+      public:
+        const char* what() const noexcept {
+            return "timeout";
+        }
+    };
+
+    // By default, the start and end functions are No-ops.
+    SScheduledPriorityQueue(function<void(T& item)> startFunction = [](T& item){},
+                            function<void(T& item)> endFunction = [](T& item){})
+      : _startFunction(startFunction), _endFunction(endFunction) {};
+
+    // Remove all items from the queue.
+    void clear();
+
+    // Returns true if there are no queued commands.
+    bool empty();
+
+    // Returns the size of the queue.
+    size_t size();
+
+    // Get an item from the queue. Optionally, a timeout can be specified.
+    // If timeout is non-zero, a timeout_error exception will be thrown after waitUS microseconds, if no work was
+    // available.
+
+    // Get an item from the queue. If `waitUS` is specified, and no items become available before the specified time
+    // period has elapsed, timeout_error is thrown.
+    T get(uint64_t waitUS = 0);
+
+    // Same as above, but increments a counter just before returning an item. This allows callers to keep accurate
+    // counts of items in or out of the queue.
+    T get(uint64_t waitUS, atomic<int>& incrementBeforeDequeue);
+
+    // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
+    void push(T&& item, Priority priority, Scheduled scheduled, Timeout timeout);
+
+  protected:
+
+    // Associate the item with it's timeout so that when we dequeue an item to return, we can also remove it's entry
+    // in our set of timeouts.
+    struct ItemTimeoutPair {
+        ItemTimeoutPair(T&& _item, Timeout _timeout) : item(move(_item)), timeout(_timeout) {}
+        T item;
+        Timeout timeout;
+    };
+
+    // Removes an item from the queue and returns it, if a suitable item is available. Throws `out_of_range` otherwise.
+    T _dequeue(atomic<int>& incrementBeforeDequeue);
+
+    // Synchronization primitives for managing access to the queue.
+    mutex _queueMutex;
+    condition_variable _queueCondition;
+
+    // The main queue is a map of priorities to the items queued at that priority, sorted by their scheduled time.
+    map<Priority, multimap<Scheduled, ItemTimeoutPair>> _queue;
+
+    // A map of timeouts back into the respective priority queue to find the item with the given timeout.
+    multimap<Timeout, pair<Priority, Scheduled>> _lookupByTimeout;
+
+    // Functions to call on each item when inserting or removing from the queue.
+    function<void(T&)> _startFunction;
+    function<void(T&)> _endFunction;
+};
+
+template<typename T>
+void SScheduledPriorityQueue<T>::clear()  {
+    SAUTOLOCK(_queueMutex);
+    _queue.clear();
+}
+
+template<typename T>
+bool SScheduledPriorityQueue<T>::empty()  {
+    SAUTOLOCK(_queueMutex);
+    return _queue.empty();
+}
+
+template<typename T>
+size_t SScheduledPriorityQueue<T>::size()  {
+    SAUTOLOCK(_queueMutex);
+    size_t size = 0;
+    for (const auto& queue : _queue) {
+        size += queue.second.size();
+    }
+    return size;
+}
+
+template<typename T>
+T SScheduledPriorityQueue<T>::get(uint64_t waitUS) {
+    atomic<int> temp;
+    return get(waitUS, temp);
+}
+
+template<typename T>
+T SScheduledPriorityQueue<T>::get(uint64_t waitUS, atomic<int>& incrementBeforeDequeue) {
+    unique_lock<mutex> queueLock(_queueMutex);
+
+    // NOTE:
+    // Possible future improvement: Say there's work in the queue, but it's not ready yet (i.e., it's scheduled in the
+    // future). Someone calls `get(1000000)`, and nothing gets added to the queue during that second (which would wake
+    // someone up to process whatever is next, which isn't necessarily the same thing that was added). BUT, some work
+    // in the queue comes due during that wait (i.e., it's timestamp is no longer in the future). Currently, we won't
+    // wake up here, we'll wait out our full second and force the caller to retry. This is fine for the current
+    // (03-2017) use case, where we interrupt every second and only really use scheduling at 1-second granularity.
+    //
+    // What we could do, is truncate the timeout to not be farther in the future than the next timestamp in the list.
+
+    // If there's already work in the queue, just return some.
+    try {
+        return _dequeue(incrementBeforeDequeue);
+    } catch (const out_of_range& e) {
+        // Nothing available.
+    }
+
+    // Otherwise, we'll wait for some.
+    if (waitUS) {
+        auto timeout = chrono::steady_clock::now() + chrono::microseconds(waitUS);
+        while (true) {
+            // Wait until we hit our timeout, or someone gives us some work.
+            _queueCondition.wait_until(queueLock, timeout);
+            
+            // If we got any work, return it.
+            try {
+                return _dequeue(incrementBeforeDequeue);
+            } catch (const out_of_range& e) {
+                // Still nothing available.
+            }
+
+            // Did we go past our timeout? If so, we give up. Otherwise, we awoke spuriously, and will retry.
+            if (chrono::steady_clock::now() > timeout) {
+                throw timeout_error();
+            }
+        }
+    } else {
+        // Wait indefinitely.
+        while (true) {
+            _queueCondition.wait(queueLock);
+            try {
+                return _dequeue(incrementBeforeDequeue);
+            } catch (const out_of_range& e) {
+                // Nothing yet, loop again.
+            }
+        }
+    }
+}
+
+template<typename T>
+void SScheduledPriorityQueue<T>::push(T&& item, Priority priority, Scheduled scheduled, Timeout timeout) {
+    SAUTOLOCK(_queueMutex);
+    auto& queue = _queue[priority];
+    _startFunction(item);
+    _lookupByTimeout.insert(make_pair(timeout, make_pair(priority, scheduled)));
+    queue.emplace(scheduled, ItemTimeoutPair(move(item), timeout));
+    _queueCondition.notify_one();
+}
+
+template<typename T>
+T SScheduledPriorityQueue<T>::_dequeue(atomic<int>& incrementBeforeDequeue) {
+    // NOTE: We don't grab a mutex here on purpose - we use a non-recursive mutex to work with condition_variable, so
+    // we need to only lock it once, which we've already done in whichever function is calling this one (since this is
+    // private).
+
+    // We need to know what time it is, so that we can compare to scheduled times.
+    uint64_t now = STimeNow();
+
+    // If anything has timed out, pull that out of the queue, and return that first.
+    if (_lookupByTimeout.size()) {
+
+        // Get the first item in the timeout map (they're in order).
+        auto timeoutIt = _lookupByTimeout.begin();
+
+        // Convenience names for legibility.
+        const Timeout& itemTimeout = timeoutIt->first;
+        const Priority& itemPriority = timeoutIt->second.first;
+        const Scheduled& itemScheduled = timeoutIt->second.second;
+
+        // Has this timed out? If so, this is the item we'll return (regardless of which priority it had).
+        if (itemTimeout <= now) {
+
+            // Find the correct priority queue for this item.
+            auto priorityQueueIt = _queue.find(itemPriority);
+            if (priorityQueueIt != _queue.end()) {
+
+                // Find all the items in this priority queue scheduled at this particular moment.
+                auto matchingItemIterators = priorityQueueIt->second.equal_range(itemScheduled);
+
+                // Iterate across the matching section of items.
+                for (auto it = matchingItemIterators.first; it != matchingItemIterators.second; it++) {
+
+                    // Convenience names for legibility.
+                    ItemTimeoutPair& thisItemTimeoutPair = it->second;
+
+                    // Is this the one that timed out?
+                    if (thisItemTimeoutPair.timeout == itemTimeout) {
+
+                        // Yep, this one timed out. Pull it out of the queue.
+                        T item = move(thisItemTimeoutPair.item);
+
+                        // Erase this item from the main queue.
+                        priorityQueueIt->second.erase(it);
+
+                        // If this priority queue is empty, erase the whole thing.
+                        if (priorityQueueIt->second.empty()) {
+                            _queue.erase(priorityQueueIt);
+                        }
+
+                        // And erase it from the timeout map, too.
+                        _lookupByTimeout.erase(timeoutIt);
+
+                        // Call the end function and return the item.
+                        _endFunction(item);
+                        return item;
+                    }
+                }
+            }
+
+            // This isn't supposed to be possible.
+            SWARN("Timeout (" << itemTimeout << ") before now, but couldn't find a item for it?");
+            _lookupByTimeout.erase(timeoutIt);
+        }
+    }
+
+    // Ok, if we got here nothing has timed out, so we'll just look at each queue, in priority order, to see if any
+    // items are ready to return.
+    for (auto queueIt = _queue.rbegin(); queueIt != _queue.rend(); ++queueIt) {
+
+        // Record the priority of the queue we're currently looking at.
+        Priority queuePriority = queueIt->first;
+
+        // And look at the first item in this particular priority queue.
+        auto itemIt = queueIt->second.begin();
+
+        // Convenience names for legibility.
+        const Scheduled& thisItemScheduled = itemIt->first;
+        ItemTimeoutPair& thisItemTimeoutPair = itemIt->second;
+        const Timeout& thisItemTimeout = thisItemTimeoutPair.timeout;
+
+        // If the item is scheduled before now, we can return it. Otherwise, since these are in scheduled order, there
+        // are no usable items in this queue, and we can go on to the next one.
+        if (thisItemScheduled <= now) {
+
+            // Pull out the item we want to return.
+            T item = move(thisItemTimeoutPair.item);
+
+            // Increment the caller's counter as we're now actually de-queuing the item.
+            incrementBeforeDequeue++;
+
+            // Delete the entry in this queue.
+            queueIt->second.erase(itemIt);
+
+            // If the whole queue is empty, delete that too.
+            if (queueIt->second.empty()) {
+                // The odd syntax in the argument converts a reverse to forward iterator.
+                _queue.erase(next(queueIt).base());
+            }
+
+            // Remove from the timeout map, as well.
+            auto matchingTimeoutIterators = _lookupByTimeout.equal_range(thisItemTimeout);
+            for (auto it = matchingTimeoutIterators.first; it != matchingTimeoutIterators.second; it++) {
+
+                // Convenience names for legibility.
+                auto& timeoutPair = it->second;
+                Priority& thisTimeoutPriority = timeoutPair.first;
+                Scheduled& thisTimeoutScheduled = timeoutPair.second;
+
+                // If this timeout entry has the same queue that we're in, and the same scheduled time, we can remove
+                // it.
+                if (thisTimeoutPriority == queuePriority && thisTimeoutScheduled == thisItemScheduled) {
+                    _lookupByTimeout.erase(it);
+                    break;
+                }
+            }
+
+            // Call the end function and return!
+            _endFunction(item);
+            return item;
+        }
+    }
+
+    // No item suitable to return.
+    throw out_of_range("No item found.");
+}
+


### PR DESCRIPTION
@coleaeason 

This is functionally a non-change. It's here as a prerequisite for multi-threaded replication, to make that PR significantly smaller and easier. I also think the new code is significantly more readable/understandable than the old code.

If you're concerned about this line:
https://github.com/Expensify/Bedrock/compare/tyler-refactor-command-queue?expand=1#diff-90c0ce5c887dbfab22b710517c35a8e7R66

See this removed line:
https://github.com/Expensify/Bedrock/compare/tyler-refactor-command-queue?expand=1#diff-b1f2d134a4d598e4ea8558039e0eab27L102

I figured it was better to just remove the code rather than assuming that untested code was actually functional.

No new tests, functionality identical to before.