### PR TITLE
Don't use invalidated references

### DIFF
--- a/libstuff/SScheduledPriorityQueue.h
+++ b/libstuff/SScheduledPriorityQueue.h
@@ -251,9 +251,9 @@ T SScheduledPriorityQueue<T>::_dequeue() {
         auto itemIt = queueIt->second.begin();
 
         // Convenience names for legibility.
-        const Scheduled& thisItemScheduled = itemIt->first;
+        const Scheduled thisItemScheduled = itemIt->first;
         ItemTimeoutPair& thisItemTimeoutPair = itemIt->second;
-        const Timeout& thisItemTimeout = thisItemTimeoutPair.timeout;
+        const Timeout thisItemTimeout = thisItemTimeoutPair.timeout;
 
         // If the item is scheduled before now, we can return it. Otherwise, since these are in scheduled order, there
         // are no usable items in this queue, and we can go on to the next one.


### PR DESCRIPTION
I found a bug in my new queue. When it goes to remove items from the timeout map, it erases an item (in `itemIt`) but then uses references to that iterator to determine which timeout to remove. This change turns the references into copies (they're just integers, anyway) so that they still exist once we delete the item the iterator points to, and then. we delete the right timeout in the map.

Potential impact of this bug:

It seems feasible that it can segfault, as there's no guarantee we own the memory that the invalidated reference points to.

It will cause a `SWARN("Timeout (" << itemTimeout << ") before now, but couldn't find a item for it?");` warning when the timeout that was supposed to be erased comes up.

I don't think there's anything else, because we clean up the orphaned timeout when we generate the above warning anyway.