### PR TITLE
Add option to set TCP_NODELAY

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1854,6 +1854,7 @@ bool BedrockServer::_isControlCommand(BedrockCommand& command) {
         SIEquals(command.request.methodLine, "Attach")                 ||
         SIEquals(command.request.methodLine, "SetConflictParams")      ||
         SIEquals(command.request.methodLine, "SetCheckpointIntervals") ||
+        SIEquals(command.request.methodLine, "SetSocketOption")        ||
         SIEquals(command.request.methodLine, "EnableSQLTracing")
         ) {
         return true;
@@ -1907,6 +1908,13 @@ void BedrockServer::_control(BedrockCommand& command) {
                 _maxConflictRetries.store(retries);
             }
         }
+    } else if (SIEquals(command.request.methodLine, "SetSocketOption")) {
+        bool oldNoDelayVal = Socket::noDelay.load();
+        if (command.request.isSet("TCP_NODELAY")) {
+            SINFO("Setting Socket::noDelay to " << (command.request.test("TCP_NODELAY") ? "true" : "false"));
+            Socket::noDelay.store(command.request.test("TCP_NODELAY"));
+        }
+        response["OLD_TCP_NODELAY"] = oldNoDelayVal ? "true" : "false";
     } else if (SIEquals(command.request.methodLine, "EnableSQLTracing")) {
         response["oldValue"] = SQLite::enableTrace ? "true" : "false";
         if (command.request.isSet("enable")) {

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -29,6 +29,8 @@ struct STCPManager {
         string sendBufferCopy();
         void setSendBuffer(const string& buffer);
 
+        static atomic<bool> noDelay;
+
       private:
         static atomic<uint64_t> socketCount;
         recursive_mutex sendRecvMutex;

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 ///
 #include <libstuff/libstuff.h>
 #include <libstuff/version.h>
+#include "libstuff/STCPManager.h"
 #include "BedrockServer.h"
 #include "BedrockPlugin.h"
 #include "plugins/Cache.h"
@@ -290,6 +291,10 @@ int main(int argc, char* argv[]) {
         // Otherwise verify the database exists
         SDEBUG("Verifying database exists");
         SASSERT(SFileExists(args["-db"]));
+    }
+    if (args.isSet("-noDelay")) {
+        SINFO("Starting up with  STCPManager::Socket::noDelay = true");
+        STCPManager::Socket::noDelay.store(true);
     }
 
     // Log stack traces if we have unhandled exceptions.


### PR DESCRIPTION
This is here in case we insist on merging it. I don't really want to merge it, because I want to have less of a grasping at straws/shotgun approach to this problem. We've never set TCP_NODELAY before and never seen the performance issues we're having now, so I don't see why this should fix it.

Nevertheless, it's here if we insist on trying it.

Existing tests pass, even if I change the default value of `noDelay` to `true`.