### PR TITLE
Tyler fix peek data mem leak

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -139,6 +139,11 @@ BedrockCommand& BedrockCommand::operator=(BedrockCommand&& from) {
         httpsRequests = move(from.httpsRequests);
         from.httpsRequests.clear();
 
+        // Same here, deallocate current data.
+        if (deallocator && peekData) {
+            deallocator(peekData);
+        }
+
         // Update our other properties.
         peekCount = from.peekCount;
         processCount = from.processCount;
@@ -153,6 +158,17 @@ BedrockCommand& BedrockCommand::operator=(BedrockCommand&& from) {
         deallocator = move(from.deallocator);
         _inProgressTiming = from._inProgressTiming;
         _timeout = from._timeout;
+
+        // If countCommand is changing, update the count.
+        if (countCommand && !from.countCommand) {
+            // this command is no longer counted.
+            _commandCount--;
+        } else if (!countCommand && from.countCommand) {
+            // We need to start counting this command.
+            _commandCount++;
+        }
+        // Now set to match the existing command.
+        countCommand = from.countCommand;
 
         // Don't delete when the old object is destroyed.
         from.peekData = nullptr;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -395,6 +395,8 @@ void BedrockServer::sync(const SData& args,
             int dropped = 0;
             try {
                 while (true) {
+                    // Reset this to blank. This releases the existing command and allows it to get cleaned up.
+                    command = BedrockCommand(move(SQLiteCommand(SData())), BedrockCommand::DONT_COUNT);
                     command = syncNodeQueuedCommands.pop();
                     if (command.initiatingClientID) {
                         // This one came from a local client, so we can save it for later.
@@ -473,6 +475,9 @@ void BedrockServer::sync(const SData& args,
             if (committingCommand) {
                 continue;
             }
+
+            // Reset this to blank. This releases the existing command and allows it to get cleaned up.
+            command = BedrockCommand(move(SQLiteCommand(SData())), BedrockCommand::DONT_COUNT);
 
             // Get the next sync node command to work on.
             command = syncNodeQueuedCommands.pop();
@@ -685,6 +690,10 @@ void BedrockServer::worker(const SData& args,
                 SWARN("Die function called early with no command, probably died in `commandQueue.get`.");
             });
 
+            // Reset this to blank. This releases the existing command and allows it to get cleaned up.
+            command = BedrockCommand(move(SQLiteCommand(SData())), BedrockCommand::DONT_COUNT);
+
+            // And get another one.
             command = commandQueue.get(1000000);
 
             SAUTOPREFIX(command.request);


### PR DESCRIPTION
@coleaeason 

This fixes a memory leak where we fail to deallocate the contents of `peekData` when using the BedrockCommand assignment operator.

While fixing this, I also fixed how commands are counted, as that was also broken.

Finally, this "resets" bedrock commands while we we wait for new ones to become available. This frees resources that might otherwise be held until a new command is ready. Notably, this lets `httpRequests` get closed, but also allows for new auth behavior to happen on command completion.