### PR TITLE
Set defauly busy timeout to zero

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -114,9 +114,6 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints
     const int DB_WRITE_OPEN_FLAGS = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX;
     SASSERT(!sqlite3_open_v2(filename.c_str(), &_db, DB_WRITE_OPEN_FLAGS, NULL));
 
-    // Set a one-second timeout for automatic retries in case of SQLITE_BUSY.
-    sqlite3_busy_timeout(_db, 1000);
-
     // WAL is what allows simultaneous read/writing.
     SASSERT(!SQuery(_db, "enabling write ahead logging", "PRAGMA journal_mode = WAL;"));
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -38,8 +38,7 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints
     _queryCount(0),
     _cacheHits(0),
     _useCache(false),
-    _isDeterministicQuery(false),
-    _checkpointThreadBusy(0)
+    _isDeterministicQuery(false)
 {
     // Perform sanity checks.
     SASSERT(!filename.empty());
@@ -264,7 +263,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
         // This thread will run independently. We capture the variables we need here and pass them by value.
         string filename = object->_filename;
         string dbNameCopy = dbName;
-        int alreadyCheckpointing = object->_checkpointThreadBusy.fetch_add(1);
+        int alreadyCheckpointing = object->_sharedData->_checkpointThreadBusy.fetch_add(1);
         if (alreadyCheckpointing) {
             SINFO("[checkpoint] Not starting checkpoint thread. It's already running.");
             return SQLITE_OK;
@@ -336,7 +335,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
             }
 
             // Allow the next checkpointer.
-            object->_checkpointThreadBusy.store(0);
+            object->_sharedData->_checkpointThreadBusy.store(0);
         }).detach();
     }
     return SQLITE_OK;
@@ -1070,5 +1069,6 @@ bool SQLite::getUpdateNoopMode() const {
 
 SQLite::SharedData::SharedData() :
 currentTransactionCount(0),
-_currentPageCount(0)
+_currentPageCount(0),
+_checkpointThreadBusy(0)
 { }

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -278,6 +278,9 @@ class SQLite {
         // This is the count of current pages waiting to be check pointed. This potentially changes with every wal callback
         // we need to store it across callbacks so we can check if the full check point thread still needs to run.
         atomic<int> _currentPageCount;
+
+        // Used as a flag to prevent starting multiple checkpoint threads simultaneously.
+        atomic<int> _checkpointThreadBusy;
     };
 
     // We have designed this so that multiple threads can write to multiple journals simultaneously, but we want
@@ -422,7 +425,4 @@ class SQLite {
 
     // Will be set to false while running a non-deterministic query to prevent it's result being cached.
     bool _isDeterministicQuery;
-
-    // Used as a flag to prevent starting multiple checkpoint threads simultaneously.
-    atomic<int> _checkpointThreadBusy;
 };


### PR DESCRIPTION
@coleaeason 

We've been running with a default busy timeout of 1 second for forever. This mostly works fine, because we rarely ever encounter a `busy` case, anyway. However, one important place we do encounter this is when using readdb. Starting a checkpoint in bedrock will encounter this when the `sqlite3` binary also looking at the DB.

This happens every time we try to commit a transaction, so each transaction waits for 1 second for the checkpoint to fail, meaning throughput of replication is limited to 1 transaction per second in this case.

Removing this default wait allows the checkpoint to fail immediately, which removes the 1/sec transaction limit (still, no checkpoints can complete until readdb completes).

We still have a retry loop in `SQuery` here: https://github.com/Expensify/Bedrock/blob/ada1874798de0f399b60cc70b7977e2b1d227900/libstuff/libstuff.cpp#L2381-L2398 which will retry after a second in the relatively rare case we ever receive `SQLITE_BUSY` as a result.

This also adds one other fix, where `_checkpointThreadBusy` was set in the wrong location (per SQLite object instead of per database), effectively making it useless.

Tests:
Existing tests pass, additionally verifying that `SQLITE_BUSY` never appears in the logs for `clustertest` (which will be logged in the part of `SQuery` linked above if it occurs).