### PR TITLE
Fix SStartsWith and log errors.

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -206,6 +206,15 @@ bool SIContains(const string& lhs, const string& rhs) {
     return SContains(SToLower(lhs), SToLower(rhs));
 }
 
+bool SStartsWith(const string& haystack, const string& needle)
+{
+    if (needle.size() > haystack.size()) {
+        return false;
+    }
+
+    return strncmp(haystack.c_str(), needle.c_str(), needle.size()) == 0;
+}
+
 // --------------------------------------------------------------------------
 string STrim(const string& lhs) {
     // Just trim off the front and back whitespace
@@ -1861,8 +1870,12 @@ bool S_sendconsume(int s, string& sendBuffer) {
 
     // Send as much as we can
     ssize_t numSent = send(s, sendBuffer.c_str(), (int)sendBuffer.size(), MSG_NOSIGNAL);
+    string errorMessage;
+    if (numSent == -1) {
+        errorMessage = " Error: "s + strerror(errno);
+    }
     SINFO("Send() took " << chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - start).count()
-        << " ms and sent " << numSent << " of " << (int)sendBuffer.size() << " bytes.");
+        << " ms and sent " << numSent << " of " << (int)sendBuffer.size() << " bytes." << errorMessage);
 
     if (numSent > 0) {
         SConsumeFront(sendBuffer, numSent);

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -476,7 +476,7 @@ inline bool SContains(const STable& nameValueMap, const string& name) {
 // General testing functions
 inline bool SIEquals(const string& lhs, const string& rhs) { return !strcasecmp(lhs.c_str(), rhs.c_str()); }
 bool SIContains(const string& haystack, const string& needle);
-inline bool SStartsWith(const string& haystack, const string& needle) { return haystack.find(needle) == 0; }
+bool SStartsWith(const string& haystack, const string& needle);
 inline bool SEndsWith(const string& haystack, const string& needle) {
     if (needle.size() > haystack.size())
         return false;


### PR DESCRIPTION
@coleaeason 

cc @flodnv 

Fixes master portion of: https://github.com/Expensify/Expensify/issues/97936

Doesn't fix the fact that slaves get slow.

When we do this check: https://github.com/Expensify/Bedrock/blob/14faa0432c09a39864f06acfdd97f795b48997f4/libstuff/libstuff.cpp#L1852

We want to fail the match quickly, as `sendBuffer` can potentially be huge. Unfortunately, the existing implementation of `SStartsWith` didn't do this.

Additionally, we add better logging for errors sending, when we encounter them.

Tests: existing Bedrock/Auth tests.