### PR TITLE
Tag performance log lines as such

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -269,7 +269,7 @@ void BedrockCommand::finalizeTimingInfo() {
     }
 
     // Log all this info.
-    SINFO("command '" << request.methodLine << "' timing info (ms): "
+    SINFO("[performance] command '" << request.methodLine << "' timing info (ms): "
           << peekTotal/1000 << " (" << peekCount << "), "
           << processTotal/1000 << " (" << processCount << "), "
           << commitWorkerTotal/1000 << ", "

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -148,7 +148,7 @@ void BedrockServer::sync(SData& args,
     workerThreads = workerThreads ? workerThreads : max(1u, thread::hardware_concurrency());
 
     // A minumum of *2* worker threads are required. One for blocking writes, one for other commands.
-    if (workerThreads < 2) { 
+    if (workerThreads < 2) {
         workerThreads = 2;
     }
 
@@ -1530,7 +1530,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
 
     // Log the timing of this loop.
     uint64_t readElapsedMS = (STimeNow() - acceptEndTime) / 1000;
-    SINFO("Read from " << socketList.size() << " sockets, attempted to deserialize " << deserializationAttempts
+    SINFO("[performance] Read from " << socketList.size() << " sockets, attempted to deserialize " << deserializationAttempts
           << " commands, " << deserializedRequests << " were complete and deserialized in " << readElapsedMS << "ms.");
 
     // Now we can close any sockets that we need to.
@@ -2122,7 +2122,7 @@ int BedrockServer::finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& comp
                 commandsCompleted++;
             }
         }
-        
+
         // Now we can erase the transaction, as it's no longer outstanding.
         _outstandingHTTPSRequests.erase(transactionIt);
     }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1904,7 +1904,7 @@ bool S_sendconsume(int s, string& sendBuffer) {
     if (numSent == -1) {
         errorMessage = " Error: "s + strerror(errno);
     }
-    SINFO("Send() took " << chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - start).count()
+    SINFO("[performance] Send() took " << chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - start).count()
         << " ms and sent " << numSent << " of " << (int)sendBuffer.size() << " bytes." << errorMessage);
 
     if (numSent > 0) {


### PR DESCRIPTION
@tylerkaraszewski Please review, cc @swhi3635. 

Marks some of the log lines from https://github.com/Expensify/Expensify/issues/103292 as performance, the ones that are most obviously for measuring performance. The remaining lines should probably be evaluated on whether or not we need them, and then either tagged or just left as is.