### PR TITLE
Update getPeerInfo, update BedrockClusterTester to include a permafollower option

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1694,6 +1694,9 @@ bool BedrockServer::getPeerInfo(list<STable>& peerData) {
         if (_syncNodeCopy) {
             for (SQLiteNode::Peer* peer : _syncNodeCopy->peerList) {
                 peerData.emplace_back(peer->nameValueMap);
+                for (auto it : peer->params) {
+                    peerData.back()[it.first] = it.second;
+                }
                 peerData.back()["host"] = peer->host;
                 peerData.back()["name"] = peer->name;
                 peerData.back()["State"] = SQLiteNode::stateName(peer->state);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1687,8 +1687,7 @@ bool BedrockServer::_isStatusCommand(BedrockCommand& command) {
     return false;
 }
 
-list<STable> BedrockServer::getPeerInfo() {
-    list<STable> peerData;
+bool BedrockServer::getPeerInfo(list<STable>& peerData) {
     if (_syncMutex.try_lock_for(chrono::milliseconds(10))) {
         lock_guard<decltype(_syncMutex)> lock(_syncMutex, adopt_lock_t());
         auto _syncNodeCopy = _syncNode;
@@ -1700,7 +1699,15 @@ list<STable> BedrockServer::getPeerInfo() {
                 peerData.back()["State"] = SQLiteNode::stateName(peer->state);
             }
         }
+    } else {
+        return false;
     }
+    return true;
+}
+
+list<STable> BedrockServer::getPeerInfo() {
+    list<STable> peerData;
+    getPeerInfo(peerData);
     return peerData;
 }
 
@@ -1791,7 +1798,6 @@ void BedrockServer::_status(BedrockCommand& command) {
 
         // We read from syncNode internal state here, so we lock to make sure that this doesn't conflict with the sync
         // thread.
-        list<STable> peerData = getPeerInfo();
         list<string> escalated;
         {
             if (_syncMutex.try_lock_for(chrono::milliseconds(10))) {
@@ -1815,10 +1821,18 @@ void BedrockServer::_status(BedrockCommand& command) {
             }
         }
 
-        // Coalesce all of the peer data into one value to return.
+        // Coalesce all of the peer data into one value to return or return
+        // an error message if we timed out getting the peerList data.
         list<string> peerList;
-        for (const STable& peerTable : peerData) {
-            peerList.push_back(SComposeJSONObject(peerTable));
+        list<STable> peerData;
+        if (getPeerInfo(peerData)) {
+            for (const STable& peerTable : peerData) {
+                peerList.push_back(SComposeJSONObject(peerTable));
+            }
+        } else {
+            STable peerListResponse;
+            peerListResponse["peerListBlocked"] = "true";
+            peerList.push_back(SComposeJSONObject(peerListResponse));
         }
 
         // We can use the `each` functionality to pass a lambda that will grab each method line in

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -195,6 +195,7 @@ class BedrockServer : public SQLiteServer {
 
     // Returns a copy of the internal state of the sync node's peers. This can be empty if there are no peers, or no
     // sync node.
+    bool getPeerInfo(list<STable>& peerData);
     list<STable> getPeerInfo();
 
     // Send a command to all of our peers. It will be wrapped appropriately.

--- a/test/clustertest/BedrockClusterTester.cpp
+++ b/test/clustertest/BedrockClusterTester.cpp
@@ -1,9 +1,11 @@
 #include "BedrockClusterTester.h"
 
 BedrockClusterTester::BedrockClusterTester(int threadID, string pluginsToLoad)
-  : BedrockClusterTester(THREE_NODE_CLUSTER, {"CREATE TABLE test (id INTEGER NOT NULL PRIMARY KEY, value TEXT NOT NULL)"}, threadID, {}, {}, pluginsToLoad) {}
+  : BedrockClusterTester(THREE_NODE_CLUSTER, {"CREATE TABLE test (id INTEGER NOT NULL PRIMARY KEY, value TEXT NOT NULL)"},
+                            threadID, {}, {}, pluginsToLoad) {}
 
-BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize size, list<string> queries, int threadID, map<string, string> _args, list<string> uniquePorts, string pluginsToLoad)
+BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize size, list<string> queries, int threadID,
+                                            map<string, string> _args, list<string> uniquePorts, string pluginsToLoad)
 : _size(size)
 {
     // Make sure we won't re-allocate.
@@ -51,15 +53,18 @@ BedrockClusterTester::BedrockClusterTester(BedrockClusterTester::ClusterSize siz
         string nodeHost    = "127.0.0.1:" + to_string(nodePort);
         string controlHost = "127.0.0.1:" + to_string(controlPort);
         string db          = BedrockTester::getTempFileName("cluster_node_" + to_string(nodePort));
-        string priority    = to_string(100 - (i * 10));
         string nodeName    = nodeNamePrefix + to_string(i);
+
+        // If we're building a 6 node cluster, make the last node a permafollower
+        string priority    = i < 5 ? to_string(100 - (i * 10)) : to_string(0);
+
 
         // Construct our list of peers.
         int j = 0;
         list<string> peerList;
         for (auto p : ports) {
             if (p[0] != nodePort) {
-                peerList.push_back("127.0.0.1:"s + to_string(p[0]) + "?nodeName=" + nodeNamePrefix + to_string(j));
+                peerList.push_back("127.0.0.1:"s + to_string(p[0]) + "?nodeName=" + nodeNamePrefix + to_string(j) + (j == 5 ? "&Permafollower=true" : ""));
             }
             j++;
         }

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -6,6 +6,7 @@ class BedrockClusterTester {
         ONE_NODE_CLUSTER   = 1,
         THREE_NODE_CLUSTER = 3,
         FIVE_NODE_CLUSTER  = 5,
+        SIX_NODE_CLUSTER  = 6,
     };
 
     // Creates a cluster of the given size and brings up all the nodes. The nodes will have priority in the order of
@@ -14,20 +15,6 @@ class BedrockClusterTester {
     BedrockClusterTester(ClusterSize size, list<string> queries = {}, int threadID = 0, map<string, string> _args = {}, list<string> uniquePorts = {}, string pluginsToLoad = "db,cache,jobs");
     BedrockClusterTester(int threadID, string pluginsToLoad = "db,cache,jobs");
     ~BedrockClusterTester();
-
-    // Returns the index of the node that's leader. Returns a negative number on error:
-    // -1: no leader
-    // -2: multiple leader
-    int getMasterNodeIndex();
-
-    // Runs the given query on all nodes and verifies the output is the same. Make sure you include "ORDER BY" if you
-    // want to verify this across multiple rows, as they're not guaranteed to be returned in the same order for all
-    // nodes.
-    bool VerifyQuery(string query);
-
-    // Wait until all nodes have the same highest commit count. Optional timeout, set to 0 for no timeout.
-    // Returns true on sync, false on timeout.
-    bool waitForSync(int timeout_usec = 0);
 
     // Returns the bedrock tester at the given index in the cluster.
     BedrockTester* getBedrockTester(size_t index);


### PR DESCRIPTION
@tylerkaraszewski will you please review?

1. Updates `getPeerInfo()` to return more information to the caller so the caller can base behaviors on what happened in the function.
2. Updates BedrockClusterTester to support a six node, 1 permafollower cluster. The last node in the cluster is always the permafollower.
3. Removes signatures for functions that are not implemented in BedrockClusterTester

This is needed for https://github.com/Expensify/Expensify/issues/107550