### PR TITLE
Add ESCALATE_RESPONSE logging and send() timings

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1849,7 +1849,7 @@ bool S_sendconsume(int s, string& sendBuffer) {
         return true; // Assume no error, still alive
     }
 
-    if (SContains(sendBuffer, "ESCALATE_RESPONSE")) {
+    if (SStartsWith(sendBuffer, "ESCALATE_RESPONSE")) {
         SData tempData;
         tempData.deserialize(sendBuffer);
         string id = tempData["id"];

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1845,11 +1845,24 @@ bool S_recvappend(int s, string& recvBuffer) {
 bool S_sendconsume(int s, string& sendBuffer) {
     SASSERT(s);
     // If empty, nothing to do
-    if (sendBuffer.empty())
+    if (sendBuffer.empty()) {
         return true; // Assume no error, still alive
+    }
+
+    if (SContains(sendBuffer, "ESCALATE_RESPONSE")) {
+        SData tempData;
+        tempData.deserialize(sendBuffer);
+        string id = tempData["id"];
+        SINFO("Sending an ESCALATE_RESPONSE for id " << id);
+    }
+
+    // Timer for tracking how long the call to send is taking to debug slow ESCALATE_RESPONSEs
+    chrono::steady_clock::time_point start = chrono::steady_clock::now();
 
     // Send as much as we can
     ssize_t numSent = send(s, sendBuffer.c_str(), (int)sendBuffer.size(), MSG_NOSIGNAL);
+    SINFO("Send() took " << chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - start).count()
+        << " ms and sent " << numSent << " of " << (int)sendBuffer.size() << " bytes.");
 
     if (numSent > 0) {
         SConsumeFront(sendBuffer, numSent);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -100,6 +100,7 @@ void SQLiteNode::sendResponse(const SQLiteCommand& command)
     SData escalate("ESCALATE_RESPONSE");
     escalate["ID"] = command.id;
     escalate.content = command.response.serialize();
+    SINFO("Sending ESCALATE_RESPONSE to " << peer->name << " for " << command.id << ".");
     _sendToPeer(peer, escalate);
 }
 


### PR DESCRIPTION
@tylerkaraszewski Please review. This should be a drastically safer version of the previous logging, as it doesn't depend on passing the logging data as part of the socket. 

## Tests
Ran conflict spam test, saw these in the logs:
```
2019-01-28T20:02:50.140570+00:00 expensidev bedrock11111: X2sirH (SQLiteNode.cpp:103) sendResponse [worker7] [info] {brcluster_node_0/MASTERING} Sending ESCALATE_RESPONSE to brcluster_node_1 for brcluster_node_1#4.
2019-01-28T20:02:50.140730+00:00 expensidev bedrock11111: X2sirH (libstuff.cpp:1856) S_sendconsume [worker7] [info] Sending an ESCALATE_RESPONSE for id brcluster_node_1#4
2019-01-28T20:03:14.866898+00:00 expensidev bedrock11111: EAGAsw (libstuff.cpp:1865) S_sendconsume [worker1] [info] Send() took 0 ms and sent 254 of 254 bytes.
```