### PR TITLE
Add new SSECURITY log line

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -342,6 +342,7 @@ void SLogStackTrace();
 #define SHMMM(_MSG_) SSYSLOG(LOG_WARNING, "[hmmm] " << SLOGPREFIX << _MSG_)
 #define SWARN(_MSG_) SSYSLOG(LOG_WARNING, "[warn] " << SLOGPREFIX << _MSG_)
 #define SALERT(_MSG_) SSYSLOG(LOG_WARNING, "[alrt] " << SLOGPREFIX << _MSG_)
+#define SSECURITY(_MSG_) SSYSLOG(LOG_INFO, "[info] [security] " << SLOGPREFIX << _MSG_)
 #define SERROR(_MSG_)                                                                                                  \
     do {                                                                                                               \
         SSYSLOG(LOG_ERR, "[eror] " << SLOGPREFIX << _MSG_);                                               \


### PR DESCRIPTION
We're going to begin tagging security related log lines in rsyslog, so we need them to follow a specific format each time.

# Test
With https://github.com/Expensify/Server-Expensify/pull/3479 and 
1. Log into account as support
2. Using ES, see if event.tags is populated as security.