### PR TITLE
Revert ESCALATE_RESPONSE logging

### DIFF
--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -260,7 +260,7 @@ bool STCPManager::Socket::send() {
     if (ssl) {
         result = SSSLSendConsume(ssl, sendBuffer);
     } else if (s > 0) {
-        result = S_sendconsume(s, sendBuffer, logString);
+        result = S_sendconsume(s, sendBuffer);
     }
     lastSendTime = STimeNow();
     return result;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1842,7 +1842,7 @@ bool S_recvappend(int s, string& recvBuffer) {
 }
 
 // --------------------------------------------------------------------------
-bool S_sendconsume(int s, string& sendBuffer, string logString) {
+bool S_sendconsume(int s, string& sendBuffer) {
     SASSERT(s);
     // If empty, nothing to do
     if (sendBuffer.empty())
@@ -1850,11 +1850,6 @@ bool S_sendconsume(int s, string& sendBuffer, string logString) {
 
     // Send as much as we can
     ssize_t numSent = send(s, sendBuffer.c_str(), (int)sendBuffer.size(), MSG_NOSIGNAL);
-
-    // FIXME: Remove once we have debugged the slow escalation responses to peers.
-    if (!logString.empty()) {
-        SINFO("Sent " << numSent << " bytes of " << (int)sendBuffer.size() << " for message " << logString);
-    }
 
     if (numSent > 0) {
         SConsumeFront(sendBuffer, numSent);

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -692,7 +692,7 @@ inline string S_recv(int s) {
     S_recvappend(s, buf);
     return buf;
 }
-bool S_sendconsume(int s, string& sendBuffer, string logString="");
+bool S_sendconsume(int s, string& sendBuffer);
 int S_poll(fd_map& fdm, uint64_t timeout);
 
 // Network helpers

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -99,10 +99,6 @@ void SQLiteNode::sendResponse(const SQLiteCommand& command)
     SData escalate("ESCALATE_RESPONSE");
     escalate["ID"] = command.id;
     escalate.content = command.response.serialize();
-    SINFO("Sending ESCALATE_RESPONSE to " << peer->name << " for " << command.id << ".");
-    if (peer->s) {
-        peer->s->logString = "ESCALATE_RESPONSE " + command.id;
-    }
     _sendToPeer(peer, escalate);
 }
 


### PR DESCRIPTION
@righdforsa Please review, reverts this logging change that has a concurrency bug in it so we can deploy a stable version. 