### PR TITLE
Add checking for timeout outside 'peek'

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -53,6 +53,18 @@ uint64_t BedrockCore::_getRemainingTime(const BedrockCommand& command) {
     return min(processTimeout, adjustedTimeout);
 }
 
+bool BedrockCore::isTimedOut(BedrockCommand& command) {
+    try {
+        _getRemainingTime(command);
+    } catch (const SException& e) {
+        // Yep, timed out.
+        _handleCommandException(command, e);
+        command.complete = true;
+        return true;
+    }
+    return false;
+}
+
 bool BedrockCore::peekCommand(BedrockCommand& command) {
     AutoTimer timer(command, BedrockCommand::PEEK);
     // Convenience references to commonly used properties.

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -21,6 +21,11 @@ class BedrockCore : public SQLiteCore {
         uint64_t _start;
     };
 
+    // Checks if a command has already timed out. Like `peekCommand` without doing any work. Returns `true` and sets
+    // the same command state as `peekCommand` would if the command has timed out. Returns `false` and does nothing if
+    // the command hasn't timed out.
+    bool isTimedOut(BedrockCommand& command);
+
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same
     // command, and it *may be called multiple times*. Preventing duplicate actions on calling peek multiple times is
     // up to the implementer, and may happen *across multiple servers*. I.e., a follower server may call `peek`, and on

--- a/test/clustertest/tests/TimeoutTest.cpp
+++ b/test/clustertest/tests/TimeoutTest.cpp
@@ -9,6 +9,7 @@ struct TimeoutTest : tpunit::TestFixture {
                               TEST(TimeoutTest::test),
                               TEST(TimeoutTest::testprocess),
                               TEST(TimeoutTest::totalTimeout),
+                              TEST(TimeoutTest::quorumHTTPS),
                               TEST(TimeoutTest::futureCommitTimeout)) { }
 
     BedrockClusterTester* tester;
@@ -35,6 +36,14 @@ struct TimeoutTest : tpunit::TestFixture {
         slow["size"] = "10000";
         slow["count"] = "10000";
         brtester->executeWaitVerifyContent(slow, "555 Timeout peeking command");
+    }
+
+    void quorumHTTPS () {
+        BedrockTester* brtester = tester->getBedrockTester(0);
+        SData request("httpstimeout");
+        request["writeConsistency"] = "2"; // QUORUM.
+        request["timeout"] = "100"; // 100ms.
+        brtester->executeWaitVerifyContent(request, "555 Timeout");
     }
 
     void testprocess()


### PR DESCRIPTION
@righdforsa cc @coleaeason @iwiznia 

Fixes:
$ https://github.com/Expensify/Expensify/issues/105930
$ https://github.com/Expensify/Expensify/issues/105931
$ https://github.com/Expensify/Expensify/issues/105933

The description of what's fixed is in both a comment in the PR and the comment thread in https://github.com/Expensify/Expensify/issues/105930, but I'll re-iterate here.

We had a `ScrapeCard` command that was auto-promoted to `QUORUM`. This command timed out. Because of the way timeouts are handled, when the `sync` thread times out a command, it returns it to the main command queue to be dealt with (because that's where all the logic for returning responses to clients is). The intention then was that that command would be `peek`ed again, and we would notice the timeout before doing anything, and return the error.

However, because `ScrapeCard` is an https command, we won't do multiple `peek`s on it, to avoid duplicate requests being made to things like banks and stripe. So, we skip `peek` in the main loop, and thus don't notice the command is timed out. Then, because it's a `QUORUM` command, we send it back to the `sync` thread, who notices it's timed out, and returns it to the main queue. This creates an infinite loop.

The fix adds a check for timed out commands outside of `peek` that is called in the main loop immediately after de-queuing a command.

# Tests
New test added. Additionally, verified that without the fixed code, the old code does the same thing as observed in the linked issue, namely, gets into an infinite loop for a particular command:

```
2019-06-12T22:23:13.211636+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:692) worker [worker5] [info] Dequeued command httpstimeout in worker, 0 commands in  queue.
2019-06-12T22:23:13.211723+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:936) worker [worker5] [info] Sending non-parallel command httpstimeout to sync thread. Sync thread has 0 queued commands.
2019-06-12T22:23:13.212946+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:483) sync [sync] [info] Sync thread dequeued command httpstimeout. Sync thread has 0 queued commands.
2019-06-12T22:23:13.213002+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:486) sync [sync] [info] Command 'httpstimeout' timed out in sync thread queue, sending back to main queue.
2019-06-12T22:23:13.214241+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:692) worker [worker2] [info] Dequeued command httpstimeout in worker, 0 commands in  queue.
2019-06-12T22:23:13.214328+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:936) worker [worker2] [info] Sending non-parallel command httpstimeout to sync thread. Sync thread has 0 queued commands.
2019-06-12T22:23:13.215372+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:483) sync [sync] [info] Sync thread dequeued command httpstimeout. Sync thread has 0 queued commands.
2019-06-12T22:23:13.215425+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:486) sync [sync] [info] Command 'httpstimeout' timed out in sync thread queue, sending back to main queue.
2019-06-12T22:23:13.216684+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:692) worker [worker7] [info] Dequeued command httpstimeout in worker, 0 commands in  queue.
2019-06-12T22:23:13.216775+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:936) worker [worker7] [info] Sending non-parallel command httpstimeout to sync thread. Sync thread has 0 queued commands.
2019-06-12T22:23:13.217881+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:483) sync [sync] [info] Sync thread dequeued command httpstimeout. Sync thread has 0 queued commands.
2019-06-12T22:23:13.217931+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:486) sync [sync] [info] Command 'httpstimeout' timed out in sync thread queue, sending back to main queue.
2019-06-12T22:23:13.219196+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:692) worker [worker3] [info] Dequeued command httpstimeout in worker, 0 commands in  queue.
2019-06-12T22:23:13.219334+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:936) worker [worker3] [info] Sending non-parallel command httpstimeout to sync thread. Sync thread has 0 queued commands.
2019-06-12T22:23:13.220610+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:483) sync [sync] [info] Sync thread dequeued command httpstimeout. Sync thread has 0 queued commands.
2019-06-12T22:23:13.220660+00:00 expensidev bedrock11111: xqIAe6 (BedrockServer.cpp:486) sync [sync] [info] Command 'httpstimeout' timed out in sync thread queue, sending back to main queue.
```