### PR TITLE
Log time spent in poll and postPoll

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -309,9 +309,9 @@ int main(int argc, char* argv[]) {
         }
 
         // Counters for seeing how long we spend in postPoll.
-        uint64_t pollCounter = 0;
-        uint64_t postPollCounter = 0;
-        uint64_t lastResetCounter = STimeNow();
+        chrono::steady_clock::duration pollCounter(0);
+        chrono::steady_clock::duration postPollCounter(0);
+        chrono::steady_clock::time_point start = chrono::steady_clock::now();
 
         uint64_t nextActivity = STimeNow();
         while (!server.shutdownComplete()) {
@@ -323,23 +323,26 @@ int main(int argc, char* argv[]) {
             fd_map fdm;
             server.prePoll(fdm);
             const uint64_t now = STimeNow();
+            auto timeBeforePoll = chrono::steady_clock::now();
             S_poll(fdm, max(nextActivity, now) - now);
-            nextActivity = STimeNow() + 1'000'000; // 1s max period
+            nextActivity = STimeNow() + STIME_US_PER_S; // 1s max period
+            auto timeAfterPoll = chrono::steady_clock::now();
             server.postPoll(fdm, nextActivity);
+            auto timeAfterPostPoll = chrono::steady_clock::now();
 
-            uint64_t end = STimeNow();
-            postPollCounter += (end - (nextActivity - 1'000'000));
-            pollCounter += ((nextActivity - 1'000'000) - now);
+            pollCounter += timeAfterPoll - timeBeforePoll;
+            postPollCounter += timeAfterPostPoll - timeAfterPoll;
 
             // Every 10s, log and reset.
-            if (end > lastResetCounter + 10'000'000) {
-                SINFO("Main poll loop: " << ((end - lastResetCounter) / 1000) << " ms elapsed. " << (pollCounter / 1000)
-                      << " ms in poll. " << (postPollCounter / 1000) << " ms in postPoll");
-                pollCounter = 0;
-                postPollCounter = 0;
-                lastResetCounter = end;
+            if (timeAfterPostPoll > (start + 10s)) {
+                SINFO("[performance] main poll loop timing: "
+                      << chrono::duration_cast<chrono::milliseconds>(timeAfterPostPoll - start).count() << " ms elapsed. "
+                      << chrono::duration_cast<chrono::milliseconds>(pollCounter).count() << " ms in poll. "
+                      << chrono::duration_cast<chrono::milliseconds>(postPollCounter).count() << " ms in postPoll.");
+                pollCounter = chrono::microseconds::zero();
+                postPollCounter = chrono::microseconds::zero();
+                start = timeAfterPostPoll;
             }
-
         }
         if (server.shutdownWhileDetached) {
             // We need to actually shut down here.


### PR DESCRIPTION
@coleaeason 

Adds logging to see how much time we spend in poll/postPoll, as an indication of when we are hitting the limits of how quickly we can accept connections and dequeue commands.

Tests:

Run in VM and watch logs, example output:
```
2019-01-10T19:23:43.432810+00:00 expensidev bedrock11114: xxxxxx (main.cpp:343) main [main] [info] [performance] main poll loop timing: 10000 ms elapsed. 9268 ms in poll. 664 ms in postPoll.
2019-01-10T19:23:53.438310+00:00 expensidev bedrock11114: xxxxxx (main.cpp:343) main [main] [info] [performance] main poll loop timing: 10005 ms elapsed. 9220 ms in poll. 662 ms in postPoll.
2019-01-10T19:24:03.468296+00:00 expensidev bedrock11114: xxxxxx (main.cpp:343) main [main] [info] [performance] main poll loop timing: 10008 ms elapsed. 9666 ms in poll. 301 ms in postPoll.
2019-01-10T19:24:13.972246+00:00 expensidev bedrock11114: xxxxxx (main.cpp:343) main [main] [info] [performance] main poll loop timing: 10525 ms elapsed. 10503 ms in poll. 20 ms in postPoll.
2019-01-10T19:24:23.980580+00:00 expensidev bedrock11114: xxxxxx (main.cpp:343) main [main] [info] [performance] main poll loop timing: 10006 ms elapsed. 9851 ms in poll. 145 ms in postPoll.
2019-01-10T19:24:33.984834+00:00 expensidev bedrock11114: xxxxxx (main.cpp:343) main [main] [info] [performance] main poll loop timing: 10006 ms elapsed. 9300 ms in poll. 586 ms in postPoll.
2019-01-10T19:24:43.997181+00:00 expensidev bedrock11114: xxxxxx (main.cpp:343) main [main] [info] [performance] main poll loop timing: 10010 ms elapsed. 9393 ms in poll. 538 ms in postPoll.
```