### PR TITLE
489 create file during clean

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2069,6 +2069,17 @@ string SAESDecryptNoStrip(const string& buffer, const size_t& bufferSize, const 
 /////////////////////////////////////////////////////////////////////////////
 
 // --------------------------------------------------------------------------
+bool SFileCreate(const string& path) {
+    // Return true if it was successfully created
+    FILE* fp = fopen(path.c_str(), "a+");
+    if (!fp)
+        return false;
+
+    if (!fclose(fp))
+        SDEBUG("SFileCreate: Could not close file.");
+
+    return true;
+}
 bool SFileExists(const string& path) {
     // Return true if it exists and is a file
     struct stat out;

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -704,6 +704,7 @@ bool SCheckNetworkErrorType(const string& logPrefix, const string& peer, int err
 // File stuff
 // --------------------------------------------------------------------------
 // Basic file loading and saving
+bool SFileCreate(const string& path);
 bool SFileExists(const string& path);
 bool SFileLoad(const string& path, string& buffer);
 string SFileLoad(const string& path);

--- a/main.cpp
+++ b/main.cpp
@@ -279,9 +279,15 @@ int main(int argc, char* argv[]) {
 
     // Reset the database if requested
     if (args.isSet("-clean")) {
-        // Remove it
         SDEBUG("Resetting database");
+
         string db = args["-db"];
+        if (!SFileExists(db)) {
+            // Touch file.
+            SASSERT(SFileCreate(db));
+        }
+
+        // Remove it
         unlink(db.c_str());
     } else if (args.isSet("-bootstrap")) {
         // Allow for bootstraping a node with no database file in place.

--- a/main.cpp
+++ b/main.cpp
@@ -281,14 +281,14 @@ int main(int argc, char* argv[]) {
     if (args.isSet("-clean")) {
         SDEBUG("Resetting database");
 
+        // Remove it
         string db = args["-db"];
+        unlink(db.c_str());
+
         if (!SFileExists(db)) {
             // Touch file.
             SASSERT(SFileCreate(db));
         }
-
-        // Remove it
-        unlink(db.c_str());
     } else if (args.isSet("-bootstrap")) {
         // Allow for bootstraping a node with no database file in place.
         SINFO("Loading in bootstrap mode, skipping check for database existance.");

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -406,6 +406,9 @@ struct LibStuff : tpunit::TestFixture {
         // File doesn't exist yet
         ASSERT_TRUE(!SFileExists(path));
 
+        // We can create an empty file
+        ASSERT_TRUE(SFileCreate(path));
+
         // We can create a file
         ASSERT_TRUE(SFileSave(path, contents));
 

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -409,7 +409,16 @@ struct LibStuff : tpunit::TestFixture {
         // We can create an empty file
         ASSERT_TRUE(SFileCreate(path));
 
-        // We can create a file
+        // The file exists
+        ASSERT_TRUE(SFileExists(path));
+
+        // We can delete the file
+        ASSERT_TRUE(SFileDelete(path));
+
+        // The file no longer exists
+        ASSERT_TRUE(!SFileExists(path));
+
+        // We can create a file (with contents)
         ASSERT_TRUE(SFileSave(path, contents));
 
         // The file exists


### PR DESCRIPTION
Makes `-clean` leave a blank file after it has run. I saw this in the `README` and figured it'd be a good excuse to check out some of the code. Lemme know if this PR doesn't make sense, for example should Bedrock always create a blank file? 

Fixes 489, 24.