### PR TITLE
Log the full slow query

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2451,7 +2451,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
 
     // Warn if it took longer than the specified threshold
     if ((int64_t)elapsed > warnThreshold)
-        SWARN("Slow query (" << elapsed / 1000 << "ms) " << sql.length() << ": " << sql.substr(0, 150));
+        SWARN("Slow query (" << elapsed / 1000 << "ms) :" << sql);
 
     // Log this if enabled
     if (_g_sQueryLogFP) {


### PR DESCRIPTION
This PR will make Bedrock logging the full slow queries (i.e. not truncated)

cc @tylerkaraszewski @coleaeason @flodnv 

# Test
1) Manually change the threshold to 1ms (i.e. change the value of `warnThreshold ` to `1000` from [here](https://github.com/Expensify/Bedrock/blob/8a1c14b4293d797162a9a326a442866c62bbede1/libstuff/libstuff.cpp#L2453))
2) Run `./script/makeAll.sh`
3) Check the log for `Slow query` (`./script/tail.sh "Slow query"`)