### PR TITLE
Add jobPriority parameter to UpdateJob

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -25,6 +25,8 @@ Bedrock::Jobs is a plugin to the [Bedrock data foundation](../README.md) that ma
  * **UpdateJob( jobID, data )** - Updates the data associated with a job.
    * *jobID* - Identifier of the job to update
    * *data* - New data object to associate with the job
+   * *repeat* - A description of how often to repeat this job (optional)
+   * *jobPriority* - New priority of the job (optional)
 
  * **QueryJob( jobID )** - Retrieves the current state and data associated with a job.
    * *jobID* - Identifier of the job to query

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -842,6 +842,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         //     - jobID - ID of the job to delete
         //     - data  - A JSON object describing work to be done
         //     - repeat - A description of how to repeat (optional)
+        //     - priority - The priority of the job (optional)
         //
         verifyAttributeInt64(request, "jobID", 1);
         verifyAttributeSize(request, "data", 1, MAX_SIZE_BLOB);
@@ -854,6 +855,14 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                 request.erase("repeat");
             } else if (!_validateRepeat(request["repeat"])) {
                 STHROW("402 Malformed repeat");
+            }
+        }
+
+        // If a priority is provided, validate it
+        if (request.isSet("priority")) {
+            int64_t priority = request.calc64("priority");
+            if (priority != 0 && priority != 500 && priority != 1000) {
+                STHROW("402 Invalid priority value");
             }
         }
 
@@ -881,6 +890,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                                 SQ(request["data"]) + " " +
                                 (request.isSet("repeat") ? ", repeat=" + SQ(SToUpper(request["repeat"])) : "") +
                                 (!newNextRun.empty() ? ", nextRun=" + newNextRun : "") +
+                                (request.isSet("priority") ? ", priority=" + request.calc64("priority") : "") +
                                 "WHERE jobID=" +
                                 SQ(request.calc64("jobID")) + ";")) {
             STHROW("502 Update failed");

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -842,7 +842,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         //     - jobID - ID of the job to delete
         //     - data  - A JSON object describing work to be done
         //     - repeat - A description of how to repeat (optional)
-        //     - priority - The priority of the job (optional)
+        //     - jobPriority - The priority of the job (optional)
         //
         verifyAttributeInt64(request, "jobID", 1);
         verifyAttributeSize(request, "data", 1, MAX_SIZE_BLOB);
@@ -859,8 +859,8 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
         }
 
         // If a priority is provided, validate it
-        if (request.isSet("priority")) {
-            int64_t priority = request.calc64("priority");
+        if (request.isSet("jobPriority")) {
+            int64_t priority = request.calc64("jobPriority");
             if (priority != 0 && priority != 500 && priority != 1000) {
                 STHROW("402 Invalid priority value");
             }
@@ -890,7 +890,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                                 SQ(request["data"]) + " " +
                                 (request.isSet("repeat") ? ", repeat=" + SQ(SToUpper(request["repeat"])) : "") +
                                 (!newNextRun.empty() ? ", nextRun=" + newNextRun : "") +
-                                (request.isSet("priority") ? ", priority=" + request.calc64("priority") : "") +
+                                (request.isSet("jobPriority") ? ", priority=" + request.calc64("jobPriority") : "") +
                                 "WHERE jobID=" +
                                 SQ(request.calc64("jobID")) + ";")) {
             STHROW("502 Update failed");

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -890,8 +890,8 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
                                 SQ(request["data"]) + " " +
                                 (request.isSet("repeat") ? ", repeat=" + SQ(SToUpper(request["repeat"])) : "") +
                                 (!newNextRun.empty() ? ", nextRun=" + newNextRun : "") +
-                                (request.isSet("jobPriority") ? ", priority=" + request.calc64("jobPriority") : "") +
-                                "WHERE jobID=" +
+                                (request.isSet("jobPriority") ? ", priority=" + SQ(request.calc64("jobPriority")) : "") +
+                                " WHERE jobID=" +
                                 SQ(request.calc64("jobID")) + ";")) {
             STHROW("502 Update failed");
         }

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -530,12 +530,7 @@ bool BedrockPlugin_Jobs::processCommand(SQLite& db, BedrockCommand& command) {
             // If no priority set, set it
             int64_t priority = SContains(job, "jobPriority") ? SToInt(job["jobPriority"]) : (SContains(job, "priority") ? SToInt(job["priority"]) : JOBS_DEFAULT_PRIORITY);
 
-            // We'd initially intended for any value to be allowable here, but for
-            // performance reasons, we currently will only allow specific values to
-            // try and keep queries fast. If you pass an invalid value, we'll throw
-            // here so that the caller can know that he did something wrong rather
-            // than having his job sit unprocessed in the queue forever. Hopefully
-            // we can remove this restriction in the future.
+            // Validate the priority passed in
             _validatePriority(priority);
 
             // Validate that the parentJobID exists and is in the right state if one was passed.
@@ -1344,6 +1339,12 @@ bool BedrockPlugin_Jobs::_isValidSQLiteDateModifier(const string& modifier) {
 }
 
 void BedrockPlugin_Jobs::_validatePriority(const int64_t priority) {
+    // We'd initially intended for any value to be allowable here, but for
+    // performance reasons, we currently will only allow specific values to
+    // try and keep queries fast. If you pass an invalid value, we'll throw
+    // here so that the caller can know that he did something wrong rather
+    // than having his job sit unprocessed in the queue forever. Hopefully
+    // we can remove this restriction in the future.
     if (priority != 0 && priority != 500 && priority != 1000) {
         STHROW("402 Invalid priority value");
     }

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -26,6 +26,7 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     // Helper functions
     string _constructNextRunDATETIME(const string& lastScheduled, const string& lastRun, const string& repeat);
     bool _validateRepeat(const string& repeat) { return !_constructNextRunDATETIME("", "", repeat).empty(); }
+    void _validatePriority(const int64_t priority);
     bool _hasPendingChildJobs(SQLite& db, int64_t jobID);
     bool _isValidSQLiteDateModifier(const string& modifier);
 };

--- a/plugins/Jobs.md
+++ b/plugins/Jobs.md
@@ -15,6 +15,8 @@ Bedrock::Jobs is a plugin to the [Bedrock data foundation](../README.md) that ma
  * **UpdateJob( jobID, data )** - Updates the data associated with a job.
    * *jobID* - Identifier of the job to update
    * *data* - New data object to associate with the job
+   * *repeat* - A description of how often to repeat this job (optional)
+   * *jobPriority* - New priority of the job (optional)
 
  * **QueryJob( jobID )** - Retrieves the current state and data associated with a job.
    * *jobID* - Identifier of the job to query

--- a/test/tests/jobs/UpdateJobTest.cpp
+++ b/test/tests/jobs/UpdateJobTest.cpp
@@ -1,0 +1,53 @@
+#include <test/lib/BedrockTester.h>
+#include <test/tests/jobs/JobTestHelper.h>
+
+struct UpdateJobTest : tpunit::TestFixture {
+    UpdateJobTest()
+            : tpunit::TestFixture("UpdateJob",
+                                  BEFORE_CLASS(UpdateJobTest::setupClass),
+                                  TEST(UpdateJobTest::updateJob),
+                                  AFTER(UpdateJobTest::tearDown),
+                                  AFTER_CLASS(UpdateJobTest::tearDownClass)) { }
+
+    BedrockTester* tester;
+
+    void setupClass() { tester = new BedrockTester(_threadID, {{"-plugins", "Jobs,DB"}}, {});}
+
+    // Reset the jobs table
+    void tearDown() {
+        SData command("Query");
+        command["query"] = "DELETE FROM jobs WHERE jobID > 0;";
+        tester->executeWaitVerifyContent(command);
+    }
+
+    void tearDownClass() { delete tester; }
+
+    // Simple UpdateJob with all parameters
+    void updateJob() {
+        // Create the job
+        SData command("CreateJob");
+        string jobName = "job";
+        command["name"] = jobName;
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+        ASSERT_GREATER_THAN(stol(jobID), 0);
+
+        // Call the UpdateJob command
+        command.clear();
+        command.methodLine = "UpdateJob";
+        command["jobID"] = jobID;
+        command["data"] = "{key:\"value\"}";
+        command["repeat"] = "HOURLY";
+        command["jobPriority"] = "1000";
+        tester->executeWaitVerifyContent(command);
+
+        // Verify that the job was actually updated
+        SQResult currentJob;
+        tester->readDB("SELECT repeat, data, priority FROM jobs WHERE jobID = " + jobID + ";", currentJob);
+        ASSERT_EQUAL(currentJob[0][0], "HOURLY");
+        ASSERT_EQUAL(currentJob[0][1], "{key:\"value\"}");
+        ASSERT_EQUAL(currentJob[0][2], "1000");
+    }
+
+} __UpdateJobTest;
+

--- a/test/tests/jobs/UpdateJobTest.cpp
+++ b/test/tests/jobs/UpdateJobTest.cpp
@@ -6,28 +6,25 @@ struct UpdateJobTest : tpunit::TestFixture {
             : tpunit::TestFixture("UpdateJob",
                                   BEFORE_CLASS(UpdateJobTest::setupClass),
                                   TEST(UpdateJobTest::updateJob),
-                                  AFTER(UpdateJobTest::tearDown),
                                   AFTER_CLASS(UpdateJobTest::tearDownClass)) { }
 
     BedrockTester* tester;
 
-    void setupClass() { tester = new BedrockTester(_threadID, {{"-plugins", "Jobs,DB"}}, {});}
-
-    // Reset the jobs table
-    void tearDown() {
-        SData command("Query");
-        command["query"] = "DELETE FROM jobs WHERE jobID > 0;";
-        tester->executeWaitVerifyContent(command);
+    void setupClass() {
+        tester = new BedrockTester(_threadID, {{"-plugins", "Jobs,DB"}}, {});
     }
 
-    void tearDownClass() { delete tester; }
+    void tearDownClass() {
+        delete tester;
+    }
 
     // Simple UpdateJob with all parameters
     void updateJob() {
         // Create the job
         SData command("CreateJob");
-        string jobName = "job";
-        command["name"] = jobName;
+        command["name"] = "job";
+        string oldPriority = "500";
+        command["jobPriority"] = oldPriority;
         STable response = tester->executeWaitVerifyContentTable(command);
         string jobID = response["jobID"];
         ASSERT_GREATER_THAN(stol(jobID), 0);
@@ -47,6 +44,7 @@ struct UpdateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(currentJob[0][0], "HOURLY");
         ASSERT_EQUAL(currentJob[0][1], "{key:\"value\"}");
         ASSERT_EQUAL(currentJob[0][2], "1000");
+        ASSERT_NOT_EQUAL(currentJob[0][2], oldPriority);
     }
 
 } __UpdateJobTest;


### PR DESCRIPTION
@mattabullock can you review this please?

cc: @coleaeason @stitesExpensify in case something would be wrong with this

Needed for https://github.com/Expensify/Expensify/issues/123018

Simple update to the `UpdateJob` command to also allow it to update the jobs priority.

Can be tested with `nc` by having a job in the db, then running

```
UpdateJob
jobID:<the existing jobID>
data:<the existing jobData>
priority:<a different priority>
```