### PR TITLE
move Bedrock Travis build to 16.04 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ notifications:
         on_success: never
 before_install:
 script: ./travis.sh
-
+dist: xenial


### PR DESCRIPTION
since all bedrock servers on 16.04 now the Travis builds should be too. 


@coleaeason 

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/97799

# Tests
https://travis-ci.org/Expensify/Bedrock/builds/486044399


# Query Timings/Plans
- N/A