### PR TITLE
Add log line for when we send an ESCALATE_RESPONSE

### DIFF
--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -260,7 +260,7 @@ bool STCPManager::Socket::send() {
     if (ssl) {
         result = SSSLSendConsume(ssl, sendBuffer);
     } else if (s > 0) {
-        result = S_sendconsume(s, sendBuffer);
+        result = S_sendconsume(s, sendBuffer, logString);
     }
     lastSendTime = STimeNow();
     return result;

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -24,6 +24,7 @@ struct STCPManager {
         bool send(const string& buffer);
         bool recv();
         uint64_t id;
+        string logString;
 
         bool sendBufferEmpty();
         string sendBufferCopy();

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1842,16 +1842,23 @@ bool S_recvappend(int s, string& recvBuffer) {
 }
 
 // --------------------------------------------------------------------------
-bool S_sendconsume(int s, string& sendBuffer) {
+bool S_sendconsume(int s, string& sendBuffer, string logString) {
     SASSERT(s);
     // If empty, nothing to do
     if (sendBuffer.empty())
         return true; // Assume no error, still alive
 
     // Send as much as we can
-    ssize_t numSent = send(s, sendBuffer.c_str(), (int)sendBuffer.size(), MSG_NOSIGNAL);
-    if (numSent > 0)
+    size_t numSent = send(s, sendBuffer.c_str(), (int)sendBuffer.size(), MSG_NOSIGNAL);
+
+    // FIXME: Remove once we have debugged the slow escalation responses to peers.
+    if (!logString.empty()) {
+        SINFO("Sent " << numSent << " bytes of " << (int)sendBuffer.size() << " for message " << logString);
+    }
+    
+    if (numSent > 0) {
         SConsumeFront(sendBuffer, numSent);
+    }
 
     // Exit of no error
     if (numSent >= 0) {

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -688,7 +688,7 @@ inline string S_recv(int s) {
     S_recvappend(s, buf);
     return buf;
 }
-bool S_sendconsume(int s, string& sendBuffer);
+bool S_sendconsume(int s, string& sendBuffer, string logString="");
 int S_poll(fd_map& fdm, uint64_t timeout);
 
 // Network helpers

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -100,6 +100,7 @@ void SQLiteNode::sendResponse(const SQLiteCommand& command)
     escalate["ID"] = command.id;
     escalate.content = command.response.serialize();
     SINFO("Sending ESCALATE_RESPONSE to " << peer->name << " for " << command.id << ".");
+    peer->s->logString = "ESCALATE_RESPONSE " + command.id;
     _sendToPeer(peer, escalate);
 }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -99,6 +99,7 @@ void SQLiteNode::sendResponse(const SQLiteCommand& command)
     SData escalate("ESCALATE_RESPONSE");
     escalate["ID"] = command.id;
     escalate.content = command.response.serialize();
+    SINFO("Sending ESCALATE_RESPONSE to " << peer->name << " for " << command.id << ".");
     _sendToPeer(peer, escalate);
 }
 


### PR DESCRIPTION
@flodnv or @tylerkaraszewski please review. Adds a log line for when we send an ESCALATE_RESPONSE so we can attempt to debug why responses are being delayed under heady load. 

## Tests
Ran the test suite, saw:
```
2019-01-18T08:18:37.148293+00:00 expensidev bedrock11111: M7ZrW8 (SQLiteNode.cpp:102) sendResponse [worker5] [info] {brcluster_node_0/MASTERING} Sending ESCALATE_RESPONSE to brcluster_node_1 for brcluster_node_1#203.
2019-01-18T18:34:53.035301+00:00 expensidev bedrock11111:  (libstuff.cpp:1856) S_sendconsume [sync] [info] Sent 335 bytes of 335 for message ESCALATE_RESPONSE brcluster_node_1#3
```