### PR TITLE
Move port logic back to postPoll

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -331,77 +331,6 @@ void BedrockServer::sync(SData& args,
         replicationState.store(nodeState);
         masterVersion.store(server._syncNode->getMasterVersion());
 
-        // If we're a slave, and the master's on a different version than us, we don't open the command port.
-        // If we do, we'll escalate all of our commands to the master, which causes undue load on master during upgrades.
-        // Instead, we'll simply not respond and let this request get re-directed to another slave.
-        string masterVersion = server._masterVersion.load();
-        {
-            // We lock around any changes to the command port state so that two threads can't run over each other.
-            lock_guard <decltype(server.portListMutex)> lock(server.portListMutex);
-            if (!server._suppressCommandPort && nodeState == SQLiteNode::SLAVING && (masterVersion != server._version)) {
-                SINFO("Node " << server._args["-nodeName"] << " slaving on version " << server._version << ", master is version: "
-                      << masterVersion << ", not opening command port.");
-                server.suppressCommandPort("master version mismatch", true);
-            } else if (server._suppressCommandPort && (nodeState == SQLiteNode::MASTERING || (masterVersion == server._version))) {
-                // If we become master, or if master's version resumes matching ours, open the command port again.
-                if (!server._suppressCommandPortManualOverride) {
-                    // Only generate this logline if we haven't manually blocked this.
-                    SINFO("Node " << server._args["-nodeName"] << " disabling previously suppressed command port after version check.");
-                }
-                server.suppressCommandPort("master version match", false);
-            }
-
-            if (!server._suppressCommandPort && (nodeState == SQLiteNode::MASTERING || nodeState == SQLiteNode::SLAVING) &&
-                server._shutdownState.load() == RUNNING) {
-                // Open the port
-                if (!server._commandPort) {
-                    SINFO("Ready to process commands, opening command port on '" << server._args["-serverHost"] << "'");
-                    server._commandPort = server.openPort(server._args["-serverHost"]);
-                }
-                if (!server._controlPort) {
-                    SINFO("Opening control port on '" << server._args["-controlPort"] << "'");
-                    server._controlPort = server.openPort(server._args["-controlPort"]);
-                }
-
-                // Open any plugin ports on enabled plugins
-                for (auto plugin : server.plugins) {
-                    string portHost = plugin->getPort();
-                    if (!portHost.empty()) {
-                        bool alreadyOpened = false;
-                        for (auto pluginPorts : server._portPluginMap) {
-                            if (pluginPorts.second == plugin) {
-                                // We've already got this one.
-                                alreadyOpened = true;
-                                break;
-                            }
-                        }
-                        // Open the port and associate it with the plugin
-                        if (!alreadyOpened) {
-                            SINFO("Opening port '" << portHost << "' for plugin '" << plugin->getName() << "'");
-                            Port* port = server.openPort(portHost);
-                            server._portPluginMap[port] = plugin;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Is the OS trying to communicate with us?
-        if (SGetSignals()) {
-            if (SGetSignal(SIGTTIN)) {
-                // Suppress command port, but only if we haven't already cleared it
-                if (!SCheckSignal(SIGTTOU)) {
-                    server.suppressCommandPort("SIGTTIN", true, true);
-                }
-            } else if (SGetSignal(SIGTTOU)) {
-                // Clear command port suppression
-                server.suppressCommandPort("SIGTTOU", false, true);
-            } else {
-                // For any other signal, just shutdown.
-                server._beginShutdown(SGetSignalDescription());
-            }
-        }
-
         // If anything was in the stand down queue, move it back to the main queue.
         if (nodeState != SQLiteNode::STANDINGDOWN) {
             while (server._standDownQueue.size()) {
@@ -1180,6 +1109,7 @@ BedrockServer::BedrockServer(const SData& args)
     _controlPort(nullptr), _commandPort(nullptr), _maxConflictRetries(3), _lastQuorumCommandTime(STimeNow())
 {
     // Initialize all the postPoll timers.
+    _postPollMisc = chrono::steady_clock::duration::zero();
     _postPollBaseClass = chrono::steady_clock::duration::zero();
     _postPollAccept = chrono::steady_clock::duration::zero();
     _postPollChooseSockets = chrono::steady_clock::duration::zero();
@@ -1352,6 +1282,81 @@ void BedrockServer::prePoll(fd_map& fdm) {
 }
 
 void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
+    auto startMisc = chrono::steady_clock::now();
+    // TODO: This whole block of junk unrelated to processing sockets should go in a different thread (everything
+    // through the signal handling bit).
+
+    // If we're a slave, and the master's on a different version than us, we don't open the command port.
+    // If we do, we'll escalate all of our commands to the master, which causes undue load on master during upgrades.
+    // Instead, we'll simply not respond and let this request get re-directed to another slave.
+    {
+        string masterVersion = _masterVersion.load();
+        // We lock around any changes to the command port state so that two threads can't run over each other.
+        lock_guard <decltype(portListMutex)> lock(portListMutex);
+        if (!_suppressCommandPort && _replicationState.load() == SQLiteNode::SLAVING && (masterVersion != _version)) {
+            SINFO("Node " << _args["-nodeName"] << " slaving on version " << _version << ", master is version: "
+                  << masterVersion << ", not opening command port.");
+            suppressCommandPort("master version mismatch", true);
+        } else if (_suppressCommandPort && (_replicationState.load() == SQLiteNode::MASTERING || (masterVersion == _version))) {
+            // If we become master, or if master's version resumes matching ours, open the command port again.
+            if (!_suppressCommandPortManualOverride) {
+                // Only generate this logline if we haven't manually blocked this.
+                SINFO("Node " << _args["-nodeName"] << " disabling previously suppressed command port after version check.");
+            }
+            suppressCommandPort("master version match", false);
+        }
+
+        if (!_suppressCommandPort && (_replicationState.load() == SQLiteNode::MASTERING || _replicationState.load() == SQLiteNode::SLAVING) &&
+            _shutdownState.load() == RUNNING) {
+            // Open the port
+            if (!_commandPort) {
+                SINFO("Ready to process commands, opening command port on '" << _args["-serverHost"] << "'");
+                _commandPort = openPort(_args["-serverHost"]);
+            }
+            if (!_controlPort) {
+                SINFO("Opening control port on '" << _args["-controlPort"] << "'");
+                _controlPort = openPort(_args["-controlPort"]);
+            }
+
+            // Open any plugin ports on enabled plugins
+            for (auto plugin : plugins) {
+                string portHost = plugin->getPort();
+                if (!portHost.empty()) {
+                    bool alreadyOpened = false;
+                    for (auto pluginPorts : _portPluginMap) {
+                        if (pluginPorts.second == plugin) {
+                            // We've already got this one.
+                            alreadyOpened = true;
+                            break;
+                        }
+                    }
+                    // Open the port and associate it with the plugin
+                    if (!alreadyOpened) {
+                        SINFO("Opening port '" << portHost << "' for plugin '" << plugin->getName() << "'");
+                        Port* port = openPort(portHost);
+                        _portPluginMap[port] = plugin;
+                    }
+                }
+            }
+        }
+    }
+
+    // Is the OS trying to communicate with us?
+    if (SGetSignals()) {
+        if (SGetSignal(SIGTTIN)) {
+            // Suppress command port, but only if we haven't already cleared it
+            if (!SCheckSignal(SIGTTOU)) {
+                suppressCommandPort("SIGTTIN", true, true);
+            }
+        } else if (SGetSignal(SIGTTOU)) {
+            // Clear command port suppression
+            suppressCommandPort("SIGTTOU", false, true);
+        } else {
+            // For any other signal, just shutdown.
+            _beginShutdown(SGetSignalDescription());
+        }
+    }
+
     auto startBaseClassPostPoll = chrono::steady_clock::now();
 
     // Let the base class do its thing. We lock around this because we allow worker threads to modify the sockets (by
@@ -1382,40 +1387,42 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
 
     auto startChooseSockets = chrono::steady_clock::now();
 
-    // Lock our socket set for the remainder of the function.
-    lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
+    // Lock our socket set while we iterate over it.
+    {
+        lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
 
-    // This works because all of our sockets in both fdm and socketSet are in sorted order by their FD.
-    // This runs in linear time across the size of socketSet plus the size of fdm.
-    // An alternative implementation could run in the size O(N*log(M)) where N is the size of fdm and M is the size of
-    // socketSet, if we could easily binary-search socketSet by FD. This is possible since that's the ordering, but
-    // it's a bit of a pain. It should be faster in the case than socketSet is larger than fdm, though.
-    auto fdmIt = fdm.begin();
-    auto socketSetIt = socketSet.begin();
-    while (true) {
-        // Are either of them past the end? If so, we're done.
-        if (fdmIt == fdm.end() || socketSetIt == socketSet.end()) {
-            break;
+        // This works because all of our sockets in both fdm and socketSet are in sorted order by their FD.
+        // This runs in linear time across the size of socketSet plus the size of fdm.
+        // An alternative implementation could run in the size O(N*log(M)) where N is the size of fdm and M is the size of
+        // socketSet, if we could easily binary-search socketSet by FD. This is possible since that's the ordering, but
+        // it's a bit of a pain. It should be faster in the case than socketSet is larger than fdm, though.
+        auto fdmIt = fdm.begin();
+        auto socketSetIt = socketSet.begin();
+        while (true) {
+            // Are either of them past the end? If so, we're done.
+            if (fdmIt == fdm.end() || socketSetIt == socketSet.end()) {
+                break;
+            }
+            // See if the two iterators have the same FD.
+            if (fdmIt->first == (*socketSetIt)->s) {
+                // They do! We want to keep this, and then move on with both of them.
+                sockets.insert(*socketSetIt);
+                fdmIt++;
+                socketSetIt++;
+            } else if (fdmIt->first < (*socketSetIt)->s) {
+                // So, if the iterator into FDM is less than the iterator into socket set, we can discard it, all the
+                // values in socketSet are larger than this.
+                fdmIt++;
+            } else if ((*socketSetIt)->s < fdmIt->first) {
+                // On the other hand, if the iterator into socketSet is lower than the one into FDM, then we can discard
+                // the one in socketSet, it's not part of our candidate set.
+                socketSetIt++;
+            }
         }
-        // See if the two iterators have the same FD.
-        if (fdmIt->first == (*socketSetIt)->s) {
-            // They do! We want to keep this, and then move on with both of them.
-            sockets.insert(*socketSetIt);
-            fdmIt++;
-            socketSetIt++;
-        } else if (fdmIt->first < (*socketSetIt)->s) {
-            // So, if the iterator into FDM is less than the iterator into socket set, we can discard it, all the
-            // values in socketSet are larger than this.
-            fdmIt++;
-        } else if ((*socketSetIt)->s < fdmIt->first) {
-            // On the other hand, if the iterator into socketSet is lower than the one into FDM, then we can discard
-            // the one in socketSet, it's not part of our candidate set.
-            socketSetIt++;
-        }
+
+        SINFO("Poll returned " << fdm.size() << " sockets to inspect and we accepted " << newSocketCount
+              << " new sockets. Total to inspect: " << sockets.size() << " of " << socketSet.size() << ".");
     }
-
-    SINFO("Poll returned " << fdm.size() << " sockets to inspect and we accepted " << newSocketCount
-          << " new sockets. Total to inspect: " << sockets.size() << " of " << socketSet.size() << ".");
 
     auto startPostProcess = chrono::steady_clock::now();
     for (auto s : sockets) {
@@ -1588,6 +1595,9 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
         if (!lastChance) {
             lastChance = STimeNow() + 5 * 1'000'000; // 5 seconds from now.
         }
+
+        // We need to lock to access socketSet.
+        lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
         // If we've run out of sockets or hit our timeout, we'll increment _shutdownState.
         if (socketSet.empty() || _gracefulShutdownTimeout.ringing()) {
             lastChance = 0;
@@ -1609,6 +1619,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
 
     // Compute timing info.
     auto end = chrono::steady_clock::now();
+    _postPollMisc += (startAccept - startMisc);
     _postPollBaseClass += (startAccept - startBaseClassPostPoll);
     _postPollAccept += (startChooseSockets - startAccept);
     _postPollChooseSockets += (startPostProcess - startChooseSockets);
@@ -1618,12 +1629,14 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     if (end > (_postPollStart + 10s)) {
         SINFO("[performance] postPoll timing: "
             << chrono::duration_cast<chrono::milliseconds>(end - _postPollStart).count() << " ms total elapsed. "
+            << chrono::duration_cast<chrono::milliseconds>(_postPollMisc).count() << " ms in misc. "
             << chrono::duration_cast<chrono::milliseconds>(_postPollBaseClass).count() << " ms in bases class. "
             << chrono::duration_cast<chrono::milliseconds>(_postPollAccept).count() << " ms in accept. "
             << chrono::duration_cast<chrono::milliseconds>(_postPollChooseSockets).count() << " ms choosing sockets. "
             << chrono::duration_cast<chrono::milliseconds>(_postPollPostProcess).count() << " ms post processing connections.");
 
         // Reset everything.
+        _postPollMisc = chrono::steady_clock::duration::zero();
         _postPollBaseClass = chrono::steady_clock::duration::zero();
         _postPollAccept = chrono::steady_clock::duration::zero();
         _postPollChooseSockets = chrono::steady_clock::duration::zero();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1619,7 +1619,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
 
     // Compute timing info.
     auto end = chrono::steady_clock::now();
-    _postPollMisc += (startAccept - startMisc);
+    _postPollMisc += (startBaseClassPostPoll - startMisc);
     _postPollBaseClass += (startAccept - startBaseClassPostPoll);
     _postPollAccept += (startChooseSockets - startAccept);
     _postPollChooseSockets += (startPostProcess - startChooseSockets);

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -463,6 +463,7 @@ class BedrockServer : public SQLiteServer {
     BedrockTimeoutCommandQueue _completedCommands;
 
     // Counters for timing postPoll and locating bottlenecks;
+    chrono::steady_clock::duration _postPollMisc;
     chrono::steady_clock::duration _postPollBaseClass;
     chrono::steady_clock::duration _postPollAccept;
     chrono::steady_clock::duration _postPollChooseSockets;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1908,6 +1908,11 @@ int S_poll(fd_map& fdm, uint64_t timeout) {
     // We're only going to return the entries that had activity, so clear out the whole structure.
     fdm.clear();
 
+    // If there were no sockets with activity, we can return early.
+    if (returnValue == 0) {
+        return 0;
+    }
+
     // And for anything that had a result, re-insert it.
     int count = 0;
     for (pollfd& pfd : pollvec) {


### PR DESCRIPTION
So, we moved a block of code out of `postPoll` into `sync`, because `postPoll` didn't really need to do this.

The block we moved dealt with opening/closing command ports, which is just sort of a miscelaneous task that needed to be done somewhere.

However, because it opens/closes the ports, it locks `portListMutex`.

Because `acceptSocket` (which is still called from inside `postPoll`) reads from these ports, it also locks `portListMutex`.

So it seems likely that moving this block caused the two threads that read from the network to compete with one another for this lock, thus causing the networking bottleneck for clients and peers to be joined into one single bottleneck instead of two smaller bottlenecks.

This undoes that change (and also returns early if `poll` finds no network activity).

Tests are running now.