### PR TITLE
Add logs for debugging recv buffers, make EAGAIN fatal for send()

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -58,6 +58,7 @@
 #define S_EHOSTUNREACH EHOSTUNREACH
 #define S_EALREADY EALREADY
 #define S_EPIPE EPIPE
+#define S_EAGAIN EAGAIN
 
 thread_local string SThreadLogPrefix;
 thread_local string SThreadLogName;
@@ -566,21 +567,23 @@ bool SParseList(const char* ptr, list<string>& valueList, char separator) {
 
 // --------------------------------------------------------------------------
 void SConsumeFront(string& lhs, ssize_t num) {
-    SASSERT((int)lhs.size() >= num);
+    ssize_t lhsSize = lhs.size();
+    SASSERT(lhsSize >= num);
     // If nothing, early out
-    if (!num)
+    if (!num){
         return;
+    }
 
     // If we're clearing the whole thing, early out
-    if ((int)lhs.size() == num) {
+    if (lhsSize == num) {
         // Clear and done
         lhs.clear();
         return;
     }
 
     // Otherwise, move the end forward and resize
-    memmove(&lhs[0], &lhs[num], (int)lhs.size() - num);
-    lhs.resize((int)lhs.size() - num);
+    memmove(&lhs[0], &lhs[num], lhsSize - num);
+    lhs.resize(lhsSize - num);
 }
 
 // --------------------------------------------------------------------------
@@ -1839,8 +1842,8 @@ bool SCheckNetworkErrorType(const string& logPrefix, const string& peer, int err
         // And these aren't interesting enough to say anything about at all (and aren't fatal).
         case S_EINTR:
         case S_EINPROGRESS:
-        case S_EWOULDBLOCK:
         case S_ESHUTDOWN:
+        case S_EWOULDBLOCK: // Same as S_EAGAIN in some distros (including Ubuntu)
             return true; // Socket still alive
     }
 }
@@ -1854,6 +1857,17 @@ bool S_recvappend(int s, string& recvBuffer) {
     int flags = fcntl(s, F_GETFL);
     bool blocking = !(flags & O_NONBLOCK);
 
+    // Log size of the buffer before we read from it.
+    int bytesInBuffer = 0;
+    int ret = 0;
+    ret = ioctl(s, FIONREAD, &bytesInBuffer);
+
+    if (ret < 0) {
+        SHMMM("Unable to get length of socket buffer error: " << strerror(S_errno));
+    } else {
+        SINFO("[performance] " << bytesInBuffer << " bytes in the socket buffer before receiving.");
+    }
+
     // Keep trying to receive as long as we can
     char buffer[4096];
     int totalRecv = 0;
@@ -1866,8 +1880,9 @@ bool S_recvappend(int s, string& recvBuffer) {
         totalRecv += numRecv;
 
         // If this is a blocking socket, don't try again, once is enough
-        if (blocking)
+        if (blocking) {
             return true; // We're still alive
+        }
     }
 
     // See how we finished
@@ -1899,21 +1914,27 @@ bool S_sendconsume(int s, string& sendBuffer) {
     chrono::steady_clock::time_point start = chrono::steady_clock::now();
 
     // Send as much as we can
-    ssize_t numSent = send(s, sendBuffer.c_str(), (int)sendBuffer.size(), MSG_NOSIGNAL);
+    ssize_t numSent = send(s, sendBuffer.c_str(), sendBuffer.size(), MSG_NOSIGNAL);
     string errorMessage;
     if (numSent == -1) {
         errorMessage = " Error: "s + strerror(errno);
     }
     SINFO("[performance] Send() took " << chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - start).count()
-        << " ms and sent " << numSent << " of " << (int)sendBuffer.size() << " bytes." << errorMessage);
+        << " ms and sent " << numSent << " of " << sendBuffer.size() << " bytes." << errorMessage);
 
     if (numSent > 0) {
-        SConsumeFront(sendBuffer, numSent);
+        SConsumeFront(sendBuffer, (size_t)numSent);
     }
 
-    // Exit of no error
+    // Exit if no error
     if (numSent >= 0) {
         return true; // No error; still alive
+    }
+
+    // EAGAIN/EWOULDBLOCK are fatal for send cases
+    if (errno == S_EAGAIN) {
+        SWARN("Closing socket after EAGAIN error in send.");
+        return false;
     }
 
     // Error, what kind?

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1923,7 +1923,7 @@ bool S_sendconsume(int s, string& sendBuffer) {
         << " ms and sent " << numSent << " of " << sendBuffer.size() << " bytes." << errorMessage);
 
     if (numSent > 0) {
-        SConsumeFront(sendBuffer, (size_t)numSent);
+        SConsumeFront(sendBuffer, numSent);
     }
 
     // Exit if no error

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -11,6 +11,7 @@
 #include <poll.h>
 #include <signal.h>
 #include <stdio.h>
+#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/time.h> // for gettimeofday()
 #include <sys/types.h>


### PR DESCRIPTION
@tylerkaraszewski Adds some logging so we can debug issues where node's receive buffers seem to be filling faster than we are able to pull off data. I would expect to a see log lines where the number of bytes is equal to the entire buffer size every time we receive on a socket if the buffer is full. This also makes EAGAIN fatal for send() which should cause the socket to be closed so we stop trying to write to it until after a disconnect. This delay in send() may be enough to actually fix the condition we're seeing, but I'm not sure. It also fixes an integer overflow for the size of a sendBuffer.

Part of: https://github.com/Expensify/Expensify/issues/105149

Tested that the log lines show up in the cluster test:
```
2019-05-29T22:18:29.458676+00:00 expensidev bedrock11111: xxxxxx (libstuff.cpp:1868) S_recvappend [sync] [info] [performance] 56 bytes in the socket buffer before receiving.
2019-05-29T22:18:29.468960+00:00 expensidev bedrock11114: xxxxxx (libstuff.cpp:1868) S_recvappend [sync] [info] [performance] 147 bytes in the socket buffer before receiving.
2019-05-29T22:18:29.496314+00:00 expensidev bedrock11111: xxxxxx (libstuff.cpp:1868) S_recvappend [sync] [info] [performance] 243 bytes in the socket buffer before receiving.
2019-05-29T22:18:29.497257+00:00 expensidev bedrock11117: xxxxxx (libstuff.cpp:1868) S_recvappend [sync] [info] [performance] 123 bytes in the socket buffer before receiving.
2019-05-29T22:18:29.497713+00:00 expensidev bedrock11114: xxxxxx (libstuff.cpp:1868) S_recvappend [sync] [info] [performance] 143 bytes in the socket buffer before receiving.
2019-05-29T22:18:29.497833+00:00 expensidev bedrock11111: xxxxxx (libstuff.cpp:1868) S_recvappend [sync] [info] [performance] 143 bytes in the socket buffer before receiving.
2019-05-29T22:18:29.756214+00:00 expensidev bedrock11117: xxxxxx (libstuff.cpp:1868) S_recvappend [main] [info] [performance] 0 bytes in the socket buffer before receiving.
```