### PR TITLE
Potential fix for observed segfault

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2100,8 +2100,12 @@ int BedrockServer::finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& comp
     lock_guard<mutex> lock(_httpsCommandMutex);
     int commandsCompleted = 0;
     for (auto transaction : completedHTTPSRequests) {
-        // We assume this is found, we should never be looking for a transaction in this list that isn't there.
         auto transactionIt = _outstandingHTTPSRequests.find(transaction);
+        if (transactionIt == _outstandingHTTPSRequests.end()) {
+            // We should never be looking for a transaction in this list that isn't there.
+            SWARN("Couldn't locate transaction in _outstandingHTTPSRequests. Skipping.");
+            continue;
+        }
         auto commandPtr = transactionIt->second;
 
         // It's possible that we've already completed this command (imagine if completedHTTPSRequests contained more


### PR DESCRIPTION
Seems like the most obvious place for this to happen:

```
cpeters@db2.sjc:~$ tac /var/log/syslog | grep bedrock: | grep "\[sync\]" | head -30
2019-03-07T00:16:38.977038+00:00 db2.sjc bedrock: xxxxxx (SSignal.cpp:174) _SSignal_StackTrace [sync] [warn] DIE function returned, aborting (if not done).
2019-03-07T00:16:38.977022+00:00 db2.sjc bedrock: xxxxxx (libstuff.cpp:1878) S_sendconsume [sync] [info] Send() took 0 ms and sent 133 of 133 bytes.
2019-03-07T00:16:38.977007+00:00 db2.sjc bedrock: xxxxxx (libstuff.cpp:1878) S_sendconsume [sync] [info] Send() took 0 ms and sent 133 of 133 bytes.
2019-03-07T00:16:38.976992+00:00 db2.sjc bedrock: xxxxxx (libstuff.cpp:1878) S_sendconsume [sync] [info] Send() took 0 ms and sent 133 of 133 bytes.
2019-03-07T00:16:38.976977+00:00 db2.sjc bedrock: xxxxxx (libstuff.cpp:1878) S_sendconsume [sync] [info] Send() took 0 ms and sent 133 of 133 bytes.
2019-03-07T00:16:38.976963+00:00 db2.sjc bedrock: xxxxxx (SQLiteNode.cpp:1938) broadcast [sync] [info] {auth.db2.sjc/MASTERING} Sending broadcast: CRASH_COMMAND#015#012Content-Length: 23#015#012#015#012#015#012Content-Length: 0
2019-03-07T00:16:38.976948+00:00 db2.sjc bedrock: xxxxxx (SSignal.cpp:171) _SSignal_StackTrace [sync] [warn] Calling DIE function.
2019-03-07T00:16:38.976932+00:00 db2.sjc bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /lib/x86_64-linux-gnu/libc.so.6(clone+0x6d) [0x7f23b6d4741d]
2019-03-07T00:16:38.976916+00:00 db2.sjc bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /lib/x86_64-linux-gnu/libpthread.so.0(+0x76ba) [0x7f23b77cf6ba]
2019-03-07T00:16:38.976883+00:00 db2.sjc bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /usr/lib/x86_64-linux-gnu/libstdc++.so.6(+0xbd57f) [0x7f23b72df57f]
2019-03-07T00:16:38.976867+00:00 db2.sjc bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /usr/sbin/bedrock(_ZN13BedrockServer11syncWrapperER5SDataRSt6atomicIN10SQLiteNode5StateEERS2_IbERS2_INSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEER26BedrockTimeoutCommandQueueRS_+0x22bc) [0x46c83c]
2019-03-07T00:16:38.976835+00:00 db2.sjc bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /usr/sbin/bedrock(_ZN13BedrockServer4syncER5SDataRSt6atomicIN10SQLiteNode5StateEERS2_IbERS2_INSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEER26BedrockTimeoutCommandQueueRS_+0x85d) [0x4602ed]
2019-03-07T00:16:38.976818+00:00 db2.sjc bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /usr/sbin/bedrock(_ZN13BedrockServer16_postPollPluginsERSt3mapIi6pollfdSt4lessIiESaISt4pairIKiS1_EEEm+0x2d7) [0x454f17]
2019-03-07T00:16:38.976800+00:00 db2.sjc bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /usr/sbin/bedrock(_ZN13BedrockServer21finishWaitingForHTTPSERNSt7__cxx114listIPN13SHTTPSManager11TransactionESaIS4_EEE+0xdd) [0x44420d]
2019-03-07T00:16:38.976783+00:00 db2.sjc bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /lib/x86_64-linux-gnu/libpthread.so.0(+0x11390) [0x7f23b77d9390]
2019-03-07T00:16:38.976765+00:00 db2.sjc bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /usr/sbin/bedrock(_Z19_SSignal_StackTraceiP9siginfo_tPv+0xaf) [0x6276df]
2019-03-07T00:16:38.976607+00:00 db2.sjc bedrock: xxxxxx (SSignal.cpp:164) _SSignal_StackTrace [sync] [warn] Signal Segmentation fault(11) caused crash, logging stack trace.
2019-03-07T00:16:38.976311+00:00 db2.sjc bedrock: xxxxxx (SHTTPSManager.cpp:145) postPoll [sync] [info] Completed request 'POST /api.php?command=getAccountHistory HTTP/1.1' to 'importapi.expensify.com:8444' with response '500' in '0'ms
2019-03-07T00:16:38.976296+00:00 db2.sjc bedrock: xxxxxx (SHTTPSManager.cpp:130) postPoll [sync] [warn] Connection died prematurely after 0ms
```