### PR TITLE
Auto-escalate HTTPS request commands

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -27,7 +27,7 @@ int64_t BedrockCommand::_getTimeout(const SData& request) {
 
 BedrockCommand::~BedrockCommand() {
     for (auto request : httpsRequests) {
-        request->owner.closeTransaction(request);
+        request->manager.closeTransaction(request);
     }
     if (countCommand) {
         _commandCount--;
@@ -117,7 +117,7 @@ BedrockCommand& BedrockCommand::operator=(BedrockCommand&& from) {
             if (!request->response) {
                 SWARN("Closing unfinished httpRequest by assigning over it. This was probably a mistake.");
             }
-            request->owner.closeTransaction(request);
+            request->manager.closeTransaction(request);
         }
         httpsRequests = move(from.httpsRequests);
         from.httpsRequests.clear();

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -97,12 +97,12 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
 
             // Try each plugin, and go with the first one that says it succeeded.
             for (auto plugin : _server.plugins) {
-                shouldSuppressTimeoutWarnings = plugin->shouldSuppressTimeoutWarnings();
+                shouldSuppressTimeoutWarnings = plugin.second->shouldSuppressTimeoutWarnings();
 
                 // Try to peek the command.
-                if (plugin->peekCommand(_db, command)) {
-                    SINFO("Plugin '" << plugin->getName() << "' peeked command '" << request.methodLine << "'");
-                    command.peekedBy = plugin;
+                if (plugin.second->peekCommand(_db, command)) {
+                    SINFO("Plugin '" << plugin.second->getName() << "' peeked command '" << request.methodLine << "'");
+                    command.peekedBy = plugin.second;
                     pluginPeeked = true;
                     break;
                 }
@@ -206,13 +206,13 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         for (auto plugin : _server.plugins) {
             // Try to process the command.
             bool (*handler)(int, const char*, string&) = nullptr;
-            bool enable = plugin->shouldEnableQueryRewriting(_db, command, &handler);
+            bool enable = plugin.second->shouldEnableQueryRewriting(_db, command, &handler);
             AutoScopeRewrite rewrite(enable, _db, handler);
             try {
-                if (plugin->processCommand(_db, command)) {
-                    SINFO("Plugin '" << plugin->getName() << "' processed command '" << request.methodLine << "'");
+                if (plugin.second->processCommand(_db, command)) {
+                    SINFO("Plugin '" << plugin.second->getName() << "' processed command '" << request.methodLine << "'");
                     pluginProcessed = true;
-                    command.processedBy = plugin;
+                    command.processedBy = plugin.second;
                     break;
                 }
             } catch (const SQLite::timeout_error& e) {

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -150,6 +150,12 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
         _db.resetTiming();
         _db.read("PRAGMA query_only = false;");
         _handleCommandException(command, e);
+    } catch (const SHTTPSManager::Transaction::NotLeading& e) {
+        _db.rollback();
+        _db.read("PRAGMA query_only = false;");
+        _db.resetTiming();
+        SINFO("Command '" << request.methodLine << "' wants to make HTTPS request, queuing for processing.");
+        return false;
     } catch (...) {
         _db.resetTiming();
         _db.read("PRAGMA query_only = false;");

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -150,7 +150,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
         _db.resetTiming();
         _db.read("PRAGMA query_only = false;");
         _handleCommandException(command, e);
-    } catch (const SHTTPSManager::Transaction::NotLeading& e) {
+    } catch (const SHTTPSManager::NotLeading& e) {
         _db.rollback();
         _db.read("PRAGMA query_only = false;");
         _db.resetTiming();

--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -2,18 +2,9 @@
 #include "BedrockPlugin.h"
 #include "BedrockServer.h"
 
-list<BedrockPlugin*>* BedrockPlugin::g_registeredPluginList = nullptr;
+map<string, function<BedrockPlugin*(BedrockServer&)>> BedrockPlugin::g_registeredPluginList;
 
-BedrockPlugin::BedrockPlugin() {
-    // Auto-register this instance into the global static list, initializing the list if that hasn't yet been done.
-    // This just makes it available for enabling via the command line: by default all plugins start out disabled.
-    //
-    // NOTE: This code runs *before* main(). This means that libstuff hasn't yet been initialized, so there is no
-    // logging.
-    if (!g_registeredPluginList) {
-        g_registeredPluginList = new list<BedrockPlugin*>;
-    }
-    g_registeredPluginList->push_back(this);
+BedrockPlugin::BedrockPlugin(BedrockServer& s) : server(s) {
 }
 
 BedrockPlugin::~BedrockPlugin() {
@@ -59,8 +50,6 @@ string BedrockPlugin::getName() {
     SERROR("No name defined by this plugin, aborting.");
 }
 
-void BedrockPlugin::initialize(const SData& args, BedrockServer& server) {}
-
 bool BedrockPlugin::peekCommand(SQLite& db, BedrockCommand& command) {
     return false;
 }
@@ -80,23 +69,6 @@ bool BedrockPlugin::preventAttach() {
 void BedrockPlugin::timerFired(SStopwatch* timer) {}
 
 void BedrockPlugin::upgradeDatabase(SQLite& db) {}
-
-BedrockPlugin* BedrockPlugin::getPluginByName(const string& name) {
-    // If our global list isn't set, there's no plugin to return.
-    if (!g_registeredPluginList) {
-        return nullptr;
-    }
-
-    // If we find our plugin in our list, we'll return it.
-    for (auto& plugin : *g_registeredPluginList) {
-        if (SIEquals(plugin->getName(), name)) {
-            return plugin;
-        }
-    }
-
-    // Didn't find it.
-    return nullptr;
-}
 
 void BedrockPlugin::handleFailedReply(const BedrockCommand& command) {
     // Default implementation does nothing.

--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -8,6 +8,9 @@ BedrockPlugin::BedrockPlugin(BedrockServer& s) : server(s) {
 }
 
 BedrockPlugin::~BedrockPlugin() {
+    for (auto httpsManager : httpsManagers) {
+        delete httpsManager;
+    }
 }
 
 void BedrockPlugin::verifyAttributeInt64(const SData& request, const string& name, size_t minSize) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1119,6 +1119,9 @@ void BedrockServer::_resetServer() {
     _gracefulShutdownTimeout.alarmDuration = 0;
 }
 
+BedrockServer::BedrockServer(SQLiteNode::State state, const SData& args_) : SQLiteServer(""), args(args_), _replicationState(SQLiteNode::LEADING)
+{}
+
 BedrockServer::BedrockServer(const SData& args_)
   : SQLiteServer(""), shutdownWhileDetached(false), args(args_), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false), _suppressCommandPort(false), _suppressCommandPortManualOverride(false),

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1221,7 +1221,9 @@ BedrockServer::BedrockServer(const SData& args_)
 BedrockServer::~BedrockServer() {
     // Shut down the sync thread, (which will shut down worker threads in turn).
     SINFO("Closing sync thread '" << _syncThreadName << "'");
-    _syncThread.join();
+    if (_syncThread.joinable()) {
+        _syncThread.join();
+    }
     SINFO("Threads closed.");
 
     // Close any sockets that are still open. We wait until the sync thread has completed to do this, as until it's

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -145,12 +145,11 @@ class BedrockServer : public SQLiteServer {
         DONE
     };
 
-    // This is the list of plugins that we're actually using, which is a subset of all available plugins. It will be
-    // initialized at construction based on the arguments passed in.
-    list<BedrockPlugin*> plugins;
+    // All of our available plugins, indexed by the name they supply.
+    map<string, BedrockPlugin*> plugins;
 
     // Our only constructor.
-    BedrockServer(const SData& args);
+    BedrockServer(const SData& args_);
 
     // Destructor
     virtual ~BedrockServer();
@@ -213,12 +212,12 @@ class BedrockServer : public SQLiteServer {
     // detached), and shouldn't need to be reset, because the server exits immediately upon seeing this.
     atomic<bool> shutdownWhileDetached;
 
+    // Arguments passed on the command line. This is modified internally and used as a general attribute store.
+    const SData& args;
+
   private:
     // The name of the sync thread.
     static constexpr auto _syncThreadName = "sync";
-
-    // Arguments passed on the command line. This is modified internally and used as a general attribute store.
-    SData _args;
 
     // Commands that aren't currently being processed are kept here.
     BedrockCommandQueue _commandQueue;
@@ -287,7 +286,7 @@ class BedrockServer : public SQLiteServer {
 
     // This is the function that launches the sync thread, which will bring up the SQLiteNode for this server, and then
     // start the worker threads.
-    static void sync(SData& args,
+    static void sync(const SData& args,
                      atomic<SQLiteNode::State>& replicationState,
                      atomic<bool>& upgradeInProgress,
                      atomic<string>& leaderVersion,
@@ -295,7 +294,7 @@ class BedrockServer : public SQLiteServer {
                      BedrockServer& server);
 
     // Wraps the sync thread main function to make it easy to add exception handling.
-    static void syncWrapper(SData& args,
+    static void syncWrapper(const SData& args,
                      atomic<SQLiteNode::State>& replicationState,
                      atomic<bool>& upgradeInProgress,
                      atomic<string>& leaderVersion,
@@ -303,7 +302,7 @@ class BedrockServer : public SQLiteServer {
                      BedrockServer& server);
 
     // Each worker thread runs this function. It gets the same data as the sync thread, plus its individual thread ID.
-    static void worker(SData& args,
+    static void worker(const SData& args,
                        atomic<SQLiteNode::State>& _replicationState,
                        atomic<bool>& upgradeInProgress,
                        atomic<string>& leaderVersion,

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -177,7 +177,7 @@ class BedrockServer : public SQLiteServer {
     bool shutdownComplete();
 
     // Exposes the replication state to plugins.
-    SQLiteNode::State getState() const { return _replicationState.load(); }
+    atomic<SQLiteNode::State>& getState() { return _replicationState; }
 
     // When a peer node logs in, we'll send it our crash command list.
     void onNodeLogin(SQLiteNode::Peer* peer);

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -216,7 +216,7 @@ class BedrockServer : public SQLiteServer {
     // detached), and shouldn't need to be reset, because the server exits immediately upon seeing this.
     atomic<bool> shutdownWhileDetached;
 
-    // Arguments passed on the command line. This is modified internally and used as a general attribute store.
+    // Arguments passed on the command line.
     const SData& args;
 
   private:

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -148,8 +148,12 @@ class BedrockServer : public SQLiteServer {
     // All of our available plugins, indexed by the name they supply.
     map<string, BedrockPlugin*> plugins;
 
-    // Our only constructor.
+    // Our primary constructor.
     BedrockServer(const SData& args_);
+
+    // A constructor that builds an object that does nothing. This exists only to pass to stubbed-out test methods that
+    // require a BedrockServer object.
+    BedrockServer(SQLiteNode::State state, const SData& args_);
 
     // Destructor
     virtual ~BedrockServer();

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -15,7 +15,7 @@ SHTTPSManager::SHTTPSManager(BedrockPlugin& plugin_, const string& pem, const st
 
 void SHTTPSManager::validate() {
     // These can only be created on a leader node.
-    if (plugin.server.getState() != SQLiteNode::LEADING) {
+    if (plugin.server.getState() != SQLiteNode::LEADING && plugin.server.getState() != SQLiteNode::STANDINGDOWN) {
         throw NotLeading();
     }
 }

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -1,10 +1,17 @@
 #include "libstuff.h"
 
-SHTTPSManager::SHTTPSManager()
+const atomic<SQLiteNode::State> SHTTPSManager::_defaultReplicationState(SQLiteNode::LEADING);
+
+SHTTPSManager::SHTTPSManager() : SHTTPSManager(_defaultReplicationState)
+{
+    SWARN("Creating SHTTPSManager with default replication state");
+}
+
+SHTTPSManager::SHTTPSManager(const atomic<SQLiteNode::State>& replicationState) : _replicationState(replicationState)
 { }
 
 SHTTPSManager::SHTTPSManager(const string& pem, const string& srvCrt, const string& caCrt)
-  : _pem(pem), _srvCrt(srvCrt), _caCrt(caCrt)
+  : _pem(pem), _srvCrt(srvCrt), _caCrt(caCrt), _replicationState(_defaultReplicationState)
 { }
 
 SHTTPSManager::~SHTTPSManager() {
@@ -158,7 +165,12 @@ SHTTPSManager::Transaction::Transaction(SHTTPSManager& owner_) :
     owner(owner_),
     isDelayedSend(0),
     sentTime(0)
-{ }
+{
+    // These can only be created on a leader node.
+    if (owner._replicationState != SQLiteNode::LEADING) {
+        throw NotLeading();
+    }
+}
 
 SHTTPSManager::Transaction::~Transaction() {
     SASSERT(!s);

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -2,12 +2,16 @@
 #include <BedrockPlugin.h>
 #include <BedrockServer.h>
 
-SHTTPSManager::SHTTPSManager(const BedrockPlugin& plugin_) : plugin(plugin_)
-{ }
+SHTTPSManager::SHTTPSManager(BedrockPlugin& plugin_) : plugin(plugin_)
+{
+    plugin.httpsManagers.push_back(this);
+}
 
-SHTTPSManager::SHTTPSManager(const BedrockPlugin& plugin_, const string& pem, const string& srvCrt, const string& caCrt)
+SHTTPSManager::SHTTPSManager(BedrockPlugin& plugin_, const string& pem, const string& srvCrt, const string& caCrt)
   : _pem(pem), _srvCrt(srvCrt), _caCrt(caCrt), plugin(plugin_)
-{ }
+{
+    plugin.httpsManagers.push_back(this);
+}
 
 SHTTPSManager::~SHTTPSManager() {
     SAUTOLOCK(_listMutex);

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -8,12 +8,28 @@ SHTTPSManager::SHTTPSManager(BedrockPlugin& plugin_) : plugin(plugin_)
 }
 
 SHTTPSManager::SHTTPSManager(BedrockPlugin& plugin_, const string& pem, const string& srvCrt, const string& caCrt)
-  : _pem(pem), _srvCrt(srvCrt), _caCrt(caCrt), plugin(plugin_)
+  : SStandaloneHTTPSManager(pem, srvCrt, caCrt), plugin(plugin_)
 {
     plugin.httpsManagers.push_back(this);
 }
 
-SHTTPSManager::~SHTTPSManager() {
+void SHTTPSManager::validate() {
+    // These can only be created on a leader node.
+    if (plugin.server.getState() != SQLiteNode::LEADING) {
+        throw NotLeading();
+    }
+}
+
+SStandaloneHTTPSManager::SStandaloneHTTPSManager()
+{
+}
+
+SStandaloneHTTPSManager::SStandaloneHTTPSManager(const string& pem, const string& srvCrt, const string& caCrt)
+  : _pem(pem), _srvCrt(srvCrt), _caCrt(caCrt)
+{
+}
+
+SStandaloneHTTPSManager::~SStandaloneHTTPSManager() {
     SAUTOLOCK(_listMutex);
 
     // Clean up outstanding transactions
@@ -27,7 +43,7 @@ SHTTPSManager::~SHTTPSManager() {
     }
 }
 
-void SHTTPSManager::closeTransaction(Transaction* transaction) {
+void SStandaloneHTTPSManager::closeTransaction(Transaction* transaction) {
     if (transaction == nullptr) {
         return;
     }
@@ -43,7 +59,7 @@ void SHTTPSManager::closeTransaction(Transaction* transaction) {
     delete transaction;
 }
 
-int SHTTPSManager::getHTTPResponseCode(const string& methodLine) {
+int SStandaloneHTTPSManager::getHTTPResponseCode(const string& methodLine) {
     // This code looks for the first space in the methodLine, and then for the first non-space
     // after that, and *then* parses the response code. If we fail to find such a code, or can't parse it as an
     // integer, we default to 400.
@@ -60,35 +76,35 @@ int SHTTPSManager::getHTTPResponseCode(const string& methodLine) {
     return 400;
 }
 
-SHTTPSManager::Socket* SHTTPSManager::openSocket(const string& host, SX509* x509) {
+SStandaloneHTTPSManager::Socket* SStandaloneHTTPSManager::openSocket(const string& host, SX509* x509) {
     // Just call the base class function but in a thread-safe way.
     return STCPManager::openSocket(host, x509, &_listMutex);
 }
 
-void SHTTPSManager::closeSocket(Socket* socket) {
+void SStandaloneHTTPSManager::closeSocket(Socket* socket) {
     // Just call the base class function but in a thread-safe way.
     SAUTOLOCK(_listMutex);
     STCPManager::closeSocket(socket);
 }
 
-void SHTTPSManager::prePoll(fd_map& fdm) {
+void SStandaloneHTTPSManager::prePoll(fd_map& fdm) {
     // Just call the base class function but in a thread-safe way.
     SAUTOLOCK(_listMutex);
     return STCPManager::prePoll(fdm);
 }
 
-void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity) {
-    list<SHTTPSManager::Transaction*> completedRequests;
+void SStandaloneHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity) {
+    list<SStandaloneHTTPSManager::Transaction*> completedRequests;
     map<Transaction*, uint64_t> transactionTimeouts;
     postPoll(fdm, nextActivity, completedRequests, transactionTimeouts);
 }
 
-void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSManager::Transaction*>& completedRequests) {
+void SStandaloneHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SStandaloneHTTPSManager::Transaction*>& completedRequests) {
     map<Transaction*, uint64_t> transactionTimeouts;
     postPoll(fdm, nextActivity, completedRequests, transactionTimeouts);
 }
 
-void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSManager::Transaction*>& completedRequests, map<Transaction*, uint64_t>& transactionTimeouts, uint64_t timeoutMS) {
+void SStandaloneHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SStandaloneHTTPSManager::Transaction*>& completedRequests, map<Transaction*, uint64_t>& transactionTimeouts, uint64_t timeoutMS) {
     SAUTOLOCK(_listMutex);
 
     // Let the base class do its thing
@@ -136,7 +152,7 @@ void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSMan
             SWARN("Connection " << (elapsed > timeout ? "timed out" : "died prematurely") << " after " << elapsed / 1000 << "ms");
             active->response = active->s->sendBufferEmpty() ? 501 : 500;
             if (active->response == 501) {
-                SHMMM("SHTTPSManager: '" << active->fullRequest.methodLine
+                SHMMM("SStandaloneHTTPSManager: '" << active->fullRequest.methodLine
                       << "' timed out receiving response in " << (elapsed / 1000) << "ms.");
             }
         } else {
@@ -156,7 +172,7 @@ void SHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list<SHTTPSMan
     }
 }
 
-SHTTPSManager::Transaction::Transaction(SHTTPSManager& manager_) :
+SStandaloneHTTPSManager::Transaction::Transaction(SStandaloneHTTPSManager& manager_) :
     s(nullptr),
     created(STimeNow()),
     finished(0),
@@ -165,17 +181,14 @@ SHTTPSManager::Transaction::Transaction(SHTTPSManager& manager_) :
     isDelayedSend(0),
     sentTime(0)
 {
-    // These can only be created on a leader node.
-    if (manager.plugin.server.getState() != SQLiteNode::LEADING) {
-        throw NotLeading();
-    }
+    manager.validate();
 }
 
-SHTTPSManager::Transaction::~Transaction() {
+SStandaloneHTTPSManager::Transaction::~Transaction() {
     SASSERT(!s);
 }
 
-SHTTPSManager::Transaction* SHTTPSManager::_createErrorTransaction() {
+SStandaloneHTTPSManager::Transaction* SStandaloneHTTPSManager::_createErrorTransaction() {
     // Sometimes we have to create transactions without an attempted connect. This could happen if we don't have the
     // host or service id yet.
     SWARN("We had to create an error transaction instead of attempting a real one.");
@@ -187,7 +200,7 @@ SHTTPSManager::Transaction* SHTTPSManager::_createErrorTransaction() {
     return transaction;
 }
 
-SHTTPSManager::Transaction* SHTTPSManager::_httpsSend(const string& url, const SData& request) {
+SStandaloneHTTPSManager::Transaction* SStandaloneHTTPSManager::_httpsSend(const string& url, const SData& request) {
     // Open a connection, optionally using SSL (if the URL is HTTPS). If that doesn't work, then just return a
     // completed transaction with an error response.
     string host, path;
@@ -219,7 +232,7 @@ SHTTPSManager::Transaction* SHTTPSManager::_httpsSend(const string& url, const S
     return transaction;
 }
 
-bool SHTTPSManager::_onRecv(Transaction* transaction)
+bool SStandaloneHTTPSManager::_onRecv(Transaction* transaction)
 {
     transaction->response = getHTTPResponseCode(transaction->fullResponse.methodLine);
     return false;

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -2,16 +2,18 @@
 
 const atomic<SQLiteNode::State> SHTTPSManager::_defaultReplicationState(SQLiteNode::LEADING);
 
+/*
 SHTTPSManager::SHTTPSManager() : SHTTPSManager(_defaultReplicationState)
 {
     SWARN("Creating SHTTPSManager with default replication state");
 }
+*/
 
 SHTTPSManager::SHTTPSManager(const atomic<SQLiteNode::State>& replicationState) : _replicationState(replicationState)
 { }
 
-SHTTPSManager::SHTTPSManager(const string& pem, const string& srvCrt, const string& caCrt)
-  : _pem(pem), _srvCrt(srvCrt), _caCrt(caCrt), _replicationState(_defaultReplicationState)
+SHTTPSManager::SHTTPSManager(const atomic<SQLiteNode::State>& replicationState, const string& pem, const string& srvCrt, const string& caCrt)
+  : _pem(pem), _srvCrt(srvCrt), _caCrt(caCrt), _replicationState(replicationState)
 { }
 
 SHTTPSManager::~SHTTPSManager() {

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -1,12 +1,14 @@
 #pragma once
 #include <libstuff/libstuff.h>
 #include <sqlitecluster/SQLiteNode.h>
+class BedrockPlugin;
 
 class SHTTPSManager : public STCPManager {
   public:
     struct Transaction {
         // Constructor/Destructor
-        Transaction(SHTTPSManager& owner_);
+        Transaction(SHTTPSManager& manager_);
+
         ~Transaction();
 
         // Attributes
@@ -17,7 +19,7 @@ class SHTTPSManager : public STCPManager {
         SData fullResponse;
         int response;
         STable values;
-        SHTTPSManager& owner;
+        SHTTPSManager& manager;
         bool isDelayedSend;
         uint64_t sentTime;
 
@@ -30,8 +32,8 @@ class SHTTPSManager : public STCPManager {
 
     // Constructor/Destructor
     //SHTTPSManager();
-    SHTTPSManager(const atomic<SQLiteNode::State>& replicationState);
-    SHTTPSManager(const atomic<SQLiteNode::State>& replicationState, const string& pem, const string& srvCrt, const string& caCrt);
+    SHTTPSManager(const BedrockPlugin& plugin_);
+    SHTTPSManager(const BedrockPlugin& plugin_, const string& pem, const string& srvCrt, const string& caCrt);
     virtual ~SHTTPSManager();
 
     // STCPServer API. Except for postPoll, these are just threadsafe wrappers around base class functions.
@@ -69,9 +71,6 @@ class SHTTPSManager : public STCPManager {
     // multiple threads can add/remove from them.
     recursive_mutex _listMutex;
 
-    // Reference to the server's replication state. This is used to be able to tell if we're LEADER or FOLLOWER.
-    const atomic<SQLiteNode::State>& _replicationState;
-
-    // A default object that can be used as the above for backwards compatibility.
-    static const atomic<SQLiteNode::State> _defaultReplicationState;
+    // Reference to the plugin that owns this object.
+    const BedrockPlugin& plugin;
 };

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -29,9 +29,9 @@ class SHTTPSManager : public STCPManager {
     };
 
     // Constructor/Destructor
-    SHTTPSManager();
+    //SHTTPSManager();
     SHTTPSManager(const atomic<SQLiteNode::State>& replicationState);
-    SHTTPSManager(const string& pem, const string& srvCrt, const string& caCrt);
+    SHTTPSManager(const atomic<SQLiteNode::State>& replicationState, const string& pem, const string& srvCrt, const string& caCrt);
     virtual ~SHTTPSManager();
 
     // STCPServer API. Except for postPoll, these are just threadsafe wrappers around base class functions.

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -32,8 +32,8 @@ class SHTTPSManager : public STCPManager {
 
     // Constructor/Destructor
     //SHTTPSManager();
-    SHTTPSManager(const BedrockPlugin& plugin_);
-    SHTTPSManager(const BedrockPlugin& plugin_, const string& pem, const string& srvCrt, const string& caCrt);
+    SHTTPSManager(BedrockPlugin& plugin_);
+    SHTTPSManager(BedrockPlugin& plugin_, const string& pem, const string& srvCrt, const string& caCrt);
     virtual ~SHTTPSManager();
 
     // STCPServer API. Except for postPoll, these are just threadsafe wrappers around base class functions.
@@ -72,5 +72,5 @@ class SHTTPSManager : public STCPManager {
     recursive_mutex _listMutex;
 
     // Reference to the plugin that owns this object.
-    const BedrockPlugin& plugin;
+    BedrockPlugin& plugin;
 };

--- a/libstuff/SLockTimer.h
+++ b/libstuff/SLockTimer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "SPerformanceTimer.h"
 
 // A class for monitoring the amount of time spent in a given lock.
 // To work properly, it requires that the lock is always accessed via this wrapper.

--- a/libstuff/SSynchronizedQueue.h
+++ b/libstuff/SSynchronizedQueue.h
@@ -54,7 +54,7 @@ SSynchronizedQueue<T>::~SSynchronizedQueue() {
         close(_pipeFD[0]);
     }
     if (_pipeFD[1] != -1) {
-        close(_pipeFD[0]);
+        close(_pipeFD[1]);
     }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -81,8 +81,8 @@ set<string> loadPlugins(SData& args) {
     set <string> postProcessedNames;
 
     // Register all of our built-in plugins.
-    BedrockPlugin::g_registeredPluginList.emplace(make_pair("DB",    [](BedrockServer& s){return new BedrockPlugin_DB(s);}));
-    BedrockPlugin::g_registeredPluginList.emplace(make_pair("JOBS",  [](BedrockServer& s){return new BedrockPlugin_Jobs(s);}));
+    BedrockPlugin::g_registeredPluginList.emplace(make_pair("DB", [](BedrockServer& s){return new BedrockPlugin_DB(s);}));
+    BedrockPlugin::g_registeredPluginList.emplace(make_pair("JOBS", [](BedrockServer& s){return new BedrockPlugin_Jobs(s);}));
     BedrockPlugin::g_registeredPluginList.emplace(make_pair("CACHE", [](BedrockServer& s){return new BedrockPlugin_Cache(s);}));
     BedrockPlugin::g_registeredPluginList.emplace(make_pair("MYSQL", [](BedrockServer& s){return new BedrockPlugin_MySQL(s);}));
 

--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -1,4 +1,5 @@
 #include "Cache.h"
+#include "BedrockServer.h"
 
 // ==========================================================================
 BedrockPlugin_Cache::LRUMap::LRUMap() {
@@ -58,21 +59,11 @@ string BedrockPlugin_Cache::LRUMap::popLRU() {
 }
 
 // ==========================================================================
-BedrockPlugin_Cache::BedrockPlugin_Cache()
-    : _maxCacheSize(0) // Will be set inside initialize()
+BedrockPlugin_Cache::BedrockPlugin_Cache(BedrockServer& s)
+    : BedrockPlugin(s), _maxCacheSize(0) // Will be set inside initialize()
 {
-    // Nothing to initialize
-}
-
-// ==========================================================================
-BedrockPlugin_Cache::~BedrockPlugin_Cache() {
-    // Nothing to clean up
-}
-
-// ==========================================================================
-void BedrockPlugin_Cache::initialize(const SData& args, BedrockServer& server) {
     // Check the configuration
-    const string& maxCache = SToUpper(args["-cache.max"]);
+    const string& maxCache = SToUpper(server.args["-cache.max"]);
     int64_t maxCacheSize = SToInt64(maxCache);
     if (SEndsWith(maxCache, "KB"))
         maxCacheSize *= 1024;
@@ -91,6 +82,11 @@ void BedrockPlugin_Cache::initialize(const SData& args, BedrockServer& server) {
     // Save this in a class constant, to enable us to access it safely in an
     // unsynchronized manner from other threads.
     *((int64_t*)&_maxCacheSize) = maxCacheSize;
+}
+
+// ==========================================================================
+BedrockPlugin_Cache::~BedrockPlugin_Cache() {
+    // Nothing to clean up
 }
 
 #undef SLOGPREFIX

--- a/plugins/Cache.h
+++ b/plugins/Cache.h
@@ -5,12 +5,11 @@
 class BedrockPlugin_Cache : public BedrockPlugin {
   public:
     // Constructor / Destructor
-    BedrockPlugin_Cache();
+    BedrockPlugin_Cache(BedrockServer& s);
     ~BedrockPlugin_Cache();
 
     // Implement base class interface
     virtual string getName() { return "Cache"; }
-    virtual void initialize(const SData& args, BedrockServer& server);
     virtual void upgradeDatabase(SQLite& db);
     virtual bool peekCommand(SQLite& db, BedrockCommand& command);
     virtual bool processCommand(SQLite& db, BedrockCommand& command);

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -1,7 +1,12 @@
 #include "DB.h"
+#include "BedrockServer.h"
 
 #undef SLOGPREFIX
-#define SLOGPREFIX "{" << _args["-nodeName"] << ":" << getName() << "} "
+#define SLOGPREFIX "{" << server.args["-nodeName"] << ":" << getName() << "} "
+
+BedrockPlugin_DB::BedrockPlugin_DB(BedrockServer& s) : BedrockPlugin(s)
+{
+}
 
 bool BedrockPlugin_DB::peekCommand(SQLite& db, BedrockCommand& command) {
     // Pull out some helpful variables

--- a/plugins/DB.h
+++ b/plugins/DB.h
@@ -4,12 +4,8 @@
 // Declare the class we're going to implement below
 class BedrockPlugin_DB : public BedrockPlugin {
   public:
+    BedrockPlugin_DB(BedrockServer& s);
     virtual string getName() { return "DB"; }
-    virtual void initialize(const SData& args, BedrockServer& server) { _args = args; }
     virtual bool peekCommand(SQLite& db, BedrockCommand& command);
     virtual bool processCommand(SQLite& db, BedrockCommand& command);
-
-  private:
-    // Attributes
-    SData _args;
 };

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -4,12 +4,13 @@
 // Declare the class we're going to implement below
 class BedrockPlugin_Jobs : public BedrockPlugin {
   public:
+    BedrockPlugin_Jobs(BedrockServer& s);
+
     // We were using MAX_SIZE_SMALL in GetJob to check the job name, but now GetJobs accepts more than one job name,
     // because of that, we need to increase the size of the param to be able to accept around 50 job names.
     static constexpr int64_t MAX_SIZE_NAME = 255 * 50;
 
     // Implement base class interface
-    virtual void initialize(const SData& args, BedrockServer& server);
     virtual string getName() { return "Jobs"; }
     virtual void upgradeDatabase(SQLite& db);
     virtual bool peekCommand(SQLite& db, BedrockCommand& command);
@@ -24,7 +25,4 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     bool _validateRepeat(const string& repeat) { return !_constructNextRunDATETIME("", "", repeat).empty(); }
     bool _hasPendingChildJobs(SQLite& db, int64_t jobID);
     bool _isValidSQLiteDateModifier(const string& modifier);
-
-    // Keep a reference to the server.
-    BedrockServer* _server = nullptr;
 };

--- a/plugins/MySQL.cpp
+++ b/plugins/MySQL.cpp
@@ -222,6 +222,10 @@ string MySQLPacket::serializeERR(int sequenceID, uint16_t code, const string& me
     return err.serialize();
 }
 
+BedrockPlugin_MySQL::BedrockPlugin_MySQL(BedrockServer& s) : BedrockPlugin(s)
+{
+}
+
 void BedrockPlugin_MySQL::onPortAccept(STCPManager::Socket* s) {
     // Send Protocol::HandshakeV10
     SINFO("Accepted MySQL request from '" << s->addr << "'");

--- a/plugins/MySQL.h
+++ b/plugins/MySQL.h
@@ -92,6 +92,7 @@ struct MySQLPacket {
  */
 class BedrockPlugin_MySQL : public BedrockPlugin {
   public:
+    BedrockPlugin_MySQL(BedrockServer& s);
     // Indicate which functions we are implementing
     virtual string getName() { return "MySQL"; }
     virtual void initialize(const SData& args, BedrockServer& server) { _args = args; }

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <libstuff/SLockTimer.h>
 #include <libstuff/sqlite3.h>
 
 // Convenience macro for locking our static commit lock.

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -154,6 +154,9 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
         usleep(command.request.calc("ProcessSleep") * 1000);
     }
     if (SStartsWith(command.request.methodLine, "sendrequest")) {
+        // This flag makes us pass through the response we got from the server, rather than returning 200 if every
+        // response we got from the server was < 400. I.e., if the server returns 202, or 304, or anything less than
+        // 400, we return 200 except when this flag is set.
         if (command.request.test("passthrough")) {
             command.response.methodLine = command.httpsRequests.front()->fullResponse.methodLine;
             if (command.httpsRequests.front()->response >= 500 && command.httpsRequests.front()->response <= 503) {

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -157,7 +157,7 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
     if (SStartsWith(command.request.methodLine, "sendrequest")) {
         if (command.request.test("passthrough")) {
             command.response.methodLine = command.httpsRequests.front()->fullResponse.methodLine;
-            if (command.httpsRequests.front()->response == 503) {
+            if (command.httpsRequests.front()->response >= 500 && command.httpsRequests.front()->response <= 503) {
                 // Error transaction, couldn't send.
                 command.response.methodLine = "NO_RESPONSE";
             }

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -10,7 +10,6 @@ extern "C" BedrockPlugin* BEDROCK_PLUGIN_REGISTER_TESTPLUGIN(BedrockServer& s) {
 BedrockPlugin_TestPlugin::BedrockPlugin_TestPlugin(BedrockServer& s) :
 BedrockPlugin(s), httpsManager(new TestHTTPSManager(*this))
 {
-    httpsManagers.push_back(httpsManager);
 }
 
 BedrockPlugin_TestPlugin::~BedrockPlugin_TestPlugin()

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -2,20 +2,22 @@
 #include <BedrockPlugin.h>
 #include <BedrockServer.h>
 
-class TestHTTPSMananager : public SHTTPSManager {
+class TestHTTPSManager : public SHTTPSManager {
   public:
+    TestHTTPSManager(const atomic<SQLiteNode::State>& replicationState) : SHTTPSManager(replicationState) { }
     Transaction* send(const string& url, const SData& request);
     virtual bool _onRecv(Transaction* transaction);
 
     // Like _httpsSend in the base class, but doesn't actually send, so we can test timeouts.
     Transaction* httpsDontSend(const string& url, const SData& request);
-    virtual ~TestHTTPSMananager();
+    virtual ~TestHTTPSManager();
 };
 
 class BedrockPlugin_TestPlugin : public BedrockPlugin
 {
   public:
     BedrockPlugin_TestPlugin();
+    ~BedrockPlugin_TestPlugin();
     void upgradeDatabase(SQLite& db);
     virtual string getName() { return "TestPlugin"; }
     virtual bool preventAttach();
@@ -24,7 +26,7 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
     bool processCommand(SQLite& db, BedrockCommand& command);
 
   private:
-    TestHTTPSMananager httpsManager;
+    TestHTTPSManager* httpsManager;
     BedrockServer* _server;
     bool shouldPreventAttach = false;
 

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -16,23 +16,20 @@ class TestHTTPSManager : public SHTTPSManager {
 class BedrockPlugin_TestPlugin : public BedrockPlugin
 {
   public:
-    BedrockPlugin_TestPlugin();
+    BedrockPlugin_TestPlugin(BedrockServer& s);
     ~BedrockPlugin_TestPlugin();
     void upgradeDatabase(SQLite& db);
     virtual string getName() { return "TestPlugin"; }
     virtual bool preventAttach();
-    void initialize(const SData& args, BedrockServer& server);
     bool peekCommand(SQLite& db, BedrockCommand& command);
     bool processCommand(SQLite& db, BedrockCommand& command);
 
   private:
     TestHTTPSManager* httpsManager;
-    BedrockServer* _server;
     bool shouldPreventAttach = false;
 
     // This is a hack, but it lets one command store data for another command to read. This lets us inspect the output
     // of one command from another, even if the first command never sends a response.
     static mutex dataLock;
     static map<string, string> arbitraryData;
-
 };

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -4,7 +4,7 @@
 
 class TestHTTPSManager : public SHTTPSManager {
   public:
-    TestHTTPSManager(const BedrockPlugin& plugin_) : SHTTPSManager(plugin_) { }
+    TestHTTPSManager(BedrockPlugin& plugin_) : SHTTPSManager(plugin_) { }
     Transaction* send(const string& url, const SData& request);
     virtual bool _onRecv(Transaction* transaction);
 

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -4,7 +4,7 @@
 
 class TestHTTPSManager : public SHTTPSManager {
   public:
-    TestHTTPSManager(const atomic<SQLiteNode::State>& replicationState) : SHTTPSManager(replicationState) { }
+    TestHTTPSManager(const BedrockPlugin& plugin_) : SHTTPSManager(plugin_) { }
     Transaction* send(const string& url, const SData& request);
     virtual bool _onRecv(Transaction* transaction);
 

--- a/test/lib/TestHTTPS.cpp
+++ b/test/lib/TestHTTPS.cpp
@@ -1,7 +1,5 @@
 #include "TestHTTPS.h"
 
-TestHTTPS::TestHTTPS() {}
-
 TestHTTPS::~TestHTTPS() {}
 
 bool TestHTTPS::_onRecv(Transaction* transaction) {

--- a/test/lib/TestHTTPS.h
+++ b/test/lib/TestHTTPS.h
@@ -3,7 +3,7 @@
 
 class TestHTTPS : public SHTTPSManager {
   public:
-    TestHTTPS(const atomic<SQLiteNode::State>& replicationState) : SHTTPSManager(replicationState) { }
+    TestHTTPS(const BedrockPlugin& plugin_) : SHTTPSManager(plugin_) { }
     virtual ~TestHTTPS();
 
     // SHTTPSManager API

--- a/test/lib/TestHTTPS.h
+++ b/test/lib/TestHTTPS.h
@@ -3,7 +3,7 @@
 
 class TestHTTPS : public SHTTPSManager {
   public:
-    TestHTTPS(const BedrockPlugin& plugin_) : SHTTPSManager(plugin_) { }
+    TestHTTPS(BedrockPlugin& plugin_) : SHTTPSManager(plugin_) { }
     virtual ~TestHTTPS();
 
     // SHTTPSManager API

--- a/test/lib/TestHTTPS.h
+++ b/test/lib/TestHTTPS.h
@@ -3,7 +3,7 @@
 
 class TestHTTPS : public SHTTPSManager {
   public:
-    TestHTTPS();
+    TestHTTPS(const atomic<SQLiteNode::State>& replicationState) : SHTTPSManager(replicationState) { }
     virtual ~TestHTTPS();
 
     // SHTTPSManager API

--- a/test/tests/SSLTest.cpp
+++ b/test/tests/SSLTest.cpp
@@ -40,7 +40,7 @@ struct SSLTest : tpunit::TestFixture {
             request["Connection"] = "Close";
             request["passthrough"] = "true";
             vector<SData> results = tester->executeWaitMultipleData({request}, 1);
-            cout << results[0].methodLine << ":" << url.second << endl;
+            cout << url.first << "> " << results[0].methodLine << ":" << url.second << endl;
             ASSERT_TRUE(SStartsWith(results[0].methodLine, url.second));
         }
     }

--- a/test/tests/SSLTest.cpp
+++ b/test/tests/SSLTest.cpp
@@ -29,8 +29,10 @@ struct SSLTest : tpunit::TestFixture {
 
     void test() {
         for (auto& url : (map<string, string>){
-            {"www.google.com", "HTTP/1.1 200 OK"},
-            {"svcs.paypal.com", "HTTP/1.1 403 Forbidden"},
+            // Verify we get some HTTP response from google and paypal. We don't care what it is, just that it's valid
+            // HTTP. We want to notice that our fake URL, fails, though.
+            {"www.google.com", "HTTP/1.1"},
+            {"svcs.paypal.com", "HTTP/1.1"},
             {"www.notarealplaceforsure.com.fake", "NO_RESPONSE"},
         }) {
             SData request("sendrequest");
@@ -38,8 +40,7 @@ struct SSLTest : tpunit::TestFixture {
             request["Connection"] = "Close";
             request["passthrough"] = "true";
             vector<SData> results = tester->executeWaitMultipleData({request}, 1);
-            cout << results[0].methodLine << ":" << url.second << endl;;
-            ASSERT_EQUAL(results[0].methodLine, url.second);
+            ASSERT_TRUE(SStartsWith(results[0].methodLine, url.second));
         }
     }
 } __SSLTest;

--- a/test/tests/SSLTest.cpp
+++ b/test/tests/SSLTest.cpp
@@ -40,6 +40,7 @@ struct SSLTest : tpunit::TestFixture {
             request["Connection"] = "Close";
             request["passthrough"] = "true";
             vector<SData> results = tester->executeWaitMultipleData({request}, 1);
+            cout << results[0].methodLine << ":" << url.second << endl;
             ASSERT_TRUE(SStartsWith(results[0].methodLine, url.second));
         }
     }

--- a/test/tests/SSLTest.cpp
+++ b/test/tests/SSLTest.cpp
@@ -38,6 +38,7 @@ struct SSLTest : tpunit::TestFixture {
             request["Connection"] = "Close";
             request["passthrough"] = "true";
             vector<SData> results = tester->executeWaitMultipleData({request}, 1);
+            cout << results[0].methodLine << ":" << url.second << endl;;
             ASSERT_EQUAL(results[0].methodLine, url.second);
         }
     }

--- a/test/tests/SSLTest.cpp
+++ b/test/tests/SSLTest.cpp
@@ -32,7 +32,7 @@ struct SSLTest : tpunit::TestFixture {
             // Verify we get some HTTP response from google and paypal. We don't care what it is, just that it's valid
             // HTTP. We want to notice that our fake URL, fails, though.
             {"www.google.com", "HTTP/1.1"},
-            {"svcs.paypal.com", "HTTP/1.1"},
+            //{"svcs.paypal.com", "HTTP/1.1"},
             {"www.notarealplaceforsure.com.fake", "NO_RESPONSE"},
         }) {
             SData request("sendrequest");

--- a/test/tests/SSLTest.cpp
+++ b/test/tests/SSLTest.cpp
@@ -40,7 +40,6 @@ struct SSLTest : tpunit::TestFixture {
             request["Connection"] = "Close";
             request["passthrough"] = "true";
             vector<SData> results = tester->executeWaitMultipleData({request}, 1);
-            cout << results[0].methodLine << ":" << url.second << endl;
             ASSERT_TRUE(SStartsWith(results[0].methodLine, url.second));
         }
     }

--- a/test/tests/SSLTest.cpp
+++ b/test/tests/SSLTest.cpp
@@ -29,10 +29,9 @@ struct SSLTest : tpunit::TestFixture {
 
     void test() {
         for (auto& url : (map<string, string>){
-            // Verify we get some HTTP response from google and paypal. We don't care what it is, just that it's valid
+            // Verify we get some HTTP response from google. We don't care what it is, just that it's valid
             // HTTP. We want to notice that our fake URL, fails, though.
             {"www.google.com", "HTTP/1.1"},
-            //{"svcs.paypal.com", "HTTP/1.1"},
             {"www.notarealplaceforsure.com.fake", "NO_RESPONSE"},
         }) {
             SData request("sendrequest");
@@ -40,7 +39,6 @@ struct SSLTest : tpunit::TestFixture {
             request["Connection"] = "Close";
             request["passthrough"] = "true";
             vector<SData> results = tester->executeWaitMultipleData({request}, 1);
-            cout << url.first << "> " << results[0].methodLine << ":" << url.second << endl;
             ASSERT_TRUE(SStartsWith(results[0].methodLine, url.second));
         }
     }

--- a/test/tests/SSLTest.cpp
+++ b/test/tests/SSLTest.cpp
@@ -1,4 +1,5 @@
 #include <libstuff/libstuff.h>
+#include <sqlitecluster/SQLiteNode.h>
 #include <test/lib/BedrockTester.h>
 
 struct SSLTest : tpunit::TestFixture {
@@ -6,8 +7,13 @@ struct SSLTest : tpunit::TestFixture {
         : tpunit::TestFixture("SSL",
                               TEST(SSLTest::testPayPal),
                               TEST(SSLTest::testGoogle),
-                              TEST(SSLTest::testFailure)) { }
+                              TEST(SSLTest::testFailure)),
 
+            state(SQLiteNode::LEADING),
+            https(state)
+    { }
+
+    atomic<SQLiteNode::State> state;
     TestHTTPS https;
 
     // Simplified version of the loop that's used in bedrock to poll for data.

--- a/test/tests/SSLTest.cpp
+++ b/test/tests/SSLTest.cpp
@@ -5,75 +5,40 @@
 struct SSLTest : tpunit::TestFixture {
     SSLTest()
         : tpunit::TestFixture("SSL",
-                              TEST(SSLTest::testPayPal),
-                              TEST(SSLTest::testGoogle),
-                              TEST(SSLTest::testFailure)),
-
-            state(SQLiteNode::LEADING),
-            https(state)
+                              BEFORE_CLASS(SSLTest::setup),
+                              TEST(SSLTest::test),
+                              AFTER_CLASS(SSLTest::teardown))
     { }
 
-    atomic<SQLiteNode::State> state;
-    TestHTTPS https;
+    BedrockTester* tester;
 
-    // Simplified version of the loop that's used in bedrock to poll for data.
-    void _wait(SHTTPSManager::Transaction* t, uint64_t timeout = STIME_US_PER_M) {
-        // Wait for the transaction to have a return code.
-        fd_map fdm;
-        uint64_t stop = STimeNow() + timeout;
-        uint64_t nextActivity = STimeNow();
-        while ((t ? t->response == 0 : true) && STimeNow() < stop) {
-            // Do another select.
-            fdm.clear();
-            https.prePoll(fdm);
-            const uint64_t now = STimeNow();
-            S_poll(fdm, max(nextActivity, now) - now);
-            nextActivity = STimeNow() + STIME_US_PER_S;
-            https.postPoll(fdm, nextActivity);
+    void setup() {
+        char cwd[1024];
+        if (!getcwd(cwd, sizeof(cwd))) {
+            STHROW("Couldn't get CWD");
         }
+
+        tester = new BedrockTester(_threadID, {
+            {"-plugins", string(cwd) + "/clustertest/testplugin/testplugin.so"},
+        });
     }
 
-    /* A response is valid if it has a response code > 0 and less than 999, and has at least some content.
-     * We're just looking that an SSL handshake succeeded here, not for any particular content, and we send junk
-     * requests on purpose.
-     */
-    bool verifyFullResponse(const int responseCode, const SData& response) {
-        if (responseCode <= 0) {
-            return false;
+    void teardown() {
+        delete tester;
+    }
+
+    void test() {
+        for (auto& url : (map<string, string>){
+            {"www.google.com", "HTTP/1.1 200 OK"},
+            {"svcs.paypal.com", "HTTP/1.1 403 Forbidden"},
+            {"www.notarealplaceforsure.com.fake", "NO_RESPONSE"},
+        }) {
+            SData request("sendrequest");
+            request["Host"] = url.first;
+            request["Connection"] = "Close";
+            request["passthrough"] = "true";
+            vector<SData> results = tester->executeWaitMultipleData({request}, 1);
+            ASSERT_EQUAL(results[0].methodLine, url.second);
         }
-        if (responseCode > 999) {
-            return false;
-        }
-        return !response.empty();
-    }
-
-    void testPayPal() {
-        SData request;
-        request.methodLine = "GET / HTTP/1.1";
-        request["Host"] = "svcs.paypal.com";
-        request["Connection"] = "Close";
-        SHTTPSManager::Transaction* t = https.sendRequest("https://svcs.paypal.com/", request);
-        _wait(t);
-        ASSERT_TRUE(verifyFullResponse(t->response, t->fullResponse));
-    }
-
-    void testGoogle() {
-        SData request;
-        request.methodLine = "GET / HTTP/1.1";
-        request["Host"] = "www.google.com";
-        request["Connection"] = "Close";
-        SHTTPSManager::Transaction* t = https.sendRequest("https://www.google.com/", request);
-        _wait(t);
-        ASSERT_TRUE(verifyFullResponse(t->response, t->fullResponse));
-    }
-
-    void testFailure() {
-        SData request;
-        request.methodLine = "GET / HTTP/1.1";
-        request["Host"] = "www.notarealplaceforsure.com.fake";
-        request["Connection"] = "Close";
-        SHTTPSManager::Transaction* t = https.sendRequest("https://www.notarealplaceforsure.com.fake/", request);
-        _wait(t);
-        ASSERT_FALSE(verifyFullResponse(t->response, t->fullResponse));
     }
 } __SSLTest;

--- a/travis.sh
+++ b/travis.sh
@@ -52,7 +52,7 @@ travis_fold end build_bedrock
 travis_fold start test_bedrock
 travis_time_start
 cd test
-./test -threads 8
+./test
 cd ..
 travis_time_finish
 travis_fold end test_bedrock
@@ -60,7 +60,7 @@ travis_fold end test_bedrock
 travis_fold start test_bedrock_cluster
 travis_time_start
 cd test/clustertest
-./clustertest -threads 8
+./clustertest
 cd ../..
 travis_time_finish
 travis_fold end test_bedrock_cluster

--- a/travis.sh
+++ b/travis.sh
@@ -52,7 +52,7 @@ travis_fold end build_bedrock
 travis_fold start test_bedrock
 travis_time_start
 cd test
-./test
+./test -threads 8
 cd ..
 travis_time_finish
 travis_fold end test_bedrock
@@ -60,7 +60,7 @@ travis_fold end test_bedrock
 travis_fold start test_bedrock_cluster
 travis_time_start
 cd test/clustertest
-./clustertest
+./clustertest -threads 8
 cd ../..
 travis_time_finish
 travis_fold end test_bedrock_cluster


### PR DESCRIPTION
This PR makes commands the attempt to create an HTTPS request automatically escalate to the leader.

To support this, and for general cleanup, the chain of ownership between a bedrock server and its plugins has been changed to be explicit, such that each plugin is owned by a particular server, instead of instantiating a single global object per plugin. This allows the plugin to easily query the server, because it can rely on its owner existing without changing.

There is a co-requisite auth change coming alongside this PR shortly.

All existing tests pass.