### PR TITLE
Better handle crashing commands

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -42,6 +42,7 @@ BedrockCommand::BedrockCommand(SQLiteCommand&& from, int dontCount) :
     peekedBy(nullptr),
     processedBy(nullptr),
     onlyProcessOnSyncThread(false),
+    crashIdentifyingValues(*this),
     _inProgressTiming(INVALID, 0, 0),
     _timeout(_getTimeout(request)),
     countCommand(dontCount != DONT_COUNT)
@@ -62,7 +63,7 @@ BedrockCommand::BedrockCommand(BedrockCommand&& from) :
     processedBy(from.processedBy),
     timingInfo(from.timingInfo),
     onlyProcessOnSyncThread(from.onlyProcessOnSyncThread),
-    crashIdentifyingValues(move(from.crashIdentifyingValues)),
+    crashIdentifyingValues(*this, move(from.crashIdentifyingValues)),
     _inProgressTiming(from._inProgressTiming),
     _timeout(from._timeout),
     countCommand(true)
@@ -82,6 +83,7 @@ BedrockCommand::BedrockCommand(SData&& _request) :
     peekedBy(nullptr),
     processedBy(nullptr),
     onlyProcessOnSyncThread(false),
+    crashIdentifyingValues(*this),
     _inProgressTiming(INVALID, 0, 0),
     _timeout(_getTimeout(request)),
     countCommand(true)
@@ -98,6 +100,7 @@ BedrockCommand::BedrockCommand(SData _request) :
     peekedBy(nullptr),
     processedBy(nullptr),
     onlyProcessOnSyncThread(false),
+    crashIdentifyingValues(*this),
     _inProgressTiming(INVALID, 0, 0),
     _timeout(_getTimeout(request)),
     countCommand(true)

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2015,11 +2015,8 @@ bool BedrockServer::shouldBackup() {
 SData BedrockServer::_generateCrashMessage(const BedrockCommand* command) {
     SData message("CRASH_COMMAND");
     SData subMessage(command->request.methodLine);
-    for (auto& field : command->crashIdentifyingValues) {
-        auto it = command->request.nameValueMap.find(field);
-        if (it != command->request.nameValueMap.end()) {
-            subMessage[field] = it->second;
-        }
+    for (auto& pair : command->crashIdentifyingValues) {
+        subMessage.emplace(pair);
     }
     message.content = subMessage.serialize();
     return message;

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -183,6 +183,12 @@ struct SData {
     SData();
     SData(const string& method);
 
+    // Allow forwarding emplacements directly so SData can act like `std::map`.
+    template <typename... Ts>
+    pair<decltype(nameValueMap)::iterator, bool> emplace(Ts&&... args) {
+        return nameValueMap.emplace(forward<Ts>(args)...);
+    }
+
     // Operators
     string& operator[](const string& name);
     string operator[](const string& name) const;

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -24,11 +24,19 @@ bool BedrockPlugin_TestPlugin::preventAttach() {
 }
 
 bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) {
+    // Always blacklist on userID.
+    command.crashIdentifyingValues.insert("userID");
+
+    // Now that we've blacklisted, mutate the command and see if things break!
+    if (command.request.isSet("userID")) {
+        command.request["userID"] = to_string(stoll(command.request["userID"]) + 1000);
+    }
+
+    // Sleep if requested.
     if (command.request.calc("PeekSleep")) {
         usleep(command.request.calc("PeekSleep") * 1000);
     }
-    // Always blacklist on userID.
-    command.crashIdentifyingValues.insert("userID");
+
     // This should never exist when calling peek.
     SASSERT(!command.httpsRequests.size());
     if (SStartsWith(command.request.methodLine,"testcommand")) {

--- a/test/clustertest/tests/BadCommandTest.cpp
+++ b/test/clustertest/tests/BadCommandTest.cpp
@@ -22,7 +22,6 @@ struct BadCommandTest : tpunit::TestFixture {
         BedrockTester* leader = tester->getBedrockTester(0);
         BedrockTester* follower = tester->getBedrockTester(1);
 
-        // This is here because we can use it to test crashIdentifyingValues, though that isn't currently implemented.
         int userID = 31;
 
         // Make sure unhandled exceptions send an error response, but don't crash the server.


### PR DESCRIPTION
cc @coleaeason 
This changes the type of `crashIdentifyingValues` from a set of strings that are the keys for values, to a map of values that are key/value pairs.

This resolves an issue we found in auth where we set the key `accountID` at the beginning of `peekCommand`, but there was no such key in the command. However, that value was added to the command in `peek`, and then when the command crashed, we populated the map with the current (mutated) value of the key and broadcast that key.

This meant that when the command was replayed, the second server to recieve it would also crash, as it had blacklisted a command with an `accountID` set, but then received a poisoned command with no such key, and so allowed it to run.

The type is slightly more complex than just changing from `set<string>` to `map<string, string>` to maintain compatibility with the existing auth (by implementing `insert` with a single string argument), and to keep most of the logic for blacklisting commands in Bedrock rather than dispersed to individual plugins.

There will be another enhancement PR for auth, but even just this Bedrock change would have avoided the multiple crashes we saw caused by this bug.

## Tests
Existing tests were updated to mutate an entry in `crashIdentifyingValues` before crashing, and were verified to fail on the existing Bedrock, and fail after this PR.