### PR TITLE
Update verifyIndex to ignore spaces around parentheses

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -484,19 +484,20 @@ bool SQLite::verifyIndex(const string& indexName, const string& tableName, const
     SQResult result;
     SASSERT(read("SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name=" + SQ(tableName) + " AND name=" + SQ(indexName) + ";", result));
 
-    string createSQL = "CREATE" + string(isUnique ? " UNIQUE " : " ") + "INDEX " + indexName + " ON " + tableName + " " + indexSQLDefinition;
     if (result.empty()) {
         if (!createIfNotExists) {
             SINFO("Index '" << indexName << "' does not exist on table '" << tableName << "'.");
             return false;
         }
+        string createSQL = "CREATE" + string(isUnique ? " UNIQUE " : " ") + "INDEX " + indexName + " ON " + tableName + " " + indexSQLDefinition + ";";
         SINFO("Creating index '" << indexName << "' on table '" << tableName << "': " << indexSQLDefinition << ". Executing '" << createSQL << "'.");
-        SASSERT(write(createSQL + ";"));
+        SASSERT(write(createSQL));
         return true;
     } else {
-        // Index exists, verify it is correct.
+        // Index exists, verify it is correct. This is almost the same as the createSQL, except there is no ';', we ignore multi-spaces and ignore 'style' around '( ' and ' )'.
         SASSERT(!result[0].empty());
-        return SIEquals(SCollapse(createSQL), SCollapse(result[0][0]));
+        string expectedSQL = SReplace(SReplace(SCollapse("CREATE" + string(isUnique ? " UNIQUE " : " ") + "INDEX " + indexName + " ON " + tableName + " " + indexSQLDefinition), "( ", "("), " )", ")");
+        return SIEquals(expectedSQL, SReplace(SReplace(SCollapse(result[0][0]), "( ", "("), " )", ")"));
     }
 }
 


### PR DESCRIPTION
@tylerkaraszewski / @iwiznia 
cc @coleaeason 

See https://github.com/Expensify/Expensify/issues/90503#issuecomment-468093878

# Tests
1. Drop and recreate the problematic index like it is on prod (missing space)
2. Pass `true` here : https://github.com/Expensify/Server-Expensify/blob/3a05ca3b3f7ae6ea1a5b5a76fd8ef26470f8a16c/auth/lib/DB.cpp#L380
3. Start bedrock, it doesn't crash (it does before this change)