### PR TITLE
Add support for plugins with custom destructors

### DIFF
--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -16,6 +16,9 @@ BedrockPlugin::BedrockPlugin() {
     g_registeredPluginList->push_back(this);
 }
 
+BedrockPlugin::~BedrockPlugin() {
+}
+
 void BedrockPlugin::verifyAttributeInt64(const SData& request, const string& name, size_t minSize) {
     if (request[name].size() < minSize) {
         STHROW("402 Missing " + name);

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -28,6 +28,7 @@ class BedrockPlugin {
 
     // Standard constructor, inserts the created plugin in `g_registeredPluginList`.
     BedrockPlugin();
+    virtual ~BedrockPlugin();
 
     // Returns a version string indicating the version of this plugin. This needs to be implemented in a thread-safe
     // manner, as it will be called from a different thread than any processing commands.


### PR DESCRIPTION
@coleaeason 

If we want Bedrock plugins to be able to implement their own destructors (which they should be able to do), we need to make the parent class destructor virtual so that the correct destructors for derived classes can get called.

No tests for this, this is intended to support upcoming changes to the Concierge plugin, but does nothing on its own.