### PR TITLE
First step towards allowing polymorphic commands.

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -29,9 +29,7 @@ BedrockCommand::~BedrockCommand() {
     for (auto request : httpsRequests) {
         request->manager.closeTransaction(request);
     }
-    if (countCommand) {
-        _commandCount--;
-    }
+    _commandCount--;
     if (deallocator && peekData) {
         deallocator(peekData);
     }
@@ -50,39 +48,9 @@ BedrockCommand::BedrockCommand(SQLiteCommand&& from, int dontCount) :
     peekData(nullptr),
     deallocator(nullptr),
     _inProgressTiming(INVALID, 0, 0),
-    _timeout(_getTimeout(request)),
-    countCommand(dontCount != DONT_COUNT)
+    _timeout(_getTimeout(request))
 {
     _init();
-    if (countCommand) {
-        _commandCount++;
-    }
-}
-
-BedrockCommand::BedrockCommand(BedrockCommand&& from) :
-    SQLiteCommand(move(from)),
-    httpsRequests(move(from.httpsRequests)),
-    priority(from.priority),
-    peekCount(from.peekCount),
-    processCount(from.processCount),
-    peekedBy(from.peekedBy),
-    processedBy(from.processedBy),
-    repeek(from.repeek),
-    timingInfo(from.timingInfo),
-    onlyProcessOnSyncThread(from.onlyProcessOnSyncThread),
-    crashIdentifyingValues(*this, move(from.crashIdentifyingValues)),
-    peekData(from.peekData),
-    deallocator(from.deallocator),
-    _inProgressTiming(from._inProgressTiming),
-    _timeout(from._timeout),
-    countCommand(true)
-{
-    // The move constructor (and likewise, the move assignment operator), don't simply copy these pointer values, but
-    // they clear them from the old object, so that when its destructor is called, the HTTPS transactions aren't
-    // closed.
-    from.httpsRequests.clear();
-    from.peekData = nullptr;
-    from.deallocator = nullptr;
     _commandCount++;
 }
 
@@ -99,8 +67,7 @@ BedrockCommand::BedrockCommand(SData&& _request) :
     peekData(nullptr),
     deallocator(nullptr),
     _inProgressTiming(INVALID, 0, 0),
-    _timeout(_getTimeout(request)),
-    countCommand(true)
+    _timeout(_getTimeout(request))
 {
     _init();
     _commandCount++;
@@ -119,66 +86,10 @@ BedrockCommand::BedrockCommand(SData _request) :
     peekData(nullptr),
     deallocator(nullptr),
     _inProgressTiming(INVALID, 0, 0),
-    _timeout(_getTimeout(request)),
-    countCommand(true)
+    _timeout(_getTimeout(request))
 {
     _init();
     _commandCount++;
-}
-
-BedrockCommand& BedrockCommand::operator=(BedrockCommand&& from) {
-    if (this != &from) {
-        // The current incarnation of this object is going away, if it had an httpsRequest, we'll need to destroy it,
-        // or it will leak and never get cleaned up.
-        for (auto request : httpsRequests) {
-            if (!request->response) {
-                SWARN("Closing unfinished httpRequest by assigning over it. This was probably a mistake.");
-            }
-            request->manager.closeTransaction(request);
-        }
-        httpsRequests = move(from.httpsRequests);
-        from.httpsRequests.clear();
-
-        // Same here, deallocate current data.
-        if (deallocator && peekData) {
-            deallocator(peekData);
-        }
-
-        // Update our other properties.
-        peekCount = from.peekCount;
-        processCount = from.processCount;
-        peekedBy = from.peekedBy;
-        processedBy = from.processedBy;
-        repeek = from.repeek;
-        priority = from.priority;
-        timingInfo = from.timingInfo;
-        onlyProcessOnSyncThread = from.onlyProcessOnSyncThread;
-        crashIdentifyingValues = move(from.crashIdentifyingValues);
-        peekData = move(from.peekData);
-        deallocator = move(from.deallocator);
-        _inProgressTiming = from._inProgressTiming;
-        _timeout = from._timeout;
-
-        // If countCommand is changing, update the count.
-        if (countCommand && !from.countCommand) {
-            // this command is no longer counted.
-            _commandCount--;
-        } else if (!countCommand && from.countCommand) {
-            // We need to start counting this command.
-            _commandCount++;
-        }
-        // Now set to match the existing command.
-        countCommand = from.countCommand;
-
-        // Don't delete when the old object is destroyed.
-        from.peekData = nullptr;
-        from.deallocator = nullptr;
-
-        // And call the base class's move constructor as well.
-        SQLiteCommand::operator=(move(from));
-    }
-
-    return *this;
 }
 
 void BedrockCommand::_init() {
@@ -338,24 +249,24 @@ void BedrockCommand::finalizeTimingInfo() {
 
 // pop and push specializations for SSynchronizedQueue that record timing info.
 template<>
-BedrockCommand SSynchronizedQueue<BedrockCommand>::pop() {
+unique_ptr<BedrockCommand> SSynchronizedQueue<unique_ptr<BedrockCommand>>::pop() {
     SAUTOLOCK(_queueMutex);
     if (!_queue.empty()) {
-        BedrockCommand item = move(_queue.front());
+        unique_ptr<BedrockCommand> item = move(_queue.front());
         _queue.pop_front();
-        item.stopTiming(BedrockCommand::QUEUE_SYNC);
+        item->stopTiming(BedrockCommand::QUEUE_SYNC);
         return item;
     }
     throw out_of_range("No commands");
 }
 
 template<>
-void SSynchronizedQueue<BedrockCommand>::push(BedrockCommand&& cmd) {
+void SSynchronizedQueue<unique_ptr<BedrockCommand>>::push(unique_ptr<BedrockCommand>&& cmd) {
     SAUTOLOCK(_queueMutex);
-    SINFO("Enqueuing command '" << cmd.request.methodLine << "', with " << _queue.size() << " commands already queued.");
+    SINFO("Enqueuing command '" << cmd->request.methodLine << "', with " << _queue.size() << " commands already queued.");
     // Just add to the queue
     _queue.push_back(move(cmd));
-    _queue.back().startTiming(BedrockCommand::QUEUE_SYNC);
+    _queue.back()->startTiming(BedrockCommand::QUEUE_SYNC);
 
     // Write arbitrary buffer to the pipe so any subscribers will be awoken.
     // **NOTE: 1 byte so write is atomic.

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -23,9 +23,6 @@ class BedrockCommand : public SQLiteCommand {
         QUEUE_SYNC,
     };
 
-    // used to create commands that don't count towards the total number of commands.
-    static constexpr int DONT_COUNT = 1;
-
     // Times in *milliseconds*.
     static const uint64_t DEFAULT_TIMEOUT = 290'000; // 290 seconds, so clients can have a 5 minute timeout.
     static const uint64_t DEFAULT_TIMEOUT_FORGET = 60'000 * 60; // 1 hour for `connection: forget` commands.
@@ -33,9 +30,6 @@ class BedrockCommand : public SQLiteCommand {
 
     // Constructor to convert from an existing SQLiteCommand (by move).
     BedrockCommand(SQLiteCommand&& from, int dontCount = 0);
-
-    // Move constructor.
-    BedrockCommand(BedrockCommand&& from);
 
     // Constructor to initialize via a request object (by move).
     BedrockCommand(SData&& _request);
@@ -45,9 +39,6 @@ class BedrockCommand : public SQLiteCommand {
 
     // Destructor.
     ~BedrockCommand();
-
-    // Move assignment operator.
-    BedrockCommand& operator=(BedrockCommand&& from);
 
     // Start recording time for a given action type.
     void startTiming(TIMING_INFO type);
@@ -147,6 +138,4 @@ class BedrockCommand : public SQLiteCommand {
     uint64_t _timeout;
 
     static atomic<size_t> _commandCount;
-
-    bool countCommand;
 };

--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -1,15 +1,15 @@
 #include <BedrockCommandQueue.h>
 
-void BedrockCommandQueue::startTiming(BedrockCommand& command) {
-    command.startTiming(BedrockCommand::QUEUE_WORKER);
+void BedrockCommandQueue::startTiming(unique_ptr<BedrockCommand>& command) {
+    command->startTiming(BedrockCommand::QUEUE_WORKER);
 }
 
-void BedrockCommandQueue::stopTiming(BedrockCommand& command) {
-    command.stopTiming(BedrockCommand::QUEUE_WORKER);
+void BedrockCommandQueue::stopTiming(unique_ptr<BedrockCommand>& command) {
+    command->stopTiming(BedrockCommand::QUEUE_WORKER);
 }
 
 BedrockCommandQueue::BedrockCommandQueue() :
-  SScheduledPriorityQueue<BedrockCommand>(function<void(BedrockCommand&)>(startTiming), function<void(BedrockCommand&)>(stopTiming))
+  SScheduledPriorityQueue<unique_ptr<BedrockCommand>>(function<void(unique_ptr<BedrockCommand>&)>(startTiming), function<void(unique_ptr<BedrockCommand>&)>(stopTiming))
 { }
 
 list<string> BedrockCommandQueue::getRequestMethodLines() {
@@ -17,7 +17,7 @@ list<string> BedrockCommandQueue::getRequestMethodLines() {
     SAUTOLOCK(_queueMutex);
     for (auto& queue : _queue) {
         for (auto& entry : queue.second) {
-            returnVal.push_back(entry.second.item.request.methodLine);
+            returnVal.push_back(entry.second.item->request.methodLine);
         }
     }
     return returnVal;
@@ -64,9 +64,9 @@ void BedrockCommandQueue::abandonFutureCommands(int msInFuture) {
     }
 }
 
-void BedrockCommandQueue::push(BedrockCommand&& command) {
-    BedrockCommand::Priority priority = command.priority;
-    uint64_t executionTime = command.request.calcU64("commandExecuteTime");
-    uint64_t timeout = command.timeout();
-    SScheduledPriorityQueue<BedrockCommand>::push(move(command), priority, executionTime, timeout);
+void BedrockCommandQueue::push(unique_ptr<BedrockCommand>&& command) {
+    BedrockCommand::Priority priority = command->priority;
+    uint64_t executionTime = command->request.calcU64("commandExecuteTime");
+    uint64_t timeout = command->timeout();
+    SScheduledPriorityQueue<unique_ptr<BedrockCommand>>::push(move(command), priority, executionTime, timeout);
 }

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -3,13 +3,13 @@
 #include <libstuff/SScheduledPriorityQueue.h>
 #include "BedrockCommand.h"
 
-class BedrockCommandQueue : public SScheduledPriorityQueue<BedrockCommand> {
+class BedrockCommandQueue : public SScheduledPriorityQueue<unique_ptr<BedrockCommand>> {
   public:
     BedrockCommandQueue();
 
     // Functions to start and stop timing on the commands when they're inserted/removed from the queue.
-    static void startTiming(BedrockCommand& command);
-    static void stopTiming(BedrockCommand& command);
+    static void startTiming(unique_ptr<BedrockCommand>& command);
+    static void stopTiming(unique_ptr<BedrockCommand>& command);
     
     // Returns a list of all the method lines for all the requests currently queued. This function exists for state
     // reporting, and is called by BedrockServer when we receive a `Status` command.
@@ -19,5 +19,5 @@ class BedrockCommandQueue : public SScheduledPriorityQueue<BedrockCommand> {
     void abandonFutureCommands(int msInFuture);
 
     // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
-    void push(BedrockCommand&& command);
+    void push(unique_ptr<BedrockCommand>&& command);
 };

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -29,23 +29,23 @@ class AutoScopeRewrite {
     bool (*_handler)(int, const char*, string&);
 };
 
-uint64_t BedrockCore::_getRemainingTime(const BedrockCommand& command) {
-    int64_t timeout = command.timeout();
+uint64_t BedrockCore::_getRemainingTime(const unique_ptr<BedrockCommand>& command) {
+    int64_t timeout = command->timeout();
     int64_t now = STimeNow();
 
     // This is what's left for the "absolute" time. If it's negative, we've already timed out.
     int64_t adjustedTimeout = timeout - now;
 
     // We also want to know the processTimeout, because we'll return early if we get stuck processing for too long.
-    int64_t processTimeout = command.request.isSet("processTimeout") ? command.request.calc("processTimeout") : BedrockCommand::DEFAULT_PROCESS_TIMEOUT;
+    int64_t processTimeout = command->request.isSet("processTimeout") ? command->request.calc("processTimeout") : BedrockCommand::DEFAULT_PROCESS_TIMEOUT;
 
     // Since timeouts are specified in ms, we convert to us.
     processTimeout *= 1000;
 
     // Already expired.
     if (adjustedTimeout <= 0 || processTimeout <= 0) {
-        SALERT("Command " << command.request.methodLine << " timed out after "
-               << ((now - command.request.calc64("commandExecuteTime")) / 1000) << "ms.");
+        SALERT("Command " << command->request.methodLine << " timed out after "
+               << ((now - command->request.calc64("commandExecuteTime")) / 1000) << "ms.");
         STHROW("555 Timeout");
     }
 
@@ -53,30 +53,30 @@ uint64_t BedrockCore::_getRemainingTime(const BedrockCommand& command) {
     return min(processTimeout, adjustedTimeout);
 }
 
-bool BedrockCore::isTimedOut(BedrockCommand& command) {
+bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command) {
     try {
         _getRemainingTime(command);
     } catch (const SException& e) {
         // Yep, timed out.
         _handleCommandException(command, e);
-        command.complete = true;
+        command->complete = true;
         return true;
     }
     return false;
 }
 
-bool BedrockCore::peekCommand(BedrockCommand& command) {
+bool BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command) {
     AutoTimer timer(command, BedrockCommand::PEEK);
     // Convenience references to commonly used properties.
-    SData& request = command.request;
-    SData& response = command.response;
-    STable& content = command.jsonContent;
+    SData& request = command->request;
+    SData& response = command->response;
+    STable& content = command->jsonContent;
 
     // We catch any exception and handle in `_handleCommandException`.
     try {
-        SDEBUG("Peeking at '" << request.methodLine << "' with priority: " << command.priority);
+        SDEBUG("Peeking at '" << request.methodLine << "' with priority: " << command->priority);
         uint64_t timeout = _getRemainingTime(command);
-        command.peekCount++;
+        command->peekCount++;
 
         _db.startTiming(timeout);
         // We start a transaction in `peekCommand` because we want to support having atomic transactions from peek
@@ -88,7 +88,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
         bool shouldSuppressTimeoutWarnings = false;
 
         try {
-            if (!_db.beginConcurrentTransaction(true, command.request.methodLine)) {
+            if (!_db.beginConcurrentTransaction(true, command->request.methodLine)) {
                 STHROW("501 Failed to begin concurrent transaction");
             }
 
@@ -102,7 +102,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
                 // Try to peek the command.
                 if (plugin.second->peekCommand(_db, command)) {
                     SINFO("Plugin '" << plugin.second->getName() << "' peeked command '" << request.methodLine << "'");
-                    command.peekedBy = plugin.second;
+                    command->peekedBy = plugin.second;
                     pluginPeeked = true;
                     break;
                 }
@@ -112,7 +112,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
             _db.read("PRAGMA query_only = false;");
         } catch (const SQLite::timeout_error& e) {
             if (!shouldSuppressTimeoutWarnings) {
-                SALERT("Command " << command.request.methodLine << " timed out after " << e.time()/1000 << "ms.");
+                SALERT("Command " << command->request.methodLine << " timed out after " << e.time()/1000 << "ms.");
             }
             STHROW("555 Timeout peeking command");
         }
@@ -147,27 +147,27 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
             }
         }
     } catch (const SException& e) {
-        command.repeek = false;
+        command->repeek = false;
         _db.resetTiming();
         _db.read("PRAGMA query_only = false;");
         _handleCommandException(command, e);
     } catch (const SHTTPSManager::NotLeading& e) {
-        command.repeek = false;
+        command->repeek = false;
         _db.rollback();
         _db.read("PRAGMA query_only = false;");
         _db.resetTiming();
         SINFO("Command '" << request.methodLine << "' wants to make HTTPS request, queuing for processing.");
         return false;
     } catch (...) {
-        command.repeek = false;
+        command->repeek = false;
         _db.resetTiming();
         _db.read("PRAGMA query_only = false;");
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
-        command.response.methodLine = "500 Unhandled Exception";
+        command->response.methodLine = "500 Unhandled Exception";
     }
 
     // If we get here, it means the command is fully completed.
-    command.complete = true;
+    command->complete = true;
 
     // Back out of the current transaction, it doesn't need to do anything.
     _db.rollback();
@@ -177,27 +177,27 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
     return true;
 }
 
-bool BedrockCore::processCommand(BedrockCommand& command) {
+bool BedrockCore::processCommand(unique_ptr<BedrockCommand>& command) {
     AutoTimer timer(command, BedrockCommand::PROCESS);
 
     // Convenience references to commonly used properties.
-    SData& request = command.request;
-    SData& response = command.response;
-    STable& content = command.jsonContent;
+    SData& request = command->request;
+    SData& response = command->response;
+    STable& content = command->jsonContent;
 
     // Keep track of whether we've modified the database and need to perform a `commit`.
     bool needsCommit = false;
     try {
         SDEBUG("Processing '" << request.methodLine << "'");
         uint64_t timeout = _getRemainingTime(command);
-        command.processCount++;
+        command->processCount++;
 
         // Time in US.
         _db.startTiming(timeout);
         // If a transaction was already begun in `peek`, then this is a no-op. We call it here to support the case where
         // peek created a httpsRequest and closed it's first transaction until the httpsRequest was complete, in which
         // case we need to open a new transaction.
-        if (!_db.insideTransaction() && !_db.beginConcurrentTransaction(true, command.request.methodLine)) {
+        if (!_db.insideTransaction() && !_db.beginConcurrentTransaction(true, command->request.methodLine)) {
             STHROW("501 Failed to begin concurrent transaction");
         }
 
@@ -205,7 +205,7 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         bool pluginProcessed = false;
 
         // If the command is mocked, turn on UpdateNoopMode.
-        _db.setUpdateNoopMode(command.request.isSet("mockRequest"));
+        _db.setUpdateNoopMode(command->request.isSet("mockRequest"));
         for (auto plugin : _server.plugins) {
             // Try to process the command.
             bool (*handler)(int, const char*, string&) = nullptr;
@@ -215,11 +215,11 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
                 if (plugin.second->processCommand(_db, command)) {
                     SINFO("Plugin '" << plugin.second->getName() << "' processed command '" << request.methodLine << "'");
                     pluginProcessed = true;
-                    command.processedBy = plugin.second;
+                    command->processedBy = plugin.second;
                     break;
                 }
             } catch (const SQLite::timeout_error& e) {
-                SALERT("Command " << command.request.methodLine << " timed out after " << e.time()/1000 << "ms.");
+                SALERT("Command " << command->request.methodLine << " timed out after " << e.time()/1000 << "ms.");
                 STHROW("555 Timeout processing command");
             }
         }
@@ -262,7 +262,7 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         needsCommit = false;
     } catch(...) {
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
-        command.response.methodLine = "500 Unhandled Exception";
+        command->response.methodLine = "500 Unhandled Exception";
         _db.rollback();
         needsCommit = false;
     }
@@ -274,12 +274,12 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
     _db.resetTiming();
 
     // Done, return whether or not we need the parent to commit our transaction.
-    command.complete = !needsCommit;
+    command->complete = !needsCommit;
     return needsCommit;
 }
 
-void BedrockCore::_handleCommandException(BedrockCommand& command, const SException& e) {
-    const string& msg = "Error processing command '" + command.request.methodLine + "' (" + e.what() + "), ignoring.";
+void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e) {
+    const string& msg = "Error processing command '" + command->request.methodLine + "' (" + e.what() + "), ignoring.";
     if (SContains(e.what(), "_ALERT_")) {
         SALERT(msg);
     } else if (SContains(e.what(), "_WARN_")) {
@@ -294,15 +294,15 @@ void BedrockCore::_handleCommandException(BedrockCommand& command, const SExcept
 
     // Set the response to the values from the exception, if set.
     if (!e.method.empty()) {
-        command.response.methodLine = e.method;
+        command->response.methodLine = e.method;
     }
     if (!e.headers.empty()) {
-        command.response.nameValueMap = e.headers;
+        command->response.nameValueMap = e.headers;
     }
     if (!e.body.empty()) {
-        command.response.content = e.body;
+        command->response.content = e.body;
     }
 
     // Add the commitCount header to the response.
-    command.response["commitCount"] = to_string(_db.getCommitCount());
+    command->response["commitCount"] = to_string(_db.getCommitCount());
 }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -100,7 +100,7 @@ bool BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command) {
                 shouldSuppressTimeoutWarnings = plugin.second->shouldSuppressTimeoutWarnings();
 
                 // Try to peek the command.
-                if (plugin.second->peekCommand(_db, command)) {
+                if (plugin.second->peekCommand(_db, *command)) {
                     SINFO("Plugin '" << plugin.second->getName() << "' peeked command '" << request.methodLine << "'");
                     command->peekedBy = plugin.second;
                     pluginPeeked = true;
@@ -209,10 +209,10 @@ bool BedrockCore::processCommand(unique_ptr<BedrockCommand>& command) {
         for (auto plugin : _server.plugins) {
             // Try to process the command.
             bool (*handler)(int, const char*, string&) = nullptr;
-            bool enable = plugin.second->shouldEnableQueryRewriting(_db, command, &handler);
+            bool enable = plugin.second->shouldEnableQueryRewriting(_db, *command, &handler);
             AutoScopeRewrite rewrite(enable, _db, handler);
             try {
-                if (plugin.second->processCommand(_db, command)) {
+                if (plugin.second->processCommand(_db, *command)) {
                     SINFO("Plugin '" << plugin.second->getName() << "' processed command '" << request.methodLine << "'");
                     pluginProcessed = true;
                     command->processedBy = plugin.second;

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -10,13 +10,13 @@ class BedrockCore : public SQLiteCore {
     // Automatic timing class that records an entry corresponding to its lifespan.
     class AutoTimer {
       public:
-        AutoTimer(BedrockCommand& command, BedrockCommand::TIMING_INFO type) :
+        AutoTimer(unique_ptr<BedrockCommand>& command, BedrockCommand::TIMING_INFO type) :
         _command(command), _type(type), _start(STimeNow()) { }
         ~AutoTimer() {
-            _command.timingInfo.emplace_back(make_tuple(_type, _start, STimeNow()));
+            _command->timingInfo.emplace_back(make_tuple(_type, _start, STimeNow()));
         }
       private:
-        BedrockCommand& _command;
+        unique_ptr<BedrockCommand>& _command;
         BedrockCommand::TIMING_INFO _type;
         uint64_t _start;
     };
@@ -24,7 +24,7 @@ class BedrockCore : public SQLiteCore {
     // Checks if a command has already timed out. Like `peekCommand` without doing any work. Returns `true` and sets
     // the same command state as `peekCommand` would if the command has timed out. Returns `false` and does nothing if
     // the command hasn't timed out.
-    bool isTimedOut(BedrockCommand& command);
+    bool isTimedOut(unique_ptr<BedrockCommand>& command);
 
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same
     // command, and it *may be called multiple times*. Preventing duplicate actions on calling peek multiple times is
@@ -33,7 +33,7 @@ class BedrockCore : public SQLiteCore {
     // should be considered an error to modify the DB from inside `peek`.
     // Returns a boolean value of `true` if the command is complete and its `response` field can be returned to the
     // caller. Returns `false` if the command will need to be passed to `process` to complete handling the command.
-    bool peekCommand(BedrockCommand& command);
+    bool peekCommand(unique_ptr<BedrockCommand>& command);
 
     // Process is the follow-up to `peek` if `peek` was insufficient to handle the command. It will only ever be called
     // on the leader node, and should always be able to resolve the command completely. When a command is passed to
@@ -45,7 +45,7 @@ class BedrockCore : public SQLiteCore {
     // replicate the transaction to follower nodes. Upon being returned `true`, the caller will attempt to perform a
     // `COMMIT` and replicate the transaction to follower nodes. It's allowable for this `COMMIT` to fail, in which case
     // this command *will be passed to process again in the future to retry*.
-    bool processCommand(BedrockCommand& command);
+    bool processCommand(unique_ptr<BedrockCommand>& command);
 
   private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.
@@ -54,8 +54,8 @@ class BedrockCore : public SQLiteCore {
     // Gets the amount of time remaining until this command times out. This is the difference between the command's
     // 'timeout' value (or the default timeout, if not set) and the time the command was initially scheduled to run. If
     // this time is already expired, this throws `555 Timeout`
-    uint64_t _getRemainingTime(const BedrockCommand& command);
+    uint64_t _getRemainingTime(const unique_ptr<BedrockCommand>& command);
 
-    void _handleCommandException(BedrockCommand& command, const SException& e);
+    void _handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e);
     const BedrockServer& _server;
 };

--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -41,7 +41,7 @@ void BedrockPlugin::verifyAttributeBool(const SData& request, const string& name
     }
 }
 
-bool BedrockPlugin::shouldEnableQueryRewriting(const SQLite& db, const BedrockCommand& command, bool (**rewriteHandler)(int, const char*, string&)) {
+bool BedrockPlugin::shouldEnableQueryRewriting(const SQLite& db, const unique_ptr<BedrockCommand>& command, bool (**rewriteHandler)(int, const char*, string&)) {
     return false;
 }
 
@@ -53,11 +53,11 @@ string BedrockPlugin::getName() {
     SERROR("No name defined by this plugin, aborting.");
 }
 
-bool BedrockPlugin::peekCommand(SQLite& db, BedrockCommand& command) {
+bool BedrockPlugin::peekCommand(SQLite& db, unique_ptr<BedrockCommand>& command) {
     return false;
 }
 
-bool BedrockPlugin::processCommand(SQLite& db, BedrockCommand& command) {
+bool BedrockPlugin::processCommand(SQLite& db, unique_ptr<BedrockCommand>& command) {
     return false;
 }
 
@@ -73,6 +73,6 @@ void BedrockPlugin::timerFired(SStopwatch* timer) {}
 
 void BedrockPlugin::upgradeDatabase(SQLite& db) {}
 
-void BedrockPlugin::handleFailedReply(const BedrockCommand& command) {
+void BedrockPlugin::handleFailedReply(const unique_ptr<BedrockCommand>& command) {
     // Default implementation does nothing.
 }

--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -41,7 +41,7 @@ void BedrockPlugin::verifyAttributeBool(const SData& request, const string& name
     }
 }
 
-bool BedrockPlugin::shouldEnableQueryRewriting(const SQLite& db, const unique_ptr<BedrockCommand>& command, bool (**rewriteHandler)(int, const char*, string&)) {
+bool BedrockPlugin::shouldEnableQueryRewriting(const SQLite& db, const BedrockCommand& command, bool (**rewriteHandler)(int, const char*, string&)) {
     return false;
 }
 
@@ -53,11 +53,11 @@ string BedrockPlugin::getName() {
     SERROR("No name defined by this plugin, aborting.");
 }
 
-bool BedrockPlugin::peekCommand(SQLite& db, unique_ptr<BedrockCommand>& command) {
+bool BedrockPlugin::peekCommand(SQLite& db, BedrockCommand& command) {
     return false;
 }
 
-bool BedrockPlugin::processCommand(SQLite& db, unique_ptr<BedrockCommand>& command) {
+bool BedrockPlugin::processCommand(SQLite& db, BedrockCommand& command) {
     return false;
 }
 
@@ -73,6 +73,6 @@ void BedrockPlugin::timerFired(SStopwatch* timer) {}
 
 void BedrockPlugin::upgradeDatabase(SQLite& db) {}
 
-void BedrockPlugin::handleFailedReply(const unique_ptr<BedrockCommand>& command) {
+void BedrockPlugin::handleFailedReply(const BedrockCommand& command) {
     // Default implementation does nothing.
 }

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -31,16 +31,16 @@ class BedrockPlugin {
     // completely handled and a response has been written into `command.response`, which can be returned to the client.
     // Should return `false` if the command needs to write to the database or otherwise could not be finished in a
     // read-only fashion (i.e., it opened an HTTPS request and is waiting for the response).
-    virtual bool peekCommand(SQLite& db, unique_ptr<BedrockCommand>& command);
+    virtual bool peekCommand(SQLite& db, BedrockCommand& command);
 
     // Called after a command has returned `false` to peek, and will attempt to commit and distribute a transaction
     // with any changes to the DB made by this plugin.
-    virtual bool processCommand(SQLite& db, unique_ptr<BedrockCommand>& command);
+    virtual bool processCommand(SQLite& db, BedrockCommand& command);
 
     // Bedrock will call this before each or `processCommand` (note: not `peekCommand`) for each plugin to allow it to
     // enable query rewriting. If a plugin would like to enable query rewriting, this should return true, and it should
     // set the rewriteHandler it would like to use.
-    virtual bool shouldEnableQueryRewriting(const SQLite& db, const unique_ptr<BedrockCommand>& command, bool (**rewriteHandler)(int, const char*, string&));
+    virtual bool shouldEnableQueryRewriting(const SQLite& db, const BedrockCommand& command, bool (**rewriteHandler)(int, const char*, string&));
 
     // Called at some point during initiation to allow the plugin to verify/change the database schema.
     virtual void upgradeDatabase(SQLite& db);
@@ -68,7 +68,7 @@ class BedrockPlugin {
     // After processing the request from this plugin, this is called to send the response
     // response The response from the processed request
     // s        Optional socket from which this request was received
-    virtual void onPortRequestComplete(const unique_ptr<BedrockCommand>& command, STCPManager::Socket* s) { }
+    virtual void onPortRequestComplete(const BedrockCommand& command, STCPManager::Socket* s) { }
 
     // Set to true if we don't want to log timeout alerts, and let the caller deal with it.
     virtual bool shouldSuppressTimeoutWarnings();
@@ -77,7 +77,7 @@ class BedrockPlugin {
 
     // A plugin can optionally handle a command for which the reply to the caller was undeliverable.
     // Note that it gets no reference to the DB, this happens after the transaction is already complete.
-    virtual void handleFailedReply(const unique_ptr<BedrockCommand>& command);
+    virtual void handleFailedReply(const BedrockCommand& command);
 
     // Map of plugin names to functions that will return a new plugin of the given type.
     static map<string, function<BedrockPlugin*(BedrockServer&)>> g_registeredPluginList;

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -31,16 +31,16 @@ class BedrockPlugin {
     // completely handled and a response has been written into `command.response`, which can be returned to the client.
     // Should return `false` if the command needs to write to the database or otherwise could not be finished in a
     // read-only fashion (i.e., it opened an HTTPS request and is waiting for the response).
-    virtual bool peekCommand(SQLite& db, BedrockCommand& command);
+    virtual bool peekCommand(SQLite& db, unique_ptr<BedrockCommand>& command);
 
     // Called after a command has returned `false` to peek, and will attempt to commit and distribute a transaction
     // with any changes to the DB made by this plugin.
-    virtual bool processCommand(SQLite& db, BedrockCommand& command);
+    virtual bool processCommand(SQLite& db, unique_ptr<BedrockCommand>& command);
 
     // Bedrock will call this before each or `processCommand` (note: not `peekCommand`) for each plugin to allow it to
     // enable query rewriting. If a plugin would like to enable query rewriting, this should return true, and it should
     // set the rewriteHandler it would like to use.
-    virtual bool shouldEnableQueryRewriting(const SQLite& db, const BedrockCommand& command, bool (**rewriteHandler)(int, const char*, string&));
+    virtual bool shouldEnableQueryRewriting(const SQLite& db, const unique_ptr<BedrockCommand>& command, bool (**rewriteHandler)(int, const char*, string&));
 
     // Called at some point during initiation to allow the plugin to verify/change the database schema.
     virtual void upgradeDatabase(SQLite& db);
@@ -68,7 +68,7 @@ class BedrockPlugin {
     // After processing the request from this plugin, this is called to send the response
     // response The response from the processed request
     // s        Optional socket from which this request was received
-    virtual void onPortRequestComplete(const BedrockCommand& command, STCPManager::Socket* s) { }
+    virtual void onPortRequestComplete(const unique_ptr<BedrockCommand>& command, STCPManager::Socket* s) { }
 
     // Set to true if we don't want to log timeout alerts, and let the caller deal with it.
     virtual bool shouldSuppressTimeoutWarnings();
@@ -77,7 +77,7 @@ class BedrockPlugin {
 
     // A plugin can optionally handle a command for which the reply to the caller was undeliverable.
     // Note that it gets no reference to the DB, this happens after the transaction is already complete.
-    virtual void handleFailedReply(const BedrockCommand& command);
+    virtual void handleFailedReply(const unique_ptr<BedrockCommand>& command);
 
     // Map of plugin names to functions that will return a new plugin of the given type.
     static map<string, function<BedrockPlugin*(BedrockServer&)>> g_registeredPluginList;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -691,7 +691,7 @@ void BedrockServer::worker(const SData& args,
     // at the bottom, which will cause our loop and thus this thread to exit when that becomes true.
     while (true) {
         try {
-            // Set a signal handler function that we can call even if we die early with no command->
+            // Set a signal handler function that we can call even if we die early with no command.
             SSetSignalHandlerDieFunc([&](){
                 SWARN("Die function called early with no command, probably died in `commandQueue.get`.");
             });
@@ -726,7 +726,7 @@ void BedrockServer::worker(const SData& args,
             // sync queue, because of the QUORUM consistency requirement, resulting in an endless loop.
             if (core.isTimedOut(command)) {
                 if (command->initiatingPeerID) {
-                    // Escalated command-> Give it back to the sync thread to respond.
+                    // Escalated command. Give it back to the sync thread to respond.
                     syncNodeCompletedCommands.push(move(command));
                 } else {
                     server._reply(command);
@@ -741,7 +741,7 @@ void BedrockServer::worker(const SData& args,
                 command->response.methodLine = "500 Refused";
                 command->complete = true;
                 if (command->initiatingPeerID) {
-                    // Escalated command-> Give it back to the sync thread to respond.
+                    // Escalated command. Give it back to the sync thread to respond.
                     syncNodeCompletedCommands.push(move(command));
                 } else {
                     server._reply(command);
@@ -752,7 +752,7 @@ void BedrockServer::worker(const SData& args,
             // If this was a command initiated by a peer as part of a cluster operation, then we process it separately
             // and respond immediately. This allows SQLiteNode to offload read-only operations to worker threads.
             if (SQLiteNode::peekPeerCommand(server._syncNode.get(), db, *command)) {
-                // Move on to the next command->
+                // Move on to the next command.
                 continue;
             }
 
@@ -907,7 +907,7 @@ void BedrockServer::worker(const SData& args,
                 if (!calledPeek || !peekResult) {
                     // We've just unsuccessfully peeked a command, which means we're in a state where we might want to
                     // write it. We'll flag that here, to keep the node from falling out of LEADING/STANDINGDOWN
-                    // until we're finished with this command->
+                    // until we're finished with this command.
                     if (command->httpsRequests.size()) {
                         // This *should* be impossible, but previous bugs have existed where it's feasible that we call
                         // `peekCommand` while leading, and by the time we're done, we're FOLLOWING, so we check just
@@ -943,7 +943,7 @@ void BedrockServer::worker(const SData& args,
                         }
                     }
 
-                    // Peek wasn't enough to handle this command-> See if we think it should be writable in parallel.
+                    // Peek wasn't enough to handle this command. See if we think it should be writable in parallel.
                     // We check `onlyProcessOnSyncThread` here, rather than before processing the command, because it's
                     // not set at creation time, it's set in `peek`, so we need to wait at least until after peek is
                     // called to check it.
@@ -1024,7 +1024,7 @@ void BedrockServer::worker(const SData& args,
                 // a conflict, and we'll retry.
                 if (command->complete) {
                     if (command->initiatingPeerID) {
-                        // Escalated command-> Send it back to the peer.
+                        // Escalated command. Send it back to the peer.
                         server._finishPeerCommand(command);
                     } else {
                         server._reply(command);
@@ -1092,7 +1092,7 @@ bool BedrockServer::_wouldCrash(const unique_ptr<BedrockCommand>& command) {
     // Look at each crash-inducing command that has the same methodLine.
     for (const STable& values : commandIt->second) {
 
-        // These are all of the keys that need to match to kill this command->
+        // These are all of the keys that need to match to kill this command.
         bool isMatch = true;
         for (auto& pair : values) {
             // We skip Content-Length, as it's added automatically when serializing commands.
@@ -1516,7 +1516,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                     // Create a command.
                     unique_ptr<BedrockCommand> command = make_unique<BedrockCommand>(request);
 
-                    // Get the source ip of the command->
+                    // Get the source ip of the command.
                     char *ip = inet_ntoa(s->addr.sin_addr);
                     if (ip != "127.0.0.1"s) {
                         // We only add this if it's not localhost because existing code expects commands that come from

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -318,7 +318,7 @@ class BedrockServer : public SQLiteServer {
 
     // Send a reply for a completed command back to the initiating client. If the `originator` of the command is set,
     // then this is an error, as the command should have been sent back to a peer.
-    void _reply(BedrockCommand&);
+    void _reply(unique_ptr<BedrockCommand>& command);
 
     // The following are constants used as methodlines by status command requests.
     static constexpr auto STATUS_IS_SLAVE          = "GET /status/isSlave HTTP/1.1";
@@ -340,10 +340,10 @@ class BedrockServer : public SQLiteServer {
     recursive_timed_mutex _syncMutex;
 
     // Functions for checking for and responding to status and control commands.
-    bool _isStatusCommand(BedrockCommand& command);
-    void _status(BedrockCommand& command);
-    bool _isControlCommand(BedrockCommand& command);
-    void _control(BedrockCommand& command);
+    bool _isStatusCommand(const unique_ptr<BedrockCommand>& command);
+    void _status(unique_ptr<BedrockCommand>& command);
+    bool _isControlCommand(const unique_ptr<BedrockCommand>& command);
+    void _control(unique_ptr<BedrockCommand>& command);
 
     // Accepts any sockets pending on our listening ports. We do this both after `poll()`, and before shutting down
     // those ports.
@@ -356,7 +356,7 @@ class BedrockServer : public SQLiteServer {
     // depends on a future commit if we're a follower that's behind leader, and a client makes two requests, one to a node
     // more current than ourselves, and a following request to us. We'll move these commands to this special map until
     // we catch up, and then move them back to the regular command queue.
-    multimap<uint64_t, BedrockCommand> _futureCommitCommands;
+    multimap<uint64_t, unique_ptr<BedrockCommand>> _futureCommitCommands;
 
     // Map of command timeouts to the indexes into _futureCommitCommands where those commands live.
     multimap<uint64_t, uint64_t> _futureCommitCommandTimeouts;
@@ -418,14 +418,14 @@ class BedrockServer : public SQLiteServer {
 
     // Takes a command that has an outstanding HTTPS request and saves it in _outstandingHTTPSCommands until its HTTPS
     // requests are complete.
-    void waitForHTTPS(BedrockCommand&& command);
+    void waitForHTTPS(unique_ptr<BedrockCommand>&& command);
 
     // Takes a list of completed HTTPS requests, and move those commands back to the main queue (as long as they don't
     // have any other incomplete requests).
     int finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& completedHTTPSRequests);
 
     // Send a reply to a command that was escalated to us from a peer, rather than a locally-connected client.
-    void _finishPeerCommand(BedrockCommand& command);
+    void _finishPeerCommand(unique_ptr<BedrockCommand>& command);
 
     // When we're standing down, we temporarily dump newly received commands here (this lets all existing
     // partially-completed commands, like commands with HTTPS requests) finish without risking getting caught in an
@@ -447,13 +447,13 @@ class BedrockServer : public SQLiteServer {
 
     // Returns whether or not the command was a status or control command. If it was, it will have already been handled
     // and responded to upon return
-    bool _handleIfStatusOrControlCommand(BedrockCommand& command);
+    bool _handleIfStatusOrControlCommand(unique_ptr<BedrockCommand>& command);
 
     // Check a command against the list of crash commands, and return whether we think the command would crash.
-    bool _wouldCrash(const BedrockCommand& command);
+    bool _wouldCrash(const unique_ptr<BedrockCommand>& command);
 
     // Generate a CRASH_COMMAND command for a given bad command.
-    static SData _generateCrashMessage(const BedrockCommand* command);
+    static SData _generateCrashMessage(const unique_ptr<BedrockCommand>& command);
 
     static void _addRequestID(SData& request);
 

--- a/BedrockTimeoutCommandQueue.cpp
+++ b/BedrockTimeoutCommandQueue.cpp
@@ -1,6 +1,6 @@
 #include <BedrockTimeoutCommandQueue.h>
 
-const BedrockCommand& BedrockTimeoutCommandQueue::front() const {
+const unique_ptr<BedrockCommand>& BedrockTimeoutCommandQueue::front() const {
     lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     if (_queue.empty()) {
         throw out_of_range("No commands");
@@ -14,7 +14,7 @@ const BedrockCommand& BedrockTimeoutCommandQueue::front() const {
     return _queue.front();
 }
 
-void BedrockTimeoutCommandQueue::push(BedrockCommand&& rhs) {
+void BedrockTimeoutCommandQueue::push(unique_ptr<BedrockCommand>&& rhs) {
     lock_guard<decltype(_queueMutex)> lock(_queueMutex);
 
     // Add to the queue and timeout map.
@@ -23,20 +23,20 @@ void BedrockTimeoutCommandQueue::push(BedrockCommand&& rhs) {
     // This is past-the-end, so we decrement it to point to the last element.
     auto lastIt = _queue.end();
     lastIt--;
-    _timeoutMap.insert(make_pair(lastIt->timeout(), lastIt));
+    _timeoutMap.insert(make_pair((*lastIt)->timeout(), lastIt));
 
     // Write arbitrary buffer to the pipe so any subscribers will be awoken.
     // **NOTE: 1 byte so write is atomic.
     SASSERT(write(_pipeFD[1], "A", 1));
 }
 
-BedrockCommand BedrockTimeoutCommandQueue::pop() {
+unique_ptr<BedrockCommand> BedrockTimeoutCommandQueue::pop() {
     lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     if (_queue.empty()) {
         throw out_of_range("No commands");
     }
     if (_timeoutMap.begin()->first < STimeNow()) {
-        BedrockCommand item = move(*(_timeoutMap.begin()->second));
+        unique_ptr<BedrockCommand> item = move(*(_timeoutMap.begin()->second));
         _queue.erase(_timeoutMap.begin()->second);
         _timeoutMap.erase(_timeoutMap.begin());
         return item;
@@ -44,7 +44,7 @@ BedrockCommand BedrockTimeoutCommandQueue::pop() {
 
     // We need to remove the reference in the timeout map for this item as well.
     auto firstCommandIt = _queue.begin();
-    auto itPair = _timeoutMap.equal_range(firstCommandIt->timeout());
+    auto itPair = _timeoutMap.equal_range((*firstCommandIt)->timeout());
     for (auto it = itPair.first; it != itPair.second; it++) {
         if (it->second == firstCommandIt) {
             // This one points at this command, remove it.
@@ -52,7 +52,7 @@ BedrockCommand BedrockTimeoutCommandQueue::pop() {
             break;
         }
     }
-    BedrockCommand item = move(*firstCommandIt);
+    unique_ptr<BedrockCommand> item = move(*firstCommandIt);
     _queue.pop_front();
     return item;
 }

--- a/BedrockTimeoutCommandQueue.h
+++ b/BedrockTimeoutCommandQueue.h
@@ -1,15 +1,15 @@
 #include <libstuff/libstuff.h>
 #include <BedrockCommand.h>
 
-class BedrockTimeoutCommandQueue : public SSynchronizedQueue<BedrockCommand> {
+class BedrockTimeoutCommandQueue : public SSynchronizedQueue<unique_ptr<BedrockCommand>> {
   public:
     // Override the base class to account for timeouts.
-    const BedrockCommand& front() const;
-    void push(BedrockCommand&& rhs);
-    BedrockCommand pop();
+    const unique_ptr<BedrockCommand>& front() const;
+    void push(unique_ptr<BedrockCommand>&& rhs);
+    unique_ptr<BedrockCommand> pop();
 
   private:
     // Map of timeouts to commands in the queue. Because the queue is a std::list, we can store iterators into it and
     // they stay valid as we manipulate the list, avoiding walking the list to re-locate them.
-    multimap<uint64_t, list<BedrockCommand>::iterator> _timeoutMap;
+    multimap<uint64_t, list<unique_ptr<BedrockCommand>>::iterator> _timeoutMap;
 };


### PR DESCRIPTION
This change replaces `BedrockCommand` with `unique_ptr<BedrockCommand>` throughout Bedrock.

This probably helps to some minor degree with performance (Bedrock commands are never moved or copied), but that's not the main point of it.

#### It will have several benefits that will be realized in follow-up PRs

Plugins create their own commands. This means that instead of this sort of thing:
https://github.com/Expensify/Bedrock/blob/45079a66cc3d52623594af04f1971081e43f3387/BedrockCore.cpp#L99-L108

A plugin will either return a new command, which will implicitly mean that `peekedBy` and `processedBy` will be the given plugin, etc. Or it will return a null pointer, indicating that this plugin can't handle this command.

#### Because a plugin either returns a command object, or it doesn't, it means that there's no potential weirdness where one plugin could feasibly peek a command and another processes it. The plugin that creates the command will peek and process it.

Also, for places in Bedrock that need to look up data about plugins for commands:
https://github.com/Expensify/Bedrock/blob/45079a66cc3d52623594af04f1971081e43f3387/BedrockServer.cpp#L1639-L1657

The command knows all the info about its plugin and bedrock doesn't need to look this up again.

But the *main* reason to do this is:

### When `peek` and `process` are instance methods on specific command types, state can persist from `peek` to `process`inside the command

We've sort of done this in a hacky, weird way now with this code:
https://github.com/Expensify/Bedrock/blob/45079a66cc3d52623594af04f1971081e43f3387/BedrockCommand.h#L111-L119

Which ends up being used like this:
https://github.com/Expensify/Server-Expensify/blob/master/auth/AuthCommand.cpp#L12-L20

And:
https://github.com/Expensify/Server-Expensify/blob/master/auth/AuthCommand.cpp#L41-L45

Which is confusing and not very maintainable.

Instead, we'll be able to do something like:

```
class AuthCommand : public BedrockCommand {
};

class BillFund : public AuthCommand {
    int accountID = 0;

    peek() {
        accountID = request.calc64("accountID");
    }

    process() {
        // Account ID persists from peek to process.
        NVP::set(accountID, "name", "value");
    }
};
```

This change doesn't do any of the above, it's a preparatory refactor for those changes. But even then we have *less* after this change than before, which is usually a move in the right direction.

This is intended to pass existing tests and have no functional changes yet.

## Tests

Existing automated tests pass.

Existing auth tests pass.