### PR TITLE
Allow parent jobs to auto retry with retryAfter

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -974,8 +974,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             // Update the parent job to PAUSED. Also update its nextRun: in case it has a retryAfter, GetJobs set the nextRun too far in the future (to account for retryAfter), so set it to what it should
             // be now that it is waiting on its children to complete.
             SINFO("Job has child jobs, PAUSING parent, QUEUING children");
-            string nextRunDateTime = _constructNextRunDATETIME(nextRun, !lastRun.empty() ? lastRun : nextRun, repeat);
-            if (!db.writeIdempotent("UPDATE jobs SET state='PAUSED', nextRun=" + SQ(nextRunDateTime) + " WHERE jobID=" + SQ(jobID) + ";")) {
+            if (!db.writeIdempotent("UPDATE jobs SET state='PAUSED', nextRun=" + SQ(lastRun) + " WHERE jobID=" + SQ(jobID) + ";")) {
                 STHROW("502 Parent update failed");
             }
 

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -745,7 +745,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             }
 
             if (!childJobs.empty()) {
-                // Add associative arrays of all children depending on their states
+                // Add arrays of children jobs to our response, 2 arrays to clearly distinguish between finished and cancelled children.
                 list<string> finishedChildJobArray;
                 list<string> cancelledChildJobArray;
                 for (auto row : childJobs.rows) {

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -227,7 +227,7 @@ struct CreateJobTest : tpunit::TestFixture {
         command.methodLine = "CreateJob";
         command["name"] = "child";
         command["parentJobID"] = parentID;
-        tester->executeWaitVerifyContent(command, "405 Can only create child job when parent is RUNNING or PAUSED");
+        tester->executeWaitVerifyContent(command, "405 Can only create child job when parent is RUNNING, RUNQUEUED or PAUSED");
     }
 
     // Cannot create a job with a running grandparent
@@ -480,6 +480,6 @@ struct CreateJobTest : tpunit::TestFixture {
         command.methodLine = "CreateJob";
         command["name"] = "testRetryableChild";
         command["parentJobID"] = jobID;
-        tester->executeWaitVerifyContent(command, "402 Auto-retrying parents cannot have children");
+        tester->executeWaitVerifyContent(command, "405 Can only create child job when parent is RUNNING, RUNQUEUED or PAUSED");
     }
 } __CreateJobTest;

--- a/test/tests/jobs/CreateJobsTest.cpp
+++ b/test/tests/jobs/CreateJobsTest.cpp
@@ -102,7 +102,7 @@ struct CreateJobsTest : tpunit::TestFixture {
         jobs.push_back(SComposeJSONObject(job1Content));
         jobs.push_back(SComposeJSONObject(job2Content));
         command["jobs"] = SComposeJSONArray(jobs);
-        tester->executeWaitVerifyContent(command, "405 Can only create child job when parent is RUNNING or PAUSED");
+        tester->executeWaitVerifyContent(command, "405 Can only create child job when parent is RUNNING, RUNQUEUED or PAUSED");
     }
 
     void createWithParentMocked() {

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -760,11 +760,12 @@ struct GetJobTest : tpunit::TestFixture {
         childState = tester->readDB("SELECT state FROM jobs WHERE jobID=" + SQ(childJobID) + ";");
         ASSERT_EQUAL(childState, "QUEUED");
 
-        // The child job is ready.
+        // The child job is ready, get it.
         getJobCommand["name"] = "ChildJob";
         getJobResponse = tester->executeWaitVerifyContentTable(getJobCommand);
         ASSERT_EQUAL(getJobResponse["jobID"], childJobID);
 
+        // The child is now RUNNING, the parent is still PAUSED.
         state = tester->readDB("SELECT state FROM jobs WHERE jobID=" + SQ(parentJobID) + ";");
         ASSERT_EQUAL(state, "PAUSED");
         childState = tester->readDB("SELECT state FROM jobs WHERE jobID=" + SQ(childJobID) + ";");

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -779,9 +779,6 @@ struct GetJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(state, "QUEUED");
         state = tester->readDB("SELECT nextRun FROM jobs WHERE jobID=" + SQ(parentJobID) + ";");
 
-        // Because we set nextRun in GetJob, we have to wait for 'retryAfter' time until the job is ready to be picked up again.
-        sleep(3);
-
         // Finish everything
         getJobCommand["name"] = "ParentJob";
         getJobResponse = tester->executeWaitVerifyContentTable(getJobCommand);


### PR DESCRIPTION
@iwiznia @tylerkaraszewski @pecanoro please review
cc @quinthar 

Relates with https://github.com/Expensify/Expensify/issues/77591#issuecomment-459709974

This is needed so that parent jobs lost in networking events retry themselves (this is a TLDR..). 

Please review carefully _especially_ the correctness of my tests. There's 1 weird thing happening, I will comment inline. 

# Tests

Automated
Will do manual soon with what I need this for. 