### PR TITLE
Improve Network read performance

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -462,8 +462,10 @@ class BedrockServer : public SQLiteServer {
     // that just needs to be returned to a peer.
     BedrockTimeoutCommandQueue _completedCommands;
 
-    // Manage the poll worker queue.
-    mutex _postPollWorkerMutex;
-    condition_variable _postPollWorkerCV;
-    list<Socket*> _pendingPollSockets;
+    // Counters for timing postPoll and locating bottlenecks;
+    chrono::steady_clock::duration _postPollBaseClass;
+    chrono::steady_clock::duration _postPollAccept;
+    chrono::steady_clock::duration _postPollChooseSockets;
+    chrono::steady_clock::duration _postPollPostProcess;
+    chrono::steady_clock::time_point _postPollStart;
 };

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -342,7 +342,7 @@ class BedrockServer : public SQLiteServer {
 
     // Accepts any sockets pending on our listening ports. We do this both after `poll()`, and before shutting down
     // those ports.
-    void _acceptSockets(bool deferRead = false);
+    set<Socket*> _acceptSockets(bool deferRead = false);
 
     // This stars the server shutting down.
     void _beginShutdown(const string& reason, bool detach = false);

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -342,7 +342,7 @@ class BedrockServer : public SQLiteServer {
 
     // Accepts any sockets pending on our listening ports. We do this both after `poll()`, and before shutting down
     // those ports.
-    void _acceptSockets();
+    void _acceptSockets(bool deferRead = false);
 
     // This stars the server shutting down.
     void _beginShutdown(const string& reason, bool detach = false);
@@ -461,4 +461,9 @@ class BedrockServer : public SQLiteServer {
     // We keep a queue of completed commands that workers will insert into when they've successfully finished a command
     // that just needs to be returned to a peer.
     BedrockTimeoutCommandQueue _completedCommands;
+
+    // Manage the poll worker queue.
+    mutex _postPollWorkerMutex;
+    condition_variable _postPollWorkerCV;
+    list<Socket*> _pendingPollSockets;
 };

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -234,9 +234,9 @@ class BedrockServer : public SQLiteServer {
     map <uint64_t, Socket*> _socketIDMap;
 
     // The above _socketIDMap is modified by multiple threads, so we lock this mutex around operations that access it.
-    // We don't need to lock around access to the base class's `socketList` because we carefully control access to it
+    // We don't need to lock around access to the base class's `socketSet` because we carefully control access to it
     // to the main thread.
-    // The only functions that access `socketList` are prePoll, postPoll, openSocket, and closeSocket, in STCPManager,
+    // The only functions that access `socketSet` are prePoll, postPoll, openSocket, and closeSocket, in STCPManager,
     // and acceptSocket in STCPServer.
     // prePoll and postPoll are only ever called by the main thread.
     // openSocket is never called by bedrockServer (it is called in SHTTPSManager and STCPNode).

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -8,7 +8,7 @@ SHTTPSManager::SHTTPSManager(const string& pem, const string& srvCrt, const stri
 { }
 
 SHTTPSManager::~SHTTPSManager() {
-    SAUTOLOCK(_listMutex);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
 
     // Clean up outstanding transactions
     SASSERTWARN(_activeTransactionList.empty());

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -25,7 +25,7 @@ void SHTTPSManager::closeTransaction(Transaction* transaction) {
     if (transaction == nullptr) {
         return;
     }
-    SAUTOLOCK(_listMutex);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
 
     // Clean up the socket and done
     _activeTransactionList.remove(transaction);
@@ -54,23 +54,6 @@ int SHTTPSManager::getHTTPResponseCode(const string& methodLine) {
     return 400;
 }
 
-SHTTPSManager::Socket* SHTTPSManager::openSocket(const string& host, SX509* x509) {
-    // Just call the base class function but in a thread-safe way.
-    return STCPManager::openSocket(host, x509, &_listMutex);
-}
-
-void SHTTPSManager::closeSocket(Socket* socket) {
-    // Just call the base class function but in a thread-safe way.
-    SAUTOLOCK(_listMutex);
-    STCPManager::closeSocket(socket);
-}
-
-void SHTTPSManager::prePoll(fd_map& fdm) {
-    // Just call the base class function but in a thread-safe way.
-    SAUTOLOCK(_listMutex);
-    return STCPManager::prePoll(fdm);
-}
-
 void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     list<SHTTPSManager::Transaction*> completedRequests;
     map<Transaction*, uint64_t> transactionTimeouts;
@@ -83,7 +66,7 @@ void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSMan
 }
 
 void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSManager::Transaction*>& completedRequests, map<Transaction*, uint64_t>& transactionTimeouts, uint64_t timeoutMS) {
-    SAUTOLOCK(_listMutex);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
 
     // Let the base class do its thing
     STCPManager::postPoll(fdm);
@@ -171,7 +154,7 @@ SHTTPSManager::Transaction* SHTTPSManager::_createErrorTransaction() {
     Transaction* transaction = new Transaction(*this);
     transaction->response = 503;
     transaction->finished = STimeNow();
-    SAUTOLOCK(_listMutex);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
     _completedTransactionList.push_front(transaction);
     return transaction;
 }
@@ -203,7 +186,7 @@ SHTTPSManager::Transaction* SHTTPSManager::_httpsSend(const string& url, const S
     transaction->s->send(request.serialize());
 
     // Keep track of the transaction.
-    SAUTOLOCK(_listMutex);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
     _activeTransactionList.push_front(transaction);
     return transaction;
 }

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -26,15 +26,11 @@ class SHTTPSManager : public STCPManager {
     virtual ~SHTTPSManager();
 
     // STCPServer API. Except for postPoll, these are just threadsafe wrappers around base class functions.
-    void prePoll(fd_map& fdm);
     void postPoll(fd_map& fdm, uint64_t& nextActivity);
     void postPoll(fd_map& fdm, uint64_t& nextActivity, list<Transaction*>& completedRequests);
 
-
     // Default timeout for HTTPS requests is 5 minutes.This can be changed on any call to postPoll.
     void postPoll(fd_map& fdm, uint64_t& nextActivity, list<Transaction*>& completedRequests, map<Transaction*, uint64_t>& transactionTimeouts, uint64_t timeoutMS = (5 * 60 * 1000));
-    Socket* openSocket(const string& host, SX509* x509 = nullptr);
-    void closeSocket(Socket* socket);
 
     // Close a transaction and remove it from our internal lists.
     void closeTransaction(Transaction* transaction);

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -51,8 +51,4 @@ class SHTTPSManager : public STCPManager {
 
     list<Transaction*> _activeTransactionList;
     list<Transaction*> _completedTransactionList;
-
-    // SHTTPSManager operations are thread-safe, we lock around any accesses to our transaction lists, so that
-    // multiple threads can add/remove from them.
-    recursive_mutex _listMutex;
 };

--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -75,6 +75,13 @@ void STCPManager::postPoll(fd_map& fdm) {
     // Walk across the sockets
     lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
     for (Socket* socket : socketSet) {
+
+        if (fdm.find(socket->s) == fdm.end()) {
+            // If this socket isn't in our fd_map, it wasn't active in `poll`, so we can skip it.
+            // TODO: ideally we don't walk the whole list for this, but only look at the sockets in `fdm`.
+            // continue;
+        }
+
         // Update this socket
         switch (socket->state.load()) {
         case Socket::CONNECTING: {

--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -79,7 +79,7 @@ void STCPManager::postPoll(fd_map& fdm) {
         if (fdm.find(socket->s) == fdm.end()) {
             // If this socket isn't in our fd_map, it wasn't active in `poll`, so we can skip it.
             // TODO: ideally we don't walk the whole list for this, but only look at the sockets in `fdm`.
-            // continue;
+            continue;
         }
 
         // Update this socket

--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -3,12 +3,14 @@
 atomic<uint64_t> STCPManager::Socket::socketCount(1);
 
 STCPManager::~STCPManager() {
-    SASSERTWARN(socketList.empty());
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
+    SASSERTWARN(socketSet.empty());
 }
 
 void STCPManager::prePoll(fd_map& fdm) {
     // Add all the sockets
-    for (Socket* socket : socketList) {
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
+    for (Socket* socket : socketSet) {
         // Make sure it's not closed
         if (socket->state.load() != Socket::CLOSED) {
             // Check and see if it looks like we're still valid.
@@ -71,7 +73,8 @@ void STCPManager::prePoll(fd_map& fdm) {
 
 void STCPManager::postPoll(fd_map& fdm) {
     // Walk across the sockets
-    for (Socket* socket : socketList) {
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
+    for (Socket* socket : socketSet) {
         // Update this socket
         switch (socket->state.load()) {
         case Socket::CONNECTING: {
@@ -211,7 +214,8 @@ void STCPManager::closeSocket(Socket* socket) {
     // Clean up this socket
     SASSERT(socket);
     SDEBUG("Closing socket '" << socket->addr << "'");
-    socketList.remove(socket);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
+    socketSet.erase(socket);
 
     delete socket;
 }
@@ -231,7 +235,7 @@ STCPManager::Socket::~Socket() {
     }
 }
 
-STCPManager::Socket* STCPManager::openSocket(const string& host, SX509* x509, recursive_mutex* listMutexPtr) {
+STCPManager::Socket* STCPManager::openSocket(const string& host, SX509* x509) {
     // Try to open the socket
     SASSERT(SHostIsValid(host));
     int s = S_socket(host, true, false, false);
@@ -244,12 +248,8 @@ STCPManager::Socket* STCPManager::openSocket(const string& host, SX509* x509, re
     socket->ssl = x509 ? SSSLOpen(socket->s, x509) : 0;
     SASSERT(!x509 || socket->ssl);
 
-    if (listMutexPtr) {
-        lock_guard<recursive_mutex> lock(*listMutexPtr);
-        socketList.push_back(socket);
-    } else {
-        socketList.push_back(socket);
-    }
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
+    socketSet.insert(socket);
     return socket;
 }
 

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -81,7 +81,3 @@ struct STCPManager {
     set<Socket*, SocketCompare> socketSet;
     recursive_mutex socketSetMutex;
 };
-
-// These allow searching socketSet with just an FD, not an entire socket object.
-//bool operator<(const STCPManager::Socket* so, const int& si) { return so->s < i; }
-//bool operator<(const int& si, const STCPManager::Socket* so) { return i < so->s; }

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -10,7 +10,7 @@ struct STCPManager {
         Socket(int sock = 0, State state_ = CONNECTING, SX509* x509 = nullptr);
         ~Socket();
         // Attributes
-        int s;
+        const int s;
         sockaddr_in addr;
         string recvBuffer;
         atomic<State> state;
@@ -52,7 +52,7 @@ struct STCPManager {
     void postPoll(fd_map& fdm);
 
     // Opens outgoing socket
-    Socket* openSocket(const string& host, SX509* x509 = nullptr, recursive_mutex* listMutexPtr = nullptr);
+    Socket* openSocket(const string& host, SX509* x509 = nullptr);
 
     // Gracefully shuts down a socket
     void shutdownSocket(Socket* socket, int how = SHUT_RDWR);
@@ -61,5 +61,6 @@ struct STCPManager {
     void closeSocket(Socket* socket);
 
     // Attributes
-    list<Socket*> socketList;
+    set<Socket*> socketSet; // TODO: Make the set sorted in a useful way.
+    recursive_mutex socketSetMutex;
 };

--- a/libstuff/STCPServer.cpp
+++ b/libstuff/STCPServer.cpp
@@ -46,7 +46,7 @@ void STCPServer::closePorts(list<Port*> except) {
     }
 }
 
-STCPManager::Socket* STCPServer::acceptSocket(Port*& portOut) {
+STCPManager::Socket* STCPServer::acceptSocket(Port*& portOut, bool deferRead) {
     // Initialize to 0 in case we don't accept anything. Note that this *does* overwrite the passed-in pointer.
     portOut = 0;
     Socket* socket = nullptr;
@@ -65,7 +65,9 @@ STCPManager::Socket* STCPServer::acceptSocket(Port*& portOut) {
             socketList.push_back(socket);
 
             // Try to read immediately
-            S_recvappend(socket->s, socket->recvBuffer);
+            if (!deferRead) {
+                S_recvappend(socket->s, socket->recvBuffer);
+            }
 
             // Record what port it was accepted on
             portOut = &port;

--- a/libstuff/STCPServer.cpp
+++ b/libstuff/STCPServer.cpp
@@ -62,7 +62,8 @@ STCPManager::Socket* STCPServer::acceptSocket(Port*& portOut, bool deferRead) {
             SDEBUG("Accepting socket from '" << addr << "' on port '" << port.host << "'");
             socket = new Socket(s, Socket::CONNECTED);
             socket->addr = addr;
-            socketList.push_back(socket);
+            lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
+            socketSet.insert(socket);
 
             // Try to read immediately
             if (!deferRead) {

--- a/libstuff/STCPServer.h
+++ b/libstuff/STCPServer.h
@@ -23,7 +23,7 @@ struct STCPServer : public STCPManager {
     void closePorts(list<Port*> except = {});
 
     // Tries to accept a new incoming socket
-    Socket* acceptSocket(Port*& port);
+    Socket* acceptSocket(Port*& port, bool deferRead = false);
     Socket* acceptSocket() {
         Port* ignore;
         return acceptSocket(ignore);

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1891,23 +1891,36 @@ int S_poll(fd_map& fdm, uint64_t timeout) {
     // functions.
 
     // Build a vector we can use to pass data to poll().
-    vector<pollfd> pollvec;
+    vector<pollfd> pollvec(fdm.size());
+    size_t i = 0;
     for (pair<int, pollfd> pfd : fdm) {
-        pollvec.push_back(pfd.second);
+        pollvec[i] = pfd.second;
+        i++;
     }
 
     // Timeout is specified in microseconds, but poll uses milliseconds, so we divide by 1000.
     int timeoutVal = int(timeout / 1000);
     int returnValue = poll(&pollvec[0], fdm.size(), timeoutVal);
-
-    // And write our returned events back to our original structure.
-    for (pollfd pfd : pollvec) {
-        fdm[pfd.fd].revents = pfd.revents;
-    }
-
     if (returnValue == -1) {
         SWARN("Poll failed with response '" << strerror(S_errno) << "' (#" << S_errno << "), ignoring");
     }
+
+    // We're only going to return the entries that had activity, so clear out the whole structure.
+    fdm.clear();
+
+    // And for anything that had a result, re-insert it.
+    int count = 0;
+    for (pollfd& pfd : pollvec) {
+        if (pfd.revents) {
+            fdm[pfd.fd] = pfd;
+            count++;
+            if (count == returnValue) {
+                // There are no more, we got them all.
+                break;
+            }
+        }
+    }
+
     return returnValue;
 }
 

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -299,7 +299,7 @@ SHTTPSManager::Transaction* TestHTTPSMananager::httpsDontSend(const string& url,
     //transaction->s->send(request.serialize());
 
     // Keep track of the transaction.
-    SAUTOLOCK(_listMutex);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
     _activeTransactionList.push_front(transaction);
     return transaction;
 }


### PR DESCRIPTION
@coleaeason 
cc @quinthar 

Initially, this was supposed to be a PR for multithreading reads from the network, but I didn't get that far, because there seemed to be a bunch of optimizations to do before we even got that far. Most notably, this PR does a couple things:

1. Grabs a big chunk of miscellaneous "stuff" out of `postPoll` and moves it to `sync()`. It's not 100% clear that this is the right place for it. I think it's a better place for it, but an even better place is probably a new `misc` thread. Still, this deals with things like opening and closing command ports on master state changes, and that seems more in-line with something the sync thread should do. Also, now that there's a `blockingCommit` thread, the sync thread should have some free time. So, that's the big chunk of ~70 lines added at the top the diff of `BedrockServer.cpp`, it's just moved out of `postPoll`.

2. Only looks at sockets that have activity on them. This includes some changes to `S_poll` and rewrites much of the top of `BedrockServer::postPoll` to only look at sockets that poll returned or that were newly accepted.

3. Some miscellaneous prep-work for multi-threading this. The next pass of this breaks out much or all of `postPoll` and lets it run in separate workers, so we took the thread-safety changes from `SHTTPSManager` and moved them down into the base class so everything based on `STCPManager` gets them as well. We also allow deferring reads until after `accept` so that we can let a different thread do the reads.

Existing tests pass.

Building and running auth and tests against this change as we speak. Will comment with whether the auth tests pass or not.