### PR TITLE
Second attempt: Improve Network Performance

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -331,6 +331,77 @@ void BedrockServer::sync(SData& args,
         replicationState.store(nodeState);
         masterVersion.store(server._syncNode->getMasterVersion());
 
+        // If we're a slave, and the master's on a different version than us, we don't open the command port.
+        // If we do, we'll escalate all of our commands to the master, which causes undue load on master during upgrades.
+        // Instead, we'll simply not respond and let this request get re-directed to another slave.
+        string masterVersion = server._masterVersion.load();
+        {
+            // We lock around any changes to the command port state so that two threads can't run over each other.
+            lock_guard <decltype(server.portListMutex)> lock(server.portListMutex);
+            if (!server._suppressCommandPort && nodeState == SQLiteNode::SLAVING && (masterVersion != server._version)) {
+                SINFO("Node " << server._args["-nodeName"] << " slaving on version " << server._version << ", master is version: "
+                      << masterVersion << ", not opening command port.");
+                server.suppressCommandPort("master version mismatch", true);
+            } else if (server._suppressCommandPort && (nodeState == SQLiteNode::MASTERING || (masterVersion == server._version))) {
+                // If we become master, or if master's version resumes matching ours, open the command port again.
+                if (!server._suppressCommandPortManualOverride) {
+                    // Only generate this logline if we haven't manually blocked this.
+                    SINFO("Node " << server._args["-nodeName"] << " disabling previously suppressed command port after version check.");
+                }
+                server.suppressCommandPort("master version match", false);
+            }
+
+            if (!server._suppressCommandPort && (nodeState == SQLiteNode::MASTERING || nodeState == SQLiteNode::SLAVING) &&
+                server._shutdownState.load() == RUNNING) {
+                // Open the port
+                if (!server._commandPort) {
+                    SINFO("Ready to process commands, opening command port on '" << server._args["-serverHost"] << "'");
+                    server._commandPort = server.openPort(server._args["-serverHost"]);
+                }
+                if (!server._controlPort) {
+                    SINFO("Opening control port on '" << server._args["-controlPort"] << "'");
+                    server._controlPort = server.openPort(server._args["-controlPort"]);
+                }
+
+                // Open any plugin ports on enabled plugins
+                for (auto plugin : server.plugins) {
+                    string portHost = plugin->getPort();
+                    if (!portHost.empty()) {
+                        bool alreadyOpened = false;
+                        for (auto pluginPorts : server._portPluginMap) {
+                            if (pluginPorts.second == plugin) {
+                                // We've already got this one.
+                                alreadyOpened = true;
+                                break;
+                            }
+                        }
+                        // Open the port and associate it with the plugin
+                        if (!alreadyOpened) {
+                            SINFO("Opening port '" << portHost << "' for plugin '" << plugin->getName() << "'");
+                            Port* port = server.openPort(portHost);
+                            server._portPluginMap[port] = plugin;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Is the OS trying to communicate with us?
+        if (SGetSignals()) {
+            if (SGetSignal(SIGTTIN)) {
+                // Suppress command port, but only if we haven't already cleared it
+                if (!SCheckSignal(SIGTTOU)) {
+                    server.suppressCommandPort("SIGTTIN", true, true);
+                }
+            } else if (SGetSignal(SIGTTOU)) {
+                // Clear command port suppression
+                server.suppressCommandPort("SIGTTOU", false, true);
+            } else {
+                // For any other signal, just shutdown.
+                server._beginShutdown(SGetSignalDescription());
+            }
+        }
+
         // If anything was in the stand down queue, move it back to the main queue.
         if (nodeState != SQLiteNode::STANDINGDOWN) {
             while (server._standDownQueue.size()) {
@@ -1086,6 +1157,7 @@ bool BedrockServer::_wouldCrash(const BedrockCommand& command) {
 }
 
 void BedrockServer::_resetServer() {
+    lock_guard <decltype(portListMutex)> lock(portListMutex);
     _requestCount = 0;
     _replicationState = SQLiteNode::SEARCHING;
     _upgradeInProgress = false;
@@ -1107,6 +1179,13 @@ BedrockServer::BedrockServer(const SData& args)
     _multiWriteEnabled(args.test("-enableMultiWrite")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),
     _controlPort(nullptr), _commandPort(nullptr), _maxConflictRetries(3), _lastQuorumCommandTime(STimeNow())
 {
+    // Initialize all the postPoll timers.
+    _postPollBaseClass = chrono::steady_clock::duration::zero();
+    _postPollAccept = chrono::steady_clock::duration::zero();
+    _postPollChooseSockets = chrono::steady_clock::duration::zero();
+    _postPollPostProcess = chrono::steady_clock::duration::zero();
+    _postPollStart = chrono::steady_clock::now();
+
     _version = SVERSION;
 
     // Output the list of plugins.
@@ -1208,13 +1287,10 @@ BedrockServer::~BedrockServer() {
         SWARN("Still have " << _socketIDMap.size() << " entries in _socketIDMap.");
     }
 
-    if (socketList.size()) {
-        SWARN("Still have " << socketList.size() << " entries in socketList.");
-        for (list<Socket*>::iterator socketIt = socketList.begin(); socketIt != socketList.end();) {
-            // Shut it down and go to the next (because closeSocket will invalidate this iterator otherwise)
-            Socket* s = *socketIt++;
-            closeSocket(s);
-        }
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
+    while (socketSet.size()) {
+        SWARN("Still have " << socketSet.size() << " entries in socketSet.");
+        closeSocket(*(socketSet.begin()));
     }
 }
 
@@ -1276,6 +1352,8 @@ void BedrockServer::prePoll(fd_map& fdm) {
 }
 
 void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
+    auto startBaseClassPostPoll = chrono::steady_clock::now();
+
     // Let the base class do its thing. We lock around this because we allow worker threads to modify the sockets (by
     // writing to them, but this can truncate send buffers).
     {
@@ -1283,91 +1361,14 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
         STCPServer::postPoll(fdm);
     }
 
-    // Open the port the first time we enter a command-processing state
-    SQLiteNode::State state = _replicationState.load();
-
-    // If we're a slave, and the master's on a different version than us, we don't open the command port.
-    // If we do, we'll escalate all of our commands to the master, which causes undue load on master during upgrades.
-    // Instead, we'll simply not respond and let this request get re-directed to another slave.
-    string masterVersion = _masterVersion.load();
-    if (!_suppressCommandPort && state == SQLiteNode::SLAVING && (masterVersion != _version)) {
-        SINFO("Node " << _args["-nodeName"] << " slaving on version " << _version << ", master is version: "
-              << masterVersion << ", not opening command port.");
-        suppressCommandPort("master version mismatch", true);
-    } else if (_suppressCommandPort && (state == SQLiteNode::MASTERING || (masterVersion == _version))) {
-        // If we become master, or if master's version resumes matching ours, open the command port again.
-        if (!_suppressCommandPortManualOverride) {
-            // Only generate this logline if we haven't manually blocked this.
-            SINFO("Node " << _args["-nodeName"] << " disabling previously suppressed command port after version check.");
-        }
-        suppressCommandPort("master version match", false);
-    }
-    if (!_suppressCommandPort && (state == SQLiteNode::MASTERING || state == SQLiteNode::SLAVING) &&
-        _shutdownState.load() == RUNNING) {
-        // Open the port
-        if (!_commandPort) {
-            SINFO("Ready to process commands, opening command port on '" << _args["-serverHost"] << "'");
-            _commandPort = openPort(_args["-serverHost"]);
-        }
-        if (!_controlPort) {
-            SINFO("Opening control port on '" << _args["-controlPort"] << "'");
-            _controlPort = openPort(_args["-controlPort"]);
-        }
-
-        // Open any plugin ports on enabled plugins
-        for (auto plugin : plugins) {
-            string portHost = plugin->getPort();
-            if (!portHost.empty()) {
-                bool alreadyOpened = false;
-                for (auto pluginPorts : _portPluginMap) {
-                    if (pluginPorts.second == plugin) {
-                        // We've already got this one.
-                        alreadyOpened = true;
-                        break;
-                    }
-                }
-                // Open the port and associate it with the plugin
-                if (!alreadyOpened) {
-                    SINFO("Opening port '" << portHost << "' for plugin '" << plugin->getName() << "'");
-                    Port* port = openPort(portHost);
-                    _portPluginMap[port] = plugin;
-                }
-            }
-        }
-    }
-
-    // **NOTE: We leave the port open between startup and shutdown, even if we enter a state where
-    //         we can't process commands -- such as a non master/slave state.  The reason is we
-    //         expect any state transitions between startup/shutdown to be due to temporary conditions
-    //         that will resolve themselves automatically in a short time.  During this period we
-    //         prefer to receive commands and queue them up, even if we can't process them immediately,
-    //         on the assumption that we'll be able to process them before the browser times out.
-
-    // Is the OS trying to communicate with us?
-    if (SGetSignals()) {
-        if (SGetSignal(SIGTTIN)) {
-            // Suppress command port, but only if we haven't already cleared it
-            if (!SCheckSignal(SIGTTOU)) {
-                suppressCommandPort("SIGTTIN", true, true);
-            }
-        } else if (SGetSignal(SIGTTOU)) {
-            // Clear command port suppression
-            suppressCommandPort("SIGTTOU", false, true);
-        } else {
-            // For any other signal, just shutdown.
-            _beginShutdown(SGetSignalDescription());
-        }
-    }
-
     // Timing variables.
     int deserializationAttempts = 0;
     int deserializedRequests = 0;
 
+    auto startAccept = chrono::steady_clock::now();
     // Accept any new connections
-    _acceptSockets();
-
-    // Time the end of the accept section.
-    uint64_t acceptEndTime = STimeNow();
+    set<Socket*> sockets = _acceptSockets(true);
+    size_t newSocketCount = sockets.size();
 
     // Process any new activity from incoming sockets. In order to not modify the socket list while we're iterating
     // over it, we'll keep a list of sockets that need closing.
@@ -1378,7 +1379,49 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     // them, and we'll stop accepting any new sockets, but if existing sockets just sit around giving us nothing, we
     // need to figure out some way to handle them. We'll wait 5 seconds and then start killing them.
     static uint64_t lastChance = 0;
-    for (auto s : socketList) {
+
+    auto startChooseSockets = chrono::steady_clock::now();
+
+    // Lock our socket set for the remainder of the function.
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
+
+    // This works because all of our sockets in both fdm and socketSet are in sorted order by their FD.
+    // This runs in linear time across the size of socketSet plus the size of fdm.
+    // An alternative implementation could run in the size O(N*log(M)) where N is the size of fdm and M is the size of
+    // socketSet, if we could easily binary-search socketSet by FD. This is possible since that's the ordering, but
+    // it's a bit of a pain. It should be faster in the case than socketSet is larger than fdm, though.
+    auto fdmIt = fdm.begin();
+    auto socketSetIt = socketSet.begin();
+    while (true) {
+        // Are either of them past the end? If so, we're done.
+        if (fdmIt == fdm.end() || socketSetIt == socketSet.end()) {
+            break;
+        }
+        // See if the two iterators have the same FD.
+        if (fdmIt->first == (*socketSetIt)->s) {
+            // They do! We want to keep this, and then move on with both of them.
+            sockets.insert(*socketSetIt);
+            fdmIt++;
+            socketSetIt++;
+        } else if (fdmIt->first < (*socketSetIt)->s) {
+            // So, if the iterator into FDM is less than the iterator into socket set, we can discard it, all the
+            // values in socketSet are larger than this.
+            fdmIt++;
+        } else if ((*socketSetIt)->s < fdmIt->first) {
+            // On the other hand, if the iterator into socketSet is lower than the one into FDM, then we can discard
+            // the one in socketSet, it's not part of our candidate set.
+            socketSetIt++;
+        }
+    }
+
+    SINFO("Poll returned " << fdm.size() << " sockets to inspect and we accepted " << newSocketCount
+          << " new sockets. Total to inspect: " << sockets.size() << " of " << socketSet.size() << ".");
+
+    auto startPostProcess = chrono::steady_clock::now();
+    for (auto s : sockets) {
+        // Do the read that we deferred above. This doesn't help a ton yet, but if we break out the below loop to a
+        // separate thread, this lets the new thread do this work.
+        S_recvappend(s->s, s->recvBuffer);
         switch (s->state.load()) {
             case STCPManager::Socket::CLOSED:
             {
@@ -1526,11 +1569,6 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
         }
     }
 
-    // Log the timing of this loop.
-    uint64_t readElapsedMS = (STimeNow() - acceptEndTime) / 1000;
-    SINFO("Read from " << socketList.size() << " sockets, attempted to deserialize " << deserializationAttempts
-          << " commands, " << deserializedRequests << " were complete and deserialized in " << readElapsedMS << "ms.");
-
     // Now we can close any sockets that we need to.
     for (auto s: socketsToClose) {
         closeSocket(s);
@@ -1551,22 +1589,46 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
             lastChance = STimeNow() + 5 * 1'000'000; // 5 seconds from now.
         }
         // If we've run out of sockets or hit our timeout, we'll increment _shutdownState.
-        if (socketList.empty() || _gracefulShutdownTimeout.ringing()) {
+        if (socketSet.empty() || _gracefulShutdownTimeout.ringing()) {
             lastChance = 0;
 
             // We empty the socket list here, we will no longer allow new requests to come in, as the sync node can
             // shutdown any time after here, and we'll have no way to handle new requests.
-            if (socketList.size()) {
+            if (socketSet.size()) {
                 SAUTOLOCK(_socketIDMutex);
-                SINFO("Killing " << socketList.size() << " remaining sockets at graceful shutdown timeout.");
-                while(socketList.size()) {
-                    auto s = socketList.front();
+                SINFO("Killing " << socketSet.size() << " remaining sockets at graceful shutdown timeout.");
+                while(socketSet.size()) {
+                    auto s = *(socketSet.begin());
                     _socketIDMap.erase(s->id);
                     closeSocket(s);
                 }
             }
             _shutdownState.store(CLIENTS_RESPONDED);
         }
+    }
+
+    // Compute timing info.
+    auto end = chrono::steady_clock::now();
+    _postPollBaseClass += (startAccept - startBaseClassPostPoll);
+    _postPollAccept += (startChooseSockets - startAccept);
+    _postPollChooseSockets += (startPostProcess - startChooseSockets);
+    _postPollPostProcess += (end - startPostProcess);
+
+    // If it's been 10s since the last time we logged something, log and reset.
+    if (end > (_postPollStart + 10s)) {
+        SINFO("[performance] postPoll timing: "
+            << chrono::duration_cast<chrono::milliseconds>(end - _postPollStart).count() << " ms total elapsed. "
+            << chrono::duration_cast<chrono::milliseconds>(_postPollBaseClass).count() << " ms in bases class. "
+            << chrono::duration_cast<chrono::milliseconds>(_postPollAccept).count() << " ms in accept. "
+            << chrono::duration_cast<chrono::milliseconds>(_postPollChooseSockets).count() << " ms choosing sockets. "
+            << chrono::duration_cast<chrono::milliseconds>(_postPollPostProcess).count() << " ms post processing connections.");
+
+        // Reset everything.
+        _postPollBaseClass = chrono::steady_clock::duration::zero();
+        _postPollAccept = chrono::steady_clock::duration::zero();
+        _postPollChooseSockets = chrono::steady_clock::duration::zero();
+        _postPollPostProcess = chrono::steady_clock::duration::zero();
+        _postPollStart = end;
     }
 }
 
@@ -1629,6 +1691,7 @@ void BedrockServer::_reply(BedrockCommand& command) {
 }
 
 void BedrockServer::suppressCommandPort(const string& reason, bool suppress, bool manualOverride) {
+    lock_guard <decltype(portListMutex)> lock(portListMutex);
     // If we've set the manual override flag, then we'll only actually make this change if we've specified it again.
     if (_suppressCommandPortManualOverride && !manualOverride) {
         return;
@@ -2062,10 +2125,11 @@ void BedrockServer::_finishPeerCommand(BedrockCommand& command) {
     }
 }
 
-void BedrockServer::_acceptSockets() {
+set<STCPManager::Socket*> BedrockServer::_acceptSockets(bool deferRead) {
     Socket* s = nullptr;
     Port* acceptPort = nullptr;
-    while ((s = acceptSocket(acceptPort))) {
+    set<Socket*> retVal;
+    while ((s = acceptSocket(acceptPort, deferRead))) {
         if (SContains(_portPluginMap, acceptPort)) {
             BedrockPlugin* plugin = _portPluginMap[acceptPort];
             // Allow the plugin to process this
@@ -2076,7 +2140,9 @@ void BedrockServer::_acceptSockets() {
             SASSERT(!s->data);
             s->data = plugin;
         }
+        retVal.insert(s);
     }
+    return retVal;
 }
 
 void BedrockServer::waitForHTTPS(BedrockCommand&& command) {

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -234,9 +234,9 @@ class BedrockServer : public SQLiteServer {
     map <uint64_t, Socket*> _socketIDMap;
 
     // The above _socketIDMap is modified by multiple threads, so we lock this mutex around operations that access it.
-    // We don't need to lock around access to the base class's `socketList` because we carefully control access to it
+    // We don't need to lock around access to the base class's `socketSet` because we carefully control access to it
     // to the main thread.
-    // The only functions that access `socketList` are prePoll, postPoll, openSocket, and closeSocket, in STCPManager,
+    // The only functions that access `socketSet` are prePoll, postPoll, openSocket, and closeSocket, in STCPManager,
     // and acceptSocket in STCPServer.
     // prePoll and postPoll are only ever called by the main thread.
     // openSocket is never called by bedrockServer (it is called in SHTTPSManager and STCPNode).
@@ -342,7 +342,7 @@ class BedrockServer : public SQLiteServer {
 
     // Accepts any sockets pending on our listening ports. We do this both after `poll()`, and before shutting down
     // those ports.
-    void _acceptSockets();
+    set<Socket*> _acceptSockets(bool deferRead = false);
 
     // This stars the server shutting down.
     void _beginShutdown(const string& reason, bool detach = false);
@@ -461,4 +461,11 @@ class BedrockServer : public SQLiteServer {
     // We keep a queue of completed commands that workers will insert into when they've successfully finished a command
     // that just needs to be returned to a peer.
     BedrockTimeoutCommandQueue _completedCommands;
+
+    // Counters for timing postPoll and locating bottlenecks;
+    chrono::steady_clock::duration _postPollBaseClass;
+    chrono::steady_clock::duration _postPollAccept;
+    chrono::steady_clock::duration _postPollChooseSockets;
+    chrono::steady_clock::duration _postPollPostProcess;
+    chrono::steady_clock::time_point _postPollStart;
 };

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -8,7 +8,7 @@ SHTTPSManager::SHTTPSManager(const string& pem, const string& srvCrt, const stri
 { }
 
 SHTTPSManager::~SHTTPSManager() {
-    SAUTOLOCK(_listMutex);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
 
     // Clean up outstanding transactions
     SASSERTWARN(_activeTransactionList.empty());
@@ -25,7 +25,7 @@ void SHTTPSManager::closeTransaction(Transaction* transaction) {
     if (transaction == nullptr) {
         return;
     }
-    SAUTOLOCK(_listMutex);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
 
     // Clean up the socket and done
     _activeTransactionList.remove(transaction);
@@ -54,23 +54,6 @@ int SHTTPSManager::getHTTPResponseCode(const string& methodLine) {
     return 400;
 }
 
-SHTTPSManager::Socket* SHTTPSManager::openSocket(const string& host, SX509* x509) {
-    // Just call the base class function but in a thread-safe way.
-    return STCPManager::openSocket(host, x509, &_listMutex);
-}
-
-void SHTTPSManager::closeSocket(Socket* socket) {
-    // Just call the base class function but in a thread-safe way.
-    SAUTOLOCK(_listMutex);
-    STCPManager::closeSocket(socket);
-}
-
-void SHTTPSManager::prePoll(fd_map& fdm) {
-    // Just call the base class function but in a thread-safe way.
-    SAUTOLOCK(_listMutex);
-    return STCPManager::prePoll(fdm);
-}
-
 void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     list<SHTTPSManager::Transaction*> completedRequests;
     map<Transaction*, uint64_t> transactionTimeouts;
@@ -83,7 +66,7 @@ void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSMan
 }
 
 void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSManager::Transaction*>& completedRequests, map<Transaction*, uint64_t>& transactionTimeouts, uint64_t timeoutMS) {
-    SAUTOLOCK(_listMutex);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
 
     // Let the base class do its thing
     STCPManager::postPoll(fdm);
@@ -171,7 +154,7 @@ SHTTPSManager::Transaction* SHTTPSManager::_createErrorTransaction() {
     Transaction* transaction = new Transaction(*this);
     transaction->response = 503;
     transaction->finished = STimeNow();
-    SAUTOLOCK(_listMutex);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
     _completedTransactionList.push_front(transaction);
     return transaction;
 }
@@ -203,7 +186,7 @@ SHTTPSManager::Transaction* SHTTPSManager::_httpsSend(const string& url, const S
     transaction->s->send(request.serialize());
 
     // Keep track of the transaction.
-    SAUTOLOCK(_listMutex);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
     _activeTransactionList.push_front(transaction);
     return transaction;
 }

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -26,15 +26,11 @@ class SHTTPSManager : public STCPManager {
     virtual ~SHTTPSManager();
 
     // STCPServer API. Except for postPoll, these are just threadsafe wrappers around base class functions.
-    void prePoll(fd_map& fdm);
     void postPoll(fd_map& fdm, uint64_t& nextActivity);
     void postPoll(fd_map& fdm, uint64_t& nextActivity, list<Transaction*>& completedRequests);
 
-
     // Default timeout for HTTPS requests is 5 minutes.This can be changed on any call to postPoll.
     void postPoll(fd_map& fdm, uint64_t& nextActivity, list<Transaction*>& completedRequests, map<Transaction*, uint64_t>& transactionTimeouts, uint64_t timeoutMS = (5 * 60 * 1000));
-    Socket* openSocket(const string& host, SX509* x509 = nullptr);
-    void closeSocket(Socket* socket);
 
     // Close a transaction and remove it from our internal lists.
     void closeTransaction(Transaction* transaction);
@@ -55,8 +51,4 @@ class SHTTPSManager : public STCPManager {
 
     list<Transaction*> _activeTransactionList;
     list<Transaction*> _completedTransactionList;
-
-    // SHTTPSManager operations are thread-safe, we lock around any accesses to our transaction lists, so that
-    // multiple threads can add/remove from them.
-    recursive_mutex _listMutex;
 };

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -10,7 +10,7 @@ struct STCPManager {
         Socket(int sock = 0, State state_ = CONNECTING, SX509* x509 = nullptr);
         ~Socket();
         // Attributes
-        int s;
+        const int s;
         sockaddr_in addr;
         string recvBuffer;
         atomic<State> state;
@@ -52,7 +52,7 @@ struct STCPManager {
     void postPoll(fd_map& fdm);
 
     // Opens outgoing socket
-    Socket* openSocket(const string& host, SX509* x509 = nullptr, recursive_mutex* listMutexPtr = nullptr);
+    Socket* openSocket(const string& host, SX509* x509 = nullptr);
 
     // Gracefully shuts down a socket
     void shutdownSocket(Socket* socket, int how = SHUT_RDWR);
@@ -60,6 +60,24 @@ struct STCPManager {
     // Hard terminate a socket
     void closeSocket(Socket* socket);
 
+    struct SocketCompare {
+        bool operator() (const Socket* lhs, const Socket* rhs) const {
+            if (lhs == 0 || rhs == 0) {
+                SWARN("Invalid socket in comparison.");
+                return false;
+            }
+            if (lhs->s == rhs->s) {
+                // This shouldn't be possible because we remove sockets before closing them, meaning the OS has no
+                // opportunity to reuse them until we've already dropped them. This is a sanity check in case something
+                // weird happens like the OS has closed the socket and reused the file descriptor before we notice
+                // that's happened. I don't think that's supposed to be possible on linux, though.
+                SALERT("Duplicate sockets in set, one will get dropped.");
+            }
+            return lhs->s < rhs->s;
+        }
+    };
+
     // Attributes
-    list<Socket*> socketList;
+    set<Socket*, SocketCompare> socketSet;
+    recursive_mutex socketSetMutex;
 };

--- a/libstuff/STCPServer.cpp
+++ b/libstuff/STCPServer.cpp
@@ -33,6 +33,7 @@ void STCPServer::closePorts(list<Port*> except) {
         while (it != portList.end()) {
             if  (find(except.begin(), except.end(), &(*it)) == except.end()) {
                 // Close this port
+                ::shutdown(it->s, SHUT_RDWR);
                 ::close(it->s);
                 SINFO("Close ports closing " << it->host << ".");
                 it = portList.erase(it);

--- a/libstuff/STCPServer.cpp
+++ b/libstuff/STCPServer.cpp
@@ -47,7 +47,7 @@ void STCPServer::closePorts(list<Port*> except) {
     }
 }
 
-STCPManager::Socket* STCPServer::acceptSocket(Port*& portOut) {
+STCPManager::Socket* STCPServer::acceptSocket(Port*& portOut, bool deferRead) {
     // Initialize to 0 in case we don't accept anything. Note that this *does* overwrite the passed-in pointer.
     portOut = 0;
     Socket* socket = nullptr;
@@ -63,10 +63,13 @@ STCPManager::Socket* STCPServer::acceptSocket(Port*& portOut) {
             SDEBUG("Accepting socket from '" << addr << "' on port '" << port.host << "'");
             socket = new Socket(s, Socket::CONNECTED);
             socket->addr = addr;
-            socketList.push_back(socket);
+            lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
+            socketSet.insert(socket);
 
             // Try to read immediately
-            S_recvappend(socket->s, socket->recvBuffer);
+            if (!deferRead) {
+                S_recvappend(socket->s, socket->recvBuffer);
+            }
 
             // Record what port it was accepted on
             portOut = &port;

--- a/libstuff/STCPServer.h
+++ b/libstuff/STCPServer.h
@@ -23,7 +23,7 @@ struct STCPServer : public STCPManager {
     void closePorts(list<Port*> except = {});
 
     // Tries to accept a new incoming socket
-    Socket* acceptSocket(Port*& port);
+    Socket* acceptSocket(Port*& port, bool deferRead = false);
     Socket* acceptSocket() {
         Port* ignore;
         return acceptSocket(ignore);

--- a/libstuff/STCPServer.h
+++ b/libstuff/STCPServer.h
@@ -37,5 +37,5 @@ struct STCPServer : public STCPManager {
     list<Port> portList;
 
     // Protect access to to the port list when multiple threads insert and delete from it.
-    mutex portListMutex;
+    recursive_mutex portListMutex;
 };

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1891,23 +1891,36 @@ int S_poll(fd_map& fdm, uint64_t timeout) {
     // functions.
 
     // Build a vector we can use to pass data to poll().
-    vector<pollfd> pollvec;
+    vector<pollfd> pollvec(fdm.size());
+    size_t i = 0;
     for (pair<int, pollfd> pfd : fdm) {
-        pollvec.push_back(pfd.second);
+        pollvec[i] = pfd.second;
+        i++;
     }
 
     // Timeout is specified in microseconds, but poll uses milliseconds, so we divide by 1000.
     int timeoutVal = int(timeout / 1000);
     int returnValue = poll(&pollvec[0], fdm.size(), timeoutVal);
-
-    // And write our returned events back to our original structure.
-    for (pollfd pfd : pollvec) {
-        fdm[pfd.fd].revents = pfd.revents;
-    }
-
     if (returnValue == -1) {
         SWARN("Poll failed with response '" << strerror(S_errno) << "' (#" << S_errno << "), ignoring");
     }
+
+    // We're only going to return the entries that had activity, so clear out the whole structure.
+    fdm.clear();
+
+    // And for anything that had a result, re-insert it.
+    int count = 0;
+    for (pollfd& pfd : pollvec) {
+        if (pfd.revents) {
+            fdm[pfd.fd] = pfd;
+            count++;
+            if (count == returnValue) {
+                // There are no more, we got them all.
+                break;
+            }
+        }
+    }
+
     return returnValue;
 }
 

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -299,7 +299,7 @@ SHTTPSManager::Transaction* TestHTTPSMananager::httpsDontSend(const string& url,
     //transaction->s->send(request.serialize());
 
     // Keep track of the transaction.
-    SAUTOLOCK(_listMutex);
+    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
     _activeTransactionList.push_front(transaction);
     return transaction;
 }


### PR DESCRIPTION
Second take on this PR:

https://github.com/Expensify/Bedrock/pull/576

It's nearly identical. The diff from the previous one to this one is below (feel free to compare yourself as well).

The main difference that fixed the issue with the command port re-opening is this:
https://github.com/Expensify/Bedrock/compare/tyler-multi-network-2?expand=1#diff-0c7cc46bbeebcb4a661ad452d6bc16f8R36

Without the call to `shutdown`, closing the port in one thread and opening it in another fails with `address in use`. The `shutdown` call clears this and allows the port to re-open successfully.

The change here can have Travis restarted after merging this change. I expect it to pass this time:
https://github.com/Expensify/Server-Expensify/pull/3225

```
diff --git a/BedrockServer.cpp b/BedrockServer.cpp
index 450b405..2ef93b9 100644
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -335,6 +335,9 @@ void BedrockServer::sync(SData& args,
         // If we do, we'll escalate all of our commands to the master, which causes undue load on master during upgrades.
         // Instead, we'll simply not respond and let this request get re-directed to another slave.
         string masterVersion = server._masterVersion.load();
+        {
+            // We lock around any changes to the command port state so that two threads can't run over each other.
+            lock_guard <decltype(server.portListMutex)> lock(server.portListMutex);
             if (!server._suppressCommandPort && nodeState == SQLiteNode::SLAVING && (masterVersion != server._version)) {
                 SINFO("Node " << server._args["-nodeName"] << " slaving on version " << server._version << ", master is version: "
                       << masterVersion << ", not opening command port.");
@@ -347,6 +350,7 @@ void BedrockServer::sync(SData& args,
                 }
                 server.suppressCommandPort("master version match", false);
             }
+
             if (!server._suppressCommandPort && (nodeState == SQLiteNode::MASTERING || nodeState == SQLiteNode::SLAVING) &&
                 server._shutdownState.load() == RUNNING) {
                 // Open the port
@@ -380,6 +384,7 @@ void BedrockServer::sync(SData& args,
                     }
                 }
             }
+        }
 
         // Is the OS trying to communicate with us?
         if (SGetSignals()) {
@@ -1152,6 +1157,7 @@ bool BedrockServer::_wouldCrash(const BedrockCommand& command) {
 }
 
 void BedrockServer::_resetServer() {
+    lock_guard <decltype(portListMutex)> lock(portListMutex);
     _requestCount = 0;
     _replicationState = SQLiteNode::SEARCHING;
     _upgradeInProgress = false;
@@ -1685,6 +1691,7 @@ void BedrockServer::_reply(BedrockCommand& command) {
 }
 
 void BedrockServer::suppressCommandPort(const string& reason, bool suppress, bool manualOverride) {
+    lock_guard <decltype(portListMutex)> lock(portListMutex);
     // If we've set the manual override flag, then we'll only actually make this change if we've specified it again.
     if (_suppressCommandPortManualOverride && !manualOverride) {
         return;
diff --git a/libstuff/STCPServer.cpp b/libstuff/STCPServer.cpp
index d5fa76b..aac937a 100644
--- a/libstuff/STCPServer.cpp
+++ b/libstuff/STCPServer.cpp
@@ -33,6 +33,7 @@ void STCPServer::closePorts(list<Port*> except) {
         while (it != portList.end()) {
             if  (find(except.begin(), except.end(), &(*it)) == except.end()) {
                 // Close this port
+                ::shutdown(it->s, SHUT_RDWR);
                 ::close(it->s);
                 SINFO("Close ports closing " << it->host << ".");
                 it = portList.erase(it);
diff --git a/libstuff/STCPServer.h b/libstuff/STCPServer.h
index 654708d..aa11165 100644
--- a/libstuff/STCPServer.h
+++ b/libstuff/STCPServer.h
@@ -37,5 +37,5 @@ struct STCPServer : public STCPManager {
     list<Port> portList;
 
     // Protect access to to the port list when multiple threads insert and delete from it.
-    mutex portListMutex;
+    recursive_mutex portListMutex;
 };
diff --git a/mbedtls b/mbedtls
--- a/mbedtls
+++ b/mbedtls
@@ -1 +1 @@
-Subproject commit c49b808ae490f03d665df5faae457f613aa31aaf
+Subproject commit c49b808ae490f03d665df5faae457f613aa31aaf-dirty
```