### PR TITLE
Exclude RUNQUEUED from fail job prevention list

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1139,9 +1139,9 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         }
         const string& state = result[0][0];
 
-        // Make sure we're failing a job that's actually running
-        if (state != "RUNNING") {
-            SINFO("Trying to fail job#" << request["jobID"] << ", but isn't RUNNING (" << state << ")");
+        // Make sure we're failing a job that's actually running or running with a retryAfter
+        if (state != "RUNNING" && state != "RUNQUEUED") {
+            SINFO("Trying to fail job#" << request["jobID"] << ", but isn't RUNNING or RUNQUEUED (" << state << ")");
             STHROW("405 Can only fail RUNNING jobs");
         }
 

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1142,7 +1142,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         // Make sure we're failing a job that's actually running or running with a retryAfter
         if (state != "RUNNING" && state != "RUNQUEUED") {
             SINFO("Trying to fail job#" << request["jobID"] << ", but isn't RUNNING or RUNQUEUED (" << state << ")");
-            STHROW("405 Can only fail RUNNING jobs");
+            STHROW("405 Can only fail RUNNING or RUNQUEUED jobs");
         }
 
         // Are we updating the data too?

--- a/test/tests/jobs/FailJobTest.cpp
+++ b/test/tests/jobs/FailJobTest.cpp
@@ -47,6 +47,7 @@ struct FailJobTest : tpunit::TestFixture {
         tester->executeWaitVerifyContent(command, "405 Can only fail RUNNING or RUNQUEUED jobs");
     }
 
+    // Fail job in RUNNING state
     void failJobInRunningState() {
         // Create a job
         SData command("CreateJob");
@@ -72,6 +73,7 @@ struct FailJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(result[0][0], "FAILED");
     }
 
+    // Fail job in RUNQUEUED state
     void failJobInRunqueuedState() {
         // Create a job
         SData command("CreateJob");

--- a/test/tests/jobs/FailJobTest.cpp
+++ b/test/tests/jobs/FailJobTest.cpp
@@ -1,0 +1,104 @@
+#include <test/lib/BedrockTester.h>
+#include <test/tests/jobs/JobTestHelper.h>
+
+struct FailJobTest : tpunit::TestFixture {
+    FailJobTest()
+        : tpunit::TestFixture("FailJob",
+                              BEFORE_CLASS(FailJobTest::setupClass),
+                              TEST(FailJobTest::nonExistentJob),
+                              TEST(FailJobTest::notInRunningRunqueuedState),
+                              TEST(FailJobTest::failJobInRunningState),
+                              TEST(FailJobTest::failJobInRunqueuedState),
+                              AFTER(FailJobTest::tearDown),
+                              AFTER_CLASS(FailJobTest::tearDownClass)) { }
+
+    BedrockTester* tester;
+
+    void setupClass() { tester = new BedrockTester(_threadID, {{"-plugins", "Jobs,DB"}}, {});}
+
+    // Reset the jobs table
+    void tearDown() {
+        SData command("Query");
+        command["query"] = "DELETE FROM jobs WHERE jobID > 0;";
+        tester->executeWaitVerifyContent(command);
+    }
+
+    void tearDownClass() { delete tester; }
+
+    // Throw an error if the job doesn't exist
+    void nonExistentJob() {
+        SData command("FailJob");
+        command["jobID"] = "1";
+        tester->executeWaitVerifyContent(command, "404 No job with this jobID");
+    }
+
+    // Throw an error if the job is not in RUNNING or REQUEUED state
+    void notInRunningRunqueuedState() {
+        // Create a job
+        SData command("CreateJob");
+        command["name"] = "job";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Finish it
+        command.clear();
+        command.methodLine = "FailJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command, "405 Can only fail RUNNING or RUNQUEUED jobs");
+    }
+
+    void failJobInRunningState() {
+        // Create a job
+        SData command("CreateJob");
+        command["name"] = "job";
+        command["retryAfter"] = "+1 MINUTES";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        command.clear();
+        command.methodLine = "Query";
+        command["query"] = "UPDATE jobs SET state = 'RUNNING' WHERE jobID = " + jobID + ";";
+        tester->executeWaitVerifyContent(command);
+
+        // Fail it
+        command.clear();
+        command.methodLine = "FailJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // Fail the job should remove it from the table
+        SQResult result;
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + jobID + ";",  result);
+        ASSERT_EQUAL(result[0][0], "FAILED");
+    }
+
+    void failJobInRunqueuedState() {
+        // Create a job
+        SData command("CreateJob");
+        command["name"] = "job";
+        command["retryAfter"] = "+1 SECOND";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm the job is in RUNQUEUED
+        SQResult result;
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + jobID + ";",  result);
+        ASSERT_EQUAL(result[0][0], "RUNQUEUED");
+
+        // Fail it
+        command.clear();
+        command.methodLine = "FailJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // Fail the job should remove it from the table
+        tester->readDB("SELECT state FROM jobs WHERE jobID = " + jobID + ";",  result);
+        ASSERT_EQUAL(result[0][0], "FAILED");
+    }
+} __FailJobTest;

--- a/test/tests/jobs/FailJobTest.cpp
+++ b/test/tests/jobs/FailJobTest.cpp
@@ -66,7 +66,7 @@ struct FailJobTest : tpunit::TestFixture {
         command["jobID"] = jobID;
         tester->executeWaitVerifyContent(command);
 
-        // Fail the job should remove it from the table
+        // Failing the job should succeed and set it as FAILED
         SQResult result;
         tester->readDB("SELECT state FROM jobs WHERE jobID = " + jobID + ";",  result);
         ASSERT_EQUAL(result[0][0], "FAILED");
@@ -97,7 +97,7 @@ struct FailJobTest : tpunit::TestFixture {
         command["jobID"] = jobID;
         tester->executeWaitVerifyContent(command);
 
-        // Fail the job should remove it from the table
+        // Failing the job should succeed and set it as FAILED
         tester->readDB("SELECT state FROM jobs WHERE jobID = " + jobID + ";",  result);
         ASSERT_EQUAL(result[0][0], "FAILED");
     }


### PR DESCRIPTION
@tylerkaraszewski @flodnv @iwiznia 
cc @pecanoro @chiragsalian 

Right now, any job that is created with a `retryAfter` set, will never be set to `RUNNING`, it will always be `RUNQUEUED`. However, the problem with this is that we only fail jobs that are in the Running state. 

This means, if a job that throws an error and we try to run `FailJob` on it, it will fail to do so. It will not set the state to `FAILED` and it will remain as `RUNQUEUED`, which means that if job is failing for a good reason, we will continue to pick it up and run it forever. 

So I'm arguing that we include `RUNQUEUED` along with `RUNNING` as state where we allow it to fail.

### Fixed Issue:
$ https://github.com/Expensify/Expensify/issues/100261

# Tests
- Pick any job, and make sure it fails. 
    e.g. I picked the job in a PR i'm working on. I manually break it by passing in a messageID (for intercom) that doesn't exist so that it never successfully pulls a conversation. And will retry 5 times before throwing an ExpError. 
- From `nc auth 8888` create a job with a retryAfter value
e.g. 
```
CreateJob
name: www-prod/IntercomCreateConversation
data: {"email":"ctseng@expensify.com", "adminID":"521022", "subject":"test", "messageType":"email", "message":"test test", "assigneeID":"1079954"}
retryAfter: +1 MINUTES
```
- With this change, the job should successfully fail once teh ExpError is thrown

You can also simply test it like so
![image](https://user-images.githubusercontent.com/12980144/53982471-dfde4200-40c9-11e9-8ebc-ecbd8d5b1b71.png)
