### PR TITLE
Add peer network throughput stats

### DIFF
--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -30,6 +30,10 @@ struct STCPManager {
         string sendBufferCopy();
         void setSendBuffer(const string& buffer);
 
+        void resetCounters();
+        uint64_t getRecvBytes();
+        uint64_t getSentBytes();
+
       private:
         static atomic<uint64_t> socketCount;
         recursive_mutex sendRecvMutex;
@@ -43,6 +47,9 @@ struct STCPManager {
         // the underlying ssl code. Once assigned, the socket owns this object for it's lifetime and will delete it
         // upon destruction.
         SX509* _x509;
+
+        uint64_t sentBytes;
+        uint64_t recvBytes;
     };
 
     // Cleans up outstanding sockets

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -323,6 +323,7 @@ bool SQLiteNode::update() {
         for (auto& p : peerList) {
             if (p->s) {
                 logMsg += p->name + " sent " + to_string(p->s->getSentBytes()) + " bytes, recv " + to_string(p->s->getRecvBytes()) + " bytes. ";
+                p->s->resetCounters();
             } else {
                 logMsg += p->name + " has no socket. ";
             }

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -206,4 +206,7 @@ class SQLiteNode : public STCPNode {
     // (i.e., approving standup) to verify that the messages we're receiving are relevant to the current state change,
     // and not stale reponses to old changes.
     int _stateChangeCount;
+
+    // Last time we recorded network stats.
+    chrono::steady_clock::time_point _lastNetStatTime;
 };


### PR DESCRIPTION
cc @quinthar 

This adds basic network stats for peers. It just logs the total bytes sent and received for each peer every 10 seconds. The logs look like many of our other performance logs. The intention is to measure how much data we're actually shipping back and forth between peers.

Example logs:

```
2019-01-19T04:34:58.026601+00:00 expensidev bedrock11114: xxxxxx (SQLiteNode.cpp:331) update [sync] [info] {brcluster_node_1/MASTERING} [performance] Network stats: 10024 ms elapsed. brcluster_node_0 has no socket. brcluster_node_2 sent 93810 bytes, recv 34720 bytes.
2019-01-19T04:35:08.031087+00:00 expensidev bedrock11114: xxxxxx (SQLiteNode.cpp:331) update [sync] [info] {brcluster_node_1/SLAVING} [performance] Network stats: 10004 ms elapsed. brcluster_node_0 sent 159859 bytes, recv 216562 bytes. brcluster_node_2 sent 113575 bytes, recv 22376 bytes.
2019-01-19T04:35:18.123160+00:00 expensidev bedrock11114: xxxxxx (SQLiteNode.cpp:331) update [sync] [info] {brcluster_node_1/SLAVING} [performance] Network stats: 10092 ms elapsed. brcluster_node_0 sent 74964 bytes, recv 309268 bytes. brcluster_node_2 sent 0 bytes, recv 0 bytes.
2019-01-19T04:35:28.587611+00:00 expensidev bedrock11114: xxxxxx (SQLiteNode.cpp:331) update [sync] [info] {brcluster_node_1/SLAVING} [performance] Network stats: 10463 ms elapsed. brcluster_node_0 sent 6326 bytes, recv 276528 bytes. brcluster_node_2 sent 26356 bytes, recv 1030 bytes.
2019-01-19T04:35:38.599905+00:00 expensidev bedrock11114: xxxxxx (SQLiteNode.cpp:331) update [sync] [info] {brcluster_node_1/MASTERING} [performance] Network stats: 10013 ms elapsed. brcluster_node_0 has no socket. brcluster_node_2 sent 45962 bytes, recv 22880 bytes.
2019-01-19T04:35:48.615765+00:00 expensidev bedrock11114: xxxxxx (SQLiteNode.cpp:331) update [sync] [info] {brcluster_node_1/MASTERING} [performance] Network stats: 10015 ms elapsed. brcluster_node_0 has no socket. brcluster_node_2 sent 50811 bytes, recv 1231 bytes.
2019-01-19T04:35:58.617322+00:00 expensidev bedrock11114: xxxxxx (SQLiteNode.cpp:331) update [sync] [info] {brcluster_node_1/MASTERING} [performance] Network stats: 10001 ms elapsed. brcluster_node_0 has no socket. brcluster_node_2 sent 276108 bytes, recv 0 bytes.
```

Not sure when the best time to merge this is, I don't know if we want to stick it in with the Saturday deploy for SMS or not.