### PR TITLE
Better notification of test failures

### DIFF
--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -147,6 +147,10 @@ BedrockTester::~BedrockTester() {
 string BedrockTester::startServer(bool dontWait) {
     string serverName = getServerName();
     int childPID = fork();
+    if (childPID == -1) {
+        cout << "Fork failed, acting like server died." << endl;
+        exit(1);
+    }
     if (!childPID) {
         // We are the child!
         list<string> args;
@@ -183,6 +187,10 @@ string BedrockTester::startServer(bool dontWait) {
 
         // And then start the new server!
         execvp(serverName.c_str(), cargs);
+
+        // The above line should only ever return if it failed, so let's check for that.
+        cout << "Starting bedrock failed." << endl;
+        exit(1);
     } else {
         // We'll kill this later.
         _serverPID = childPID;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -30,6 +30,10 @@ string BedrockTester::getServerName() {
             return location;
         }
     }
+    cout << "Couldn't find bedrock server" << endl;
+    exit(1);
+
+    // Won't get hit.
     return "";
 }
 
@@ -189,7 +193,11 @@ string BedrockTester::startServer(bool dontWait) {
         execvp(serverName.c_str(), cargs);
 
         // The above line should only ever return if it failed, so let's check for that.
-        cout << "Starting bedrock failed." << endl;
+        cout << "Starting bedrock failed: " << serverName;
+        for (auto& arg : args) {
+            cout << " " << arg;
+        }
+        cout << endl;
         exit(1);
     } else {
         // We'll kill this later.


### PR DESCRIPTION
When adding tests in Server-Expensify, I triggered a strange error case that was ghard to debug because we expected that `execvp` never returned, but in this case it did return. This change logs and then exits in that case, making it clear why the failure occured.