### PR TITLE
Add orderByCreated parameter to GetJob

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -124,6 +124,7 @@ bool BedrockPlugin_Jobs::peekCommand(SQLite& db, BedrockCommand& command) {
         //     - connection - (optional) If "wait" will pause up to "timeout" for a match
         //     - jobPriority - (optional) Only check for jobs with this priority
         //     - timeout - (optional) maximum time (in ms) to wait, default forever
+        //     - orderByCreated - (optional) order results by created time instead of nextRun
         //
         //     Returns:
         //     - 200 - OK
@@ -661,7 +662,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         const list<string> nameList = SParseList(request["name"]);
         string safeNumResults = SQ(max(request.calc("numResults"),1));
         bool mockRequest = command.request.isSet("mockRequest") || command.request.isSet("getMockedJobs");
-        bool orderByCreated = command.request.isSet("orderByCreated") ? request.test("orderByCreated") : false;
+        bool orderByCreated = request.test("orderByCreated");
         string orderByQuery = "ORDER BY ";
         if (orderByCreated) {
             orderByQuery += "created ASC";


### PR DESCRIPTION
@mattabullock  

Related issue: https://github.com/Expensify/Expensify/issues/118854

Context for this solution: https://github.com/Expensify/Expensify/issues/118854#issuecomment-550572350

# Tests
Automated

Can be manually tested with these PRs:
https://github.com/Expensify/Web-Expensify/pull/26251
https://github.com/Expensify/Bedrock-PHP/pull/142

# Query Timings/Plans
No new query, just adding the option to change an `ORDER BY` to be based on created, not just nextRun