### PR TITLE
Fix socket concurrency issue.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1356,6 +1356,7 @@ void BedrockServer::_network(BedrockServer& server) {
                 // TODO: Cancel any outstanding commands initiated by this socket. This isn't critical, and is an
                 // optimization. Otherwise, they'll continue to get processed to completion, and will just never be
                 // able to have their responses returned.
+                SINFO("TYLER, socket looks closed, erasing from _socketIDMap: " << socket->id);
                 lock_guard<decltype(server._socketIDMutex)> lock(server._socketIDMutex);
                 server._socketIDMap.erase(socket->id);
                 server.closeSocket(socket);
@@ -1758,10 +1759,12 @@ void BedrockServer::_reply(BedrockCommand& command) {
         }
 
         // We only keep track of sockets with pending commands.
+        SINFO("TYLER Replying to socket for " << socketIt->first << " and removing.");
         _socketIDMap.erase(socketIt);
     } else {
         if (!SIEquals(command.request["Connection"], "forget")) {
-            SINFO("No socket to reply for: '" << command.request.methodLine << "' #" << command.initiatingClientID);
+            SINFO("No socket to reply for: '" << command.request.methodLine << "' #" << command.initiatingClientID << ", socket: " << socketIt->first);
+            SINFO("TYLER:" << command.request.serialize());
         }
 
         // If the command was processed, tell the plugin we couldn't send the response.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1356,7 +1356,6 @@ void BedrockServer::_network(BedrockServer& server) {
                 // TODO: Cancel any outstanding commands initiated by this socket. This isn't critical, and is an
                 // optimization. Otherwise, they'll continue to get processed to completion, and will just never be
                 // able to have their responses returned.
-                SINFO("TYLER, socket looks closed, erasing from _socketIDMap: " << socket->id);
                 lock_guard<decltype(server._socketIDMutex)> lock(server._socketIDMutex);
                 server._socketIDMap.erase(socket->id);
                 server.closeSocket(socket);
@@ -1759,12 +1758,10 @@ void BedrockServer::_reply(BedrockCommand& command) {
         }
 
         // We only keep track of sockets with pending commands.
-        SINFO("TYLER Replying to socket for " << socketIt->first << " and removing.");
         _socketIDMap.erase(socketIt);
     } else {
         if (!SIEquals(command.request["Connection"], "forget")) {
-            SINFO("No socket to reply for: '" << command.request.methodLine << "' #" << command.initiatingClientID << ", socket: " << socketIt->first);
-            SINFO("TYLER:" << command.request.serialize());
+            SINFO("No socket to reply for: '" << command.request.methodLine << "' #" << command.initiatingClientID);
         }
 
         // If the command was processed, tell the plugin we couldn't send the response.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -231,7 +231,7 @@ class BedrockServer : public SQLiteServer {
     // Each time we read a command off a socket, we put the socket in this map, so that we can respond to it when the
     // command completes. We remove the socket from the map when we reply to the command, even if the socket is still
     // open. It will be re-inserted in this set when another command is read from it.
-    map <uint64_t, Socket*> _socketIDMap;
+    map <uint64_t, shared_ptr<Socket>> _socketIDMap;
 
     // The above _socketIDMap is modified by multiple threads, so we lock this mutex around operations that access it.
     // We don't need to lock around access to the base class's `socketSet` because we carefully control access to it
@@ -342,7 +342,7 @@ class BedrockServer : public SQLiteServer {
 
     // Accepts any sockets pending on our listening ports. We do this both after `poll()`, and before shutting down
     // those ports.
-    set<Socket*> _acceptSockets(bool deferRead = false);
+    set<shared_ptr<Socket>> _acceptSockets(bool deferRead = false);
 
     // This stars the server shutting down.
     void _beginShutdown(const string& reason, bool detach = false);
@@ -478,7 +478,7 @@ class BedrockServer : public SQLiteServer {
     thread _networkThread;
     condition_variable _networkCV;
     mutex _networkMutex;
-    set<Socket*> _networkThreadSocketActivitySet;
+    set<shared_ptr<Socket>> _networkThreadSocketActivitySet;
     atomic<bool> _networkThreadShouldExit;
     // This is a timestamp, after which we'll start giving up on any sockets that don't seem to be giving us any data.
     // The case for this is that once we start shutting down, we'll close any sockets when we respond to a command on

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -172,7 +172,7 @@ SHTTPSManager::Transaction* SHTTPSManager::_httpsSend(const string& url, const S
 
     // If this is going to be an https transaction, create a certificate and give it to the socket.
     SX509* x509 = SStartsWith(url, "https://") ? SX509Open(_pem, _srvCrt, _caCrt) : nullptr;
-    Socket* s = openSocket(host, x509);
+    shared_ptr<Socket> s = openSocket(host, x509);
     if (!s) {
         return _createErrorTransaction();
     }

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -8,7 +8,7 @@ class SHTTPSManager : public STCPManager {
         ~Transaction();
 
         // Attributes
-        STCPManager::Socket* s;
+        shared_ptr<STCPManager::Socket> s;
         uint64_t created;
         uint64_t finished;
         SData fullRequest;

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -35,7 +35,7 @@ struct STCPManager {
         recursive_mutex sendRecvMutex;
 
         // this is false for the lifetime of the socket, and set to true when we close the socket. This prevents other
-        // threads that still ahve shared pointers to this socket from performing operations on it.:w
+        // threads that still have shared pointers to this socket from performing operations on it.
         bool completed;
 
         // This is private because it's used by our synchronized send() functions. This requires it to only

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -5,6 +5,7 @@
 struct STCPManager {
     // Captures all the state for a single socket
     class Socket {
+        friend class STCPManager;
       public:
         enum State { CONNECTING, CONNECTED, SHUTTINGDOWN, CLOSED };
         Socket(int sock = 0, State state_ = CONNECTING, SX509* x509 = nullptr);
@@ -33,6 +34,10 @@ struct STCPManager {
         static atomic<uint64_t> socketCount;
         recursive_mutex sendRecvMutex;
 
+        // this is false for the lifetime of the socket, and set to true when we close the socket. This prevents other
+        // threads that still ahve shared pointers to this socket from performing operations on it.:w
+        bool completed;
+
         // This is private because it's used by our synchronized send() functions. This requires it to only
         // be accessed through the (also synchronized) wrapper functions above.
         // NOTE: Currently there's no synchronization around `recvBuffer`. It can only be accessed by one thread.
@@ -52,16 +57,16 @@ struct STCPManager {
     void postPoll(fd_map& fdm);
 
     // Opens outgoing socket
-    Socket* openSocket(const string& host, SX509* x509 = nullptr);
+    shared_ptr<Socket> openSocket(const string& host, SX509* x509 = nullptr);
 
     // Gracefully shuts down a socket
-    void shutdownSocket(Socket* socket, int how = SHUT_RDWR);
+    void shutdownSocket(shared_ptr<Socket> socket, int how = SHUT_RDWR);
 
     // Hard terminate a socket
-    void closeSocket(Socket* socket);
+    void closeSocket(shared_ptr<Socket> socket);
 
     struct SocketCompare {
-        bool operator() (const Socket* lhs, const Socket* rhs) const {
+        bool operator() (const shared_ptr<Socket> lhs, const shared_ptr<Socket> rhs) const {
             if (lhs == 0 || rhs == 0) {
                 SWARN("Invalid socket in comparison.");
                 return false;
@@ -71,6 +76,6 @@ struct STCPManager {
     };
 
     // Attributes
-    set<Socket*, SocketCompare> socketSet;
+    set<shared_ptr<Socket>, SocketCompare> socketSet;
     recursive_mutex socketSetMutex;
 };

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -9,7 +9,7 @@ STCPNode::STCPNode(const string& name_, const string& host, const uint64_t recvT
 
 STCPNode::~STCPNode() {
     // Clean up all the sockets and peers
-    for (Socket* socket : acceptedSocketList) {
+    for (shared_ptr<Socket> socket : acceptedSocketList) {
         closeSocket(socket);
     }
     acceptedSocketList.clear();
@@ -60,17 +60,17 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     STCPServer::postPoll(fdm);
 
     // Accept any new peers
-    Socket* socket = nullptr;
+    shared_ptr<Socket> socket = nullptr;
     while ((socket = acceptSocket()))
         acceptedSocketList.push_back(socket);
 
     // Process the incoming sockets
-    list<Socket*>::iterator nextSocketIt = acceptedSocketList.begin();
+    list<shared_ptr<Socket>>::iterator nextSocketIt = acceptedSocketList.begin();
     while (nextSocketIt != acceptedSocketList.end()) {
         // See if we've logged in (we know we're already connected because
         // we're accepting an inbound connection)
-        list<Socket*>::iterator socketIt = nextSocketIt++;
-        Socket* socket = *socketIt;
+        list<shared_ptr<Socket>>::iterator socketIt = nextSocketIt++;
+        shared_ptr<Socket> socket = *socketIt;
         try {
             // Verify it's still alive
             if (socket->state.load() != Socket::CONNECTED)

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -43,7 +43,7 @@ struct STCPNode : public STCPServer {
         void sendMessage(const SData& message);
 
       private:
-        Socket* s;
+        shared_ptr<Socket> s;
         recursive_mutex socketMutex;
     };
 
@@ -54,7 +54,7 @@ struct STCPNode : public STCPServer {
     string name;
     uint64_t recvTimeout;
     vector<Peer*> peerList;
-    list<Socket*> acceptedSocketList;
+    list<shared_ptr<Socket>> acceptedSocketList;
 
     // Called when we first establish a connection with a new peer
     virtual void _onConnect(Peer* peer) = 0;

--- a/libstuff/STCPServer.cpp
+++ b/libstuff/STCPServer.cpp
@@ -47,10 +47,10 @@ void STCPServer::closePorts(list<Port*> except) {
     }
 }
 
-STCPManager::Socket* STCPServer::acceptSocket(Port*& portOut, bool deferRead) {
+shared_ptr<STCPManager::Socket> STCPServer::acceptSocket(Port*& portOut, bool deferRead) {
     // Initialize to 0 in case we don't accept anything. Note that this *does* overwrite the passed-in pointer.
     portOut = 0;
-    Socket* socket = nullptr;
+    shared_ptr<Socket> socket = nullptr;
 
     // See if we can accept on any port
     lock_guard <decltype(portListMutex)> lock(portListMutex);
@@ -61,7 +61,7 @@ STCPManager::Socket* STCPServer::acceptSocket(Port*& portOut, bool deferRead) {
         if (s > 0) {
             // Received a socket, wrap
             SDEBUG("Accepting socket from '" << addr << "' on port '" << port.host << "'");
-            socket = new Socket(s, Socket::CONNECTED);
+            socket = make_shared<Socket>(s, Socket::CONNECTED);
             socket->addr = addr;
             lock_guard<decltype(socketSetMutex)> lock(socketSetMutex);
             socketSet.insert(socket);

--- a/libstuff/STCPServer.h
+++ b/libstuff/STCPServer.h
@@ -23,8 +23,8 @@ struct STCPServer : public STCPManager {
     void closePorts(list<Port*> except = {});
 
     // Tries to accept a new incoming socket
-    Socket* acceptSocket(Port*& port, bool deferRead = false);
-    Socket* acceptSocket() {
+    shared_ptr<Socket> acceptSocket(Port*& port, bool deferRead = false);
+    shared_ptr<Socket> acceptSocket() {
         Port* ignore;
         return acceptSocket(ignore);
     }

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -284,7 +284,7 @@ SHTTPSManager::Transaction* TestHTTPSMananager::httpsDontSend(const string& url,
 
     // If this is going to be an https transaction, create a certificate and give it to the socket.
     SX509* x509 = SStartsWith(url, "https://") ? SX509Open(_pem, _srvCrt, _caCrt) : nullptr;
-    Socket* s = openSocket(host, x509);
+    shared_ptr<Socket> s = openSocket(host, x509);
     if (!s) {
         return _createErrorTransaction();
     }


### PR DESCRIPTION
This was discovered by running the Concierge tests (which crashed).

The main fix was:
```
-        S_recvappend(socket->s, socket->recvBuffer);
+        socket->recv();
```

In `BedrockServer.cpp`. The problem was that the first call is not synchronized, and so can write to the recv buffer while some other thread is also using it.

The second call is synchronized, and will block if another thread is also making a read/write operation on that socket.

However, the bigger change is that this made me realize we now have multiple threads that can close a socket, which means they either needed to lock the whole `socketSet` object while they operated on any socket (so another thread couldn't close the socket while this happend), or we needed a better mechanism for this. So now instead of `Socket*` we use `shsred_ptr<Socket>` and the last instance of a socket will delete the underlying object when it's destroyed. The `Socket` class itself has been updated to return early if any of it's members are called on a socket that's already been closed by a different thread.

Running auth/concierge tests now.