### PR TITLE
Have any job that finishes with delete:true in their data object delete itself

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -963,6 +963,12 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 STHROW("500 Mock Mismatch");
             }
 
+            // If the Job data indicates that this job should be deleted, clear the repeat value so that we delete this job further down.
+            if (SContains(newData, "delete") && newData["delete"] == "true") {
+                SINFO("Job was marked for deletion in the data object, clearing repeat value.");
+                repeat = "";
+            }
+
             // Update the data to the new value.
             if (!db.writeIdempotent("UPDATE jobs SET data=" + SQ(data) + " WHERE jobID=" + SQ(jobID) + ";")) {
                 STHROW("502 Failed to update job data");


### PR DESCRIPTION
@tylerkaraszewski @iwiznia please review

Coming from https://github.com/Expensify/Web-Expensify/pull/23921#discussion_r253056529, we want the ability for a recurring job that has `"delete": true` in its data object to be able to delete itself.

Tests:
- I did the test steps in https://github.com/Expensify/Web-Expensify/pull/23921#issue-249411586, and made sure the same results happened with this change as opposed to the `UPDATE` query being in that PR.