### PR TITLE
Revert "Log normalized slow query"

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -772,8 +772,12 @@ void SQueryLogOpen(const string& logFilename);
 void SQueryLogClose();
 
 // Returns an SQLite result code.
-int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, bool skipWarn = false);
-int SQuery(sqlite3* db, const char* e, const string& sql, bool skipWarn = false);
+int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result,
+           int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
+inline int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false) {
+    SQResult ignore;
+    return SQuery(db, e, sql, ignore, warnThreshold, skipWarn);
+}
 
 bool SQVerifyTable(sqlite3* db, const string& tableName, const string& sql);
 bool SQVerifyTableExists(sqlite3* db, const string& tableName);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -231,13 +231,8 @@ void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg) {
 }
 
 int SQLite::_sqliteTraceCallback(unsigned int traceCode, void* c, void* p, void* x) {
-    if (traceCode == SQLITE_TRACE_STMT) {
-        SQLite* sqlite = static_cast<SQLite*>(c);
-        sqlite3_stmt* statement = static_cast<sqlite3_stmt*>(p);
-        sqlite->_lastQuery = sqlite3_normalized_sql(statement);
-        if (enableTrace) {
-            SINFO("NORMALIZED_SQL:" << sqlite->_lastQuery);
-        }
+    if (enableTrace && traceCode == SQLITE_TRACE_STMT) {
+        SINFO("NORMALIZED_SQL:" << sqlite3_normalized_sql((sqlite3_stmt*)p));
     }
     return 0;
 }
@@ -543,7 +538,7 @@ bool SQLite::read(const string& query, SQResult& result) {
         }
     }
     _isDeterministicQuery = true;
-    bool queryResult = !timedQuery("read only query", query, result);
+    bool queryResult = !SQuery(_db, "read only query", query, result);
     if (_useCache && _isDeterministicQuery && queryResult) {
         _queryCache.emplace(make_pair(query, result));
     }
@@ -614,19 +609,19 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
     bool result = false;
     bool usedRewrittenQuery = false;
     if (_enableRewrite) {
-        int resultCode = timedQuery("read/write transaction", query, chrono::milliseconds(2000), true);
+        int resultCode = SQuery(_db, "read/write transaction", query, 2000 * STIME_US_PER_MS, true);
         if (resultCode == SQLITE_AUTH) {
             // Run re-written query.
             _currentlyRunningRewritten = true;
             SASSERT(SEndsWith(_rewrittenQuery, ";"));
-            result = !timedQuery("read/write transaction", _rewrittenQuery);
+            result = !SQuery(_db, "read/write transaction", _rewrittenQuery);
             usedRewrittenQuery = true;
             _currentlyRunningRewritten = false;
         } else {
             result = !resultCode;
         }
     } else {
-        result = !timedQuery("read/write transaction", query);
+        result = !SQuery(_db, "read/write transaction", query);
     }
     _checkTiming("timeout in SQLite::write"s);
     _writeElapsed += STimeNow() - before;
@@ -1070,22 +1065,6 @@ void SQLite::setUpdateNoopMode(bool enabled) {
 
 bool SQLite::getUpdateNoopMode() const {
     return _noopUpdateMode;
-}
-
-int SQLite::timedQuery(const char *e, const string &sql, SQResult &result, chrono::milliseconds warnThreshold, bool skipWarn) {
-    auto start = chrono::steady_clock::now();
-    int queryResult = SQuery(_db, e, sql, result, skipWarn);
-    auto end = chrono::steady_clock::now();
-    auto elapsed = chrono::duration_cast<chrono::milliseconds>(end - start);
-    if (elapsed > warnThreshold) {
-        SWARN("Slow query (" << elapsed.count() << "ms) " << ": " << _lastQuery);
-    }
-    return queryResult;
-}
-
-int SQLite::timedQuery(const char* e, const string& sql, chrono::milliseconds warnThreshold, bool skipWarn) {
-    SQResult ignore;
-    return timedQuery(e, sql, ignore, warnThreshold, skipWarn);
 }
 
 SQLite::SharedData::SharedData() :

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -91,11 +91,6 @@ class SQLite {
     void setUpdateNoopMode(bool enabled);
     bool getUpdateNoopMode() const;
 
-    int timedQuery(const char* e, const string& sql, SQResult& result, chrono::milliseconds warnThreshold = chrono::milliseconds(2000),
-            bool skipWarn = false);
-    int timedQuery(const char* e, const string& sql, chrono::milliseconds warnThreshold = chrono::milliseconds(2000),
-            bool skipWarn = false);
-
     // Prepare to commit or rollback the transaction. This also inserts the current uncommitted query into the
     // journal; no additional writes are allowed until the next transaction has begun.
     bool prepare();
@@ -430,7 +425,4 @@ class SQLite {
 
     // Will be set to false while running a non-deterministic query to prevent it's result being cached.
     bool _isDeterministicQuery;
-
-    // Last query to log
-    string _lastQuery;
 };


### PR DESCRIPTION
Reverts Expensify/Bedrock#665

This drastically reduced performance of bedrock. My guess is normalizing every query run has a huge overhead