### PR TITLE
Rename MASTER/SLAVE to LEADER/FOLLOWER

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -236,7 +236,7 @@ void BedrockCommand::finalizeTimingInfo() {
         {"unaccountedTime", unaccountedTime},
     };
 
-    // We also want to know what master did if we're on a slave.
+    // We also want to know what leader did if we're on a follower.
     uint64_t upstreamPeekTime = 0;
     uint64_t upstreamProcessTime = 0;
     uint64_t upstreamUnaccountedTime = 0;
@@ -244,7 +244,7 @@ void BedrockCommand::finalizeTimingInfo() {
 
     // Now promote any existing values that were set upstream. This prepends `upstream` and makes the first existing
     // character of the name uppercase, (i.e. myValue -> upstreamMyValue), letting us keep anything that was set by the
-    // master server. We clear these values after setting the new ones, so that we can add our own values.
+    // leader server. We clear these values after setting the new ones, so that we can add our own values.
     for (const auto& p : valuePairs) {
         auto it = response.nameValueMap.find(p.first);
         if (it != response.nameValueMap.end()) {

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -23,22 +23,22 @@ class BedrockCore : public SQLiteCore {
 
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same
     // command, and it *may be called multiple times*. Preventing duplicate actions on calling peek multiple times is
-    // up to the implementer, and may happen *across multiple servers*. I.e., a slave server may call `peek`, and on
-    // its returning false, the command will be escalated to the master server, where `peek` will be called again. It
+    // up to the implementer, and may happen *across multiple servers*. I.e., a follower server may call `peek`, and on
+    // its returning false, the command will be escalated to the leader server, where `peek` will be called again. It
     // should be considered an error to modify the DB from inside `peek`.
     // Returns a boolean value of `true` if the command is complete and its `response` field can be returned to the
     // caller. Returns `false` if the command will need to be passed to `process` to complete handling the command.
     bool peekCommand(BedrockCommand& command);
 
     // Process is the follow-up to `peek` if `peek` was insufficient to handle the command. It will only ever be called
-    // on the master node, and should always be able to resolve the command completely. When a command is passed to
+    // on the leader node, and should always be able to resolve the command completely. When a command is passed to
     // `process`, the caller will *usually* have already begun a database transaction with either `BEGIN TRANSACTION`
     // or `BEGIN CONCURRENT`, and it's up to `process` to add the rest of the transaction, without performing a
     // `ROLLBACK` or `COMMIT`, which will be handled by the caller. It returns `true` if it has modified the database
     // and requires the caller to perform a `commit`, and `false` if no changes requiring a `commit` have been made.
     // Upon being returned `false`, the caller will perform a `ROLLBACK` of the empty transaction, and will not
-    // replicate the transaction to slave nodes. Upon being returned `true`, the caller will attempt to perform a
-    // `COMMIT` and replicate the transaction to slave nodes. It's allowable for this `COMMIT` to fail, in which case
+    // replicate the transaction to follower nodes. Upon being returned `true`, the caller will attempt to perform a
+    // `COMMIT` and replicate the transaction to follower nodes. It's allowable for this `COMMIT` to fail, in which case
     // this command *will be passed to process again in the future to retry*.
     bool processCommand(BedrockCommand& command);
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -96,7 +96,7 @@ bool BedrockServer::canStandDown() {
 void BedrockServer::syncWrapper(SData& args,
                          atomic<SQLiteNode::State>& replicationState,
                          atomic<bool>& upgradeInProgress,
-                         atomic<string>& masterVersion,
+                         atomic<string>& leaderVersion,
                          BedrockTimeoutCommandQueue& syncNodeQueuedCommands,
                          BedrockServer& server)
 {
@@ -121,7 +121,7 @@ void BedrockServer::syncWrapper(SData& args,
             SINFO("Bedrock server entering attached state.");
         }
         server._resetServer();
-        sync(args, replicationState, upgradeInProgress, masterVersion, syncNodeQueuedCommands, server);
+        sync(args, replicationState, upgradeInProgress, leaderVersion, syncNodeQueuedCommands, server);
 
         // Now that we've run the sync thread, we can exit if it hasn't set _detach again.
         if (!server._detach) {
@@ -133,7 +133,7 @@ void BedrockServer::syncWrapper(SData& args,
 void BedrockServer::sync(SData& args,
                          atomic<SQLiteNode::State>& replicationState,
                          atomic<bool>& upgradeInProgress,
-                         atomic<string>& masterVersion,
+                         atomic<string>& leaderVersion,
                          BedrockTimeoutCommandQueue& syncNodeQueuedCommands,
                          BedrockServer& server)
 {
@@ -172,8 +172,8 @@ void BedrockServer::sync(SData& args,
         SWARN("_completedCommands not empty at startup of sync thread.");
     }
 
-    // The node is now coming up, and should eventually end up in a `MASTERING` or `SLAVING` state. We can start adding
-    // our worker threads now. We don't wait until the node is `MASTERING` or `SLAVING`, as it's state can change while
+    // The node is now coming up, and should eventually end up in a `LEADING` or `FOLLOWING` state. We can start adding
+    // our worker threads now. We don't wait until the node is `LEADING` or `FOLLOWING`, as it's state can change while
     // it's running, and our workers will have to maintain awareness of that state anyway.
     SINFO("Starting " << workerThreads << " worker threads.");
     list<thread> workerThreadList;
@@ -182,7 +182,7 @@ void BedrockServer::sync(SData& args,
                                       ref(args),
                                       ref(replicationState),
                                       ref(upgradeInProgress),
-                                      ref(masterVersion),
+                                      ref(leaderVersion),
                                       ref(syncNodeQueuedCommands),
                                       ref(server._completedCommands),
                                       ref(server),
@@ -275,8 +275,8 @@ void BedrockServer::sync(SData& args,
 
         // If we're in a state where we can initialize shutdown, then go ahead and do so.
         // Having responded to all clients means there are no *local* clients, but it doesn't mean there are no
-        // escalated commands. This is fine though - if we're slaving, there can't be any escalated commands, and if
-        // we're mastering, then the next update() loop will set us to standing down, and then we won't accept any new
+        // escalated commands. This is fine though - if we're following, there can't be any escalated commands, and if
+        // we're leading, then the next update() loop will set us to standing down, and then we won't accept any new
         // commands, and we'll shortly run through the existing queue.
         if (server._shutdownState.load() == CLIENTS_RESPONDED) {
             // The total time we'll wait for the sync node is whatever we haven't already waited from the original
@@ -331,7 +331,7 @@ void BedrockServer::sync(SData& args,
         while (server._syncNode->update()) {}
         SQLiteNode::State nodeState = server._syncNode->getState();
         replicationState.store(nodeState);
-        masterVersion.store(server._syncNode->getMasterVersion());
+        leaderVersion.store(server._syncNode->getLeaderVersion());
 
         // If anything was in the stand down queue, move it back to the main queue.
         if (nodeState != SQLiteNode::STANDINGDOWN) {
@@ -341,30 +341,30 @@ void BedrockServer::sync(SData& args,
         } else if (preUpdateState != SQLiteNode::STANDINGDOWN) {
             // Otherwise,if we just started standing down, discard any commands that had been scheduled in the future.
             // In theory, it should be fine to keep these, as they shouldn't have sockets associated with them, and
-            // they could be re-escalated to master in the future, but there's not currently a way to decide if we've
+            // they could be re-escalated to leader in the future, but there's not currently a way to decide if we've
             // run through all of the commands that might need peer responses before standing down aside from seeing if
             // the entire queue is empty.
             server._commandQueue.abandonFutureCommands(5000);
         }
 
-        // If we're not mastering, we turn off multi-write until we've finished upgrading the DB. This persists until
-        // after we're mastering  again.
-        if (nodeState != SQLiteNode::MASTERING) {
+        // If we're not leading, we turn off multi-write until we've finished upgrading the DB. This persists until
+        // after we're leading again.
+        if (nodeState != SQLiteNode::LEADING) {
             server._suppressMultiWrite.store(true);
         }
 
         // If the node's not in a ready state at this point, we'll probably need to read from the network, so start the
         // main loop over. This can let us wait for logins from peers (for example).
-        if (nodeState != SQLiteNode::MASTERING &&
-            nodeState != SQLiteNode::SLAVING   &&
+        if (nodeState != SQLiteNode::LEADING &&
+            nodeState != SQLiteNode::FOLLOWING   &&
             nodeState != SQLiteNode::STANDINGDOWN) {
             continue;
         }
 
-        // If we've just switched to the mastering state, we want to upgrade the DB. We'll set a global flag to let
+        // If we've just switched to the leading state, we want to upgrade the DB. We'll set a global flag to let
         // worker threads know that a DB upgrade is in progress, and start the upgrade process, which works basically
         // like a regular distributed commit.
-        if (preUpdateState != SQLiteNode::MASTERING && nodeState == SQLiteNode::MASTERING) {
+        if (preUpdateState != SQLiteNode::LEADING && nodeState == SQLiteNode::LEADING) {
             // Store this before we start writing to the DB, which can take a while depending on what changes were made
             // (for instance, adding an index).
             upgradeInProgress.store(true);
@@ -382,14 +382,14 @@ void BedrockServer::sync(SData& args,
                 upgradeInProgress.store(false);
                 server._suppressMultiWrite.store(false);
             }
-        } else if ((preUpdateState == SQLiteNode::MASTERING || preUpdateState == SQLiteNode::STANDINGDOWN)
+        } else if ((preUpdateState == SQLiteNode::LEADING || preUpdateState == SQLiteNode::STANDINGDOWN)
                    && nodeState == SQLiteNode::SEARCHING) {
-            // If we were MASTERING, but now we're searching, then something's gone wrong (perhaps we got disconnected
+            // If we were LEADING, but now we're searching, then something's gone wrong (perhaps we got disconnected
             // from the cluster). We should give up an any commands, and let them be re-escalated. If commands were
             // initiated locally, we can just re-queue them, they will get re-checked once things clear up, and then
-            // they'll get processed here, or escalated to the new master.
-            // Commands initiated on slaves just get dropped, they will need to be re-escalated, potentially to a
-            // different master.
+            // they'll get processed here, or escalated to the new leader.
+            // Commands initiated on followers just get dropped, they will need to be re-escalated, potentially to a
+            // different leader.
             int requeued = 0;
             int dropped = 0;
             try {
@@ -401,7 +401,7 @@ void BedrockServer::sync(SData& args,
                     }
                 }
             } catch (const out_of_range& e) {
-                SWARN("Abruptly stopped MASTERING. Re-queued " << requeued << " commands, Dropped " << dropped << " commands.");
+                SWARN("Abruptly stopped LEADING. Re-queued " << requeued << " commands, Dropped " << dropped << " commands.");
             }
         }
 
@@ -436,10 +436,10 @@ void BedrockServer::sync(SData& args,
             } else {
                 // This should only happen if the cluster becomes largely disconnected while we were in the process of
                 // committing a QUORUM command - if we no longer have enough peers to reach QUORUM, we'll fall out of
-                // mastering. This code won't actually run until the node comes back up in a MASTERING or SLAVING
-                // state, because this loop is skipped except when MASTERING, SLAVING, or STANDINGDOWN. It's also
-                // theoretically feasible for this to happen if a slave fails to commit a transaction, but that
-                // probably indicates a bug (or a slave disk failure).
+                // leading. This code won't actually run until the node comes back up in a LEADING or FOLLOWING
+                // state, because this loop is skipped except when LEADING, FOLLOWING, or STANDINGDOWN. It's also
+                // theoretically feasible for this to happen if a follower fails to commit a transaction, but that
+                // probably indicates a bug (or a follower disk failure).
                 SINFO("requeueing command " << command.request.methodLine
                       << " after failed sync commit. Sync thread has " << syncNodeQueuedCommands.size()
                       << " queued commands.");
@@ -450,7 +450,7 @@ void BedrockServer::sync(SData& args,
             command.request.clear();
         }
 
-        // We're either mastering, standing down, or slaving. There could be a commit in progress on `command`, but
+        // We're either leading, standing down, or following. There could be a commit in progress on `command`, but
         // there could also be other finished work to handle while we wait for that to complete. Let's see if we can
         // handle any of that work.
         try {
@@ -495,7 +495,7 @@ void BedrockServer::sync(SData& args,
             });
 
             // And now we'll decide how to handle it.
-            if (nodeState == SQLiteNode::MASTERING || nodeState == SQLiteNode::STANDINGDOWN) {
+            if (nodeState == SQLiteNode::LEADING || nodeState == SQLiteNode::STANDINGDOWN) {
 
                 // We need to grab this before peekCommand (or wherever our transaction is started), to verify that
                 // no worker thread can commit in the middle of our transaction. We need our entire transaction to
@@ -572,9 +572,9 @@ void BedrockServer::sync(SData& args,
                         server._reply(command);
                     }
                 }
-            } else if (nodeState == SQLiteNode::SLAVING) {
-                // If we're slaving, we just escalate directly to master without peeking. We can only get an incomplete
-                // command on the slave sync thread if a slave worker thread peeked it unsuccessfully, so we don't
+            } else if (nodeState == SQLiteNode::FOLLOWING) {
+                // If we're following, we just escalate directly to leader without peeking. We can only get an incomplete
+                // command on the follower sync thread if a follower worker thread peeked it unsuccessfully, so we don't
                 // bother peeking it again.
                 auto it = command.request.nameValueMap.find("Connection");
                 bool forget = it != command.request.nameValueMap.end() && SIEquals(it->second, "forget");
@@ -656,7 +656,7 @@ void BedrockServer::sync(SData& args,
 void BedrockServer::worker(SData& args,
                            atomic<SQLiteNode::State>& replicationState,
                            atomic<bool>& upgradeInProgress,
-                           atomic<string>& masterVersion,
+                           atomic<string>& leaderVersion,
                            BedrockTimeoutCommandQueue& syncNodeQueuedCommands,
                            BedrockTimeoutCommandQueue& syncNodeCompletedCommands,
                            BedrockServer& server,
@@ -726,8 +726,8 @@ void BedrockServer::worker(SData& args,
 
             // We just spin until the node looks ready to go. Typically, this doesn't happen expect briefly at startup.
             while (upgradeInProgress.load() ||
-                   (replicationState.load() != SQLiteNode::MASTERING &&
-                    replicationState.load() != SQLiteNode::SLAVING &&
+                   (replicationState.load() != SQLiteNode::LEADING &&
+                    replicationState.load() != SQLiteNode::FOLLOWING &&
                     replicationState.load() != SQLiteNode::STANDINGDOWN)
             ) {
                 // Make sure that the node isn't shutting down, leaving us in an endless loop.
@@ -744,7 +744,7 @@ void BedrockServer::worker(SData& args,
             }
 
             // If this command is dependent on a commitCount newer than what we have (maybe it's a follow-up to a
-            // command that was escalated to master), we'll set it aside for later processing. When the sync node
+            // command that was escalated to leader), we'll set it aside for later processing. When the sync node
             // finishes its update loop, it will re-queue any of these commands that are no longer blocked on our
             // updated commit count.
             uint64_t commitCount = db.getCommitCount();
@@ -767,19 +767,19 @@ void BedrockServer::worker(SData& args,
             // OK, so this is the state right now, which isn't necessarily anything in particular, because the sync
             // node can change it at any time, and we're not synchronizing on it. We're going to go ahead and assume
             // it's something reasonable, because in most cases, that's pretty safe. If we think we're anything but
-            // MASTERING, we'll just peek this command and return it's result, which should be harmless. If we think
-            // we're mastering, we'll go ahead and start a `process` for the command, but we'll synchronously verify
+            // LEADING, we'll just peek this command and return it's result, which should be harmless. If we think
+            // we're leading, we'll go ahead and start a `process` for the command, but we'll synchronously verify
             // our state right before we commit.
             SQLiteNode::State state = replicationState.load();
 
-            // If we find that we've gotten a command with an initiatingPeerID, but we're not in a mastering or
+            // If we find that we've gotten a command with an initiatingPeerID, but we're not in a leading or
             // standing down state, we'll have no way of returning this command to the caller, so we discard it. The
-            // original caller will need to re-send the request. This can happen if we're mastering, and receive a
-            // request from a peer, but then we stand down from mastering. The SQLiteNode should have already told its
+            // original caller will need to re-send the request. This can happen if we're leading, and receive a
+            // request from a peer, but then we stand down from leading. The SQLiteNode should have already told its
             // peers that their outstanding requests were being canceled at this point.
-            if (command.initiatingPeerID && !(state == SQLiteNode::MASTERING || state == SQLiteNode::STANDINGDOWN)) {
+            if (command.initiatingPeerID && !(state == SQLiteNode::LEADING || state == SQLiteNode::STANDINGDOWN)) {
                 SWARN("Found " << (command.complete ? "" : "in") << "complete " << "command "
-                      << command.request.methodLine << " from peer, but not mastering. Too late for it, discarding.");
+                      << command.request.methodLine << " from peer, but not leading. Too late for it, discarding.");
 
                 // If the command was processed, tell the plugin we couldn't send the response.
                 if (command.processedBy) {
@@ -789,13 +789,13 @@ void BedrockServer::worker(SData& args,
                 continue;
             }
 
-            // If this command is already complete, then we should be a slave, and the sync node got a response back
-            // from a command that had been escalated to master, and queued it for a worker to respond to. We'll send
+            // If this command is already complete, then we should be a follower, and the sync node got a response back
+            // from a command that had been escalated to leader, and queued it for a worker to respond to. We'll send
             // that response now.
             if (command.complete) {
                 // If this command is already complete, we can return it to the caller.
                 // If it has an initiator, it should have been returned to a peer by a sync node instead, but if we've
-                // just switched states out of mastering, we might have an old command in the queue. All we can do here
+                // just switched states out of leading, we might have an old command in the queue. All we can do here
                 // is note that and discard it, as we have nobody to deliver it to.
                 if (command.initiatingPeerID) {
                     // Let's note how old this command is.
@@ -832,7 +832,7 @@ void BedrockServer::worker(SData& args,
 
             // More checks for parallel writing.
             canWriteParallel = canWriteParallel && !server._suppressMultiWrite.load();
-            canWriteParallel = canWriteParallel && (state == SQLiteNode::MASTERING);
+            canWriteParallel = canWriteParallel && (state == SQLiteNode::LEADING);
             canWriteParallel = canWriteParallel && (command.writeConsistency == SQLiteNode::ASYNC);
 
             // If all the other checks have passed, and we haven't sent a quorum command to the sync thread in a while,
@@ -874,14 +874,14 @@ void BedrockServer::worker(SData& args,
 
                 if (!calledPeek || !peekResult) {
                     // We've just unsuccessfully peeked a command, which means we're in a state where we might want to
-                    // write it. We'll flag that here, to keep the node from falling out of MASTERING/STANDINGDOWN
+                    // write it. We'll flag that here, to keep the node from falling out of LEADING/STANDINGDOWN
                     // until we're finished with this command.
                     if (command.httpsRequests.size()) {
                         // This *should* be impossible, but previous bugs have existed where it's feasible that we call
-                        // `peekCommand` while mastering, and by the time we're done, we're SLAVING, so we check just
+                        // `peekCommand` while leading, and by the time we're done, we're FOLLOWING, so we check just
                         // in case we ever introduce another similar bug.
-                        if (state != SQLiteNode::MASTERING && state != SQLiteNode::STANDINGDOWN) {
-                            SALERT("Not mastering or standing down (" << SQLiteNode::stateNames[state]
+                        if (state != SQLiteNode::LEADING && state != SQLiteNode::STANDINGDOWN) {
+                            SALERT("Not leading or standing down (" << SQLiteNode::stateName(state)
                                    << ") but have outstanding HTTPS command: " << command.request.methodLine
                                    << ", returning 500.");
                             command.response.methodLine = "500 STANDDOWN TIMEOUT";
@@ -946,7 +946,7 @@ void BedrockServer::worker(SData& args,
                             }
 
                             // This is the first place we get really particular with the state of the node from a
-                            // worker thread. We only want to do this commit if we're *SURE* we're mastering, and
+                            // worker thread. We only want to do this commit if we're *SURE* we're leading, and
                             // not allow the state of the node to change while we're committing. If it turns out
                             // we've changed states, we'll roll this command back, so we lock the node's state
                             // until we complete.
@@ -957,10 +957,10 @@ void BedrockServer::worker(SData& args,
                             // locks in the same order. Always acquiring the locks in the same order prevents the
                             // deadlocks.
                             shared_lock<decltype(server._syncNode->stateMutex)> lock2(server._syncNode->stateMutex);
-                            if (replicationState.load() != SQLiteNode::MASTERING &&
+                            if (replicationState.load() != SQLiteNode::LEADING &&
                                 replicationState.load() != SQLiteNode::STANDINGDOWN) {
-                                SALERT("Node State changed from MASTERING to "
-                                       << SQLiteNode::stateNames[replicationState.load()]
+                                SALERT("Node State changed from LEADING to "
+                                       << SQLiteNode::stateName(replicationState.load())
                                        << " during worker commit. Rolling back transaction!");
                                 core.rollback();
                             } else {
@@ -971,7 +971,7 @@ void BedrockServer::worker(SData& args,
                         if (commitSuccess) {
                             SINFO("Successfully committed " << command.request.methodLine << " on worker thread. blocking: "
                                   << (threadId ? "false" : "true"));
-                            // So we must still be mastering, and at this point our commit has succeeded, let's
+                            // So we must still be leading, and at this point our commit has succeeded, let's
                             // mark it as complete. We add the currentCommit count here as well.
                             command.response["commitCount"] = to_string(db.getCommitCount());
                             command.complete = true;
@@ -1174,7 +1174,7 @@ BedrockServer::BedrockServer(const SData& args)
         }
     }
 
-    // Allow sending control commands when the server's not MASTERING/SLAVING.
+    // Allow sending control commands when the server's not LEADING/FOLLOWING.
     SINFO("Opening control port on '" << _args["-controlPort"] << "'");
     _controlPort = openPort(_args["-controlPort"]);
 
@@ -1193,7 +1193,7 @@ BedrockServer::BedrockServer(const SData& args)
                      ref(_args),
                      ref(_replicationState),
                      ref(_upgradeInProgress),
-                     ref(_masterVersion),
+                     ref(_leaderVersion),
                      ref(_syncNodeQueuedCommands),
                      ref(*this));
 }
@@ -1260,7 +1260,7 @@ bool BedrockServer::shutdownComplete() {
             }
         }
         SWARN("Graceful shutdown timed out. "
-              << "Replication State: " << SQLiteNode::stateNames[_replicationState.load()] << ". "
+              << "Replication State: " << SQLiteNode::stateName(_replicationState.load()) << ". "
               << "Command queue size: " << _commandQueue.size() << ". "
               << "Blocking command queue size: " << _blockingCommandQueue.size() << ". "
               << "Commands queued: " << commandCounts << ". "
@@ -1288,23 +1288,23 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     // Open the port the first time we enter a command-processing state
     SQLiteNode::State state = _replicationState.load();
 
-    // If we're a slave, and the master's on a different version than us, we don't open the command port.
-    // If we do, we'll escalate all of our commands to the master, which causes undue load on master during upgrades.
-    // Instead, we'll simply not respond and let this request get re-directed to another slave.
-    string masterVersion = _masterVersion.load();
-    if (!_suppressCommandPort && state == SQLiteNode::SLAVING && (masterVersion != _version)) {
-        SINFO("Node " << _args["-nodeName"] << " slaving on version " << _version << ", master is version: "
-              << masterVersion << ", not opening command port.");
-        suppressCommandPort("master version mismatch", true);
-    } else if (_suppressCommandPort && (state == SQLiteNode::MASTERING || (masterVersion == _version))) {
-        // If we become master, or if master's version resumes matching ours, open the command port again.
+    // If we're a follower, and the leader's on a different version than us, we don't open the command port.
+    // If we do, we'll escalate all of our commands to the leader, which causes undue load on leader during upgrades.
+    // Instead, we'll simply not respond and let this request get re-directed to another follower.
+    string leaderVersion = _leaderVersion.load();
+    if (!_suppressCommandPort && state == SQLiteNode::FOLLOWING && (leaderVersion != _version)) {
+        SINFO("Node " << _args["-nodeName"] << " following on version " << _version << ", leader is version: "
+              << leaderVersion << ", not opening command port.");
+        suppressCommandPort("leader version mismatch", true);
+    } else if (_suppressCommandPort && (state == SQLiteNode::LEADING || (leaderVersion == _version))) {
+        // If we become leader, or if leader's version resumes matching ours, open the command port again.
         if (!_suppressCommandPortManualOverride) {
             // Only generate this logline if we haven't manually blocked this.
             SINFO("Node " << _args["-nodeName"] << " disabling previously suppressed command port after version check.");
         }
-        suppressCommandPort("master version match", false);
+        suppressCommandPort("leader version match", false);
     }
-    if (!_suppressCommandPort && (state == SQLiteNode::MASTERING || state == SQLiteNode::SLAVING) &&
+    if (!_suppressCommandPort && (state == SQLiteNode::LEADING || state == SQLiteNode::FOLLOWING) &&
         _shutdownState.load() == RUNNING) {
         // Open the port
         if (!_commandPort) {
@@ -1339,7 +1339,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     }
 
     // **NOTE: We leave the port open between startup and shutdown, even if we enter a state where
-    //         we can't process commands -- such as a non master/slave state.  The reason is we
+    //         we can't process commands -- such as a non leader/follower state.  The reason is we
     //         expect any state transitions between startup/shutdown to be due to temporary conditions
     //         that will resolve themselves automatically in a short time.  During this period we
     //         prefer to receive commands and queue them up, even if we can't process them immediately,
@@ -1485,7 +1485,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                     }
 
                     // This is important! All commands passed through the entire cluster must have unique IDs, or they
-                    // won't get routed properly from slave to master and back.
+                    // won't get routed properly from follower to leader and back.
                     command.id = _args["-nodeName"] + "#" + to_string(_requestCount++);
 
                     // And we and keep track of the client that initiated this command, so we can respond later, except
@@ -1659,6 +1659,7 @@ void BedrockServer::suppressCommandPort(const string& reason, bool suppress, boo
 
 bool BedrockServer::_isStatusCommand(BedrockCommand& command) {
     if (SIEquals(command.request.methodLine, STATUS_IS_SLAVE)          ||
+        SIEquals(command.request.methodLine, STATUS_IS_FOLLOWER)       ||
         SIEquals(command.request.methodLine, STATUS_HANDLING_COMMANDS) ||
         SIEquals(command.request.methodLine, STATUS_PING)              ||
         SIEquals(command.request.methodLine, STATUS_STATUS)            ||
@@ -1701,27 +1702,27 @@ void BedrockServer::_status(BedrockCommand& command) {
     SData& request  = command.request;
     SData& response = command.response;
 
-    // We'll return whether or not this server is slaving.
-    if (SIEquals(request.methodLine, STATUS_IS_SLAVE)) {
+    // We'll return whether or not this server is following.
+    if (SIEquals(request.methodLine, STATUS_IS_SLAVE) || SIEquals(request.methodLine, STATUS_IS_FOLLOWER)) {
         // Used for liveness check for HAProxy. It's limited to HTTP style requests for it's liveness checks, so let's
         // pretend to be an HTTP server for this purpose. This allows us to load balance incoming requests.
         //
         // HAProxy interprets 2xx/3xx level responses as alive, 4xx/5xx level responses as dead.
         SQLiteNode::State state = _replicationState.load();
-        if (state == SQLiteNode::SLAVING) {
-            response.methodLine = "HTTP/1.1 200 Slaving";
+        string verbing = SIEquals(request.methodLine, STATUS_IS_FOLLOWER) ? "Following" : "Slaving";
+        if (state == SQLiteNode::FOLLOWING) {
+            response.methodLine = "HTTP/1.1 200 "+ verbing;
         } else {
-            response.methodLine = "HTTP/1.1 500 Not slaving. State="
-                                  + SQLiteNode::stateNames[state];
+            response.methodLine = "HTTP/1.1 500 Not " + verbing + ". State=" + SQLiteNode::stateName(state);
         }
     }
 
     else if (SIEquals(request.methodLine, STATUS_HANDLING_COMMANDS)) {
         // This is similar to the above check, and is used for letting HAProxy load-balance commands.
         SQLiteNode::State state = _replicationState.load();
-        if (state != SQLiteNode::SLAVING) {
-            response.methodLine = "HTTP/1.1 500 Not slaving. State=" + SQLiteNode::stateNames[state];
-        } else if (_version != _masterVersion.load()) {
+        if (state != SQLiteNode::FOLLOWING) {
+            response.methodLine = "HTTP/1.1 500 Not following. State=" + SQLiteNode::stateName(state);
+        } else if (_version != _leaderVersion.load()) {
             response.methodLine = "HTTP/1.1 500 Mismatched version. Version=" + _version;
         } else {
             response.methodLine = "HTTP/1.1 200 Slaving";
@@ -1743,9 +1744,12 @@ void BedrockServer::_status(BedrockCommand& command) {
             pluginData["name"] = plugin->getName();
             pluginList.push_back(SComposeJSONObject(pluginData));
         }
-        content["isMaster"] = state == SQLiteNode::MASTERING ? "true" : "false";
+        content["isLeader"] = state == SQLiteNode::LEADING ? "true" : "false";
+
+        // TODO: Remove this line when everything has been updated to use 'leader'.
+        content["isMaster"] = content["isLeader"];
         content["plugins"]  = SComposeJSONArray(pluginList);
-        content["state"]    = SQLiteNode::stateNames[state];
+        content["state"]    = SQLiteNode::stateName(state);
         content["version"]  = _version;
         content["host"]     = _args["-nodeHost"];
 
@@ -1759,8 +1763,8 @@ void BedrockServer::_status(BedrockCommand& command) {
             content["crashCommands"] = totalCount;
         }
 
-        // On master, return the current multi-write blacklists.
-        if (state == SQLiteNode::MASTERING) {
+        // On leader, return the current multi-write blacklists.
+        if (state == SQLiteNode::LEADING) {
             // Both of these need to be in the correct state for multi-write to be enabled.
             bool multiWriteOn =  _multiWriteEnabled.load() && !_suppressMultiWrite;
             content["multiWriteEnabled"] = multiWriteOn ? "true" : "false";
@@ -2050,12 +2054,12 @@ void BedrockServer::onNodeLogin(SQLiteNode::Peer* peer)
 }
 
 void BedrockServer::_finishPeerCommand(BedrockCommand& command) {
-    // See if we're supposed to forget this command (because the slave is not listening for a response).
+    // See if we're supposed to forget this command (because the follower is not listening for a response).
     auto it = command.request.nameValueMap.find("Connection");
     bool forget = it != command.request.nameValueMap.end() && SIEquals(it->second, "forget");
     command.finalizeTimingInfo();
     if (forget) {
-        SINFO("Not responding to 'forget' command '" << command.request.methodLine << "' from slave.");
+        SINFO("Not responding to 'forget' command '" << command.request.methodLine << "' from follower.");
     } else {
         auto _syncNodeCopy = _syncNode;
         if (_syncNodeCopy) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1680,6 +1680,7 @@ list<STable> BedrockServer::getPeerInfo() {
                 peerData.emplace_back(peer->nameValueMap);
                 peerData.back()["host"] = peer->host;
                 peerData.back()["name"] = peer->name;
+                peerData.back()["State"] = SQLiteNode::stateName(peer->state);
             }
         }
     }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -15,14 +15,14 @@ class BedrockServer : public SQLiteServer {
     //
     // Shutting down is pretty obvious - when we want to turn a server off, we shut it down. The shut down process
     // tries to do this without interrupting any client requests.
-    // Standing down is a little less obvious. If we're the master node in a cluster, there are two ways to stand down.
+    // Standing down is a little less obvious. If we're the leader node in a cluster, there are two ways to stand down.
     // The first is that we are shutting down, in which case we'll need to let the rest of the cluster know that it
-    // will need to pick a new master. The other is if a higher-priority master asks to stand up in our place. In this
+    // will need to pick a new leader. The other is if a higher-priority leader asks to stand up in our place. In this
     // second case, we'll stand down without shutting down.
     //
     //
     // # Shutting Down
-    // Let's start with shutting down. Standing down is a subset of shutting down (when we start out mastering), and
+    // Let's start with shutting down. Standing down is a subset of shutting down (when we start out leading), and
     // we'll get to that later.
     //
     // When a BedrockServer comes up, it's _shutdownState is RUNNING. This is the normal operational state. When the
@@ -31,13 +31,13 @@ class BedrockServer : public SQLiteServer {
     // 1. The command port is closed, and no new connections are accepted from clients.
     // 2. When we respond to commands, we add a `Connection: close` header to them, and close the socket after the
     //    response is sent.
-    // 3. We set timeouts for any HTTPS commands to five seconds. Note that if we are slaving, this has no effect on
-    //    commands that were escalated to master, we continue waiting for those commands.
+    // 3. We set timeouts for any HTTPS commands to five seconds. Note that if we are following, this has no effect on
+    //    commands that were escalated to leader, we continue waiting for those commands.
     //
     // The server then continues operating as normal until there are no client connections left (because we've stopped
     // accepting them, and closed any connections as we responded to their commands), at which point it switches to
     // CLIENTS_RESPONDED. The sync node notices this, and on it's next update() loop, it begins shutting down. If it
-    // was mastering, the first thing it does in this case is switch to STANDINGDOWN. See more on standing down in the
+    // was leading, the first thing it does in this case is switch to STANDINGDOWN. See more on standing down in the
     // next section.
     //
     // The sync node will continue STANDINGDOWN until two conditions are true:
@@ -49,9 +49,9 @@ class BedrockServer : public SQLiteServer {
     // queue. We increment the count of these commands when we dequeue a command from the main queue, and decrememnt it
     // when we respond to the command (and also in a few other exception cases where the command is abandoned or does
     // not require a response). This means that if a command has been moved to the queue of outstanding HTTPS commands,
-    // or the sync thread queue, or is currently being handled by a worker, or escalated to master, it's "in progress".
+    // or the sync thread queue, or is currently being handled by a worker, or escalated to leader, it's "in progress".
     //
-    // If we were not mastering, there is no STANDINGDOWN state to wait through - all of a slaves commands come from
+    // If we were not leading, there is no STANDINGDOWN state to wait through - all of a followers commands come from
     // local clients, and once those connections are all closed, then that means every command has been responded to,
     // implying that there are neither queued commands nor commands in progress.
     //
@@ -64,7 +64,7 @@ class BedrockServer : public SQLiteServer {
     // # Standing Down
     // Standing down when shutting down is covered in the above section, but there's an additional bit of work to do of
     // we're standing down without shutting down. The main difference is that we are not waiting on all existing
-    // clients to be disconnected while we stand down - we will be able to service these same clients as a slave as
+    // clients to be disconnected while we stand down - we will be able to service these same clients as a follower as
     // soon as we finish this operation. However, we still have the same criteria for STANDINGDOWN as listed above, no
     // commands in progress, and an empty command queue.
     //
@@ -82,7 +82,7 @@ class BedrockServer : public SQLiteServer {
     // HTTPS transaction is "in progress" until the transaction completes, but then re-queued for processing by a
     // worker thread. If we allowed commands to remain in the main queue while standing down, some of them could be
     // HTTPS commands with completed requests. If these didn't get processed until after the node finished standing
-    // down, then we'd try and run processCommand() while slaving, which would be invalid. For this reason, we need to
+    // down, then we'd try and run processCommand() while following, which would be invalid. For this reason, we need to
     // make sure any command that has ever been started gets completed before we finish standing down. Unfortunately,
     // once a command has been added to the main queue, there's no way of knowing whether it's ever been started
     // without inspecting every command in the queue, hence the `_standDownQueue`.
@@ -108,14 +108,14 @@ class BedrockServer : public SQLiteServer {
     // need to support it for now. Here's the case that should look catastrophic, but is actually quite common, and what
     // we should eventually do about it:
     //
-    // A slave begins shutdown, and sets a 60 second timeout. It has escalated commands to master. It wants to wait for
+    // A follower begins shutdown, and sets a 60 second timeout. It has escalated commands to leader. It wants to wait for
     // the responses to these commands before it finishes shutting down, but *there is no timeout on escalated
     // commands*. Normally, we won't try to shut down the sync node until we've responded to all connected clients.
     // Because there will always be connected clients waiting for these responses to escalated commands, we'll wait the
     // full 60 seconds, and then we'll just die with no responses. Effectively, the sever `kill -9`'s itself here,
     // leaving clients hanging with no cleanup.
     //
-    // On master, this state could be catastrophic, though master doesn't need to worry about a lack of timeouts on
+    // On leader, this state could be catastrophic, though leader doesn't need to worry about a lack of timeouts on
     // escalations, so let's look at a different case - a command running a custom query that takes longer than our 60
     // second timeout. There will be a local client waiting for the response to this command, so the same criteria
     // breaks - we can't shut down the sync thread until it's complete, but the command it's waiting for doesn't return
@@ -250,9 +250,9 @@ class BedrockServer : public SQLiteServer {
     // This gets set to true when a database upgrade is in progress, letting workers know not to try to start any work.
     atomic<bool> _upgradeInProgress;
 
-    // This is the current version of the master node, updated after every SQLiteNode::update() iteration. A
+    // This is the current version of the leader node, updated after every SQLiteNode::update() iteration. A
     // reference to this object is passed to the sync thread to allow this update.
-    atomic<string> _masterVersion;
+    atomic<string> _leaderVersion;
 
     // This is a synchronized queued that can wake up a `poll()` call if something is added to it. This contains the
     // list of commands that worker threads were unable to complete on their own that needed to be passed back to the
@@ -274,7 +274,7 @@ class BedrockServer : public SQLiteServer {
     atomic<bool> _syncThreadComplete;
 
     // Give all of our plugins a chance to verify and/or modify the database schema. This will run every time this node
-    // becomes master. It will return true if the DB has changed and needs to be committed.
+    // becomes leader. It will return true if the DB has changed and needs to be committed.
     bool _upgradeDB(SQLite& db);
 
     // Iterate across all of our plugins and call `prePoll` and `postPoll` on any httpsManagers they've created.
@@ -289,7 +289,7 @@ class BedrockServer : public SQLiteServer {
     static void sync(SData& args,
                      atomic<SQLiteNode::State>& replicationState,
                      atomic<bool>& upgradeInProgress,
-                     atomic<string>& masterVersion,
+                     atomic<string>& leaderVersion,
                      BedrockTimeoutCommandQueue& syncNodeQueuedCommands,
                      BedrockServer& server);
 
@@ -297,7 +297,7 @@ class BedrockServer : public SQLiteServer {
     static void syncWrapper(SData& args,
                      atomic<SQLiteNode::State>& replicationState,
                      atomic<bool>& upgradeInProgress,
-                     atomic<string>& masterVersion,
+                     atomic<string>& leaderVersion,
                      BedrockTimeoutCommandQueue& syncNodeQueuedCommands,
                      BedrockServer& server);
 
@@ -305,7 +305,7 @@ class BedrockServer : public SQLiteServer {
     static void worker(SData& args,
                        atomic<SQLiteNode::State>& _replicationState,
                        atomic<bool>& upgradeInProgress,
-                       atomic<string>& masterVersion,
+                       atomic<string>& leaderVersion,
                        BedrockTimeoutCommandQueue& syncNodeQueuedCommands,
                        BedrockTimeoutCommandQueue& syncNodeCompletedCommands,
                        BedrockServer& server,
@@ -318,6 +318,7 @@ class BedrockServer : public SQLiteServer {
 
     // The following are constants used as methodlines by status command requests.
     static constexpr auto STATUS_IS_SLAVE          = "GET /status/isSlave HTTP/1.1";
+    static constexpr auto STATUS_IS_FOLLOWER       = "GET /status/isFollower HTTP/1.1";
     static constexpr auto STATUS_HANDLING_COMMANDS = "GET /status/handlingCommands HTTP/1.1";
     static constexpr auto STATUS_PING              = "Ping";
     static constexpr auto STATUS_STATUS            = "Status";
@@ -348,7 +349,7 @@ class BedrockServer : public SQLiteServer {
     void _beginShutdown(const string& reason, bool detach = false);
 
     // This is a map of commit counts in the future to commands that depend on them. We can receive a command that
-    // depends on a future commit if we're a slave that's behind master, and a client makes two requests, one to a node
+    // depends on a future commit if we're a follower that's behind leader, and a client makes two requests, one to a node
     // more current than ourselves, and a following request to us. We'll move these commands to this special map until
     // we catch up, and then move them back to the regular command queue.
     multimap<uint64_t, BedrockCommand> _futureCommitCommands;
@@ -363,7 +364,7 @@ class BedrockServer : public SQLiteServer {
     // is committing. This mutex is *not* recursive.
     shared_timed_mutex _syncThreadCommitMutex;
 
-    // Set this when we switch mastering.
+    // Set this when we switch leading.
     atomic<bool> _suppressMultiWrite;
 
     // A set of command names that will always be run with QUORUM consistency level.

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -21,6 +21,53 @@ STCPNode::~STCPNode() {
     peerList.clear();
 }
 
+const string& STCPNode::stateName(STCPNode::State state) {
+    // This returns the legacy names MASTERING/SLAVING until all nodes have been updated to be able to
+    // understand the new LEADING/FOLLOWING names.
+    static string placeholder = "";
+    static map<State, string> lookup = {
+        {UNKNOWN, "UNKNOWN"},
+        {SEARCHING, "SEARCHING"},
+        {SYNCHRONIZING, "SYNCHRONIZING"},
+        {WAITING, "WAITING"},
+        {STANDINGUP, "STANDINGUP"},
+        {LEADING, "MASTERING"},
+        {STANDINGDOWN, "STANDINGDOWN"},
+        {SUBSCRIBING, "SUBSCRIBING"},
+        {FOLLOWING, "SLAVING"},
+    };
+    auto it = lookup.find(state);
+    if (it == lookup.end()) {
+        return placeholder;
+    } else {
+        return it->second;
+    }
+}
+
+STCPNode::State STCPNode::stateFromName(const string& name) {
+    string normalizedName = SToUpper(name);
+
+    // Accept both old and new state names, but map them all to the new states.
+    static map<string, State> lookup = {
+        {"SEARCHING", SEARCHING},
+        {"SYNCHRONIZING", SYNCHRONIZING},
+        {"WAITING", WAITING},
+        {"STANDINGUP", STANDINGUP},
+        {"LEADING", LEADING},
+        {"MASTERING", LEADING},
+        {"STANDINGDOWN", STANDINGDOWN},
+        {"SUBSCRIBING", SUBSCRIBING},
+        {"FOLLOWING", FOLLOWING},
+        {"SLAVING", FOLLOWING},
+    };
+    auto it = lookup.find(normalizedName);
+    if (it == lookup.end()) {
+        return UNKNOWN;
+    } else {
+        return it->second;
+    }
+}
+
 void STCPNode::addPeer(const string& peerName, const string& host, const STable& params) {
     // Create a new peer and ready it for connection
     SASSERT(SHostIsValid(host));

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -47,6 +47,7 @@ struct STCPNode : public STCPServer {
         bool connected() { return (s && s->state.load() == STCPManager::Socket::CONNECTED); }
         void reset() {
             clear();
+            state = SEARCHING;
             s = nullptr;
             latency = 0;
         }

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -5,6 +5,21 @@ struct STCPNode : public STCPServer {
     STCPNode(const string& name, const string& host, const uint64_t recvTimeout_ = STIME_US_PER_M);
     virtual ~STCPNode();
 
+    // Possible states of a node in a DB cluster
+    enum State {
+        UNKNOWN,
+        SEARCHING,     // Searching for peers
+        SYNCHRONIZING, // Synchronizing with highest priority peer
+        WAITING,       // Waiting for an opportunity to leader or follower
+        STANDINGUP,    // Taking over leadership
+        LEADING,       // Acting as leader node
+        STANDINGDOWN,  // Giving up leader role
+        SUBSCRIBING,   // Preparing to follow the leader
+        FOLLOWING      // Following the leader node
+    };
+    static const string& stateName(State state);
+    static State stateFromName(const string& name);
+
     // Updates all peers
     void prePoll(fd_map& fdm);
     void postPoll(fd_map& fdm, uint64_t& nextActivity);
@@ -18,6 +33,7 @@ struct STCPNode : public STCPServer {
         string name;
         string host;
         STable params;
+        State state;
         uint64_t latency;
         uint64_t nextReconnect;
         uint64_t id;
@@ -25,7 +41,7 @@ struct STCPNode : public STCPServer {
 
         // Helper methods
         Peer(const string& name_, const string& host_, const STable& params_, uint64_t id_)
-          : name(name_), host(host_), params(params_), latency(0), nextReconnect(0), id(id_),
+          : name(name_), host(host_), params(params_), state(SEARCHING), latency(0), nextReconnect(0), id(id_),
             failedConnections(0), s(nullptr)
         { }
         bool connected() { return (s && s->state.load() == STCPManager::Socket::CONNECTED); }

--- a/main.cpp
+++ b/main.cpp
@@ -243,7 +243,7 @@ int main(int argc, char* argv[]) {
         cout << "- Put each Bedrock node on a different server." << endl;
         cout << endl;
         cout << "- Assign each node a different priority (greater than 0).  The highest priority node will be the "
-                "'master', which will coordinate distributed transactions."
+                "'leader', which will coordinate distributed transactions."
              << endl;
         cout << endl;
         return 1;

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -278,9 +278,9 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
                     STHROW("502 Select failed");
                 }
 
-                // If there's no job or the existing job doesn't match the data we've been passed, escalate to master.
+                // If there's no job or the existing job doesn't match the data we've been passed, escalate to leader.
                 if (!result.empty() && ((job["data"].empty() && result[0][1] == "{}") || (!job["data"].empty() && result[0][1] == job["data"]))) {
-                    // Return early, no need to pass to master, there are no more jobs to create.
+                    // Return early, no need to pass to leader, there are no more jobs to create.
                     SINFO("Job already existed and unique flag was passed, reusing existing job " << result[0][0] << ", mocked? "
                       << (command.request.isSet("mockRequest") ? "true" : "false"));
                     content["jobID"] = result[0][0];
@@ -428,7 +428,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         list<string> jobIDs;
         for (auto& job : jsonJobs) {
             // If unique flag was passed and the job exist in the DB, then we can finish the command without escalating to
-            // master.
+            // leader.
 
             // If this is a mock request, we insert that into the data.
             string originalData = job["data"];

--- a/sqlitecluster/SQLiteCommand.h
+++ b/sqlitecluster/SQLiteCommand.h
@@ -4,7 +4,7 @@
 class SQLiteCommand {
   public:
     // If this command was created via an escalation from a peer, this value will point to that peer object. As such,
-    // this should only ever be set on master nodes, though it does not *need* to be set on master nodes, as they can
+    // this should only ever be set on leader nodes, though it does not *need* to be set on leader nodes, as they can
     // also accept connections directly from clients.
     // A value of zero is an invalid ID, and is interpreted to mean "not set".
     // A negative value indicates a valid ID of an invalid peer (a psuedo-peer, or a disconnected peer), that we can't
@@ -12,7 +12,7 @@ class SQLiteCommand {
     int64_t initiatingPeerID;
 
     // If this command was created via a direct client connection, this value should be set. This can be set on both
-    // master and slaves, but should not be set simultaneously with `initiatingPeerID`. A command was initiated either
+    // leader and followers, but should not be set simultaneously with `initiatingPeerID`. A command was initiated either
     // by a client, or by a peer.
     // A value of zero is an invalid ID, and is interpreted to mean "not set".
     // A negative value indicates a valid ID of an invalid client (a psuedo-client, or a disconnected client), that we
@@ -20,7 +20,7 @@ class SQLiteCommand {
     int64_t initiatingClientID;
 
     // Each command is given a unique id that can be serialized and passed back and forth across nodes. Its id must be
-    // uniquely identifiable for cases where, for instance, two peers escalate commands to the master, and master will
+    // uniquely identifiable for cases where, for instance, two peers escalate commands to the leader, and leader will
     // need to  respond to them.
     string id;
 
@@ -43,13 +43,13 @@ class SQLiteCommand {
     bool complete;
 
     // Performance metrics.
-    // This is the amount of time a command spent in escalation. A master node will record this from the time it first
-    // dequeues and parses the command, until the time it sends the response back to a slave. A slave node will record
-    // this from just before it sends the command to master until it gets the response back.
+    // This is the amount of time a command spent in escalation. A leader node will record this from the time it first
+    // dequeues and parses the command, until the time it sends the response back to a follower. A follower node will record
+    // this from just before it sends the command to leader until it gets the response back.
     uint64_t escalationTimeUS;
 
     // Timestamp at which this command was created. This is specific to the current server - it's not persisted from
-    // slave to master.
+    // follower to leader.
     uint64_t creationTime;
 
     // Construct that takes a request object.

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -12,32 +12,23 @@
 // FIXME: Handle the case where two nodes have conflicting databases. Should find where they fork, tag the affected
 //        accounts for manual review, and adopt the higher-priority
 //
-// FIXME: Master should detect whether any slaves fall out of sync for any reason, identify/tag affected accounts, and
+// FIXME: Leader should detect whether any followers fall out of sync for any reason, identify/tag affected accounts, and
 //        re-synchronize.
 //
-// FIXME: Add test to measure how long it takes for master to stabilize.
+// FIXME: Add test to measure how long it takes for leader to stabilize.
 //
-// FIXME: If master dies before sending ESCALATE_RESPONSE (or if slave dies before receiving it), then a command might
+// FIXME: If leader dies before sending ESCALATE_RESPONSE (or if follower dies before receiving it), then a command might
 //        have been committed to the database without notifying whoever initiated it. Perhaps have the caller identify
 //        each command with a unique command id, and verify inside the query that the command hasn't been executed yet?
 
 #undef SLOGPREFIX
-#define SLOGPREFIX "{" << name << "/" << SQLiteNode::stateNames[_state] << "} "
+#define SLOGPREFIX "{" << name << "/" << SQLiteNode::stateName(_state) << "} "
 
 // Initializations for static vars.
 const uint64_t SQLiteNode::SQL_NODE_DEFAULT_RECV_TIMEOUT = STIME_US_PER_M * 5;
 const uint64_t SQLiteNode::SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT = STIME_US_PER_S * 30;
 atomic<bool> SQLiteNode::unsentTransactions(false);
 uint64_t SQLiteNode::_lastSentTransactionID = 0;
-
-const string SQLiteNode::stateNames[] = {"SEARCHING",
-                                         "SYNCHRONIZING",
-                                         "WAITING",
-                                         "STANDINGUP",
-                                         "MASTERING",
-                                         "STANDINGDOWN",
-                                         "SUBSCRIBING",
-                                         "SLAVING"};
 
 const string SQLiteNode::consistencyLevelNames[] = {"ASYNC",
                                                     "ONE",
@@ -53,7 +44,7 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, SQLite& db, const string& name, con
     _priority = priority;
     _state = SEARCHING;
     _syncPeer = nullptr;
-    _masterPeer = nullptr;
+    _leadPeer = nullptr;
     _stateTimeout = STimeNow() + firstTimeout;
     _version = version;
 
@@ -67,6 +58,14 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, SQLite& db, const string& name, con
         string host;
         STable params;
         SASSERT(SParseURIPath(peer, host, params));
+
+        // Support legacy 'Permaslave' name.
+        auto it = params.find("Permaslave");
+        if (it != params.end()) {
+            auto value = it->second;
+            params.erase(it);
+            params.emplace("Permafollower", value);
+        }
         string name = SGetDomain(host);
         if (params.find("nodeName") != params.end()) {
             name = params["nodeName"];
@@ -124,7 +123,7 @@ bool SQLiteNode::_isNothingBlockingShutdown() {
         return false;
     }
 
-    // If we have non-"Connection: wait" commands escalated to master, not done
+    // If we have non-"Connection: wait" commands escalated to leader, not done
     if (!_escalatedCommandMap.empty()) {
         return false;
     }
@@ -157,7 +156,7 @@ bool SQLiteNode::shutdownComplete() {
     if (_state > WAITING) {
         // Not in a shutdown state
         SINFO("Can't graceful shutdown yet because state="
-              << SQLiteNode::stateNames[_state] << ", commitInProgress=" << commitInProgress()
+              << stateName(_state) << ", commitInProgress=" << commitInProgress()
               << ", escalated=" << _escalatedCommandMap.size());
 
         // If we end up with anything left in the escalated command map when we're trying to shut down, let's log it,
@@ -218,7 +217,10 @@ void SQLiteNode::_sendOutstandingTransactions() {
         transaction["Command"] = "ASYNC";
         transaction["NewCount"] = to_string(id);
         transaction["NewHash"] = hash;
-        transaction["masterSendTime"] = sendTime;
+        transaction["leaderSendTime"] = sendTime;
+
+        // TODO: Remove this line when everything uses 'leader'.
+        transaction["masterSendTime"] = transaction["leaderSendTime"];
         transaction["ID"] = "ASYNC_" + to_string(id);
         transaction.content = query;
         _sendToAllPeers(transaction, true); // subscribed only
@@ -237,35 +239,35 @@ void SQLiteNode::_sendOutstandingTransactions() {
 }
 
 void SQLiteNode::escalateCommand(SQLiteCommand&& command, bool forget) {
-    // If the master is currently standing down, we won't escalate, we'll give the command back to the caller.
-    if((*_masterPeer)["State"] == "STANDINGDOWN") {
-        SINFO("Asked to escalate command but master standing down, letting server retry.");
+    // If the leader is currently standing down, we won't escalate, we'll give the command back to the caller.
+    if(_leadPeer->state == STANDINGDOWN) {
+        SINFO("Asked to escalate command but leader standing down, letting server retry.");
         _server.acceptCommand(move(command), false);
         return;
     }
 
-    // Send this to the MASTER
-    SASSERT(_masterPeer);
-    SASSERTEQUALS((*_masterPeer)["State"], "MASTERING");
+    // Send this to the leader
+    SASSERT(_leadPeer);
+    SASSERTEQUALS(_leadPeer->state, LEADING);
     uint64_t elapsed = STimeNow() - command.request.calcU64("commandExecuteTime");
-    SINFO("Escalating '" << command.request.methodLine << "' (" << command.id << ") to MASTER '" << _masterPeer->name
+    SINFO("Escalating '" << command.request.methodLine << "' (" << command.id << ") to leader '" << _leadPeer->name
           << "' after " << elapsed / 1000 << " ms");
 
-    // Create a command to send to our master.
+    // Create a command to send to our leader.
     SData escalate("ESCALATE");
     escalate["ID"] = command.id;
     escalate.content = command.request.serialize();
 
     // Store the command as escalated, unless we intend to forget about it anyway.
     if (forget) {
-        SINFO("Firing and forgetting command '" << command.request.methodLine << "' to master.");
+        SINFO("Firing and forgetting command '" << command.request.methodLine << "' to leader.");
     } else {
         command.escalationTimeUS = STimeNow();
         _escalatedCommandMap.emplace(command.id, move(command));
     }
 
-    // And send to master.
-    _sendToPeer(_masterPeer, escalate);
+    // And send to leader.
+    _sendToPeer(_leadPeer, escalate);
 }
 
 list<string> SQLiteNode::getEscalatedCommandRequestMethodLines() {
@@ -288,9 +290,9 @@ list<string> SQLiteNode::getEscalatedCommandRequestMethodLines() {
 //                               WAITING
 //                    ___________/     \____________
 //                   |                              |
-//              STANDINGUP                    SUBSCRIBING
+//              STANDINGUP                     SUBSCRIBING
 //                   |                              |
-//               MASTERING                       SLAVING
+//                LEADING                       FOLLOWING
 //                   |                              |
 //             STANDINGDOWN                         |
 //                   |___________       ____________|
@@ -301,8 +303,8 @@ list<string> SQLiteNode::getEscalatedCommandRequestMethodLines() {
 // to establish all its peer connections.  Once done, each node SYNCHRONIZES with
 // the freshest peer, meaning they download whatever "commits" they are
 // missing.  Then they WAIT until the highest priority node "stands up" to become
-// the new "master".  All other nodes then SUBSCRIBE and become "slaves".  If the
-// master "stands down", then all slaves unsubscribe and everybody goes back into
+// the new "leader".  All other nodes then SUBSCRIBE and become "followers".  If the
+// leader "stands down", then all followers unsubscribe and everybody goes back into
 // the SEARCHING state and tries it all over again.
 //
 //
@@ -337,25 +339,25 @@ bool SQLiteNode::update() {
     ///     we were able to successfully connect to -- if anyone.  The
     ///     logic for this state is as follows:
     ///
-    ///         if( no peers configured )             goto MASTERING
+    ///         if( no peers configured )             goto LEADING
     ///         if( !timeout )                        keep waiting
-    ///         if( no peers connected )              goto MASTERING
+    ///         if( no peers connected )              goto LEADING
     ///         if( nobody has more commits than us ) goto WAITING
     ///         else send SYNCHRONIZE and goto SYNCHRONIZING
     ///
     case SEARCHING: {
         SASSERTWARN(!_syncPeer);
-        SASSERTWARN(!_masterPeer);
+        SASSERTWARN(!_leadPeer);
         SASSERTWARN(_db.getUncommittedHash().empty());
         // If we're trying to shut down, just do nothing
         if (shutdownComplete())
             return false; // Don't re-update
 
-        // If no peers, we're the master, unless we're shutting down.
+        // If no peers, we're the leader, unless we're shutting down.
         if (peerList.empty()) {
-            // There are no peers, jump straight to mastering
-            SHMMM("No peers configured, jumping to MASTERING");
-            _changeState(MASTERING);
+            // There are no peers, jump straight to leading
+            SHMMM("No peers configured, jumping to LEADING");
+            _changeState(LEADING);
             return true; // Re-update immediately
         }
 
@@ -365,14 +367,14 @@ bool SQLiteNode::update() {
         Peer* freshestPeer = nullptr;
         for (auto peer : peerList) {
             // Wait until all connected (or failed) and logged in
-            bool permaSlave = peer->params["Permaslave"] == "true";
+            bool permaFollower = peer->params["Permafollower"] == "true";
             bool loggedIn = peer->test("LoggedIn");
 
-            // Count how many full peers (non-permaslaves) we have
-            numFullPeers += !permaSlave;
+            // Count how many full peers (non-permafollowers) we have
+            numFullPeers += !permaFollower;
 
             // Count how many full peers are logged in
-            numLoggedInFullPeers += (!permaSlave) && loggedIn;
+            numLoggedInFullPeers += (!permaFollower) && loggedIn;
 
             // Find the freshest peer
             if (loggedIn) {
@@ -383,9 +385,9 @@ bool SQLiteNode::update() {
             }
         }
 
-        // Keep searching until we connect to at least half our non-permaslave peers OR timeout
+        // Keep searching until we connect to at least half our non-permafollowers peers OR timeout
         SINFO("Signed in to " << numLoggedInFullPeers << " of " << numFullPeers << " full peers (" << peerList.size()
-                              << " with permaslaves), timeout in " << (_stateTimeout - STimeNow()) / 1000
+                              << " with permafollowers), timeout in " << (_stateTimeout - STimeNow()) / 1000
                               << "ms");
         if (((float)numLoggedInFullPeers < numFullPeers / 2.0) && (STimeNow() < _stateTimeout))
             return false;
@@ -442,7 +444,7 @@ bool SQLiteNode::update() {
     ///
     case SYNCHRONIZING: {
         SASSERTWARN(_syncPeer);
-        SASSERTWARN(!_masterPeer);
+        SASSERTWARN(!_leadPeer);
         SASSERTWARN(_db.getUncommittedHash().empty());
         // Nothing to do but wait
         if (STimeNow() > _stateTimeout) {
@@ -462,20 +464,20 @@ bool SQLiteNode::update() {
     ///         loop across "LoggedIn" peers to find the following:
     ///             - freshest peer (most commits)
     ///             - highest priority peer
-    ///             - current master (might be STANDINGUP or STANDINGDOWN)
+    ///             - current leader (might be STANDINGUP or STANDINGDOWN)
     ///         if( no peers logged in )
     ///             goto SEARCHING
-    ///         if( a higher-priority MASTERING master exists )
+    ///         if( a higher-priority LEADING leader exists )
     ///             send SUBSCRIBE and go SUBSCRIBING
     ///         if( the freshest peer has more commits han us )
     ///             goto SEARCHING
-    ///         if( no master and we're the highest prioriy )
+    ///         if( no leader and we're the highest prioriy )
     ///             clear "StandupResponse" on all peers
     ///             goto STANDINGUP
     ///
     case WAITING: {
         SASSERTWARN(!_syncPeer);
-        SASSERTWARN(!_masterPeer);
+        SASSERTWARN(!_leadPeer);
         SASSERTWARN(_db.getUncommittedHash().empty());
         SASSERTWARN(_escalatedCommandMap.empty());
         // If we're trying and ready to shut down, do nothing.
@@ -489,28 +491,28 @@ bool SQLiteNode::update() {
                 return false; // No fast update
             } else {
                 // We do have outstanding commands, even though a graceful shutdown
-                // has been requested.  This is probably due to us previously being a master
+                // has been requested.  This is probably due to us previously being a leader
                 // to which commands had been sent directly -- we got the signal to shutdown,
-                // and stood down immediately.  All the slaves will re-escalate whatever
+                // and stood down immediately.  All the followers will re-escalate whatever
                 // commands they were waiting on us to process, so they're fine.  But our own
-                // commands still need to be processed.  We're no longer the master, so we
+                // commands still need to be processed.  We're no longer the leader, so we
                 // can't do it.  Rather, even though we're trying to do a graceful shutdown,
-                // we need to find and slave to the new master, and have it process our
-                // commands.  Once the new master has processed our commands, then we can
+                // we need to find and follower to the new leader, and have it process our
+                // commands.  Once the new leader has processed our commands, then we can
                 // shut down gracefully.
                 SHMMM("Graceful shutdown underway but queued commands so continuing...");
             }
         }
 
-        // Loop across peers and find the highest priority and master
+        // Loop across peers and find the highest priority and leader
         int numFullPeers = 0;
         int numLoggedInFullPeers = 0;
         Peer* highestPriorityPeer = nullptr;
         Peer* freshestPeer = nullptr;
-        Peer* currentMaster = nullptr;
+        Peer* currentLeader = nullptr;
         for (auto peer : peerList) {
             // Make sure we're a full peer
-            if (peer->params["Permaslave"] != "true") {
+            if (peer->params["Permafollower"] != "true") {
                 // Verify we're logged in
                 ++numFullPeers;
                 if (SIEquals((*peer)["LoggedIn"], "true")) {
@@ -523,15 +525,13 @@ bool SQLiteNode::update() {
                     if (!highestPriorityPeer || peer->calc("Priority") > highestPriorityPeer->calc("Priority"))
                         highestPriorityPeer = peer;
 
-                    // See if it is currently the master (or standing up/down)
-                    const string& peerState = (*peer)["State"];
-                    if (SIEquals(peerState, "STANDINGUP") || SIEquals(peerState, "MASTERING") ||
-                        SIEquals(peerState, "STANDINGDOWN")) {
-                        // Found the current master
-                        if (currentMaster)
-                            PHMMM("Multiple peers trying to stand up (also '" << currentMaster->name
+                    // See if it is currently the leader (or standing up/down)
+                    if (peer->state == STANDINGUP || peer->state == LEADING || peer->state == STANDINGDOWN) {
+                        // Found the current leader
+                        if (currentLeader)
+                            PHMMM("Multiple peers trying to stand up (also '" << currentLeader->name
                                                                               << "'), let's hope they sort it out.");
-                        currentMaster = peer;
+                        currentLeader = peer;
                     }
                 }
             }
@@ -547,21 +547,20 @@ bool SQLiteNode::update() {
         SASSERT(highestPriorityPeer);
         SASSERT(freshestPeer);
 
-        // If there is already a master that is higher priority than us,
+        // If there is already a leader that is higher priority than us,
         // subscribe -- even if we're not in sync with it.  (It'll bring
         // us back up to speed while subscribing.)
-        if (currentMaster && _priority < highestPriorityPeer->calc("Priority") &&
-            SIEquals((*currentMaster)["State"], "MASTERING")) {
-            // Subscribe to the master
-            SINFO("Subscribing to master '" << currentMaster->name << "'");
-            _masterPeer = currentMaster;
-            _masterVersion = (*_masterPeer)["Version"];
-            _sendToPeer(currentMaster, SData("SUBSCRIBE"));
+        if (currentLeader && _priority < highestPriorityPeer->calc("Priority") && currentLeader->state == LEADING) {
+            // Subscribe to the leader
+            SINFO("Subscribing to leader '" << currentLeader->name << "'");
+            _leadPeer = currentLeader;
+            _leaderVersion = (*_leadPeer)["Version"];
+            _sendToPeer(currentLeader, SData("SUBSCRIBE"));
             _changeState(SUBSCRIBING);
             return true; // Re-update
         }
 
-        // No master to subscribe to, let's see if there's anybody else
+        // No leader to subscribe to, let's see if there's anybody else
         // out there with commits we don't have.  Might as well synchronize
         // while waiting.
         if (freshestPeer->calcU64("CommitCount") > _db.getCommitCount()) {
@@ -571,16 +570,16 @@ bool SQLiteNode::update() {
             return true; // Re-update
         }
 
-        // No master and we're in sync, perhaps everybody is waiting for us
+        // No leader and we're in sync, perhaps everybody is waiting for us
         // to stand up?  If we're higher than the highest priority, and are
         // connected to enough full peers to achieve quorum we should be
-        // master.
-        if (!currentMaster && numLoggedInFullPeers * 2 >= numFullPeers &&
+        // leader.
+        if (!currentLeader && numLoggedInFullPeers * 2 >= numFullPeers &&
             _priority > highestPriorityPeer->calc("Priority")) {
             // Yep -- time for us to stand up -- clear everyone's
             // last approval status as they're about to send them.
-            SASSERT(_priority > 0); // Permaslave should never stand up
-            SINFO("No master and we're highest priority (over " << highestPriorityPeer->name << "), STANDINGUP");
+            SASSERT(_priority > 0); // Permafollower should never stand up
+            SINFO("No leader and we're highest priority (over " << highestPriorityPeer->name << "), STANDINGUP");
             for (auto peer : peerList) {
                 peer->erase("StandupResponse");
             }
@@ -590,7 +589,7 @@ bool SQLiteNode::update() {
 
         // Keep waiting
         SDEBUG("Connected to " << numLoggedInFullPeers << " of " << numFullPeers << " full peers (" << peerList.size()
-                               << " with permaslaves), priority=" << _priority);
+                               << " with permafollowers), priority=" << _priority);
         break;
     }
 
@@ -600,13 +599,13 @@ bool SQLiteNode::update() {
     ///         if( at least one peer has denied standup )
     ///             goto SEARCHING
     ///         if( everybody has responded and approved )
-    ///             goto MASTERING
+    ///             goto LEADING
     ///         if( somebody hasn't responded but we're timing out )
     ///             goto SEARCHING
     ///
     case STANDINGUP: {
         SASSERTWARN(!_syncPeer);
-        SASSERTWARN(!_masterPeer);
+        SASSERTWARN(!_leadPeer);
         SASSERTWARN(_db.getUncommittedHash().empty());
         // Wait for everyone to respond
         bool allResponded = true;
@@ -619,7 +618,7 @@ bool SQLiteNode::update() {
         }
         for (auto peer : peerList) {
             // Check this peer; if not logged in, tacit approval
-            if (peer->params["Permaslave"] != "true") {
+            if (peer->params["Permafollower"] != "true") {
                 ++numFullPeers;
                 if (SIEquals((*peer)["LoggedIn"], "true")) {
                     // Connected and logged in.
@@ -643,8 +642,8 @@ bool SQLiteNode::update() {
         bool majorityConnected = numLoggedInFullPeers * 2 >= numFullPeers;
         if (allResponded && majorityConnected) {
             // Complete standup
-            SINFO("All peers approved standup, going MASTERING.");
-            _changeState(MASTERING);
+            SINFO("All peers approved standup, going LEADING.");
+            _changeState(LEADING);
             return true; // Re-update
         }
 
@@ -659,33 +658,33 @@ bool SQLiteNode::update() {
         break;
     }
 
-    /// - MASTERING / STANDINGDOWN : These are the states where the magic
+    /// - LEADING / STANDINGDOWN : These are the states where the magic
     ///     happens.  In both states, the node will execute distributed
     ///     transactions.  However, new transactions are only
-    ///     started in the MASTERING state (while existing transactions are
+    ///     started in the LEADING state (while existing transactions are
     ///     concluded in the STANDINGDOWN) state.  The logic for this state
     ///     is as follows:
     ///
     ///         if( we're processing a transaction )
-    ///             if( all subscribed slaves have responded/approved )
+    ///             if( all subscribed followers have responded/approved )
     ///                 commit this transaction to the local DB
-    ///                 broadcast COMMIT_TRANSACTION to all subscribed slaves
+    ///                 broadcast COMMIT_TRANSACTION to all subscribed followers
     ///                 send a STATE to show we've committed a new transaction
     ///                 notify the caller that the command is complete
-    ///         if( we're MASTERING and not processing a command )
-    ///             if( there is another MASTER )         goto STANDINGDOWN
+    ///         if( we're LEADING and not processing a command )
+    ///             if( there is another LEADER )         goto STANDINGDOWN
     ///             if( there is a higher priority peer ) goto STANDINGDOWN
     ///             if( a command is queued )
     ///                 if( processing the command affects the database )
     ///                    clear the TransactionResponse of all peers
-    ///                    broadcast BEGIN_TRANSACTION to subscribed slaves
-    ///         if( we're standing down and all slaves have unsubscribed )
+    ///                    broadcast BEGIN_TRANSACTION to subscribed followers
+    ///         if( we're standing down and all followers have unsubscribed )
     ///             goto SEARCHING
     ///
-    case MASTERING:
+    case LEADING:
     case STANDINGDOWN: {
         SASSERTWARN(!_syncPeer);
-        SASSERTWARN(!_masterPeer);
+        SASSERTWARN(!_leadPeer);
 
         // NOTE: This block very carefully will not try and call _changeState() while holding SQLite::g_commitLock,
         // because that could cause a deadlock when called by an outside caller!
@@ -700,19 +699,19 @@ bool SQLiteNode::update() {
         // waiting on peers to approve the transaction. We can do this even after we've begun standing down.
         if (_commitState == CommitState::COMMITTING) {
             // Loop across all peers configured to see how many are:
-            int numFullPeers = 0;     // Num non-permaslaves configured
-            int numFullSlaves = 0;    // Num full peers that are "subscribed"
+            int numFullPeers = 0;     // Num non-permafollowers configured
+            int numFullFollowers = 0; // Num full peers that are "subscribed"
             int numFullResponded = 0; // Num full peers that have responded approve/deny
             int numFullApproved = 0;  // Num full peers that have approved
             int numFullDenied = 0;    // Num full peers that have denied
             for (auto peer : peerList) {
-                // Check this peer to see if it's full or a permaslave
-                if (peer->params["Permaslave"] != "true") {
+                // Check this peer to see if it's full or a permafollower
+                if (peer->params["Permafollower"] != "true") {
                     // It's a full peer -- is it subscribed, and if so, how did it respond?
                     ++numFullPeers;
                     if ((*peer)["Subscribed"] == "true") {
                         // Subscribed, did it respond?
-                        numFullSlaves++;
+                        numFullFollowers++;
                         const string& response = (*peer)["TransactionResponse"];
                         if (response.empty()) {
                             continue;
@@ -753,14 +752,14 @@ bool SQLiteNode::update() {
                     break;
             }
 
-            // See if all active non-permaslaves have responded.
-            // NOTE: This can be true if nobody responds if there are no full slaves - this includes machines that
-            // should be slaves that are disconnected.
-            bool everybodyResponded = numFullResponded >= numFullSlaves;
+            // See if all active non-permafollowers have responded.
+            // NOTE: This can be true if nobody responds if there are no full followers - this includes machines that
+            // should be followers that are disconnected.
+            bool everybodyResponded = numFullResponded >= numFullFollowers;
 
             // Record these for posterity
             SDEBUG(     "numFullPeers="           << numFullPeers
-                   << ", numFullSlaves="          << numFullSlaves
+                   << ", numFullFollowers="       << numFullFollowers
                    << ", numFullResponded="       << numFullResponded
                    << ", numFullApproved="        << numFullApproved
                    << ", majorityApproved="       << majorityApproved
@@ -772,13 +771,13 @@ bool SQLiteNode::update() {
             // If anyone denied this transaction, roll this back. Alternatively, roll it back if everyone we're
             // currently connected to has responded, but that didn't generate enough consistency. This could happen, in
             // theory, if we were disconnected from enough of the cluster that we could no longer reach QUORUM, but
-            // this should have been detected earlier and forced us out of mastering.
+            // this should have been detected earlier and forced us out of leading.
             // TODO: we might want to remove the `numFullDenied` condition here. A single failure shouldn't cause the
-            // entire cluster to break. Imagine a scenario where a slave disk was full, and every write operation
+            // entire cluster to break. Imagine a scenario where a follower disk was full, and every write operation
             // failed with an sqlite3 error.
             if (numFullDenied || (everybodyResponded && !consistentEnough)) {
                 SINFO("Rolling back transaction because everybody currently connected responded "
-                      "but not consistent enough. Num denied: " << numFullDenied << ". Slave write failure?");
+                      "but not consistent enough. Num denied: " << numFullDenied << ". Follower write failure?");
                 _db.rollback();
 
                 // Notify everybody to rollback
@@ -814,7 +813,7 @@ bool SQLiteNode::update() {
                     uint64_t beginElapsed, readElapsed, writeElapsed, prepareElapsed, commitElapsed, rollbackElapsed;
                     uint64_t totalElapsed = _db.getLastTransactionTiming(beginElapsed, readElapsed, writeElapsed,
                                                                          prepareElapsed, commitElapsed, rollbackElapsed);
-                    SINFO("Committed master transaction for '"
+                    SINFO("Committed leader transaction for '"
                           << _db.getCommitCount() << " (" << _db.getCommittedHash() << "). "
                           << " (consistencyRequired=" << consistencyLevelNames[_commitConsistency] << "), "
                           << numFullApproved << " of " << numFullPeers << " approved (" << peerList.size() << " total) in "
@@ -882,7 +881,10 @@ bool SQLiteNode::update() {
                   << _db.getUncommittedHash() << ")");
             transaction.set("NewCount", commitCount + 1);
             transaction.set("NewHash", _db.getUncommittedHash());
-            transaction.set("masterSendTime", to_string(STimeNow()));
+            transaction.set("leaderSendTime", to_string(STimeNow()));
+
+            // TODO: Remove when we've switched to 'leader'
+            transaction.set("masterSendTime", transaction["leaderSendTime"]);
             if (_commitConsistency == ASYNC) {
                 transaction["ID"] = "ASYNC_" + to_string(_lastSentTransactionID + 1);
             } else {
@@ -906,10 +908,10 @@ bool SQLiteNode::update() {
         }
 
         // Check to see if we should stand down. We'll finish any outstanding commits before we actually do.
-        if (_state == MASTERING) {
+        if (_state == LEADING) {
             string standDownReason;
             if (gracefulShutdown()) {
-                // Graceful shutdown. Set priority 1 and stand down so we'll re-connect to the new master and finish
+                // Graceful shutdown. Set priority 1 and stand down so we'll re-connect to the new leader and finish
                 // up our commands.
                 standDownReason = "Shutting down, setting priority 1 and STANDINGDOWN.";
                 _priority = 1;
@@ -917,22 +919,22 @@ bool SQLiteNode::update() {
                 // Loop across peers
                 for (auto peer : peerList) {
                     // Check this peer
-                    if (SIEquals((*peer)["State"], "MASTERING")) {
-                        // Hm... somehow we're in a multi-master scenario -- not good.
+                    if (peer->state == LEADING) {
+                        // Hm... somehow we're in a multi-leader scenario -- not good.
                         // Let's get out of this as soon as possible.
-                        standDownReason = "Found another MASTER (" + peer->name + "), STANDINGDOWN to clean it up.";
-                    } else if (SIEquals((*peer)["State"], "WAITING")) {
+                        standDownReason = "Found another LEADER (" + peer->name + "), STANDINGDOWN to clean it up.";
+                    } else if (peer->state == WAITING) {
                         // We have a WAITING peer; is it waiting to STANDUP?
                         if (peer->calc("Priority") > _priority) {
                             // We've got a higher priority peer in the works; stand down so it can stand up.
                             standDownReason = "Found higher priority WAITING peer (" + peer->name
-                                              + ") while MASTERING, STANDINGDOWN";
+                                              + ") while LEADING, STANDINGDOWN";
                         } else if (peer->calcU64("CommitCount") > _db.getCommitCount()) {
                             // It's got data that we don't, stand down so we can get it.
                             standDownReason = "Found WAITING peer (" + peer->name +
                                               ") with more data than us (we have " + SToStr(_db.getCommitCount()) +
                                               "/" + _db.getCommittedHash() + ", it has " + (*peer)["CommitCount"] +
-                                              "/" + (*peer)["Hash"] + ") while MASTERING, STANDINGDOWN";
+                                              "/" + (*peer)["Hash"] + ") while LEADING, STANDINGDOWN";
                         }
                     }
                 }
@@ -963,58 +965,58 @@ bool SQLiteNode::update() {
             _changeState(SEARCHING);
 
             // We're no longer waiting on responses from peers, we can re-update immediately and start becoming a
-            // slave node instead.
+            // follower node instead.
             return true;
         }
         break;
     }
 
     /// - SUBSCRIBING: We're waiting for a SUBSCRIPTION_APPROVED from the
-    ///     master.  When we receive it, we'll go SLAVING.  Otherwise, if we
+    ///     leader.  When we receive it, we'll go FOLLOWING. Otherwise, if we
     ///     timeout, go SEARCHING.
     ///
     case SUBSCRIBING:
         SASSERTWARN(!_syncPeer);
-        SASSERTWARN(_masterPeer);
+        SASSERTWARN(_leadPeer);
         SASSERTWARN(_db.getUncommittedHash().empty());
         // Nothing to do but wait
         if (STimeNow() > _stateTimeout) {
             // Give up
-            SHMMM("Timed out waiting for SUBSCRIPTION_APPROVED, reconnecting to master and re-SEARCHING.");
-            _reconnectPeer(_masterPeer);
-            _masterPeer = nullptr;
+            SHMMM("Timed out waiting for SUBSCRIPTION_APPROVED, reconnecting to leader and re-SEARCHING.");
+            _reconnectPeer(_leadPeer);
+            _leadPeer = nullptr;
             _changeState(SEARCHING);
             return true; // Re-update
         }
         break;
 
-    /// - SLAVING: This is where the other half of the magic happens.  Most
+    /// - FOLLOWING: This is where the other half of the magic happens.  Most
     ///     nodes will (hopefully) spend 99.999% of their time in this state.
-    ///     SLAVING nodes simply begin and commit transactions with the
+    ///     FOLLOWING nodes simply begin and commit transactions with the
     ///     following logic:
     ///
-    ///         if( master steps down or disconnects ) goto SEARCHING
-    ///         if( new queued commands ) send ESCALATE to master
+    ///         if( leader steps down or disconnects ) goto SEARCHING
+    ///         if( new queued commands ) send ESCALATE to leader
     ///
-    case SLAVING:
+    case FOLLOWING:
         SASSERTWARN(!_syncPeer);
-        SASSERT(_masterPeer);
-        // If graceful shutdown requested, stop slaving once there is
+        SASSERT(_leadPeer);
+        // If graceful shutdown requested, stop following once there is
         // nothing blocking shutdown.  We stop listening for new commands
         // immediately upon TERM.)
         if (gracefulShutdown() && _isNothingBlockingShutdown()) {
-            // Go searching so we stop slaving
-            SINFO("Stopping SLAVING in order to gracefully shut down, SEARCHING.");
+            // Go searching so we stop following
+            SINFO("Stopping FOLLOWING in order to gracefully shut down, SEARCHING.");
             _changeState(SEARCHING);
             return false; // Don't update
         }
 
-        // If the master stops mastering (or standing down), we'll go SEARCHING, which allows us to look for a new
-        // master. We don't want to go searching before that, because we won't know when master is done sending its
+        // If the leader stops leading (or standing down), we'll go SEARCHING, which allows us to look for a new
+        // leader. We don't want to go searching before that, because we won't know when leader is done sending its
         // final transactions.
-        if (!SIEquals((*_masterPeer)["State"], "MASTERING") && !SIEquals((*_masterPeer)["State"], "STANDINGDOWN")) {
-            // Master stepping down
-            SHMMM("Master stepping down, re-queueing commands.");
+        if (_leadPeer->state != LEADING && _leadPeer->state != LEADING && _leadPeer->state != STANDINGDOWN) {
+            // Leader stepping down
+            SHMMM("Leader stepping down, re-queueing commands.");
 
             // If there were escalated commands, give them back to the server to retry.
             for (auto& cmd : _escalatedCommandMap) {
@@ -1025,7 +1027,7 @@ bool SQLiteNode::update() {
             // Are we in the middle of a commit? This should only happen if we received a `BEGIN_TRANSACTION` without a
             // corresponding `COMMIT` or `ROLLBACK`, this isn't supposed to happen.
             if (!_db.getUncommittedHash().empty()) {
-                SWARN("Master stepped down with transaction in progress, rolling back.");
+                SWARN("Leader stepped down with transaction in progress, rolling back.");
                 _db.rollback();
             }
             _changeState(SEARCHING);
@@ -1074,20 +1076,20 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         if (!message.isSet("Version")) {
             STHROW("missing Version");
         }
-        if (peer->params["Permaslave"] == "true" && message.calc("Priority")) {
-            STHROW("you're supposed to be a 0-priority permaslave");
+        if (peer->params["Permafollower"] == "true" && message.calc("Priority")) {
+            STHROW("you're supposed to be a 0-priority permafollower");
         }
-        if (peer->params["Permaslave"] != "true" && !message.calc("Priority")) {
-            STHROW("you're *not* supposed to be a 0-priority permaslave");
+        if (peer->params["Permafollower"] != "true" && !message.calc("Priority")) {
+            STHROW("you're *not* supposed to be a 0-priority permafollower");
         }
         // It's an error to have to peers configured with the same priority, except 0.
         SASSERT(!_priority || message.calc("Priority") != _priority);
         PINFO("Peer logged in at '" << message["State"] << "', priority #" << message["Priority"] << " commit #"
               << message["CommitCount"] << " (" << message["Hash"] << ")");
         peer->set("Priority", message["Priority"]);
-        peer->set("State",    message["State"]);
         peer->set("LoggedIn", "true");
         peer->set("Version",  message["Version"]);
+        peer->state = stateFromName(message["State"]);
 
         // Let the server know that a peer has logged in.
         _server.onNodeLogin(peer);
@@ -1103,43 +1105,32 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         if (!message.isSet("Priority")) {
             STHROW("missing Priority");
         }
-        string oldState = (*peer)["State"];
+        const State from = peer->state;
         peer->set("Priority", message["Priority"]);
-        peer->set("State",    message["State"]);
-        const string& newState = (*peer)["State"];
-        if (oldState == newState) {
+        peer->state = stateFromName(message["State"]);
+        const State to = peer->state;
+        if (from == to) {
             // No state change, just new commits?
-            PINFO("Peer received new commit in state '" << oldState << "', commit #" << message["CommitCount"] << " ("
+            PINFO("Peer received new commit in state '" << stateName(from) << "', commit #" << message["CommitCount"] << " ("
                   << message["Hash"] << ")");
         } else {
             // State changed -- first see if it's doing anything unusual
-            PINFO("Peer switched from '" << oldState << "' to '" << newState << "' commit #" << message["CommitCount"]
+            PINFO("Peer switched from '" << stateName(from) << "' to '" << stateName(to) << "' commit #" << message["CommitCount"]
                   << " (" << message["Hash"] << ")");
-            int from = 0, to = 0;
-
-            // Make sure "to" and "from" are known states
-            for (from = SEARCHING; from <= SLAVING; from++) {
-                if (SIEquals(oldState, stateNames[from])) {
-                    break;
-                }
+            if (from == UNKNOWN) {
+                PWARN("Peer coming from unrecognized state '" << stateName(from) << "'");
             }
-            for (to = SEARCHING; to <= SLAVING; to++) {
-                if (SIEquals(newState, stateNames[to])) {
-                    break;
-                }
-            }
-            if (from > SLAVING) {
-                PWARN("Peer coming from unrecognized state '" << oldState << "'");
-            }
-            if (to > SLAVING) {
-                PWARN("Peer going to unrecognized state '" << newState << "'");
+            if (to == UNKNOWN) {
+                PWARN("Peer going to unrecognized state '" << stateName(to) << "'");
             }
 
             // Make sure transition states are an approved pair
             bool okTransition = false;
             switch (from) {
+            case UNKNOWN:
+                break;
             case SEARCHING:
-                okTransition = (to == SYNCHRONIZING || to == WAITING || to == MASTERING);
+                okTransition = (to == SYNCHRONIZING || to == WAITING || to == LEADING);
                 break;
             case SYNCHRONIZING:
                 okTransition = (to == SEARCHING || to == WAITING);
@@ -1148,23 +1139,23 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 okTransition = (to == SEARCHING || to == STANDINGUP || to == SUBSCRIBING);
                 break;
             case STANDINGUP:
-                okTransition = (to == SEARCHING || to == MASTERING);
+                okTransition = (to == SEARCHING || to == LEADING);
                 break;
-            case MASTERING:
+            case LEADING:
                 okTransition = (to == SEARCHING || to == STANDINGDOWN);
                 break;
             case STANDINGDOWN:
                 okTransition = (to == SEARCHING);
                 break;
             case SUBSCRIBING:
-                okTransition = (to == SEARCHING || to == SLAVING);
+                okTransition = (to == SEARCHING || to == FOLLOWING);
                 break;
-            case SLAVING:
+            case FOLLOWING:
                 okTransition = (to == SEARCHING);
                 break;
             }
             if (!okTransition) {
-                PWARN("Peer making invalid transition from '" << stateNames[from] << "' to '" << stateNames[to] << "'");
+                PWARN("Peer making invalid transition from '" << stateName(from) << "' to '" << stateName(to) << "'");
             }
 
             // Next, should we do something about it?
@@ -1176,57 +1167,57 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 peer->erase("Subscribed");
             } else if (to == STANDINGUP) {
                 // STANDINGUP: When a peer announces it intends to stand up, we immediately respond with approval or
-                // denial. We determine this by checking to see if there is any  other peer who is already master or
+                // denial. We determine this by checking to see if there is any  other peer who is already leader or
                 // also trying to stand up.
                 //
                 // **FIXME**: Should it also deny if it knows of a higher priority peer?
                 SData response("STANDUP_RESPONSE");
                 // Parrot back the node's attempt count so that it can differentiate stale responses.
                 response["StateChangeCount"] = message["StateChangeCount"];
-                if (peer->params["Permaslave"] == "true") {
-                    // We think it's a permaslave, deny
-                    PHMMM("Permaslave trying to stand up, denying.");
+                if (peer->params["Permafollower"] == "true") {
+                    // We think it's a permafollower, deny
+                    PHMMM("Permafollower trying to stand up, denying.");
                     response["Response"] = "deny";
-                    response["Reason"] = "You're a permaslave";
+                    response["Reason"] = "You're a permafollower";
                 }
 
                 // What's our state
                 if (SWITHIN(STANDINGUP, _state, STANDINGDOWN)) {
-                    // Oh crap, it's trying to stand up while we're mastering. Who is higher priority?
+                    // Oh crap, it's trying to stand up while we're leading. Who is higher priority?
                     if (peer->calc("Priority") > _priority) {
                         // The other peer is a higher priority than us, so we should stand down (maybe it crashed, we
-                        // came up as master, and now it's been brought back up). We'll want to stand down here, but we
+                        // came up as leader, and now it's been brought back up). We'll want to stand down here, but we
                         // do it gracefully so that we won't lose any transactions in progress.
                         if (_state == STANDINGUP) {
                             PWARN("Higher-priority peer is trying to stand up while we are STANDINGUP, SEARCHING.");
                             _changeState(SEARCHING);
-                        } else if (_state == MASTERING) {
-                            PWARN("Higher-priority peer is trying to stand up while we are MASTERING, STANDINGDOWN.");
+                        } else if (_state == LEADING) {
+                            PWARN("Higher-priority peer is trying to stand up while we are LEADING, STANDINGDOWN.");
                             _changeState(STANDINGDOWN);
                         } else {
                             PWARN("Higher-priority peer is trying to stand up while we are STANDINGDOWN, continuing.");
                         }
                     } else {
-                        // Deny because we're currently in the process of mastering and we're higher priority.
+                        // Deny because we're currently in the process of leading and we're higher priority.
                         response["Response"] = "deny";
-                        response["Reason"] = "I am mastering";
+                        response["Reason"] = "I am leading";
 
                         // Hmm, why is a lower priority peer trying to stand up? Is it possible we're no longer in
                         // control of the cluster? Let's see how many nodes are subscribed.
                         if (_majoritySubscribed()) {
                             // we have a majority of the cluster, so ignore this oddity.
-                            PHMMM("Lower-priority peer is trying to stand up while we are " << stateNames[_state]
+                            PHMMM("Lower-priority peer is trying to stand up while we are " << stateName(_state)
                                   << " with a majority of the cluster; denying and ignoring.");
                         } else {
                             // We don't have a majority of the cluster -- maybe it knows something we don't?  For
                             // example, it could be that the rest of the cluster has forked away from us. This can
-                            // happen if the master hangs while processing a command: by the time it finishes, the
-                            // cluster might have elected a new master, forked, and be a thousand commits in the future.
+                            // happen if the leader hangs while processing a command: by the time it finishes, the
+                            // cluster might have elected a new leader, forked, and be a thousand commits in the future.
                             // In this case, let's just reset everything anyway to be safe.
-                            PWARN("Lower-priority peer is trying to stand up while we are " << stateNames[_state]
+                            PWARN("Lower-priority peer is trying to stand up while we are " << stateName(_state)
                                   << ", but we don't have a majority of the cluster so reconnecting and SEARCHING.");
                             _reconnectAll();
-                            // TODO: This puts us in an ambiguous state if we switch to SEARCHING from MASTERING,
+                            // TODO: This puts us in an ambiguous state if we switch to SEARCHING from LEADING,
                             // without going through the STANDDOWN process. We'll need to handle it better, but it's
                             // unclear if this can ever happen at all. exit() may be a reasonable strategy here.
                             _changeState(SEARCHING);
@@ -1237,13 +1228,19 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                     response["Response"] = "approve"; // Optimistic; will override
                     for (auto otherPeer : peerList) {
                         if (otherPeer != peer) {
-                            // See if it's trying to be master
-                            const string& state = (*otherPeer)["State"];
-                            if (SIEquals(state, "STANDINGUP") || SIEquals(state, "MASTERING") ||
-                                SIEquals(state, "STANDINGDOWN")) {
+                            // See if it's trying to be leader
+                            if (otherPeer->state == STANDINGUP || otherPeer->state == LEADING || otherPeer->state == STANDINGDOWN) {
                                 // We need to contest this standup
                                 response["Response"] = "deny";
-                                response["Reason"] = "peer '" + otherPeer->name + "' is '" + state + "'";
+                                response["Reason"] = "peer '" + otherPeer->name + "' is '" + stateName(otherPeer->state) + "'";
+                                uint64_t recvTime = 0;
+                                if (otherPeer->s) {
+                                    recvTime = otherPeer->s->lastRecvTime;
+                                }
+                                cout << "When was the last time we heard from this guy (" << otherPeer->name << ")? " << recvTime << endl;
+                                SData ping("PING");
+                                ping["Timestamp"] = to_string(STimeNow());
+                                _sendToPeer(otherPeer, ping);
                                 break;
                             }
                         }
@@ -1262,10 +1259,10 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 // transaction (and if we do, we warn and rollback).
                 if (!_db.getUncommittedHash().empty()) {
                     // Crap, we were waiting for a response that will apparently never come. I guess roll it back? This
-                    // should never happen, however, as the master shouldn't STANDOWN unless all subscribed slaves
+                    // should never happen, however, as the leader shouldn't STANDOWN unless all subscribed followers
                     // (including us) have already unsubscribed, and we wouldn't do that in the middle of a
                     // transaction. But just in case...
-                    SASSERTWARN(_state == SLAVING);
+                    SASSERTWARN(_state == FOLLOWING);
                     PWARN("Was expecting a response for transaction #"
                           << _db.getCommitCount() + 1 << " (" << _db.getUncommittedHash()
                           << ") but stood down prematurely, rolling back and hoping for the best.");
@@ -1290,7 +1287,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             }
             if (peer->isSet("StandupResponse")) {
                 PWARN("Already received standup response '" << (*peer)["StandupResponse"] << "', now receiving '"
-                      << message["Response"] << "', odd -- multiple masters competing?");
+                      << message["Response"] << "', odd -- multiple leaders competing?");
             }
             if (SIEquals(message["Response"], "approve")) {
                 PINFO("Received standup approval");
@@ -1302,10 +1299,10 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             SINFO("Got STANDUP_RESPONSE but not STANDINGUP. Probably a late message, ignoring.");
         }
     } else if (SIEquals(message.methodLine, "SYNCHRONIZE")) {
-        // If we're SLAVING, we'll let worker threads handle SYNCHRONIZATION messages. We don't on master, because if
-        // there's a backlog of commands, these can get stale, and by the time they reach the slave, it's already
+        // If we're FOLLOWING, we'll let worker threads handle SYNCHRONIZATION messages. We don't on leader, because if
+        // there's a backlog of commands, these can get stale, and by the time they reach the follower, it's already
         // behind, thus never catching up.
-        if (_state == SLAVING) {
+        if (_state == FOLLOWING) {
             // Attach all of the state required to populate a SYNCHRONIZE_RESPONSE to this message. All of this is
             // processed asynchronously, but that is fine, the final `SUBSCRIBE` message and its response will be
             // processed synchronously.
@@ -1386,22 +1383,22 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             throw e;
         }
     } else if (SIEquals(message.methodLine, "SUBSCRIBE")) {
-        // SUBSCRIBE: Sent by a node in the WAITING state to the current master to begin SLAVING. Respond
+        // SUBSCRIBE: Sent by a node in the WAITING state to the current leader to begin FOLLOWING. Respond
         // SUBSCRIPTION_APPROVED with any COMMITs that the subscribing peer lacks (for example, any commits that have
         // occurred after it completed SYNCHRONIZING but before this SUBSCRIBE was received). Tag this peer as
-        // "subscribed" for use in the MASTERING and STANDINGDOWN update loops. Finally, if there is an outstanding
-        // distributed transaction being processed, send it to this new slave.
-        if (_state != MASTERING) {
-            STHROW("not mastering");
+        // "subscribed" for use in the LEADING and STANDINGDOWN update loops. Finally, if there is an outstanding
+        // distributed transaction being processed, send it to this new follower.
+        if (_state != LEADING && _state != LEADING) {
+            STHROW("not leading");
         }
-        PINFO("Received SUBSCRIBE, accepting new slave");
+        PINFO("Received SUBSCRIBE, accepting new follower");
         SData response("SUBSCRIPTION_APPROVED");
         _queueSynchronize(peer, response, true); // Send everything it's missing
         _sendToPeer(peer, response);
         SASSERTWARN(!SIEquals((*peer)["Subscribed"], "true"));
         (*peer)["Subscribed"] = "true";
 
-        // New slave; are we in the midst of a transaction?
+        // New follower; are we in the midst of a transaction?
         if (_commitState == CommitState::COMMITTING) {
             // Invite the new peer to participate in the transaction
             SINFO("Inviting peer into distributed transaction already underway (" << _db.getUncommittedHash() << ")");
@@ -1413,18 +1410,21 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                   << _db.getUncommittedHash() << ")");
             transaction.set("NewCount", commitCount + 1);
             transaction.set("NewHash", _db.getUncommittedHash());
-            transaction.set("masterSendTime", to_string(STimeNow()));
+            transaction.set("leaderSendTime", to_string(STimeNow()));
+
+            // TODO: Remove when we've switched to 'leader'
+            transaction.set("masterSendTime", transaction["leaderSendTime"]);
             transaction.set("ID", _lastSentTransactionID + 1);
             transaction.content = _db.getUncommittedQuery();
             _sendToPeer(peer, transaction);
         }
     } else if (SIEquals(message.methodLine, "SUBSCRIPTION_APPROVED")) {
-        // SUBSCRIPTION_APPROVED: Sent by a slave's new master to complete the subscription process. Includes zero or
+        // SUBSCRIPTION_APPROVED: Sent by a follower's new leader to complete the subscription process. Includes zero or
         // more COMMITS that should be immediately applied to the database.
         if (_state != SUBSCRIBING) {
             STHROW("not subscribing");
         }
-        if (_masterPeer != peer) {
+        if (_leadPeer != peer) {
             STHROW("not subscribing to you");
         }
         SINFO("Received SUBSCRIPTION_APPROVED, final synchronization.");
@@ -1432,24 +1432,29 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             // Done synchronizing
             _recvSynchronize(peer, message);
             SINFO("Subscription complete, at commitCount #" << _db.getCommitCount() << " (" << _db.getCommittedHash()
-                  << "), SLAVING");
-            _changeState(SLAVING);
+                  << "), FOLLOWING");
+            _changeState(FOLLOWING);
         } catch (const SException& e) {
             // Transaction failed
-            SWARN("Subscription failed '" << e.what() << "', reconnecting to master and re-SEARCHING.");
-            _reconnectPeer(_masterPeer);
+            SWARN("Subscription failed '" << e.what() << "', reconnecting to leader and re-SEARCHING.");
+            _reconnectPeer(_leadPeer);
             _changeState(SEARCHING);
             throw e;
         }
     } else if (SIEquals(message.methodLine, "BEGIN_TRANSACTION")) {
-        // BEGIN_TRANSACTION: Sent by the MASTER to all subscribed slaves to begin a new distributed transaction. Each
-        // slave begins a local transaction with this query and responds APPROVE_TRANSACTION. If the slave cannot start
-        // the transaction for any reason, it is broken somehow -- disconnect from the master.
-        // **FIXME**: What happens if MASTER steps down before sending BEGIN?
-        // **FIXME**: What happens if MASTER steps down or disconnects after BEGIN?
+        // BEGIN_TRANSACTION: Sent by the LEADER to all subscribed followers to begin a new distributed transaction. Each
+        // follower begins a local transaction with this query and responds APPROVE_TRANSACTION. If the follower cannot start
+        // the transaction for any reason, it is broken somehow -- disconnect from the leader.
+        // **FIXME**: What happens if LEADER steps down before sending BEGIN?
+        // **FIXME**: What happens if LEADER steps down or disconnects after BEGIN?
         bool success = true;
-        uint64_t masterSentTimestamp = message.calcU64("masterSendTime");
-        uint64_t slaveDequeueTimestamp = STimeNow();
+        uint64_t leaderSentTimestamp = message.calcU64("leaderSendTime");
+
+        // TODO: Remove when everything uses 'leader'.
+        if (!leaderSentTimestamp) {
+            leaderSentTimestamp = message.calcU64("masterSendTime");
+        }
+        uint64_t followerDequeueTimestamp = STimeNow();
         if (!message.isSet("ID")) {
             STHROW("missing ID");
         }
@@ -1459,11 +1464,11 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         if (!message.isSet("NewHash")) {
             STHROW("missing NewHash");
         }
-        if (_state != SLAVING) {
-            STHROW("not slaving");
+        if (_state != FOLLOWING) {
+            STHROW("not following");
         }
-        if (!_masterPeer) {
-            STHROW("no master?");
+        if (!_leadPeer) {
+            STHROW("no leader?");
         }
         if (!_db.getUncommittedHash().empty()) {
             STHROW("already in a transaction");
@@ -1500,44 +1505,44 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
 
         // Are we participating in quorum?
         if (_priority) {
-            // If the ID is /ASYNC_\d+/, no need to respond, master will ignore it anyway.
+            // If the ID is /ASYNC_\d+/, no need to respond, leader will ignore it anyway.
             string verb = success ? "APPROVE_TRANSACTION" : "DENY_TRANSACTION";
             if (!SStartsWith(message["ID"], "ASYNC_")) {
-                // Not a permaslave, approve the transaction
+                // Not a permafollower, approve the transaction
                 PINFO(verb << " #" << _db.getCommitCount() + 1 << " (" << message["NewHash"] << ").");
                 SData response(verb);
                 response["NewCount"] = SToStr(_db.getCommitCount() + 1);
                 response["NewHash"] = success ? _db.getUncommittedHash() : message["NewHash"];
                 response["ID"] = message["ID"];
-                _sendToPeer(_masterPeer, response);
+                _sendToPeer(_leadPeer, response);
             } else {
                 PINFO("Skipping " << verb << " for ASYNC command.");
             }
         } else {
             PINFO("Would approve/deny transaction #" << _db.getCommitCount() + 1 << " (" << _db.getUncommittedHash()
-                  << ") for command '" << message["Command"] << "', but a permaslave -- keeping quiet.");
+                  << ") for command '" << message["Command"] << "', but a permafollower -- keeping quiet.");
         }
 
         // Check our escalated commands and see if it's one being processed
         auto commandIt = _escalatedCommandMap.find(message["ID"]);
         if (commandIt != _escalatedCommandMap.end()) {
             // We're starting the transaction for a given command; note this
-            // so we know that this command might be corrupted if the master
+            // so we know that this command might be corrupted if the leader
             // crashes.
-            SINFO("Master is processing our command " << message["ID"] << " (" << message["Command"] << ")");
+            SINFO("Leader is processing our command " << message["ID"] << " (" << message["Command"] << ")");
             commandIt->second.transaction = message;
         }
 
-        uint64_t transitTimeUS = slaveDequeueTimestamp - masterSentTimestamp;
-        uint64_t applyTimeUS = STimeNow() - slaveDequeueTimestamp;
+        uint64_t transitTimeUS = followerDequeueTimestamp - leaderSentTimestamp;
+        uint64_t applyTimeUS = STimeNow() - followerDequeueTimestamp;
         float transitTimeMS = (float)transitTimeUS / 1000.0;
         float applyTimeMS = (float)applyTimeUS / 1000.0;
-        PINFO("Replicated transaction " << message.calcU64("NewCount") << ", sent by master at " << masterSentTimestamp
+        PINFO("Replicated transaction " << message.calcU64("NewCount") << ", sent by leader at " << leaderSentTimestamp
               << ", transit/dequeue time: " << transitTimeMS << "ms, applied in: " << applyTimeMS << "ms, should COMMIT next.");
     } else if (SIEquals(message.methodLine, "APPROVE_TRANSACTION") ||
                SIEquals(message.methodLine, "DENY_TRANSACTION")) {
-        // APPROVE_TRANSACTION: Sent to the master by a slave when it confirms it was able to begin a transaction and
-        // is ready to commit. Note that this peer approves the transaction for use in the MASTERING and STANDINGDOWN
+        // APPROVE_TRANSACTION: Sent to the leader by a follower when it confirms it was able to begin a transaction and
+        // is ready to commit. Note that this peer approves the transaction for use in the LEADING and STANDINGDOWN
         // update loop.
         if (!message.isSet("ID")) {
             STHROW("missing ID");
@@ -1548,8 +1553,8 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         if (!message.isSet("NewHash")) {
             STHROW("missing NewHash");
         }
-        if (_state != MASTERING && _state != STANDINGDOWN) {
-            STHROW("not mastering");
+        if (_state != LEADING && _state != STANDINGDOWN) {
+            STHROW("not leading");
         }
         string response = SIEquals(message.methodLine, "APPROVE_TRANSACTION") ? "approve" : "deny";
         try {
@@ -1563,8 +1568,8 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                     STHROW("commit count mismatch. Expected: " + message["NewCount"] + ", but would actually be: "
                           + to_string(_db.getCommitCount() + 1));
                 }
-                if (peer->params["Permaslave"] == "true") {
-                    STHROW("permaslaves shouldn't approve/deny");
+                if (peer->params["Permafollower"] == "true") {
+                    STHROW("permafollowers shouldn't approve/deny");
                 }
                 PINFO("Peer " << response << " transaction #" << message["NewCount"] << " (" << message["NewHash"] << ")");
                 (*peer)["TransactionResponse"] = response;
@@ -1575,21 +1580,21 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             }
         } catch (const SException& e) {
             // Doesn't correspond to the outstanding transaction not necessarily fatal. This can happen if, for
-            // example, a command is escalated from/ one slave, approved by the second, but where the first slave dies
-            // before the second's approval is received by the master. In this case the master will drop the command
+            // example, a command is escalated from/ one follower, approved by the second, but where the first follower dies
+            // before the second's approval is received by the leader. In this case the leader will drop the command
             // when the initiating peer is lost, and thus won't have an outstanding transaction (or will be processing
             // a new transaction) when the old, outdated approval is received. Furthermore, in this case we will have
-            // already sent a ROLLBACK, so it will already correct itself. If not, then we'll wait for the slave to
+            // already sent a ROLLBACK, so it will already correct itself. If not, then we'll wait for the follower to
             // determine it's screwed and reconnect.
             SWARN("Received " << message.methodLine << " for transaction #"
                   << message.calc("NewCount") << " (" << message["NewHash"] << ", " << message["ID"] << ") but '"
                   << e.what() << "', ignoring.");
         }
     } else if (SIEquals(message.methodLine, "COMMIT_TRANSACTION")) {
-        // COMMIT_TRANSACTION: Sent to all subscribed slaves by the master when it determines that the current
+        // COMMIT_TRANSACTION: Sent to all subscribed followers by the leader when it determines that the current
         // outstanding transaction should be committed to the database. This completes a given distributed transaction.
-        if (_state != SLAVING) {
-            STHROW("not slaving");
+        if (_state != FOLLOWING) {
+            STHROW("not following");
         }
         if (_db.getUncommittedHash().empty()) {
             STHROW("no outstanding transaction");
@@ -1605,7 +1610,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         SDEBUG("Committing current transaction because COMMIT_TRANSACTION: " << _db.getUncommittedQuery());
         _db.commit();
 
-        // Clear the list of committed transactions. We're slaving, so we don't need to send these.
+        // Clear the list of committed transactions. We're following, so we don't need to send these.
         _db.getCommittedTransactions();
 
         // Log timing info.
@@ -1613,7 +1618,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         uint64_t beginElapsed, readElapsed, writeElapsed, prepareElapsed, commitElapsed, rollbackElapsed;
         uint64_t totalElapsed = _db.getLastTransactionTiming(beginElapsed, readElapsed, writeElapsed, prepareElapsed,
                                                              commitElapsed, rollbackElapsed);
-        SINFO("Committed slave transaction #" << message["CommitCount"] << " (" << message["Hash"] << ") in "
+        SINFO("Committed follower transaction #" << message["CommitCount"] << " (" << message["Hash"] << ") in "
               << totalElapsed / 1000 << " ms (" << beginElapsed / 1000 << "+"
               << readElapsed / 1000 << "+" << writeElapsed / 1000 << "+"
               << prepareElapsed / 1000 << "+" << commitElapsed / 1000 << "+"
@@ -1623,18 +1628,18 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         auto commandIt = _escalatedCommandMap.find(message["ID"]);
         if (commandIt != _escalatedCommandMap.end()) {
             // We're starting the transaction for a given command; note this so we know that this command might be
-            // corrupted if the master crashes.
-            SINFO("Master has committed in response to our command " << message["ID"]);
+            // corrupted if the leader crashes.
+            SINFO("Leader has committed in response to our command " << message["ID"]);
             commandIt->second.transaction = message;
         }
     } else if (SIEquals(message.methodLine, "ROLLBACK_TRANSACTION")) {
-        // ROLLBACK_TRANSACTION: Sent to all subscribed slaves by the master when it determines that the current
+        // ROLLBACK_TRANSACTION: Sent to all subscribed followers by the leader when it determines that the current
         // outstanding transaction should be rolled back. This completes a given distributed transaction.
         if (!message.isSet("ID")) {
             STHROW("missing ID");
         }
-        if (_state != SLAVING) {
-            STHROW("not slaving");
+        if (_state != FOLLOWING) {
+            STHROW("not following");
         }
         if (_db.getUncommittedHash().empty()) {
             SINFO("Received ROLLBACK_TRANSACTION with no outstanding transaction.");
@@ -1645,28 +1650,28 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         auto commandIt = _escalatedCommandMap.find(message["ID"]);
         if (commandIt != _escalatedCommandMap.end()) {
             // We're starting the transaction for a given command; note this so we know that this command might be
-            // corrupted if the master crashes.
-            SINFO("Master has rolled back in response to our command " << message["ID"]);
+            // corrupted if the leader crashes.
+            SINFO("Leader has rolled back in response to our command " << message["ID"]);
             commandIt->second.transaction = message;
         }
     } else if (SIEquals(message.methodLine, "ESCALATE")) {
-        // ESCALATE: Sent to the master by a slave. Is processed like a normal command, except when complete an
-        // ESCALATE_RESPONSE is sent to the slave that initiated the escalation.
+        // ESCALATE: Sent to the leader by a follower. Is processed like a normal command, except when complete an
+        // ESCALATE_RESPONSE is sent to the follower that initiated the escalation.
         if (!message.isSet("ID")) {
             STHROW("missing ID");
         }
-        if (_state != MASTERING) {
-            // Reject escalation because we're no longer mastering
+        if (_state != LEADING) {
+            // Reject escalation because we're no longer leading
             if (_state != STANDINGDOWN) {
                 // Don't warn if we're standing down, this is expected.
-                PWARN("Received ESCALATE but not MASTERING or STANDINGDOWN, aborting command.");
+                PWARN("Received ESCALATE but not LEADING or STANDINGDOWN, aborting command.");
             }
             SData aborted("ESCALATE_ABORTED");
             aborted["ID"] = message["ID"];
-            aborted["Reason"] = "not mastering";
+            aborted["Reason"] = "not leading";
             _sendToPeer(peer, aborted);
         } else {
-            // We're mastering, make sure the rest checks out
+            // We're leading, make sure the rest checks out
             SData request;
             if (!request.deserialize(message.content)) {
                 STHROW("malformed request");
@@ -1686,18 +1691,18 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             _server.acceptCommand(move(command), true);
         }
     } else if (SIEquals(message.methodLine, "ESCALATE_CANCEL")) {
-        // ESCALATE_CANCEL: Sent to the master by a slave. Indicates that the slave would like to cancel the escalated
+        // ESCALATE_CANCEL: Sent to the leader by a follower. Indicates that the follower would like to cancel the escalated
         // command, such that it is not processed. For example, if the client that sent the original request
-        // disconnects from the slave before an answer is returned, there is no value (and sometimes a negative value)
-        // to the master going ahead and completing it.
+        // disconnects from the follower before an answer is returned, there is no value (and sometimes a negative value)
+        // to the leader going ahead and completing it.
         if (!message.isSet("ID")) {
             STHROW("missing ID");
         }
-        if (_state != MASTERING) {
-            // Reject escalation because we're no longer mastering
-            PWARN("Received ESCALATE_CANCEL but not MASTERING, ignoring.");
+        if (_state != LEADING) {
+            // Reject escalation because we're no longer leading
+            PWARN("Received ESCALATE_CANCEL but not LEADING, ignoring.");
         } else {
-            // We're mastering, make sure the rest checks out
+            // We're leading, make sure the rest checks out
             SData request;
             if (!request.deserialize(message.content)) {
                 STHROW("malformed request");
@@ -1717,9 +1722,9 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             _server.cancelCommand(commandID);
         }
     } else if (SIEquals(message.methodLine, "ESCALATE_RESPONSE")) {
-        // ESCALATE_RESPONSE: Sent when the master processes the ESCALATE.
-        if (_state != SLAVING) {
-            STHROW("not slaving");
+        // ESCALATE_RESPONSE: Sent when the leader processes the ESCALATE.
+        if (_state != FOLLOWING) {
+            STHROW("not following");
         }
         if (!message.isSet("ID")) {
             STHROW("missing ID");
@@ -1748,9 +1753,9 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             SHMMM("Received ESCALATE_RESPONSE for unknown command ID '" << message["ID"] << "', ignoring. ");
         }
     } else if (SIEquals(message.methodLine, "ESCALATE_ABORTED")) {
-        // ESCALATE_RESPONSE: Sent when the master aborts processing an escalated command. Re-submit to the new master.
-        if (_state != SLAVING) {
-            STHROW("not slaving");
+        // ESCALATE_RESPONSE: Sent when the leader aborts processing an escalated command. Re-submit to the new leader.
+        if (_state != FOLLOWING) {
+            STHROW("not following");
         }
         if (!message.isSet("ID")) {
             STHROW("missing ID");
@@ -1785,7 +1790,7 @@ void SQLiteNode::_onConnect(Peer* peer) {
     PINFO("Sending LOGIN");
     SData login("LOGIN");
     login["Priority"] = to_string(_priority);
-    login["State"] = stateNames[_state];
+    login["State"] = stateName(_state);
     login["Version"] = _version;
     _sendToPeer(peer, login);
 }
@@ -1800,7 +1805,7 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
     SASSERT(peer);
     /// - Verify we don't have any important data buffered for sending to this
     ///   peer.  In particular, make sure we're not sending an ESCALATION_RESPONSE
-    ///   because that means the initiating slave's command was successfully
+    ///   because that means the initiating follower's command was successfully
     ///   processed, but it died before learning this.  This won't corrupt the
     ///   database per se (all nodes will still be synchronized, or will repair
     ///   themselves on reconnect), but it means that the data in the database
@@ -1808,18 +1813,18 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
     ///   know it.  Not cool!
     ///
     if (peer->s && peer->s->sendBufferCopy().find("ESCALATE_RESPONSE") != string::npos)
-        PWARN("Initiating slave died before receiving response to escalation: " << peer->s->sendBufferCopy());
+        PWARN("Initiating follower died before receiving response to escalation: " << peer->s->sendBufferCopy());
 
-    /// - Verify we didn't just lose contact with our master.  This should
-    ///   only be possible if we're SUBSCRIBING or SLAVING.  If we did lose our
-    ///   master, roll back any uncommitted transaction and go SEARCHING.
+    /// - Verify we didn't just lose contact with our leader.  This should
+    ///   only be possible if we're SUBSCRIBING or FOLLOWING.  If we did lose our
+    ///   leader, roll back any uncommitted transaction and go SEARCHING.
     ///
-    if (peer == _masterPeer) {
-        // We've lost our master: make sure we aren't waiting for
+    if (peer == _leadPeer) {
+        // We've lost our leader: make sure we aren't waiting for
         // transaction response and re-SEARCH
-        PHMMM("Lost our MASTER, re-SEARCHING.");
-        SASSERTWARN(_state == SUBSCRIBING || _state == SLAVING);
-        _masterPeer = nullptr;
+        PHMMM("Lost our LEADER, re-SEARCHING.");
+        SASSERTWARN(_state == SUBSCRIBING || _state == FOLLOWING);
+        _leadPeer = nullptr;
         if (!_db.getUncommittedHash().empty()) {
             // We're in the middle of a transaction and waiting for it to
             // approve or deny, but we'll never get its response.  Roll it
@@ -1831,9 +1836,9 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
         }
 
         // If there were escalated commands, give them back to the server to retry, unless it looks like they were in
-        // progress when the master died, in which case we say they completed with a 500 Error.
+        // progress when the leader died, in which case we say they completed with a 500 Error.
         for (auto& cmd : _escalatedCommandMap) {
-            // If this isn't set, the master hadn't actually started processing this, and we can re-queue it.
+            // If this isn't set, the leader hadn't actually started processing this, and we can re-queue it.
             if (!cmd.second.transaction.methodLine.empty()) {
                 PWARN("Aborting escalated command '" << cmd.second.request.methodLine << "' (" << cmd.second.id
                       << ") in transaction state '" << cmd.second.transaction.methodLine << "'");
@@ -1858,9 +1863,9 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
         _changeState(SEARCHING);
     }
 
-    // If we're master, but we've lost quorum, we can't commit anything, nor can worker threads. We need to drop out of
+    // If we're leader, but we've lost quorum, we can't commit anything, nor can worker threads. We need to drop out of
     // a state that implies we can perform commits, and cancel any outstanding commits.
-    if (_state == MASTERING || _state == STANDINGUP || _state == STANDINGDOWN) {
+    if (_state == LEADING || _state == STANDINGUP || _state == STANDINGDOWN) {
         int numFullPeers = 0;
         int numLoggedInFullPeers = 0;
         for (auto otherPeer : peerList) {
@@ -1869,7 +1874,7 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
                 continue;
             }
             // Make sure we're a full peer
-            if (otherPeer->params["Permaslave"] != "true") {
+            if (otherPeer->params["Permafollower"] != "true") {
                 // Verify we're logged in
                 ++numFullPeers;
                 if (SIEquals((*otherPeer)["LoggedIn"], "true")) {
@@ -1886,8 +1891,8 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
             // completed, or they won't be able to until after this changes, and then they'll see the wrong state.
             //
             // It works for the sync thread as well, as there's handling in _changeState to rollback a commit when
-            // dropping out of mastering or standing down (and there can't be commits in progress in other states).
-            SWARN("We were " << stateNames[_state] << " but lost quorum. Going to SEARCHING.");
+            // dropping out of leading or standing down (and there can't be commits in progress in other states).
+            SWARN("We were " << stateName(_state) << " but lost quorum. Going to SEARCHING.");
             _changeState(SEARCHING);
         }
     }
@@ -1945,15 +1950,15 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
     unique_lock<decltype(stateMutex)> lock(stateMutex);
 
     // We send any unsent transactions here before we finish switching states. Normally, this does nothing, unless
-    // we're switching down from MASTERING or STANDINGDOWN, but we need to make sure these are all sent to the new
-    // master before we complete the transition.
+    // we're switching down from LEADING or STANDINGDOWN, but we need to make sure these are all sent to the new
+    // leader before we complete the transition.
     _sendOutstandingTransactions();
 
     // Did we actually change _state?
     SQLiteNode::State oldState = _state;
     if (newState != oldState) {
         // Depending on the state, set a timeout
-        SINFO("Switching from '" << stateNames[_state] << "' to '" << stateNames[newState] << "'");
+        SINFO("Switching from '" << stateName(_state) << "' to '" << stateName(newState) << "'");
         uint64_t timeout = 0;
         if (newState == STANDINGUP) {
             // If two nodes try to stand up simultaneously, they can get in a conflicted state where they're waiting
@@ -1972,11 +1977,11 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
         _stateTimeout = STimeNow() + timeout;
 
         // Additional logic for some old states
-        if (SWITHIN(MASTERING, _state, STANDINGDOWN) && !SWITHIN(MASTERING, newState, STANDINGDOWN)) {
-            // We are no longer mastering.  Are we processing a command?
+        if (SWITHIN(LEADING, _state, STANDINGDOWN) && !SWITHIN(LEADING, newState, STANDINGDOWN)) {
+            // We are no longer leading.  Are we processing a command?
             if (commitInProgress()) {
                 // Abort this command
-                SWARN("Stopping MASTERING/STANDINGDOWN with commit in progress. Canceling.");
+                SWARN("Stopping LEADING/STANDINGDOWN with commit in progress. Canceling.");
                 _commitState = CommitState::FAILED;
                 _db.rollback();
             }
@@ -1984,12 +1989,12 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
 
         // Clear some state if we can
         if (newState < SUBSCRIBING) {
-            // We're no longer SUBSCRIBING or SLAVING, so we have no master
-            _masterPeer = nullptr;
+            // We're no longer SUBSCRIBING or FOLLOWING, so we have no leader
+            _leadPeer = nullptr;
         }
 
         // Additional logic for some new states
-        if (newState == MASTERING) {
+        if (newState == LEADING) {
             // Seed our last sent transaction.
             {
                 SQLITE_COMMIT_AUTOLOCK;
@@ -2003,7 +2008,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
             _standDownTimeOut.alarmDuration = STIME_US_PER_S * 30; // 30s timeout before we give up
             _standDownTimeOut.start();
 
-            // Abort all remote initiated commands if no longer MASTERING
+            // Abort all remote initiated commands if no longer LEADING
             // TODO: No we don't, we finish it, as per other documentation in this file.
         } else if (newState == SEARCHING) {
             if (!_escalatedCommandMap.empty()) {
@@ -2012,7 +2017,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
                 // gives us any more useful info in the future.
                 _escalatedCommandMap.clear();
                 SWARN(
-                    "Switching from '" << stateNames[_state] << "' to '" << stateNames[newState]
+                    "Switching from '" << stateName(_state) << "' to '" << stateName(newState)
                                        << "' but _escalatedCommandMap not empty. Clearing it and hoping for the best.");
             }
         }
@@ -2024,7 +2029,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
         _state = newState;
         SData state("STATE");
         state["StateChangeCount"] = to_string(++_stateChangeCount);
-        state["State"] = stateNames[_state];
+        state["State"] = stateName(_state);
         state["Priority"] = SToStr(_priority);
         _sendToAllPeers(state);
     }
@@ -2034,7 +2039,7 @@ void SQLiteNode::_queueSynchronize(Peer* peer, SData& response, bool sendAll) {
     _queueSynchronizeStateless(peer->nameValueMap, name, peer->name, _state, (unsentTransactions.load() ? _lastSentTransactionID : _db.getCommitCount()), _db, response, sendAll);
 }
 
-void SQLiteNode::_queueSynchronizeStateless(const STable& params, const string& name, const string& peerName, int _state, uint64_t targetCommit, SQLite& db, SData& response, bool sendAll) {
+void SQLiteNode::_queueSynchronizeStateless(const STable& params, const string& name, const string& peerName, State _state, uint64_t targetCommit, SQLite& db, SData& response, bool sendAll) {
     // This is a hack to make the PXXXX macros works, since they expect `peer->name` to be defined.
     struct {string name;} peerBase;
     auto peer = &peerBase;
@@ -2245,20 +2250,20 @@ void SQLiteNode::_reconnectAll() {
 }
 
 bool SQLiteNode::_majoritySubscribed() {
-    // Count up how may full and subscribed peers we have (A "full" peer is one that *isn't* a permaslave).
+    // Count up how may full and subscribed peers we have (A "full" peer is one that *isn't* a permafollower).
     int numFullPeers = 0;
-    int numFullSlaves = 0;
+    int numFullFollowers = 0;
     for (auto peer : peerList) {
-        if (peer->params["Permaslave"] != "true") {
+        if (peer->params["Permafollower"] != "true") {
             ++numFullPeers;
             if (peer->test("Subscribed")) {
-                ++numFullSlaves;
+                ++numFullFollowers;
             }
         }
     }
 
     // Done!
-    return (numFullSlaves * 2 >= numFullPeers);
+    return (numFullFollowers * 2 >= numFullPeers);
 }
 
 bool SQLiteNode::peekPeerCommand(SQLiteNode* node, SQLite& db, SQLiteCommand& command)
@@ -2275,7 +2280,7 @@ bool SQLiteNode::peekPeerCommand(SQLiteNode* node, SQLite& db, SQLiteCommand& co
             _queueSynchronizeStateless(command.request.nameValueMap,
                                        command.request["name"],
                                        command.request["peerName"],
-                                       SToInt(command.request["state"]),
+                                       node->_state,
                                        SToUInt64(command.request["targetCommit"]),
                                        db,
                                        command.response,

--- a/test/clustertest/BedrockClusterTester.cpp
+++ b/test/clustertest/BedrockClusterTester.cpp
@@ -97,7 +97,7 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
     }
 
     // Ok, now we should be able to wait for the cluster to come up. Let's wait until each server responds to 'status',
-    // master first.
+    // leader first.
     vector<string> states(size);
     int count = 0;
     for (size_t i = 0; i < size; i++) {
@@ -123,7 +123,7 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
 
 BedrockClusterTester::~BedrockClusterTester()
 {
-    // Shut them down in reverse order so they don't try and stand up as master in the middle of everything.
+    // Shut them down in reverse order so they don't try and stand up as leader in the middle of everything.
     for (int i = _size - 1; i >= 0; i--) {
         stopNode(i);
     }

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -9,15 +9,15 @@ class BedrockClusterTester {
     };
 
     // Creates a cluster of the given size and brings up all the nodes. The nodes will have priority in the order of
-    // their creation (i.e., node 0 is highest priority and will become master.
+    // their creation (i.e., node 0 is highest priority and will become leader.
     // You can also specify plugins to load if for some reason you need to override the default configuration.
     BedrockClusterTester(ClusterSize size, list<string> queries = {}, int threadID = 0, map<string, string> _args = {}, list<string> uniquePorts = {}, string pluginsToLoad = "db,cache,jobs");
     BedrockClusterTester(int threadID, string pluginsToLoad = "db,cache,jobs");
     ~BedrockClusterTester();
 
-    // Returns the index of the node that's mastering. Returns a negative number on error:
-    // -1: no master
-    // -2: multiple masters
+    // Returns the index of the node that's leader. Returns a negative number on error:
+    // -1: no leader
+    // -2: multiple leader
     int getMasterNodeIndex();
 
     // Runs the given query on all nodes and verifies the output is the same. Make sure you include "ORDER BY" if you

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -66,8 +66,8 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
         command.response["stored_not_special"] = arbitraryData["not_special"];
         return true;
     } else if (SStartsWith(command.request.methodLine, "sendrequest")) {
-        if (_server->getState() != SQLiteNode::MASTERING && _server->getState() != SQLiteNode::STANDINGDOWN) {
-            // Only start HTTPS requests on master, otherwise, we'll escalate.
+        if (_server->getState() != SQLiteNode::LEADING && _server->getState() != SQLiteNode::STANDINGDOWN) {
+            // Only start HTTPS requests on leader, otherwise, we'll escalate.
             return false;
         }
         int requestCount = 1;
@@ -97,9 +97,9 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
         return true;
     } else if (SStartsWith(command.request.methodLine, "httpstimeout")) {
         // This command doesn't actually make the connection for 35 seconds, allowing us to use it to test what happens
-        // when there's a blocking command and master needs to stand down, to verify the timeout for that works.
+        // when there's a blocking command and leader needs to stand down, to verify the timeout for that works.
         // It *does* eventually connect and return, so that we can also verify that the leftover command gets cleaned
-        // up correctly on the former master.
+        // up correctly on the former leader.
         SData request("GET / HTTP/1.1");
         request["Host"] = "www.google.com";
         auto transaction = httpsManager.httpsDontSend("https://www.google.com/", request);

--- a/test/clustertest/tests/BadCommandTest.cpp
+++ b/test/clustertest/tests/BadCommandTest.cpp
@@ -19,9 +19,10 @@ struct BadCommandTest : tpunit::TestFixture {
 
     void test()
     {
-        BedrockTester* master = tester->getBedrockTester(0);
-        BedrockTester* slave = tester->getBedrockTester(1);
+        BedrockTester* leader = tester->getBedrockTester(0);
+        BedrockTester* follower = tester->getBedrockTester(1);
 
+        cout << "A" << endl;
         // This is here because we can use it to test crashIdentifyingValues, though that isn't currently implemented.
         int userID = 31;
 
@@ -29,25 +30,28 @@ struct BadCommandTest : tpunit::TestFixture {
         SData cmd("exceptioninpeek");
         cmd["userID"] = to_string(userID++);
         try {
-            master->executeWaitVerifyContent(cmd, "500 Unhandled Exception");
+            leader->executeWaitVerifyContent(cmd, "500 Unhandled Exception");
         } catch (...) {
             cout << "failing in first block." << endl;
             throw;
         }
 
+        cout << "B" << endl;
         // Same in process.
         cmd = SData("exceptioninprocess");
         cmd["userID"] = to_string(userID++);
         try {
-            master->executeWaitVerifyContent(cmd, "500 Unhandled Exception");
+            leader->executeWaitVerifyContent(cmd, "500 Unhandled Exception");
         } catch (...) {
             cout << "failing in second block." << endl;
             throw;
         }
 
-        // Then for three other commands, verify they kill the master, but the slave then refuses the same command.
-        // This tests cases where keeping master alive isn't feasible.
+        cout << "C" << endl;
+        // Then for three other commands, verify they kill the leader, but the follower then refuses the same command.
+        // This tests cases where keeping leader alive isn't feasible.
         for (auto commandName : {"generatesegfaultpeek", "generateassertpeek", "generatesegfaultprocess"}) {
+        cout << "D (" << commandName << ")" << endl;
             
             // Create the command with the current userID.
             userID++;
@@ -55,28 +59,29 @@ struct BadCommandTest : tpunit::TestFixture {
             command.methodLine = commandName;
             command["userID"] = to_string(userID);
             int error = 0;
-            master->executeWaitMultipleData({command}, 1, false, true, &error);
+            leader->executeWaitMultipleData({command}, 1, false, true, &error);
 
             // This error indicates we couldn't read a response after sending a command. We assume this means the
             // server died. Even if it didn't and we just had a weird flaky network connection,  we'll still fail this
-            // test if the slave doesn't refuse the same command.
+            // test if the follower doesn't refuse the same command.
             ASSERT_EQUAL(error, 4);
 
-            // Now send the command to the slave and verify the command was refused.
+            // Now send the command to the follower and verify the command was refused.
             error = 0;
-            vector<SData> results = slave->executeWaitMultipleData({command}, 1, false, false, &error);
+            vector<SData> results = follower->executeWaitMultipleData({command}, 1, false, false, &error);
             if (results[0].methodLine != "500 Refused") {
                 cout << "Didn't get '500 refused', got '" << results[0].methodLine << "' testing '" << commandName << "', error code was set to: " << error << endl;
                 ASSERT_TRUE(false);
             }
 
-            // TODO: This is where we could send the command with a different userID to the slave and verify it's not
-            // refused. We don't currently do this because these commands will kill the slave. We could handle that as
+            // TODO: This is where we could send the command with a different userID to the follower and verify it's not
+            // refused. We don't currently do this because these commands will kill the follower. We could handle that as
             // the expected case as well, though.
 
-            // Bring master back up.
-            master->startServer();
-            ASSERT_TRUE(master->waitForState("MASTERING"));
+            // Bring leader back up.
+            leader->startServer();
+            ASSERT_TRUE(leader->waitForStates({"LEADING", "MASTERING"}));
+        cout << "E (done)" << endl;
         }
     }
 

--- a/test/clustertest/tests/BadCommandTest.cpp
+++ b/test/clustertest/tests/BadCommandTest.cpp
@@ -22,7 +22,6 @@ struct BadCommandTest : tpunit::TestFixture {
         BedrockTester* leader = tester->getBedrockTester(0);
         BedrockTester* follower = tester->getBedrockTester(1);
 
-        cout << "A" << endl;
         // This is here because we can use it to test crashIdentifyingValues, though that isn't currently implemented.
         int userID = 31;
 
@@ -36,7 +35,6 @@ struct BadCommandTest : tpunit::TestFixture {
             throw;
         }
 
-        cout << "B" << endl;
         // Same in process.
         cmd = SData("exceptioninprocess");
         cmd["userID"] = to_string(userID++);
@@ -47,11 +45,9 @@ struct BadCommandTest : tpunit::TestFixture {
             throw;
         }
 
-        cout << "C" << endl;
         // Then for three other commands, verify they kill the leader, but the follower then refuses the same command.
         // This tests cases where keeping leader alive isn't feasible.
         for (auto commandName : {"generatesegfaultpeek", "generateassertpeek", "generatesegfaultprocess"}) {
-        cout << "D (" << commandName << ")" << endl;
             
             // Create the command with the current userID.
             userID++;
@@ -81,7 +77,6 @@ struct BadCommandTest : tpunit::TestFixture {
             // Bring leader back up.
             leader->startServer();
             ASSERT_TRUE(leader->waitForStates({"LEADING", "MASTERING"}));
-        cout << "E (done)" << endl;
         }
     }
 

--- a/test/clustertest/tests/BroadcastTest.cpp
+++ b/test/clustertest/tests/BroadcastTest.cpp
@@ -20,8 +20,8 @@ struct BroadcastCommandTest : tpunit::TestFixture {
 
     void test()
     {
-        BedrockTester* master = tester->getBedrockTester(0);
-        BedrockTester* slave = tester->getBedrockTester(1);
+        BedrockTester* leader = tester->getBedrockTester(0);
+        BedrockTester* follower = tester->getBedrockTester(1);
 
         // We want to test when this command runs.
         uint64_t now = STimeNow();
@@ -29,19 +29,19 @@ struct BroadcastCommandTest : tpunit::TestFixture {
         // Make sure unhandled exceptions send the right response.
         SData cmd("broadcastwithtimeouts");
         try {
-            master->executeWaitVerifyContent(cmd);
+            leader->executeWaitVerifyContent(cmd);
         } catch (...) {
             cout << "Couldn't send broadcastwithtimeouts" << endl;
             throw;
         }
 
-        // Now wait for the slave to have received and run the command.
+        // Now wait for the follower to have received and run the command.
         sleep(5);
 
         SData cmd2("getbroadcasttimeouts");
         vector<SData> results;
         try {
-            results = slave->executeWaitMultipleData({cmd2});
+            results = follower->executeWaitMultipleData({cmd2});
         } catch (...) {
             cout << "Couldn't send getbroadcasttimeouts" << endl;
             throw;

--- a/test/clustertest/tests/ConflictSpamTest.cpp
+++ b/test/clustertest/tests/ConflictSpamTest.cpp
@@ -214,7 +214,7 @@ struct ConflictSpamTest : tpunit::TestFixture {
         ASSERT_EQUAL(allResults[0], allResults[1]);
         ASSERT_EQUAL(allResults[1], allResults[2]);
 
-        // Let's query the master DB's journals, and see how many rows each had.
+        // Let's query the leader DB's journals, and see how many rows each had.
         {
             BedrockTester* brtester = tester->getBedrockTester(0);
 
@@ -239,7 +239,7 @@ struct ConflictSpamTest : tpunit::TestFixture {
                 lines.pop_front();
             }
             // We can't verify the size of the journal, because we can insert any number of 'upgrade database' rows as
-            // each node comes online as master during startup.
+            // each node comes online as leader during startup.
             // ASSERT_EQUAL(totalRows, 69);
         }
 

--- a/test/clustertest/tests/ControlCommandTest.cpp
+++ b/test/clustertest/tests/ControlCommandTest.cpp
@@ -21,27 +21,27 @@ struct ControlCommandTest : tpunit::TestFixture {
     void testPreventAttach()
     {
         // Test a control command
-        BedrockTester* slave = tester->getBedrockTester(1);
+        BedrockTester* follower = tester->getBedrockTester(1);
 
         // Tell the plugin to prevent attaching
         SData command("preventattach");
-        slave->executeWaitVerifyContent(command, "200");
+        follower->executeWaitVerifyContent(command, "200");
 
         // Detach
         SData detachCommand("detach");
-        slave->executeWaitVerifyContent(detachCommand, "203", true);
+        follower->executeWaitVerifyContent(detachCommand, "203", true);
 
         // Wait for it to detach
         sleep(3);
         // Try to attach
         SData attachCommand("attach");
-        slave->executeWaitVerifyContent(attachCommand, "401 Attaching prevented by TestPlugin", true);
+        follower->executeWaitVerifyContent(attachCommand, "401 Attaching prevented by TestPlugin", true);
 
         sleep(5);
 
         // Try to attach again, should be allowed now that the sleep in the plugin
         // has passed.
-        slave->executeWaitVerifyContent(attachCommand, "204", true);
+        follower->executeWaitVerifyContent(attachCommand, "204", true);
     }
 
 } __ControlCommandTest;

--- a/test/clustertest/tests/FutureExecutionTest.cpp
+++ b/test/clustertest/tests/FutureExecutionTest.cpp
@@ -19,7 +19,7 @@ struct FutureExecutionTest : tpunit::TestFixture {
     }
 
     void FutureExecution() {
-        // We only care about master because future execution only works on Master.
+        // We only care about leader because future execution only works on leader.
         BedrockTester* brtester = tester->getBedrockTester(0);
 
         // Let's run a command in the future.
@@ -27,7 +27,7 @@ struct FutureExecutionTest : tpunit::TestFixture {
 
         // Three seconds from now.
         query["commandExecuteTime"] = to_string(STimeNow() + 3000000);
-        query["Query"] = "INSERT INTO test VALUES(" + SQ(50011) + ", " + SQ("sent_by_master") + ");";
+        query["Query"] = "INSERT INTO test VALUES(" + SQ(50011) + ", " + SQ("sent_by_leader") + ");";
         string result = brtester->executeWaitVerifyContent(query, "202"); 
 
         // Ok, Now let's wait a second

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -175,6 +175,7 @@ struct GracefulFailoverTest : tpunit::TestFixture {
         // Verify everything was either a 202 or a 756.
         for (auto& p : *counts) {
             ASSERT_TRUE(p.first == "202" || p.first == "756");
+            cout << "method: " << p.first << ", count: " << p.second << endl;
         }
         
         // Now that we've verified that, we can start spamming again, and verify failover works in a crash situation.

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -145,7 +145,7 @@ struct GracefulFailoverTest : tpunit::TestFixture {
             list<string> peers = SParseJSONArray(peerList);
             for (auto& peer : peers) {
                 STable peerInfo = SParseJSONObject(peer);
-                if (peerInfo["name"] == "brcluster_node_2" && peerInfo["State"] == "") {
+                if (peerInfo["name"] == "brcluster_node_2" && (peerInfo["State"] == "" || peerInfo["State"] == "SEARCHING")) {
                     success = true;
                     break;
                 }

--- a/test/clustertest/tests/HTTPSTest.cpp
+++ b/test/clustertest/tests/HTTPSTest.cpp
@@ -13,7 +13,7 @@
  * However, to actually verify that you saw a conflict during the test, you can look at the logs for something like:
  *
  * Feb 22 00:32:16 vagrant-ubuntu-trusty-64 bedrock: brcluster_node_0 (SQLiteNode.cpp:1298) update [sync] [warn] 
- *     {brcluster_node_0/MASTERING} ROLLBACK, conflicted on sync: brcluster_node_0#109 : sendrequest
+ *     {brcluster_node_0/LEADING} ROLLBACK, conflicted on sync: brcluster_node_0#109 : sendrequest
  */
 struct HTTPSTest : tpunit::TestFixture {
     HTTPSTest()
@@ -55,7 +55,7 @@ struct HTTPSTest : tpunit::TestFixture {
         // to cause a conflict.
         mutex m;
 
-        // Every 10th request on master is an HTTP request.
+        // Every 10th request on leader is an HTTP request.
         int nthHasRequest = 10;
 
         // Let's spin up three threads, each spamming commands at one of our nodes.
@@ -89,7 +89,7 @@ struct HTTPSTest : tpunit::TestFixture {
         }
         threads.clear();
 
-        // Look at all the responses from master, to make sure they're all 200s, and either had a body or did not,
+        // Look at all the responses from leader, to make sure they're all 200s, and either had a body or did not,
         // according with what sort of command they were.
         for (size_t i = 0; i < responses[0].size(); i++) {
             string code = responses[0][i].methodLine;

--- a/test/clustertest/tests/JobIDTest.cpp
+++ b/test/clustertest/tests/JobIDTest.cpp
@@ -20,30 +20,30 @@ struct JobIDTest : tpunit::TestFixture {
 
     void test()
     {
-        BedrockTester* master = tester->getBedrockTester(0);
-        BedrockTester* slave = tester->getBedrockTester(1);
+        BedrockTester* leader = tester->getBedrockTester(0);
+        BedrockTester* follower = tester->getBedrockTester(1);
 
-        // Create a job in master
+        // Create a job in leader
         SData createCmd("CreateJob");
         createCmd["name"] = "TestJob";
-        STable response = master->executeWaitVerifyContentTable(createCmd);
+        STable response = leader->executeWaitVerifyContentTable(createCmd);
 
-        // Restart slave. This is a regression test, before we only re-initialized the lastID if it was !=0 which made
-        // these tests pass (because the first ID is 0) but fail in the real life. So here we make sure that when a slave
-        // becomes master, it gets the correct ID and the inserts do not fail the unique constrain due to repeated ID.
+        // Restart follower. This is a regression test, before we only re-initialized the lastID if it was !=0 which made
+        // these tests pass (because the first ID is 0) but fail in the real life. So here we make sure that when a follower
+        // becomes leader, it gets the correct ID and the inserts do not fail the unique constrain due to repeated ID.
         tester->stopNode(1);
         tester->startNode(1);
 
-        // Stop master
+        // Stop leader
         tester->stopNode(0);
 
         int count = 0;
         bool success = false;
         while (count++ < 50) {
             SData cmd("Status");
-            string response = slave->executeWaitVerifyContent(cmd);
+            string response = follower->executeWaitVerifyContent(cmd);
             STable json = SParseJSONObject(response);
-            if (json["state"] == "MASTERING") {
+            if (json["state"] == "LEADING" || json["state"] == "MASTERING") {
                 success = true;
                 break;
             }
@@ -55,19 +55,19 @@ struct JobIDTest : tpunit::TestFixture {
         // make sure it actually succeeded.
         ASSERT_TRUE(success);
 
-        // Create a job in the slave
-        response = slave->executeWaitVerifyContentTable(createCmd, "200");
+        // Create a job in the follower
+        response = follower->executeWaitVerifyContentTable(createCmd, "200");
 
-        // Restart master
+        // Restart leader
         tester->startNode(0);
 
         count = 0;
         success = false;
         while (count++ < 50) {
             SData cmd("Status");
-            string response = master->executeWaitVerifyContent(cmd);
+            string response = leader->executeWaitVerifyContent(cmd);
             STable json = SParseJSONObject(response);
-            if (json["state"] == "MASTERING") {
+            if (json["state"] == "LEADING" || json["state"] == "MASTERING") {
                 success = true;
                 break;
             }
@@ -76,14 +76,14 @@ struct JobIDTest : tpunit::TestFixture {
             sleep(1);
         }
 
-        // Create a new job in master.
-        response = master->executeWaitVerifyContentTable(createCmd);
+        // Create a new job in leader.
+        response = leader->executeWaitVerifyContentTable(createCmd);
 
         // Get the 3 jobs to leave the db clean
         SData getCmd("GetJobs");
         getCmd["name"] = "*";
         getCmd["numResults"] = 3;
-        slave->executeWaitVerifyContentTable(getCmd, "200");
+        follower->executeWaitVerifyContentTable(getCmd, "200");
     }
 
 } __JobIDTest;

--- a/test/clustertest/tests/StatusTest.cpp
+++ b/test/clustertest/tests/StatusTest.cpp
@@ -48,9 +48,9 @@ struct StatusTest : tpunit::TestFixture {
             STable json = SParseJSONObject(responses[i]);
             auto peers = SParseJSONArray(json["peerList"]);
             if (i == 0) {
-                ASSERT_EQUAL(json["isMaster"], "true");
+                ASSERT_EQUAL(json["isLeader"], "true");
             } else {
-                ASSERT_EQUAL(json["isMaster"], "false");
+                ASSERT_EQUAL(json["isLeader"], "false");
             }
             ASSERT_EQUAL(peers.size(), 2);
         }

--- a/test/clustertest/tests/TimingTest.cpp
+++ b/test/clustertest/tests/TimingTest.cpp
@@ -52,7 +52,7 @@ struct TimingTest : tpunit::TestFixture {
             uint64_t processTime = SToUInt64(result["processTime"]);
             uint64_t totalTime = SToUInt64(result["totalTime"]);
 
-            // Only master is expected to have these set.
+            // Only leader is expected to have these set.
             if (i == 0) {
                 if (peekTime <= 0 || processTime <= 0) {
                     cout << "peekTime: " << peekTime << endl;
@@ -78,7 +78,7 @@ struct TimingTest : tpunit::TestFixture {
             ASSERT_LESS_THAN(peekTime + processTime, totalTime);
 
             if (i != 0) {
-                // Extra data on slaves.
+                // Extra data on followers.
                 uint64_t escalationTime = SToUInt64(result["escalationTime"]);
                 uint64_t upstreamPeekTime = SToUInt64(result["upstreamPeekTime"]);
                 uint64_t upstreamProcessTime = SToUInt64(result["upstreamProcessTime"]);

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -501,13 +501,18 @@ int BedrockTester::getControlPort() {
     return _controlPort;
 }
 
-bool BedrockTester::waitForState(string state, uint64_t timeoutUS)
+bool BedrockTester::waitForState(string state, uint64_t timeoutUS) {
+    return waitForStates({state}, timeoutUS);
+}
+
+bool BedrockTester::waitForStates(set<string> states, uint64_t timeoutUS)
 {
     uint64_t start = STimeNow();
     while (STimeNow() < start + timeoutUS) {
         try {
             STable json = SParseJSONObject(executeWaitVerifyContent(SData("Status")));
-            if (json["state"] == state) {
+            auto it = states.find(json["state"]);
+            if (it != states.end()) {
                 return true;
             }
             // It's still not there, let it try again.

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -77,6 +77,9 @@ class BedrockTester {
     // false if the timeout is hit.
     bool waitForState(string state, uint64_t timeoutUS = 60'000'000);
 
+    // Like `waitForState` but wait for any of a set of states.
+    bool waitForStates(set<string> states, uint64_t timeoutUS = 60'000'000);
+
     // Waits for a particular port to be free to bind to. This is useful when we've killed a server, because sometimes
     // it takes the OS a few seconds to make the port available again.
     static int waitForPort(int port);


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/102992

This is the first step towards renaming these states. This changes the internal representation of these states, but keeps the existing names externally for backwards compatibility, while recognizing the new state names as well. This allows for a two-stage upgrade:

1. Upgrade the cluster to this version that supports both names but sends old names. This allows existing nodes to connect to new nodes during the upgrade.
2. Upgrade to a future version that only uses the new names. At this point, existing nodes are on a version that recognizes the new names.

In practice, there are a bunch of other changes to make in between steps 1 and 2 to recognize either the old or new name, and then again, after step 2, we can remove support in these things for the old name.

This is co-requisite with: https://github.com/Expensify/Server-Expensify/pull/3478