### PR TITLE
[HOLD] Don't close command port when master's offline, but don't run commands

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -823,7 +823,7 @@ void BedrockServer::worker(SData& args,
 
             // We can only peek a command if we're connected to a master on the same version as us. Otherwise, we'll
             // potentially be operating on an outdated schema.
-            bool canPeek = (state == SQLiteNode::LEADING) || (_leaderVersion.load() == _version);
+            bool canPeek = (state == SQLiteNode::LEADING) || (server._leaderVersion.load() == server._version);
 
             // See if this is a feasible command to write parallel. If not, then be ready to forward it to the sync
             // thread, if it doesn't finish in peek.

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2002,6 +2002,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
             // Abort all remote initiated commands if no longer LEADING
             // TODO: No we don't, we finish it, as per other documentation in this file.
         } else if (newState == SEARCHING) {
+            _leaderVersion = "";
             if (!_escalatedCommandMap.empty()) {
                 // This isn't supposed to happen, though we've seen in logs where it can.
                 // So what we'll do is try and correct the problem and log the state we're coming from to see if that


### PR DESCRIPTION
@coleaeason @righdforsa @coleaeason 

This change is the same as here:
https://github.com/Expensify/Bedrock/pull/647

For this issue:
Expensify/Expensify#104706

Except it also checks that we can peek commands, and skips peek (and thus escalates) when we can't.