### PR TITLE
Make sure validate gets called on the httpsManager before a socket is opened

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -211,15 +211,17 @@ SStandaloneHTTPSManager::Transaction* SStandaloneHTTPSManager::_httpsSend(const 
         host += ":443";
     }
 
+    // Create a new transaction. This can throw if `validate` fails. We explicitly do this *before* creating a socket.
+    Transaction* transaction = new Transaction(*this);
+
     // If this is going to be an https transaction, create a certificate and give it to the socket.
     SX509* x509 = SStartsWith(url, "https://") ? SX509Open(_pem, _srvCrt, _caCrt) : nullptr;
     Socket* s = openSocket(host, x509);
     if (!s) {
+        delete transaction;
         return _createErrorTransaction();
     }
 
-    // Wrap in a transaction
-    Transaction* transaction = new Transaction(*this);
     transaction->s = s;
     transaction->fullRequest = request;
 


### PR DESCRIPTION
When we create a `Transaction` object, we call `validate` which throws when we need to escalate. However, we were creating a socket *before* doing this check, which just sat idle.

This change has us call `validate` *before* creating the socket.