### PR TITLE
[HOLD] Prioritize blocking commit thread mutex locks

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -362,6 +362,8 @@ class BedrockServer : public SQLiteServer {
     // unlocked afterward. Workers do the same, so that they won't try to start a new transaction while the sync thread
     // is committing. This mutex is *not* recursive.
     shared_timed_mutex _syncThreadCommitMutex;
+    atomic<int> _syncThreadCommitMutexWaitCount;
+    shared_timed_mutex _syncThreadCommitOrderMutex;
 
     // Set this when we switch mastering.
     atomic<bool> _suppressMultiWrite;


### PR DESCRIPTION
This attempts to let the blocking commit thread acquire the commit mutex first, before any other threads that are waiting on it.

It does seem to reduce the number of locks the blocking queue waits for, but I'm not sure it makes any real difference for overall performance. I think really, our problem is other threads waiting on the blocking thread and vice versa. We need to get fewer commands to end up in this queue.