### PR TITLE
[WIP] Fix multiple master sync race condition

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -206,6 +206,7 @@ void SQLiteNode::_sendOutstandingTransactions() {
         return;
     }
     auto transactions = _db.getCommittedTransactions();
+    auto transactionCount = transactions.size();
     string sendTime = to_string(STimeNow());
     for (auto& i : transactions) {
         uint64_t id = i.first;
@@ -233,6 +234,7 @@ void SQLiteNode::_sendOutstandingTransactions() {
         _sendToAllPeers(commit, true); // subscribed only
         _lastSentTransactionID = id;
     }
+    SINFO("Sent all " << transactionCount << " outstanding transactions.");
     unsentTransactions.store(false);
 }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -549,6 +549,9 @@ bool SQLiteNode::update() {
         SASSERT(highestPriorityPeer);
         SASSERT(freshestPeer);
 
+        const string& _currentMasterName = currentMaster ? currentMaster->name : "none";
+        SDEBUG( "Dumping evaluated cluster state: numLoggedInFullPeers=" << numLoggedInFullPeers << " freshestPeer=" << freshestPeer->name << " highestPriorityPeer=" << highestPriorityPeer->name << " currentMaster=" << _currentMasterName );
+
         // If there is already a master that is higher priority than us,
         // subscribe -- even if we're not in sync with it.  (It'll bring
         // us back up to speed while subscribing.)

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -555,7 +555,7 @@ bool SQLiteNode::update() {
         // If there is already a master that is higher priority than us,
         // subscribe -- even if we're not in sync with it.  (It'll bring
         // us back up to speed while subscribing.)
-        if (currentMaster && _priority < highestPriorityPeer->calc("Priority") &&
+        if (currentMaster && _priority < currentMaster->calc("Priority") &&
             SIEquals((*currentMaster)["State"], "MASTERING")) {
             // Subscribe to the master
             SINFO("Subscribing to master '" << currentMaster->name << "'");

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -140,6 +140,10 @@ class SQLiteNode : public STCPNode {
     // the highest priority in the cluster will attempt to become the MASTER.
     int _priority;
 
+    // When the node starts, it is not ready to serve requests without first connecting to the other nodes, and checking
+    // to make sure it's up-to-date. Store the configured priority here and use "0" until we're ready to fully join the cluster.
+    int _originalPriority;
+
     // Our current State.
     State _state;
     

--- a/test/clustertest/tests/MultipleMasterSyncTest.cpp
+++ b/test/clustertest/tests/MultipleMasterSyncTest.cpp
@@ -1,0 +1,239 @@
+#include "../BedrockClusterTester.h"
+
+struct MultipleMasterSyncTest : tpunit::TestFixture {
+    MultipleMasterSyncTest()
+        : tpunit::TestFixture("MultipleMasterSyncTest",
+                              BEFORE_CLASS(MultipleMasterSyncTest::setup),
+                              AFTER_CLASS(MultipleMasterSyncTest::teardown),
+                              TEST(MultipleMasterSyncTest::test)
+                             ) { }
+
+    BedrockClusterTester* tester;
+
+    void setup() {
+        // create a 5 node cluster
+        tester = new BedrockClusterTester(BedrockClusterTester::FIVE_NODE_CLUSTER, {"CREATE TABLE test (id INTEGER NOT NULL PRIMARY KEY, value TEXT NOT NULL)"}, _threadID);
+
+        // make sure the whole cluster is up
+        ASSERT_TRUE(tester->getBedrockTester(0)->waitForState("MASTERING"));
+        for (int i = 1; i <= 4; i++) {
+            ASSERT_TRUE(tester->getBedrockTester(i)->waitForState("SLAVING"));
+        }
+
+        // shut down primary master
+        tester->stopNode(0);
+
+        // Wait for node 1 to be master.
+        ASSERT_TRUE(tester->getBedrockTester(1)->waitForState("MASTERING"));
+
+        // write a bunch more commands
+        runTrivialWrites(250, 4);
+
+        // give a beat to make sure everything's in sync
+        sleep(10);
+
+        int commitCount;
+        std::string debugMsg;
+        commitCount = tester->getBedrockTester(4)->getCommitCount();
+        debugMsg = "debug: commitCount " + SToStr(commitCount);
+        cout << debugMsg << endl;
+        ASSERT_TRUE(tester->getBedrockTester(4)->getCommitCount() >= 250);
+
+        // shut down secondary master
+        tester->stopNode(1);
+
+        // Wait for node 2 to be master.
+        ASSERT_TRUE(tester->getBedrockTester(2)->waitForState("MASTERING"));
+
+        // write a bunch more commands
+        runTrivialWrites(250, 4);
+
+        sleep(10);
+
+        // check for the correct number of commits
+        commitCount = tester->getBedrockTester(4)->getCommitCount();
+        debugMsg = "debug: commitCount " + SToStr(commitCount);
+        cout << debugMsg << endl;
+        ASSERT_TRUE(tester->getBedrockTester(4)->getCommitCount() >= 500);
+    }
+
+    void teardown() {
+        delete tester;
+    }
+
+    void runTrivialWrites(int writeCount, int nodeID = 0) {
+        // Create a bunch of trivial write commands.
+        vector<SData> requests(writeCount);
+        int count = 0;
+        for (auto& request : requests) {
+            if (!count) {
+                request.methodLine = "Query";
+                request["writeConsistency"] = "ASYNC";
+                request["query"] = "INSERT INTO test VALUES(12345, '');";
+                count++;
+            } else {
+                request.methodLine = "Query";
+                request["writeConsistency"] = "ASYNC";
+                request["query"] = "UPDATE test SET value = 'xxx" + to_string(count++) + "' WHERE id = 12345;";
+            }
+        }
+
+        // Send these all to the commandNode.
+        BedrockTester* commandNode = tester->getBedrockTester(nodeID);
+        commandNode->executeWaitMultipleData(requests);
+    }
+
+    void startClientThreads(list<thread>& threads, atomic<bool>& done, map<string, int>& counts,
+                            atomic<int>& commandID, mutex& mu, vector<list<SData>>& allresults) {
+        // Ok, start up some clients.
+        for (size_t i = 0; i < allresults.size(); i++) {
+            // Start a thread.
+            BedrockClusterTester* localTester = tester;
+            threads.emplace_back([localTester, i, &mu, &done, &allresults, &counts, &commandID]() {
+                int currentNodeIndex = i % 3;
+                while(!done.load()) {
+                    // Send some read or some write commands.
+                    vector<SData> requests;
+                    size_t numCommands = 50;
+                    for (size_t j = 0; j < numCommands; j++) {
+                        string randCommand = " r_" + to_string(commandID.fetch_add(1)) + "_r";
+                        // Every 10th client makes HTTPS requests (1/5th as many, cause they take forever).
+                        // We ask for `756` responses to verify we don't accidentally get back something besides what
+                        // we expect (some default value).
+                        int randNum = SRandom::rand64();
+                        int randNum2 = SRandom::rand64();
+                        if (randNum % 10 == 0) {
+                            if (randNum2 % 5 == 0) {
+                                SData query("sendrequest" + randCommand);
+                                if (randNum2 % 15 == 0) {
+                                    // In this case, let's make them `Connection: forget` to make sure they're
+                                    // forgotten.
+                                    query["Connection"] = "forget";
+                                }
+                                query["writeConsistency"] = "ASYNC";
+                                query["senttonode"] = to_string(currentNodeIndex);
+                                query["clientID"] = to_string(i);
+                                query["response"] = "756";
+                                requests.push_back(query);
+                            }
+                        } else if (randNum % 2 == 0) {
+                            // Every remaining even client makes write requests.
+                            SData query("idcollision" + randCommand);
+                            query["writeConsistency"] = "ASYNC";
+                            query["peekSleep"] = "5";
+                            query["processSleep"] = "5";
+                            query["response"] = "756";
+                            query["senttonode"] = to_string(currentNodeIndex);
+                            query["clientID"] = to_string(i);
+                            requests.push_back(query);
+                        } else {
+                            // Any other client makes read requests.
+                            SData query("testcommand" + randCommand);
+                            // A few of them will get scheduled in the future to make sure they don't block shutdown.
+                            if (randNum2 % 50 == 15) {
+                                query["commandExecuteTime"] = to_string(STimeNow() + 1000000 * 60);
+                            }
+                            query["peekSleep"] = "10";
+                            query["response"] = "756";
+                            query["senttonode"] = to_string(currentNodeIndex);
+                            query["clientID"] = to_string(i);
+                            requests.push_back(query);
+                        }
+                    }
+
+                    // Ok, send them all!
+                    BedrockTester* node = localTester->getBedrockTester(currentNodeIndex);
+                    auto results = node->executeWaitMultipleData(requests, 1, false, true);
+                    size_t completed = 0;
+                    for (auto& r : results) {
+                        lock_guard<mutex> lock(mu);
+                        if (r.methodLine != "002 Socket Failed") {
+                            if (counts.find(r.methodLine) != counts.end()) {
+                                counts[r.methodLine]++;
+                            } else {
+                                counts[r.methodLine] = 1;
+                            }
+                            completed++;
+                        } else {
+                            // Got a disconnection. Try on the next node.
+                            break;
+                        }
+                    }
+                    currentNodeIndex++;
+                    currentNodeIndex %= 3;
+                }
+            });
+        }
+    }
+
+    void test() {
+        // just a check for ready state
+        ASSERT_TRUE(tester->getBedrockTester(2)->waitForState("MASTERING"));
+
+        //// dbs are prepped, Let's start spamming.
+        //list<thread>* threads = new list<thread>();
+        //atomic<bool> done;
+        //done.store(false);
+        //map<string, int>* counts = new map<string, int>();
+
+        //// start some clients
+        //atomic<int> commandID(10000);
+        //mutex mu;
+        //vector<list<SData>>* allresults = new vector<list<SData>>(60);
+        //startClientThreads(*threads, done, *counts, commandID, mu, *allresults);
+
+        // Bring masters back up in reverse order, should go quickly to SYNCHRONIZING
+        tester->getBedrockTester(1)->startServer(true);
+        tester->getBedrockTester(0)->startServer(true);
+        ASSERT_TRUE(tester->getBedrockTester(1)->waitForState("SYNCHRONIZING", 5'000'000 ));
+        ASSERT_TRUE(tester->getBedrockTester(0)->waitForState("SYNCHRONIZING", 5'000'000 ));
+
+        // tertiary master should still be MASTERING for a while
+        ASSERT_TRUE(tester->getBedrockTester(2)->waitForState("MASTERING", 5'000'000 ));
+
+        // secondary master should catch up first and go MASTERING, wait up to 30s
+        ASSERT_TRUE(tester->getBedrockTester(1)->waitForState("MASTERING", 30'000'000 ));
+
+        // when primary master catches up it should go MASTERING, wait up to 30s
+        ASSERT_TRUE(tester->getBedrockTester(0)->waitForState("MASTERING", 30'000'000 ));
+
+        //// We're done, let spammers finish.
+        //done.store(true);
+        //for (auto& t : *threads) {
+        //    t.join();
+        //}
+        //threads->clear();
+        //counts->clear();
+        //allresults->clear();
+        //allresults->resize(60);
+        //done.store(false);
+
+        //// Verify everything was either a 202 or a 756.
+        //for (auto& p : *counts) {
+        //    ASSERT_TRUE(p.first == "202" || p.first == "756");
+        //    cout << "method: " << p.first << ", count: " << p.second << endl;
+        //}
+        
+        //// Now that we've verified that, we can start spamming again, and verify failover works in a crash situation.
+        //startClientThreads(*threads, done, *counts, commandID, mu, *allresults);
+
+        //// Wait for them to be busy.
+        //sleep(2);
+
+        // We're really done, let everything finish a last time.
+        //done.store(true);
+        //for (auto& t : *threads) {
+        //    t.join();
+        //}
+        //threads->clear();
+        //counts->clear();
+        //allresults->clear();
+        //allresults->resize(60);
+        //done.store(false);
+
+        //delete counts;
+        //delete threads;
+        //delete allresults;
+    }
+
+} __MultipleMasterSyncTest;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -501,6 +501,10 @@ int BedrockTester::getControlPort() {
     return _controlPort;
 }
 
+int BedrockTester::getCommitCount() {
+    return getSQLiteDB().getCommitCount();
+}
+
 bool BedrockTester::waitForState(string state, uint64_t timeoutUS)
 {
     uint64_t start = STimeNow();

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -73,6 +73,9 @@ class BedrockTester {
     int getNodePort();
     int getControlPort();
 
+    // Get the highest journal ID
+    int getCommitCount();
+
     // Waits up to timeoutUS for the node to be in state `state`, returning true as soon as that state is reached, or
     // false if the timeout is hit.
     bool waitForState(string state, uint64_t timeoutUS = 60'000'000);


### PR DESCRIPTION
@tylerkaraszewski This solves the issue where secondary master won't stand up if it hits WAITING and sees a higher priority node, even if that node is in SYNCHRONIZING. Because nodes start at 0 priority, it also doesn't have the high velocity churn between WAITING nodes when they drop back to SYNCHRONIZING to catch up on new commits.

Tests:
manual out-of-sync master test: PASS (secondary master stands up instead of waiting for primary master)
new automated test (doesn't pass yet)