### PR TITLE
Allow multiple serial HTTPS requests

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -41,6 +41,7 @@ BedrockCommand::BedrockCommand(SQLiteCommand&& from, int dontCount) :
     processCount(0),
     peekedBy(nullptr),
     processedBy(nullptr),
+    repeek(false),
     onlyProcessOnSyncThread(false),
     crashIdentifyingValues(*this),
     _inProgressTiming(INVALID, 0, 0),
@@ -61,6 +62,7 @@ BedrockCommand::BedrockCommand(BedrockCommand&& from) :
     processCount(from.processCount),
     peekedBy(from.peekedBy),
     processedBy(from.processedBy),
+    repeek(from.repeek),
     timingInfo(from.timingInfo),
     onlyProcessOnSyncThread(from.onlyProcessOnSyncThread),
     crashIdentifyingValues(*this, move(from.crashIdentifyingValues)),
@@ -82,6 +84,7 @@ BedrockCommand::BedrockCommand(SData&& _request) :
     processCount(0),
     peekedBy(nullptr),
     processedBy(nullptr),
+    repeek(false),
     onlyProcessOnSyncThread(false),
     crashIdentifyingValues(*this),
     _inProgressTiming(INVALID, 0, 0),
@@ -99,6 +102,7 @@ BedrockCommand::BedrockCommand(SData _request) :
     processCount(0),
     peekedBy(nullptr),
     processedBy(nullptr),
+    repeek(false),
     onlyProcessOnSyncThread(false),
     crashIdentifyingValues(*this),
     _inProgressTiming(INVALID, 0, 0),
@@ -127,6 +131,7 @@ BedrockCommand& BedrockCommand::operator=(BedrockCommand&& from) {
         processCount = from.processCount;
         peekedBy = from.peekedBy;
         processedBy = from.processedBy;
+        repeek = from.repeek;
         priority = from.priority;
         timingInfo = from.timingInfo;
         onlyProcessOnSyncThread = from.onlyProcessOnSyncThread;

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -76,6 +76,8 @@ class BedrockCommand : public SQLiteCommand {
     BedrockPlugin* peekedBy;
     BedrockPlugin* processedBy;
 
+    bool repeek;
+
     // A list of timing sets, with an info type, start, and end.
     list<tuple<TIMING_INFO, uint64_t, uint64_t>> timingInfo;
 

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -76,6 +76,9 @@ class BedrockCommand : public SQLiteCommand {
     BedrockPlugin* peekedBy;
     BedrockPlugin* processedBy;
 
+    // A command can set this to true to indicate it would like to have `peek` called again after completing a HTTPS
+    // request. This allows a single command to make multiple serial HTTPS requests. The command should clear this when
+    // all HTTPS requests are complete. It will be automatically cleared if the command throws an exception.
     bool repeek;
 
     // A list of timing sets, with an info type, start, and end.

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -147,16 +147,19 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
             }
         }
     } catch (const SException& e) {
+        command.repeek = false;
         _db.resetTiming();
         _db.read("PRAGMA query_only = false;");
         _handleCommandException(command, e);
     } catch (const SHTTPSManager::NotLeading& e) {
+        command.repeek = false;
         _db.rollback();
         _db.read("PRAGMA query_only = false;");
         _db.resetTiming();
         SINFO("Command '" << request.methodLine << "' wants to make HTTPS request, queuing for processing.");
         return false;
     } catch (...) {
+        command.repeek = false;
         _db.resetTiming();
         _db.read("PRAGMA query_only = false;");
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);

--- a/test/tests/ChainedHTTPTest.cpp
+++ b/test/tests/ChainedHTTPTest.cpp
@@ -1,0 +1,63 @@
+#include <libstuff/libstuff.h>
+#include <sqlitecluster/SQLiteNode.h>
+#include <test/lib/BedrockTester.h>
+
+struct ChainedHTTPTest : tpunit::TestFixture {
+    ChainedHTTPTest()
+        : tpunit::TestFixture("ChainedHTTP",
+                              TEST(ChainedHTTPTest::test))
+    { }
+
+    void test() {
+        // Load the clustertest testplugin that implements our chained command.
+        char cwd[1024];
+        if (!getcwd(cwd, sizeof(cwd))) {
+            STHROW("Couldn't get CWD");
+        }
+        BedrockTester tester(_threadID, {
+            {"-plugins", string(cwd) + "/clustertest/testplugin/testplugin.so"},
+        });
+
+        // Some of the biggest sites on the internet. These sites in particular were chosen by the fact that they
+        // return 200s even with our super-simple request format.
+        list<string> urls = {
+            "www.google.com",
+            "www.youtube.com",
+            "www.amazon.com",
+        };
+
+        SData request("chainedrequest");
+        request["urls"] = SComposeList(urls);
+        vector<SData> result = tester.executeWaitMultipleData({request}, 1);
+
+        // Verify we have a result.
+        ASSERT_EQUAL(result.size(), 1);
+
+        // Then parse and verify the response.
+        list<string> results = SParseList(result[0].content, '\n');
+        map<string, int64_t> resultMap;
+        for(auto& site : urls) {
+            resultMap.emplace(make_pair(site, -1));
+        }
+        for (auto& r : results) {
+            list<string> split = SParseList(r, ':');
+            if (split.size() == 2) {
+                resultMap[split.front()] = stoll(split.back());
+            } else if (split.size() == 1) {
+                ASSERT_EQUAL(split.front(), "PROCESSED");
+                break;
+            } else {
+                // We should have had exactly one or two results.
+                ASSERT_TRUE(false);
+            }
+        }
+
+        // At this point, we should have good result values in our map, verify that.
+        for (auto& r : urls) {
+            int64_t result = resultMap.at(r);
+
+            // See if this looks like a non-error return code.
+            ASSERT_TRUE(result > 0 && result < 400);
+        }
+    }
+} __ChainedHTTPTest;


### PR DESCRIPTION
@coleaeason @flodnv @mattabullock @cead22 

This turned out to be way simpler than everyone thought.

Fixes:
$ https://github.com/Expensify/Expensify/issues/117718

## Tests
Automated tests included. Though, the real tests will come when we implement an auth command based on it.