### PR TITLE
Fix auto-promotion of commands to quorum

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -40,7 +40,7 @@ void BedrockServer::acceptCommand(SQLiteCommand&& command, bool isNew) {
             && _syncCommands.find(newCommand.request.methodLine) != _syncCommands.end()) {
 
             newCommand.writeConsistency = SQLiteNode::QUORUM;
-            _lastQuorumCommandTime = 0;
+            _lastQuorumCommandTime = STimeNow();
             SINFO("Forcing QUORUM consistency for command " << newCommand.request.methodLine);
         }
         SINFO("Queued new '" << newCommand.request.methodLine << "' command from bedrock node, with " << _commandQueue.size()
@@ -1486,7 +1486,6 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                         && _syncCommands.find(command.request.methodLine) != _syncCommands.end()) {
 
                         command.writeConsistency = SQLiteNode::QUORUM;
-                        _syncNode->startCommit(SQLiteNode::QUORUM);
                         SINFO("Forcing QUORUM consistency for command " << command.request.methodLine);
                     }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1486,6 +1486,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                         && _syncCommands.find(command.request.methodLine) != _syncCommands.end()) {
 
                         command.writeConsistency = SQLiteNode::QUORUM;
+                        _lastQuorumCommandTime = STimeNow();
                         SINFO("Forcing QUORUM consistency for command " << command.request.methodLine);
                     }
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -455,4 +455,10 @@ class BedrockServer : public SQLiteServer {
     static SData _generateCrashMessage(const BedrockCommand* command);
 
     static void _addRequestID(SData& request);
+
+    // The number of seconds to wait between forcing a command to QUORUM.
+    uint64_t _quorumCheckpointSeconds;
+
+    // Timestamp for the last time we promoted a command to QUORUM.
+    atomic<uint64_t> _lastQuorumCommandTime;
 };

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -44,8 +44,7 @@ const string SQLiteNode::consistencyLevelNames[] = {"ASYNC",
                                                     "QUORUM"};
 
 SQLiteNode::SQLiteNode(SQLiteServer& server, SQLite& db, const string& name, const string& host,
-                       const string& peerList, int priority, uint64_t firstTimeout, const string& version,
-                       int quorumCheckpointSeconds)
+                       const string& peerList, int priority, uint64_t firstTimeout, const string& version)
     : STCPNode(name, host, max(SQL_NODE_DEFAULT_RECV_TIMEOUT, SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT)),
       _db(db), _commitState(CommitState::UNINITIALIZED), _server(server), _stateChangeCount(0)
     {
@@ -56,8 +55,6 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, SQLite& db, const string& name, con
     _masterPeer = nullptr;
     _stateTimeout = STimeNow() + firstTimeout;
     _version = version;
-    _lastQuorumTime = 0;
-    _quorumCheckpointSeconds = quorumCheckpointSeconds;
 
     // Get this party started
     _changeState(SEARCHING);
@@ -748,8 +745,7 @@ bool SQLiteNode::update() {
                    << ", writeConsistency="       << consistencyLevelNames[_commitConsistency]
                    << ", consistencyRequired="    << consistencyLevelNames[_commitConsistency]
                    << ", consistentEnough="       << consistentEnough
-                   << ", everybodyResponded="     << everybodyResponded
-                   << ", lastQuorumTime="         << _lastQuorumTime);
+                   << ", everybodyResponded="     << everybodyResponded);
 
             // If anyone denied this transaction, roll this back. Alternatively, roll it back if everyone we're
             // currently connected to has responded, but that didn't generate enough consistency. This could happen, in
@@ -817,11 +813,6 @@ bool SQLiteNode::update() {
                     // Update the last sent transaction ID to reflect that this is finished.
                     _lastSentTransactionID = _db.getCommitCount();
 
-                    // If this was a quorum commit, we'll reset our counter, otherwise, we'll update it.
-                    if (_commitConsistency == QUORUM) {
-                        _lastQuorumTime = STimeNow();
-                    }
-
                     // Done!
                     _commitState = CommitState::SUCCESS;
                 }
@@ -846,12 +837,6 @@ bool SQLiteNode::update() {
             // Lock the database. We'll unlock it when we complete in a future update cycle.
             SQLite::g_commitLock.lock();
             _commitState = CommitState::COMMITTING;
-
-            // Figure out how much consistency we need. Go with whatever the caller specified, unless we're over our
-            // checkpoint limit.
-            if (STimeNow() > _lastQuorumTime + (_quorumCheckpointSeconds * 1'000'000)) {
-                _commitConsistency = QUORUM;
-            }
             SINFO("[performance] Beginning " << consistencyLevelNames[_commitConsistency] << " commit.");
 
             // Now that we've grabbed the commit lock, we can safely clear out any outstanding transactions, no new

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -49,7 +49,7 @@ class SQLiteNode : public STCPNode {
 
     // Constructor/Destructor
     SQLiteNode(SQLiteServer& server, SQLite& db, const string& name, const string& host, const string& peerList,
-               int priority, uint64_t firstTimeout, const string& version, int quorumCheckpointSeconds = 0);
+               int priority, uint64_t firstTimeout, const string& version);
     ~SQLiteNode();
 
     // Simple Getters. See property definitions for details.

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -27,14 +27,24 @@ class TestServer : public SQLiteServer {
 
 struct SQLiteNodeTest : tpunit::TestFixture {
     SQLiteNodeTest() : tpunit::TestFixture("SQLiteNode",
+                                           AFTER_CLASS(SQLiteNodeTest::teardown),
                                            TEST(SQLiteNodeTest::testFindSyncPeer)) { }
+
+    // Filename for temp DB.
+    char filename[17] = "br_sync_dbXXXXXX";
+
+    void teardown() {
+        unlink(filename);
+    }
 
     void testFindSyncPeer() {
 
         // This exposes just enough to test the peer selection logic.
-        SQLite db(":memory:", 1000000, 100, 5000, -1, -1);
+        int fd = mkstemp(filename);
+        close(fd);
+        SQLite db(filename, 1000000, 100, 5000, -1, -1);
         TestServer server("");
-        SQLiteNode testNode(server, db, "test", "localhost:19998", "", 1, 1000000000, "1.0", 100);
+        SQLiteNode testNode(server, db, "test", "localhost:19998", "", 1, 1000000000, "1.0");
 
         STable dummyParams;
         testNode.addPeer("peer1", "host1.fake:15555", dummyParams);


### PR DESCRIPTION
@coleaeason 

Quorum has been sort of broken since we fixed the conflict rate in Bedrock, because only the sync thread does quorum, and we send so few commands to the sync thread, it was possible to go quite a while between QUORUM commands.

This change moves responsibility for promoting commands to QUORUM up a level to BedrockServer, since SQLiteNode no longer has enough information to make good decisions here.

For clarification: QUORUM has worked fine this whole time, but we were very seldom using it, because almost no commands were eligible. I also think that long term, auto-promotion to QUORUM doesn't add any value and should be removed, but possibly replaced with some other mechanism to make sure that master and slaves are roughly in-sync, but one that doesn't require a blocking round-trip between all the servers.

Tests:
No new tests. Grepped the logs during clustertest for `grep 'bedrock.*QUORUM'` to verify QUORUM is happening.