### PR TITLE
Fix memory-mapped I/O support

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -120,6 +120,10 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints
     // WAL is what allows simultaneous read/writing.
     SASSERT(!SQuery(_db, "enabling write ahead logging", "PRAGMA journal_mode = WAL;"));
 
+    if (mmapSizeGB) {
+        SASSERT(!SQuery(_db, "enabling memory-mapped I/O", "PRAGMA mmap_size=" + to_string(mmapSizeGB * 1024 * 1024 * 1024) + ";"));
+    }
+
     // PRAGMA legacy_file_format=OFF sets the default for creating new databases, so it must be called before creating
     // any tables to be effective.
     SASSERT(!SQuery(_db, "new file format for DESC indexes", "PRAGMA legacy_file_format = OFF"));

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -80,7 +80,7 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints
         if (mmapSizeGB) {
             SINFO("Enabling Memory-Mapped I/O with " << mmapSizeGB << " GB.");
             const int64_t GB = 1024 * 1024 * 1024;
-            sqlite3_config(SQLITE_CONFIG_MMAP_SIZE, _sqliteLogCallback, mmapSizeGB * GB, 16 * 1024 * GB); // Max is 16TB
+            sqlite3_config(SQLITE_CONFIG_MMAP_SIZE, mmapSizeGB * GB, 16 * 1024 * GB); // Max is 16TB
         }
 
         // Disable a mutex around `malloc`, which is *EXTREMELY IMPORTANT* for multi-threaded performance. Without this

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -78,6 +78,7 @@ BedrockTester::BedrockTester(int threadID, const map<string, string>& args, cons
         {"-priority",         "200"},
         {"-plugins",          "db"},
         {"-workerThreads",    "8"},
+        {"-mmapSizeGB",       "1"},
         {"-maxJournalSize",   "25000"},
         {"-v",                ""},
         {"-quorumCheckpoint", "50"},


### PR DESCRIPTION
This sqlite_config parameter does not have a callback. Also, even if the maximums are set, it needs to be turned on.

To use this in production, we also need to turn on the command-line parameter for it.

Tests:
Enabled mmap for tests, still pass.