### PR TITLE
Add crash identifying values for cache plugin

### DIFF
--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -153,6 +153,7 @@ bool BedrockPlugin_Cache::peekCommand(SQLite& db, BedrockCommand& command) {
         //
         verifyAttributeSize(request, "name", 1, MAX_SIZE_SMALL);
         const string& name = request["name"];
+        command.crashIdentifyingValues.insert("name");
 
         // Get the list
         SQResult result;
@@ -209,6 +210,10 @@ bool BedrockPlugin_Cache::processCommand(SQLite& db, BedrockCommand& command) {
         //
         verifyAttributeSize(request, "name", 1, MAX_SIZE_SMALL);
         const string& valueHeader = request["value"];
+        const string& name = request["name"];
+        command.crashIdentifyingValues.insert("name");
+        command.crashIdentifyingValues.insert("value");
+
         if (!valueHeader.empty()) {
             // Value is provided via the header -- make sure it's not too long
             if (valueHeader.size() > MAX_SIZE_BLOB) {
@@ -252,7 +257,6 @@ bool BedrockPlugin_Cache::processCommand(SQLite& db, BedrockCommand& command) {
         }
 
         // Insert the new entry
-        const string& name = request["name"];
         const string& safeValue = SQ(valueHeader.empty() ? request.content : valueHeader);
         if (!db.write("INSERT OR REPLACE INTO cache ( name, value ) "
                       "VALUES( " +
@@ -270,4 +274,3 @@ bool BedrockPlugin_Cache::processCommand(SQLite& db, BedrockCommand& command) {
     // Didn't recognize this command
     return false;
 }
-


### PR DESCRIPTION
@tylerkaraszewski Please review.

We had a crash in the cache plugin which resulted in blacklisting all write caches. We should key off the unique info for each cache command.