### PR TITLE
Check peer socket exists before adding logging param

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -100,7 +100,9 @@ void SQLiteNode::sendResponse(const SQLiteCommand& command)
     escalate["ID"] = command.id;
     escalate.content = command.response.serialize();
     SINFO("Sending ESCALATE_RESPONSE to " << peer->name << " for " << command.id << ".");
-    peer->s->logString = "ESCALATE_RESPONSE " + command.id;
+    if (peer->s) {
+        peer->s->logString = "ESCALATE_RESPONSE " + command.id;
+    }
     _sendToPeer(peer, escalate);
 }
 


### PR DESCRIPTION
@tylerkaraszewski this is the worst logging change ever 🤕 . We need to check the socket exists here or else we can try to add a logString to a socket that doesn't exist, creating a crash like this:
```
2019-01-19T05:46:25.141996+00:00 db1.sjc bedrock: Erok3z (SQLiteNode.cpp:102) sendResponse [worker184] [info] {auth.db1.sjc/MASTERING} Sending ESCALATE_RESPONSE to auth.db2.rno for auth.db2.rno#395286.
2019-01-19T05:46:25.147121+00:00 db1.sjc bedr: Erok3z (SSignal.cpp:164) _SSignal_StackTrace [worker184] [warn] Signal Aborted(6) caused crash, logging stack trace.
```