### PR TITLE
Log normalized slow query

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2423,7 +2423,7 @@ static int _SQueryCallback(void* data, int argc, char** argv, char** colNames) {
 
 // --------------------------------------------------------------------------
 // Executes a SQLite query
-int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold, bool skipWarn) {
+int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, bool skipWarn) {
 #define MAX_TRIES 3
     // Execute the query and get the results
     uint64_t startTime = STimeNow();
@@ -2447,11 +2447,8 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
             sleep(1);
         }
     }
-    uint64_t elapsed = STimeNow() - startTime;
 
-    // Warn if it took longer than the specified threshold
-    if ((int64_t)elapsed > warnThreshold)
-        SWARN("Slow query (" << elapsed / 1000 << "ms) " << sql.length() << ": " << sql.substr(0, 150));
+    uint64_t elapsed = STimeNow() - startTime;
 
     // Log this if enabled
     if (_g_sQueryLogFP) {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2462,6 +2462,11 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, bool
     return error;
 }
 
+int SQuery(sqlite3* db, const char* e, const string& sql, bool skipWarn) {
+    SQResult ignore;
+    return SQuery(db, e, sql, ignore, skipWarn);
+}
+
 // --------------------------------------------------------------------------
 // Creates a table, if not there, or verifies it's defined correctly
 bool SQVerifyTable(sqlite3* db, const string& tableName, const string& sql) {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2426,7 +2426,6 @@ static int _SQueryCallback(void* data, int argc, char** argv, char** colNames) {
 int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, bool skipWarn) {
 #define MAX_TRIES 3
     // Execute the query and get the results
-    uint64_t startTime = STimeNow();
     int error = 0;
     int extErr = 0;
     for (int tries = 0; tries < MAX_TRIES; tries++) {
@@ -2446,17 +2445,6 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, bool
         if ((tries + 1) < MAX_TRIES) {
             sleep(1);
         }
-    }
-
-    uint64_t elapsed = STimeNow() - startTime;
-
-    // Log this if enabled
-    if (_g_sQueryLogFP) {
-        // Log this query as an SQL statement ready for insertion
-        const string& dbFilename = sqlite3_db_filename(db, "main");
-        const string& csvRow =
-            "\"" + dbFilename + "\", " + "\"" + SEscape(STrim(sql), "\"", '"') + "\", " + SToStr(elapsed) + "\n";
-        SASSERT(fwrite(csvRow.c_str(), 1, csvRow.size(), _g_sQueryLogFP) == csvRow.size());
     }
 
     // Only OK and commit conflicts are allowed without warning.

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -772,11 +772,10 @@ void SQueryLogOpen(const string& logFilename);
 void SQueryLogClose();
 
 // Returns an SQLite result code.
-int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result,
-           int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
-inline int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false) {
+int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, bool skipWarn = false);
+inline int SQuery(sqlite3* db, const char* e, const string& sql, bool skipWarn = false) {
     SQResult ignore;
-    return SQuery(db, e, sql, ignore, warnThreshold, skipWarn);
+    return SQuery(db, e, sql, ignore, skipWarn);
 }
 
 bool SQVerifyTable(sqlite3* db, const string& tableName, const string& sql);

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -773,10 +773,7 @@ void SQueryLogClose();
 
 // Returns an SQLite result code.
 int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, bool skipWarn = false);
-inline int SQuery(sqlite3* db, const char* e, const string& sql, bool skipWarn = false) {
-    SQResult ignore;
-    return SQuery(db, e, sql, ignore, skipWarn);
-}
+int SQuery(sqlite3* db, const char* e, const string& sql, bool skipWarn = false);
 
 bool SQVerifyTable(sqlite3* db, const string& tableName, const string& sql);
 bool SQVerifyTableExists(sqlite3* db, const string& tableName);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -114,25 +114,25 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints
     SASSERT(!sqlite3_open_v2(filename.c_str(), &_db, DB_WRITE_OPEN_FLAGS, NULL));
 
     // WAL is what allows simultaneous read/writing.
-    SASSERT(!timedSQuery("enabling write ahead logging", "PRAGMA journal_mode = WAL;"));
+    SASSERT(!timedQuery("enabling write ahead logging", "PRAGMA journal_mode = WAL;"));
 
     if (mmapSizeGB) {
-        SASSERT(!timedSQuery("enabling memory-mapped I/O", "PRAGMA mmap_size=" + to_string(mmapSizeGB * 1024 * 1024 * 1024) + ";"));
+        SASSERT(!timedQuery("enabling memory-mapped I/O", "PRAGMA mmap_size=" + to_string(mmapSizeGB * 1024 * 1024 * 1024) + ";"));
     }
 
     // PRAGMA legacy_file_format=OFF sets the default for creating new databases, so it must be called before creating
     // any tables to be effective.
-    SASSERT(!timedSQuery("new file format for DESC indexes", "PRAGMA legacy_file_format = OFF"));
+    SASSERT(!timedQuery("new file format for DESC indexes", "PRAGMA legacy_file_format = OFF"));
 
     // Check if synchronous has been set and run query to use a custom synchronous setting
     if (!synchronous.empty()) {
-        SASSERT(!timedSQuery("setting custom synchronous commits", "PRAGMA synchronous = " + SQ(synchronous)  + ";"));
+        SASSERT(!timedQuery("setting custom synchronous commits", "PRAGMA synchronous = " + SQ(synchronous)  + ";"));
     } else {
         DBINFO("Using SQLite default PRAGMA synchronous");
     }
 
     // These other pragmas only relate to read/write databases.
-    SASSERT(!timedSQuery("disabling change counting", "PRAGMA count_changes = OFF;"));
+    SASSERT(!timedQuery("disabling change counting", "PRAGMA count_changes = OFF;"));
 
     // Do our own checkpointing.
     sqlite3_wal_hook(_db, _sqliteWALCallback, this);
@@ -142,7 +142,7 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints
 
     // Update the cache. -size means KB; +size means pages
     SINFO("Setting cache_size to " << cacheSize << "KB");
-    timedSQuery("increasing cache size", "PRAGMA cache_size = -" + SQ(cacheSize) + ";");
+    timedQuery("increasing cache size", "PRAGMA cache_size = -" + SQ(cacheSize) + ";");
 
     // Now we (if we're the initializer) verify (and create if non-existent) all of our required journal tables.
     if (initializer) {
@@ -179,9 +179,9 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints
 
     // Look up the min and max values in the database.
     SQResult result;
-    SASSERT(!timedSQuery("getting commit min", minQuery, result));
+    SASSERT(!timedQuery("getting commit min", minQuery, result));
     uint64_t min = SToUInt64(result[0][0]);
-    SASSERT(!timedSQuery("getting commit max", maxQuery, result));
+    SASSERT(!timedQuery("getting commit max", maxQuery, result));
     uint64_t max = SToUInt64(result[0][0]);
 
     // And save the difference as the size of the journal.
@@ -410,7 +410,7 @@ bool SQLite::beginTransaction(bool useCache, const string& transactionName) {
     _sharedData->blockNewTransactionsCV.notify_one();
     SDEBUG("Beginning transaction");
     uint64_t before = STimeNow();
-    _insideTransaction = !timedSQuery("starting db transaction", "BEGIN TRANSACTION");
+    _insideTransaction = !timedQuery("starting db transaction", "BEGIN TRANSACTION");
     _queryCache.clear();
     _transactionName = transactionName;
     _useCache = useCache;
@@ -436,7 +436,7 @@ bool SQLite::beginConcurrentTransaction(bool useCache, const string& transaction
     _sharedData->blockNewTransactionsCV.notify_one();
     SDEBUG("[concurrent] Beginning transaction");
     uint64_t before = STimeNow();
-    _insideTransaction = !timedSQuery("starting db transaction", "BEGIN CONCURRENT");
+    _insideTransaction = !timedQuery("starting db transaction", "BEGIN CONCURRENT");
     _queryCache.clear();
     _transactionName = transactionName;
     _useCache = useCache;
@@ -543,7 +543,7 @@ bool SQLite::read(const string& query, SQResult& result) {
         }
     }
     _isDeterministicQuery = true;
-    bool queryResult = !timedSQuery("read only query", query, result);
+    bool queryResult = !timedQuery("read only query", query, result);
     if (_useCache && _isDeterministicQuery && queryResult) {
         _queryCache.emplace(make_pair(query, result));
     }
@@ -604,7 +604,7 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
 
     // First, check our current state
     SQResult results;
-    SASSERT(!timedSQuery("looking up schema version", "PRAGMA schema_version;", results));
+    SASSERT(!timedQuery("looking up schema version", "PRAGMA schema_version;", results));
     SASSERT(!results.empty() && !results[0].empty());
     uint64_t schemaBefore = SToUInt64(results[0][0]);
     uint64_t changesBefore = sqlite3_total_changes(_db);
@@ -614,19 +614,19 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
     bool result = false;
     bool usedRewrittenQuery = false;
     if (_enableRewrite) {
-        int resultCode = timedSQuery("read/write transaction", query, 2000 * STIME_US_PER_MS, true);
+        int resultCode = timedQuery("read/write transaction", query, 2000 * STIME_US_PER_MS, true);
         if (resultCode == SQLITE_AUTH) {
             // Run re-written query.
             _currentlyRunningRewritten = true;
             SASSERT(SEndsWith(_rewrittenQuery, ";"));
-            result = !timedSQuery("read/write transaction", _rewrittenQuery);
+            result = !timedQuery("read/write transaction", _rewrittenQuery);
             usedRewrittenQuery = true;
             _currentlyRunningRewritten = false;
         } else {
             result = !resultCode;
         }
     } else {
-        result = !timedSQuery("read/write transaction", query);
+        result = !timedQuery("read/write transaction", query);
     }
     _checkTiming("timeout in SQLite::write"s);
     _writeElapsed += STimeNow() - before;
@@ -635,7 +635,7 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
     }
 
     // See if the query changed anything
-    SASSERT(!timedSQuery("looking up schema version", "PRAGMA schema_version;", results));
+    SASSERT(!timedQuery("looking up schema version", "PRAGMA schema_version;", results));
     SASSERT(!results.empty() && !results[0].empty());
     uint64_t schemaAfter = SToUInt64(results[0][0]);
     uint64_t changesAfter = sqlite3_total_changes(_db);
@@ -669,7 +669,7 @@ bool SQLite::prepare() {
     // These are the values we're currently operating on, until we either commit or rollback.
     _sharedData->_inFlightTransactions[commitCount + 1] = make_pair(_uncommittedQuery, _uncommittedHash);
 
-    int result = timedSQuery("updating journal", query);
+    int result = timedQuery("updating journal", query);
     _prepareElapsed += STimeNow() - before;
     if (result) {
         // Couldn't insert into the journal; roll back the original commit
@@ -698,13 +698,13 @@ int SQLite::commit() {
         string query = "DELETE FROM " + _journalName + " "
                        "WHERE id < (SELECT MAX(id) FROM " + _journalName + ") - " + SQ(_maxJournalSize) + " "
                        "LIMIT 10";
-        SASSERT(!timedSQuery("Deleting oldest journal rows", query));
+        SASSERT(!timedQuery("Deleting oldest journal rows", query));
 
         // Figure out the new journal size.
         SQResult result;
-        SASSERT(!timedSQuery("getting commit min", "SELECT MIN(id) AS id FROM " + _journalName, result));
+        SASSERT(!timedQuery("getting commit min", "SELECT MIN(id) AS id FROM " + _journalName, result));
         uint64_t min = SToUInt64(result[0][0]);
-        SASSERT(!timedSQuery("getting commit max", "SELECT MAX(id) AS id FROM " + _journalName, result));
+        SASSERT(!timedQuery("getting commit max", "SELECT MAX(id) AS id FROM " + _journalName, result));
         uint64_t max = SToUInt64(result[0][0]);
         newJournalSize = max - min;
 
@@ -721,7 +721,7 @@ int SQLite::commit() {
 
     uint64_t before = STimeNow();
     uint64_t beforeCommit = STimeNow();
-    result = timedSQuery("committing db transaction", "COMMIT");
+    result = timedQuery("committing db transaction", "COMMIT");
     SINFO("SQuery 'COMMIT' took " << ((STimeNow() - beforeCommit)/1000) << "ms.");
 
     // And record pages after the commit.
@@ -808,7 +808,7 @@ void SQLite::rollback() {
                 SINFO("Rolling back transaction: " << _uncommittedQuery.substr(0, 100));
             }
             uint64_t before = STimeNow();
-            SASSERT(!timedSQuery("rolling back db transaction", "ROLLBACK"));
+            SASSERT(!timedQuery("rolling back db transaction", "ROLLBACK"));
             _rollbackElapsed += STimeNow() - before;
         }
 
@@ -861,7 +861,7 @@ bool SQLite::getCommit(uint64_t id, string& query, string& hash) {
     // Look up the query and hash for the given commit
     string q= _getJournalQuery({"SELECT query, hash FROM", "WHERE id = " + SQ(id)});
     SQResult result;
-    SASSERT(!timedSQuery("getting commit", q, result));
+    SASSERT(!timedQuery("getting commit", q, result));
     if (!result.empty()) {
         query = result[0][0];
         hash = result[0][1];
@@ -889,7 +889,7 @@ bool SQLite::getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result) 
                                     (toIndex ? " AND id <= " + SQ(toIndex) : "")});
     SDEBUG("Getting commits #" << fromIndex << "-" << toIndex);
     query = "SELECT hash, query FROM (" + query  + ") ORDER BY id";
-    return !timedSQuery("getting commits", query, result);
+    return !timedQuery("getting commits", query, result);
 }
 
 int64_t SQLite::getLastInsertRowID() {
@@ -908,7 +908,7 @@ uint64_t SQLite::_getCommitCount() {
     string query = _getJournalQuery({"SELECT MAX(id) as maxIDs FROM"}, true);
     query = "SELECT MAX(maxIDs) FROM (" + query + ")";
     SQResult result;
-    SASSERT(!timedSQuery("getting commit count", query, result));
+    SASSERT(!timedQuery("getting commit count", query, result));
     if (result.empty()) {
         return 0;
     }
@@ -1058,7 +1058,7 @@ void SQLite::setUpdateNoopMode(bool enabled) {
 
     // Enable or disable this query.
     string query = "PRAGMA noop_update="s + (enabled ? "ON" : "OFF") + ";";
-    timedSQuery("setting noop-update mode", query);
+    timedQuery("setting noop-update mode", query);
     _noopUpdateMode = enabled;
 
     // If we're inside a transaction, make sure this gets saved so it can be replicated.
@@ -1072,7 +1072,7 @@ bool SQLite::getUpdateNoopMode() const {
     return _noopUpdateMode;
 }
 
-int SQLite::timedSQuery(const char *e, const string &sql, SQResult &result, int64_t warnThreshold, bool skipWarn) {
+int SQLite::timedQuery(const char *e, const string &sql, SQResult &result, int64_t warnThreshold, bool skipWarn) {
     uint64_t startTime = STimeNow();
     int queryResult = SQuery(_db, e, sql, result, skipWarn);
     uint64_t elapsed = STimeNow() - startTime;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -233,9 +233,10 @@ void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg) {
 }
 
 int SQLite::_sqliteTraceCallback(unsigned int traceCode, void* c, void* p, void* x) {
-    if (enableTrace && traceCode == SQLITE_TRACE_STMT) {
+    if (traceCode == SQLITE_TRACE_STMT) {
         _lastQuery = (sqlite3_stmt*)p;
-        SINFO("NORMALIZED_SQL:" << sqlite3_normalized_sql(_lastQuery));
+        if (enableTrace)
+            SINFO("NORMALIZED_SQL:" << sqlite3_normalized_sql(_lastQuery));
     }
     return 0;
 }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -9,6 +9,8 @@ recursive_mutex SQLite::_commitLock;
 // Global map for looking up shared data by file when creating new instances.
 map<string, SQLite::SharedData*> SQLite::_sharedDataLookupMap;
 
+map<string, sqlite3_stmt*> SQLite::_queries;
+
 // This is our only public static variable. It needs to be initialized after `_commitLock`.
 SLockTimer<recursive_mutex> SQLite::g_commitLock("Commit Lock", SQLite::_commitLock);
 
@@ -232,9 +234,19 @@ void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg) {
 
 int SQLite::_sqliteTraceCallback(unsigned int traceCode, void* c, void* p, void* x) {
     if (enableTrace && traceCode == SQLITE_TRACE_STMT) {
-        SINFO("NORMALIZED_SQL:" << sqlite3_normalized_sql((sqlite3_stmt*)p));
+        sqlite3_stmt* q = (sqlite3_stmt*)p;
+//        _queries[hashed(q)] = q;
+        SINFO("NORMALIZED_SQL:" << sqlite3_normalized_sql(q));
     }
     return 0;
+}
+
+void SQLite::logSlowQueryIfNeeded(const string& sql, int64_t elapsed, int64_t warnThreshold) {
+    if (elapsed > warnThreshold) {
+//        sqlite3_stmt* q = _queries[hashed(sql)];
+//        SWARN("Slow query (" << elapsed / 1000 << "ms) " << sql.length() << ": " << sqlite3_normalized_sql(q));
+//        _queries.erase(hashed(sql));
+    }
 }
 
 int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int pageCount) {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -114,25 +114,25 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints
     SASSERT(!sqlite3_open_v2(filename.c_str(), &_db, DB_WRITE_OPEN_FLAGS, NULL));
 
     // WAL is what allows simultaneous read/writing.
-    SASSERT(!timedQuery("enabling write ahead logging", "PRAGMA journal_mode = WAL;"));
+    SASSERT(!SQuery("enabling write ahead logging", "PRAGMA journal_mode = WAL;"));
 
     if (mmapSizeGB) {
-        SASSERT(!timedQuery("enabling memory-mapped I/O", "PRAGMA mmap_size=" + to_string(mmapSizeGB * 1024 * 1024 * 1024) + ";"));
+        SASSERT(!SQuery("enabling memory-mapped I/O", "PRAGMA mmap_size=" + to_string(mmapSizeGB * 1024 * 1024 * 1024) + ";"));
     }
 
     // PRAGMA legacy_file_format=OFF sets the default for creating new databases, so it must be called before creating
     // any tables to be effective.
-    SASSERT(!timedQuery("new file format for DESC indexes", "PRAGMA legacy_file_format = OFF"));
+    SASSERT(!SQuery("new file format for DESC indexes", "PRAGMA legacy_file_format = OFF"));
 
     // Check if synchronous has been set and run query to use a custom synchronous setting
     if (!synchronous.empty()) {
-        SASSERT(!timedQuery("setting custom synchronous commits", "PRAGMA synchronous = " + SQ(synchronous)  + ";"));
+        SASSERT(!SQuery("setting custom synchronous commits", "PRAGMA synchronous = " + SQ(synchronous)  + ";"));
     } else {
         DBINFO("Using SQLite default PRAGMA synchronous");
     }
 
     // These other pragmas only relate to read/write databases.
-    SASSERT(!timedQuery("disabling change counting", "PRAGMA count_changes = OFF;"));
+    SASSERT(!SQuery("disabling change counting", "PRAGMA count_changes = OFF;"));
 
     // Do our own checkpointing.
     sqlite3_wal_hook(_db, _sqliteWALCallback, this);
@@ -142,7 +142,7 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints
 
     // Update the cache. -size means KB; +size means pages
     SINFO("Setting cache_size to " << cacheSize << "KB");
-    timedQuery("increasing cache size", "PRAGMA cache_size = -" + SQ(cacheSize) + ";");
+    SQuery("increasing cache size", "PRAGMA cache_size = -" + SQ(cacheSize) + ";");
 
     // Now we (if we're the initializer) verify (and create if non-existent) all of our required journal tables.
     if (initializer) {
@@ -179,9 +179,9 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints
 
     // Look up the min and max values in the database.
     SQResult result;
-    SASSERT(!timedQuery("getting commit min", minQuery, result));
+    SASSERT(!SQuery("getting commit min", minQuery, result));
     uint64_t min = SToUInt64(result[0][0]);
-    SASSERT(!timedQuery("getting commit max", maxQuery, result));
+    SASSERT(!SQuery("getting commit max", maxQuery, result));
     uint64_t max = SToUInt64(result[0][0]);
 
     // And save the difference as the size of the journal.
@@ -410,7 +410,7 @@ bool SQLite::beginTransaction(bool useCache, const string& transactionName) {
     _sharedData->blockNewTransactionsCV.notify_one();
     SDEBUG("Beginning transaction");
     uint64_t before = STimeNow();
-    _insideTransaction = !timedQuery("starting db transaction", "BEGIN TRANSACTION");
+    _insideTransaction = !SQuery("starting db transaction", "BEGIN TRANSACTION");
     _queryCache.clear();
     _transactionName = transactionName;
     _useCache = useCache;
@@ -436,7 +436,7 @@ bool SQLite::beginConcurrentTransaction(bool useCache, const string& transaction
     _sharedData->blockNewTransactionsCV.notify_one();
     SDEBUG("[concurrent] Beginning transaction");
     uint64_t before = STimeNow();
-    _insideTransaction = !timedQuery("starting db transaction", "BEGIN CONCURRENT");
+    _insideTransaction = !SQuery("starting db transaction", "BEGIN CONCURRENT");
     _queryCache.clear();
     _transactionName = transactionName;
     _useCache = useCache;
@@ -604,7 +604,7 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
 
     // First, check our current state
     SQResult results;
-    SASSERT(!timedQuery("looking up schema version", "PRAGMA schema_version;", results));
+    SASSERT(!SQuery("looking up schema version", "PRAGMA schema_version;", results));
     SASSERT(!results.empty() && !results[0].empty());
     uint64_t schemaBefore = SToUInt64(results[0][0]);
     uint64_t changesBefore = sqlite3_total_changes(_db);
@@ -635,7 +635,7 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
     }
 
     // See if the query changed anything
-    SASSERT(!timedQuery("looking up schema version", "PRAGMA schema_version;", results));
+    SASSERT(!SQuery("looking up schema version", "PRAGMA schema_version;", results));
     SASSERT(!results.empty() && !results[0].empty());
     uint64_t schemaAfter = SToUInt64(results[0][0]);
     uint64_t changesAfter = sqlite3_total_changes(_db);
@@ -669,7 +669,7 @@ bool SQLite::prepare() {
     // These are the values we're currently operating on, until we either commit or rollback.
     _sharedData->_inFlightTransactions[commitCount + 1] = make_pair(_uncommittedQuery, _uncommittedHash);
 
-    int result = timedQuery("updating journal", query);
+    int result = SQuery("updating journal", query);
     _prepareElapsed += STimeNow() - before;
     if (result) {
         // Couldn't insert into the journal; roll back the original commit
@@ -698,13 +698,13 @@ int SQLite::commit() {
         string query = "DELETE FROM " + _journalName + " "
                        "WHERE id < (SELECT MAX(id) FROM " + _journalName + ") - " + SQ(_maxJournalSize) + " "
                        "LIMIT 10";
-        SASSERT(!timedQuery("Deleting oldest journal rows", query));
+        SASSERT(!SQuery("Deleting oldest journal rows", query));
 
         // Figure out the new journal size.
         SQResult result;
-        SASSERT(!timedQuery("getting commit min", "SELECT MIN(id) AS id FROM " + _journalName, result));
+        SASSERT(!SQuery("getting commit min", "SELECT MIN(id) AS id FROM " + _journalName, result));
         uint64_t min = SToUInt64(result[0][0]);
-        SASSERT(!timedQuery("getting commit max", "SELECT MAX(id) AS id FROM " + _journalName, result));
+        SASSERT(!SQuery("getting commit max", "SELECT MAX(id) AS id FROM " + _journalName, result));
         uint64_t max = SToUInt64(result[0][0]);
         newJournalSize = max - min;
 
@@ -721,7 +721,7 @@ int SQLite::commit() {
 
     uint64_t before = STimeNow();
     uint64_t beforeCommit = STimeNow();
-    result = timedQuery("committing db transaction", "COMMIT");
+    result = SQuery("committing db transaction", "COMMIT");
     SINFO("SQuery 'COMMIT' took " << ((STimeNow() - beforeCommit)/1000) << "ms.");
 
     // And record pages after the commit.
@@ -808,7 +808,7 @@ void SQLite::rollback() {
                 SINFO("Rolling back transaction: " << _uncommittedQuery.substr(0, 100));
             }
             uint64_t before = STimeNow();
-            SASSERT(!timedQuery("rolling back db transaction", "ROLLBACK"));
+            SASSERT(!SQuery("rolling back db transaction", "ROLLBACK"));
             _rollbackElapsed += STimeNow() - before;
         }
 
@@ -861,7 +861,7 @@ bool SQLite::getCommit(uint64_t id, string& query, string& hash) {
     // Look up the query and hash for the given commit
     string q= _getJournalQuery({"SELECT query, hash FROM", "WHERE id = " + SQ(id)});
     SQResult result;
-    SASSERT(!timedQuery("getting commit", q, result));
+    SASSERT(!SQuery("getting commit", q, result));
     if (!result.empty()) {
         query = result[0][0];
         hash = result[0][1];
@@ -889,7 +889,7 @@ bool SQLite::getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result) 
                                     (toIndex ? " AND id <= " + SQ(toIndex) : "")});
     SDEBUG("Getting commits #" << fromIndex << "-" << toIndex);
     query = "SELECT hash, query FROM (" + query  + ") ORDER BY id";
-    return !timedQuery("getting commits", query, result);
+    return !SQuery("getting commits", query, result);
 }
 
 int64_t SQLite::getLastInsertRowID() {
@@ -908,7 +908,7 @@ uint64_t SQLite::_getCommitCount() {
     string query = _getJournalQuery({"SELECT MAX(id) as maxIDs FROM"}, true);
     query = "SELECT MAX(maxIDs) FROM (" + query + ")";
     SQResult result;
-    SASSERT(!timedQuery("getting commit count", query, result));
+    SASSERT(!SQuery("getting commit count", query, result));
     if (result.empty()) {
         return 0;
     }
@@ -1058,7 +1058,7 @@ void SQLite::setUpdateNoopMode(bool enabled) {
 
     // Enable or disable this query.
     string query = "PRAGMA noop_update="s + (enabled ? "ON" : "OFF") + ";";
-    timedQuery("setting noop-update mode", query);
+    SQuery("setting noop-update mode", query);
     _noopUpdateMode = enabled;
 
     // If we're inside a transaction, make sure this gets saved so it can be replicated.

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1083,6 +1083,11 @@ int SQLite::timedQuery(const char *e, const string &sql, SQResult &result, chron
     return queryResult;
 }
 
+int SQLite::timedQuery(const char* e, const string& sql, chrono::milliseconds warnThreshold, bool skipWarn) {
+    SQResult ignore;
+    return timedQuery(e, sql, ignore, warnThreshold, skipWarn);
+}
+
 SQLite::SharedData::SharedData() :
 currentTransactionCount(0),
 _currentPageCount(0),

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -91,6 +91,8 @@ class SQLite {
     void setUpdateNoopMode(bool enabled);
     bool getUpdateNoopMode() const;
 
+    void timedSQuery(const char* e, const string& sql, SQResult& result, int64_t warnThreshold, bool skipWarn);
+
     // Prepare to commit or rollback the transaction. This also inserts the current uncommitted query into the
     // journal; no additional writes are allowed until the next transaction has begun.
     bool prepare();
@@ -191,6 +193,8 @@ class SQLite {
 
     // Enable/disable SQL statement tracing.
     static atomic<bool> enableTrace;
+
+    static atomic<sqlite3_stmt*> _lastQuery;
 
   private:
 
@@ -297,8 +301,6 @@ class SQLite {
     // database file. It's a map of canonicalized filename to a sharedData object.
     static map<string, SharedData*> _sharedDataLookupMap;
 
-    static map<string, sqlite3_stmt*> _queries;
-
     // Pointer to our SharedData object. Having a pointer directly to the object avoids having to lock the lookup map
     // to access this memory.
     SharedData* _sharedData;
@@ -382,8 +384,6 @@ class SQLite {
 
     // Handles running checkpointing operations.
     static int _sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int pageCount);
-
-    static void logSlowQueryIfNeeded(const string& sql, int64_t elapsed, int64_t warnThreshold);
 
     // Callback function for progress tracking.
     static int _progressHandlerCallback(void* arg);

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -297,6 +297,8 @@ class SQLite {
     // database file. It's a map of canonicalized filename to a sharedData object.
     static map<string, SharedData*> _sharedDataLookupMap;
 
+    static map<string, sqlite3_stmt*> _queries;
+
     // Pointer to our SharedData object. Having a pointer directly to the object avoids having to lock the lookup map
     // to access this memory.
     SharedData* _sharedData;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -383,6 +383,8 @@ class SQLite {
     // Handles running checkpointing operations.
     static int _sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int pageCount);
 
+    static void logSlowQueryIfNeeded(const string& sql, int64_t elapsed, int64_t warnThreshold);
+
     // Callback function for progress tracking.
     static int _progressHandlerCallback(void* arg);
     uint64_t _timeoutLimit;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -198,7 +198,7 @@ class SQLite {
     // Enable/disable SQL statement tracing.
     static atomic<bool> enableTrace;
 
-    static atomic<sqlite3_stmt*> _lastQuery;
+    string _lastQuery;
 
   private:
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -91,7 +91,11 @@ class SQLite {
     void setUpdateNoopMode(bool enabled);
     bool getUpdateNoopMode() const;
 
-    void timedSQuery(const char* e, const string& sql, SQResult& result, int64_t warnThreshold, bool skipWarn);
+    int timedSQuery(const char* e, const string& sql, SQResult& result, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
+    inline int timedSQuery(const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false) {
+        SQResult ignore;
+        return timedSQuery(e, sql, ignore, warnThreshold, skipWarn);
+    }
 
     // Prepare to commit or rollback the transaction. This also inserts the current uncommitted query into the
     // journal; no additional writes are allowed until the next transaction has begun.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -93,11 +93,8 @@ class SQLite {
 
     int timedQuery(const char* e, const string& sql, SQResult& result, chrono::milliseconds warnThreshold = chrono::milliseconds(2000),
             bool skipWarn = false);
-    inline int timedQuery(const char* e, const string& sql,  chrono::milliseconds warnThreshold = chrono::milliseconds(2000),
-            bool skipWarn = false) {
-        SQResult ignore;
-        return timedQuery(e, sql, ignore, warnThreshold, skipWarn);
-    }
+    int timedQuery(const char* e, const string& sql, chrono::milliseconds warnThreshold = chrono::milliseconds(2000),
+            bool skipWarn = false);
 
     // Prepare to commit or rollback the transaction. This also inserts the current uncommitted query into the
     // journal; no additional writes are allowed until the next transaction has begun.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -91,10 +91,10 @@ class SQLite {
     void setUpdateNoopMode(bool enabled);
     bool getUpdateNoopMode() const;
 
-    int timedSQuery(const char* e, const string& sql, SQResult& result, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
-    inline int timedSQuery(const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false) {
+    int timedQuery(const char* e, const string& sql, SQResult& result, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
+    inline int timedQuery(const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false) {
         SQResult ignore;
-        return timedSQuery(e, sql, ignore, warnThreshold, skipWarn);
+        return timedQuery(e, sql, ignore, warnThreshold, skipWarn);
     }
 
     // Prepare to commit or rollback the transaction. This also inserts the current uncommitted query into the

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -197,8 +197,6 @@ class SQLite {
     // Enable/disable SQL statement tracing.
     static atomic<bool> enableTrace;
 
-    string _lastQuery;
-
   private:
 
     // This structure contains all of the data that's shared between a set of SQLite objects that share the same
@@ -432,4 +430,7 @@ class SQLite {
 
     // Will be set to false while running a non-deterministic query to prevent it's result being cached.
     bool _isDeterministicQuery;
+
+    // Last query to log
+    string _lastQuery;
 };

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -91,8 +91,10 @@ class SQLite {
     void setUpdateNoopMode(bool enabled);
     bool getUpdateNoopMode() const;
 
-    int timedQuery(const char* e, const string& sql, SQResult& result, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
-    inline int timedQuery(const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false) {
+    int timedQuery(const char* e, const string& sql, SQResult& result, chrono::milliseconds warnThreshold = chrono::milliseconds(2000),
+            bool skipWarn = false);
+    inline int timedQuery(const char* e, const string& sql,  chrono::milliseconds warnThreshold = chrono::milliseconds(2000),
+            bool skipWarn = false) {
         SQResult ignore;
         return timedQuery(e, sql, ignore, warnThreshold, skipWarn);
     }


### PR DESCRIPTION
@tylerkaraszewski @iwiznia @flodnv 

This PR will make Bedrock logging the normalised slow queries

# Test
1) Manually change the threshold to 1ms
2) `makeAll`
3) Check the log for Slow query