### PR TITLE
Fix/c++14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ VERSION = $(shell git log -1 | head -n 1 | cut -d ' ' -f 2)
 
 # Turn on C++14.
 CFLAGS =-g -DSVERSION="\"$(VERSION)\"" -Wall
-CXXFLAGS =-std=gnu++14
+CXXFLAGS =-std=c++14
 CXXFLAGS +=-I$(PROJECT) -I$(PROJECT)/mbedtls/include -Werror -Wno-unused-result
 
 # This works because 'PRODUCTION' is passed as a command-line param, and so is ignored here when set that way.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # Set the compiler, if it's not set by the environment.
 ifndef GXX
-	GXX = g++-6
+	GXX = g++
 endif
 
 ifndef CC
-	CC = gcc-6
+	CC = gcc
 endif
 
 # We use our project directory as a search path so we don't need "../../../.." all over the place.

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2429,16 +2429,29 @@ string SGetCurrentExceptionName()
     // exception name.
     int status = 0;
     size_t length = 1000;
-    char buffer[length] = {0};
+    char *buffer;
+    string exceptionName;
+    buffer = static_cast<char*>(malloc(length));
 
-    // Demangle the name of the current exception.
-    // See: https://libcxxabi.llvm.org/spec.html for details on this ABI interface.
-    abi::__cxa_demangle(abi::__cxa_current_exception_type()->name(), buffer, &length, &status);
-    string exceptionName = buffer;
+    if(NULL == buffer) {
+        SALERT("OOM");
+        abort();
+    } else {
+        for(size_t i=0; i < length; i++) {
+            buffer[i] = 0;
+        }
 
-    // If it failed, use the original name instead.
-    if (status) {
-        exceptionName = "(mangled) "s + abi::__cxa_current_exception_type()->name();
+        // Demangle the name of the current exception.
+        // See: https://libcxxabi.llvm.org/spec.html for details on this ABI interface.
+        // Notice `buffer` must be allocate by `malloc` per the docs.
+        abi::__cxa_demangle(abi::__cxa_current_exception_type()->name(), buffer, &length, &status);
+        exceptionName = buffer;
+        free(buffer);
+
+        // If it failed, use the original name instead.
+        if (status) {
+            exceptionName = "(mangled) "s + abi::__cxa_current_exception_type()->name();
+        }
     }
     return exceptionName;
 }

--- a/test/clustertest/testplugin/Makefile
+++ b/test/clustertest/testplugin/Makefile
@@ -1,10 +1,10 @@
 # # Set the compiler, if it's not set by the environment.
 ifndef GXX
-	GXX = g++-6
+	GXX = g++
 endif
 
 ifndef CC
-	CC = gcc-6
+	CC = gcc
 endif
 
 # We use our project directory as a search path so we don't need "../../../.." all over the place.

--- a/test/clustertest/testplugin/Makefile
+++ b/test/clustertest/testplugin/Makefile
@@ -14,7 +14,7 @@ PROJECT = $(shell pwd)/../../..
 VERSION = $(shell git log -1 | head -n 1 | cut -d ' ' -f 2)
 
 # Turn on C++14.
-CXXFLAGS =-g -std=gnu++14 -fpic -DSVERSION="\"$(VERSION)\"" -Wall -Werror -Wno-unused-result
+CXXFLAGS =-g -std=c++14 -fpic -DSVERSION="\"$(VERSION)\"" -Wall -Werror -Wno-unused-result
 CXXFLAGS +=-I$(PROJECT) -I../../../mbedtls/include
 
 # This works because 'PRODUCTION' is passed as a command-line param, and so is ignored here when set that way.


### PR DESCRIPTION
These changes are just a bit of standardization:

* Move from gnu++14 to c++14
* Use cxa_demangle in a manner consistent with the spec.
* Call gcc and g++ instead of an explicit version of the compiler