### PR TITLE
Exit early if blocking check point thread has no work to do

### DIFF
--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -271,7 +271,7 @@ class SQLite {
         set<SQLite*> validObjects;
 
         // This is the count of current pages waiting to be check pointed. This potentially changes with every wal callback
-        // we need to store it across callbacks so we can check if the full check point thread still needs to run.  
+        // we need to store it across callbacks so we can check if the full check point thread still needs to run.
         atomic<int> _currentPageCount;
     };
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -186,7 +186,7 @@ class SQLite {
 
     // Enable/disable SQL statement tracing.
     static atomic<bool> enableTrace;
-    
+
   private:
 
     // This structure contains all of the data that's shared between a set of SQLite objects that share the same
@@ -269,6 +269,10 @@ class SQLite {
         // This contains a list of all the valid objects for this data. This lets the checkpoint thread bail out early
         // if the SQLite object that initiated it has been deleted since it started.
         set<SQLite*> validObjects;
+
+        // This is the count of current pages waiting to be check pointed. This potentially changes with every wal callback
+        // we need to store it across callbacks so we can check if the full check point thread still needs to run.  
+        atomic<int> _currentPageCount;
     };
 
     // We have designed this so that multiple threads can write to multiple journals simultaneously, but we want
@@ -283,7 +287,7 @@ class SQLite {
 
     // This map is how a new SQLite object can look up the existing state for the other SQLite objects sharing the same
     // database file. It's a map of canonicalized filename to a sharedData object.
-    static map<string, SharedData*> _sharedDataLookupMap; 
+    static map<string, SharedData*> _sharedDataLookupMap;
 
     // Pointer to our SharedData object. Having a pointer directly to the object avoids having to lock the lookup map
     // to access this memory.


### PR DESCRIPTION
@tylerkaraszewski please review, there seems to be an odd condition we're hitting in production where we start the blocking check pointer and begin waiting for several hundred transactions to finish, then while we're waiting we block all worker threads as they finish, but at the same we we also run a passive check point on a worker which check points all of the pages the blocking check pointer was going to check point. This causes us to block worker threads for no reason, we could just exit when the page count to be checkpointed drops below the amount that we have set for full check points. 

Held on figuring out how test, the test suite isn't letting me replicate this issue.