### PR TITLE
Add command-duration storage

### DIFF
--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -117,6 +117,10 @@ class BedrockCommand : public SQLiteCommand {
     };
     CrashMap crashIdentifyingValues;
 
+    // A command can store anything it likes here in peek, it will persist until `process` so it can be retrieved.
+    // It's up to the command to handle destroying that data.
+    void* peekData;
+
     // Return the timestamp by which this command must finish executing.
     uint64_t timeout() const { return _timeout; }
 

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -118,7 +118,7 @@ class BedrockCommand : public SQLiteCommand {
     CrashMap crashIdentifyingValues;
 
     // To accommodate plugins that need to store extra data for a command besides the built-in data for a
-    // BedrockCommand, we provide a pointer that the command can use to refer to extra storage. However, because tthe
+    // BedrockCommand, we provide a pointer that the command can use to refer to extra storage. However, because the
     // lifespan of this storage should match that of the BedrockCommand, we also need to provide a deallocation
     // function to free this memory when the command completes.
     // A better solution for this would be to use polymorphism and allow plugins to derive command objects from the

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -117,9 +117,15 @@ class BedrockCommand : public SQLiteCommand {
     };
     CrashMap crashIdentifyingValues;
 
-    // A command can store anything it likes here in peek, it will persist until `process` so it can be retrieved.
-    // It's up to the command to handle destroying that data.
+    // To accommodate plugins that need to store extra data for a command besides the built-in data for a
+    // BedrockCommand, we provide a pointer that the command can use to refer to extra storage. However, because tthe
+    // lifespan of this storage should match that of the BedrockCommand, we also need to provide a deallocation
+    // function to free this memory when the command completes.
+    // A better solution for this would be to use polymorphism and allow plugins to derive command objects from the
+    // base class of BedrockCommand, but that's too significant of a change to the architecture for the current
+    // timeline, so that is left as a future enhancement.
     void* peekData;
+    void (*deallocator) (void*);
 
     // Return the timestamp by which this command must finish executing.
     uint64_t timeout() const { return _timeout; }

--- a/libstuff/SData.cpp
+++ b/libstuff/SData.cpp
@@ -1,5 +1,6 @@
 #include "libstuff.h"
 
+const string SData::placeholder;
 // --------------------------------------------------------------------------
 SData::SData() {
     // Nothing to do here
@@ -18,11 +19,11 @@ string& SData::operator[](const string& name) {
 }
 
 // --------------------------------------------------------------------------
-string SData::operator[](const string& name) const {
+const string& SData::operator[](const string& name) const {
     // This version takes care not to create an entry if none is present
     STable::const_iterator it = nameValueMap.find(name);
     if (it == nameValueMap.end()) {
-        return "";
+        return placeholder;
     } else {
         return it->second;
     }

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -190,9 +190,10 @@ struct SData {
         return nameValueMap.emplace(forward<Ts>(args)...);
     }
 
+
     // Operators
     string& operator[](const string& name);
-    string operator[](const string& name) const;
+    const string& operator[](const string& name) const;
 
     // Two templated versions of `set` are provided. One for arithmetic types, and one for other types (which must be
     // convertible to 'string'). These allow you to do the following:
@@ -233,6 +234,7 @@ struct SData {
 
     // Create an SData object; if no Content-Length then take everything as the content
     static SData create(const string& rhs);
+    static const string placeholder;
 };
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Up until now, the main mechanism for a command to store temporary data between `peek` and process has been to add it to the `request` object. This however, has caused a class of bugs that cause the request object to modified multiple times, depending on how many times the command is peeked, particularly across escalations, where we might modify the command once on a follower and then again on the leader.

This adds temporary storage that does not persist across escalations, but does persist for the life of a command on a particular node.

The intention is to move towards making `command.request` `const`, though this change does not do that explicitly. It allows for `auth` or any other plugin to treat a request as `const`, without breaking backwards compatibility.

## Tests:
Existing tests pass. This makes no useful functional changes by itself.