### PR TITLE
Use polymorphic commands

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -24,10 +24,7 @@ BedrockCommand::BedrockCommand(SQLiteCommand&& baseCommand) :
     peekCount(0),
     processCount(0),
     repeek(false),
-    onlyProcessOnSyncThread(false),
     crashIdentifyingValues(*this),
-    peekData(nullptr),
-    deallocator(nullptr),
     _inProgressTiming(INVALID, 0, 0),
     _timeout(_getTimeout(request))
 {
@@ -80,9 +77,6 @@ BedrockCommand::~BedrockCommand() {
         request->manager.closeTransaction(request);
     }
     _commandCount--;
-    if (deallocator && peekData) {
-        deallocator(peekData);
-    }
 }
 
 void BedrockCommand::startTiming(TIMING_INFO type) {

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -29,7 +29,7 @@ class BedrockCommand : public SQLiteCommand {
     static const uint64_t DEFAULT_PROCESS_TIMEOUT = 30'000; // 30 seconds.
 
     // Constructor to initialize via a request object (by move).
-    BedrockCommand(SData&& _request);
+    BedrockCommand(SQLiteCommand&& baseCommand);
 
     // Destructor.
     virtual ~BedrockCommand();
@@ -140,13 +140,8 @@ class BedrockCommand : public SQLiteCommand {
     // Return the timestamp by which this command must finish executing.
     uint64_t timeout() const { return _timeout; }
 
-    // Return the number of commands in existence that weren't created with DONT_COUNT.
+    // Return the number of commands in existence.
     static size_t getCommandCount() { return _commandCount.load(); }
-
-    // This acts sort of like a copy constructor after the fact. I may want to improve this, but hopefully avoiding
-    // making command handler implementors add two constructors.
-    // Maybe I should give them a valid base-class command to derive from.
-    void cloneFromSQLiteCommand(SQLiteCommand&& from);
 
   private:
     // Set certain initial state on construction. Common functionality to several constructors.
@@ -167,7 +162,7 @@ class BedrockCommand : public SQLiteCommand {
 // Simple command handler for unrecognized commands.
 class UnhandledBedrockCommand : public BedrockCommand {
   public:
-    UnhandledBedrockCommand(SData&& _request);
+    UnhandledBedrockCommand(SQLiteCommand&& baseCommand);
     virtual bool peek(SQLite& db);
     virtual const string& getName();
   private:

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -94,9 +94,9 @@ class BedrockCommand : public SQLiteCommand {
     // A list of timing sets, with an info type, start, and end.
     list<tuple<TIMING_INFO, uint64_t, uint64_t>> timingInfo;
 
-    // This defaults to false, but a specific plugin can set it to 'true' in peek() to force this command to be passed
+    // This defaults to false, but a specific plugin can set it to 'true' to force this command to be passed
     // to the sync thread for processing, thus guaranteeing that process() will not result in a conflict.
-    bool onlyProcessOnSyncThread;
+    virtual bool onlyProcessOnSyncThread() { return false; }
 
     // This is a set of name/value pairs that must be present and matching for two commands to compare as "equivalent"
     // for the sake of determining whether they're likely to cause a crash.
@@ -126,16 +126,6 @@ class BedrockCommand : public SQLiteCommand {
         BedrockCommand& cmd;
     };
     CrashMap crashIdentifyingValues;
-
-    // To accommodate plugins that need to store extra data for a command besides the built-in data for a
-    // BedrockCommand, we provide a pointer that the command can use to refer to extra storage. However, because the
-    // lifespan of this storage should match that of the BedrockCommand, we also need to provide a deallocation
-    // function to free this memory when the command completes.
-    // A better solution for this would be to use polymorphism and allow plugins to derive command objects from the
-    // base class of BedrockCommand, but that's too significant of a change to the architecture for the current
-    // timeline, so that is left as a future enhancement.
-    void* peekData;
-    void (*deallocator) (void*);
 
     // Return the timestamp by which this command must finish executing.
     uint64_t timeout() const { return _timeout; }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -68,7 +68,7 @@ bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command) {
 bool BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command) {
     AutoTimer timer(command, BedrockCommand::PEEK);
     // Convenience references to commonly used properties.
-    SData& request = command->request;
+    const SData& request = command->request;
     SData& response = command->response;
     STable& content = command->jsonContent;
 
@@ -164,7 +164,7 @@ bool BedrockCore::processCommand(unique_ptr<BedrockCommand>& command) {
     AutoTimer timer(command, BedrockCommand::PROCESS);
 
     // Convenience references to commonly used properties.
-    SData& request = command->request;
+    const SData& request = command->request;
     SData& response = command->response;
     STable& content = command->jsonContent;
 

--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -41,28 +41,12 @@ void BedrockPlugin::verifyAttributeBool(const SData& request, const string& name
     }
 }
 
-bool BedrockPlugin::shouldEnableQueryRewriting(const SQLite& db, const BedrockCommand& command, bool (**rewriteHandler)(int, const char*, string&)) {
-    return false;
-}
-
 STable BedrockPlugin::getInfo() {
     return STable();
 }
 
 string BedrockPlugin::getName() {
     SERROR("No name defined by this plugin, aborting.");
-}
-
-bool BedrockPlugin::peekCommand(SQLite& db, BedrockCommand& command) {
-    return false;
-}
-
-bool BedrockPlugin::processCommand(SQLite& db, BedrockCommand& command) {
-    return false;
-}
-
-bool BedrockPlugin::shouldSuppressTimeoutWarnings() {
-    return false;
 }
 
 bool BedrockPlugin::preventAttach() {
@@ -72,7 +56,3 @@ bool BedrockPlugin::preventAttach() {
 void BedrockPlugin::timerFired(SStopwatch* timer) {}
 
 void BedrockPlugin::upgradeDatabase(SQLite& db) {}
-
-void BedrockPlugin::handleFailedReply(const BedrockCommand& command) {
-    // Default implementation does nothing.
-}

--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -45,7 +45,7 @@ STable BedrockPlugin::getInfo() {
     return STable();
 }
 
-string BedrockPlugin::getName() {
+const string& BedrockPlugin::getName() const {
     SERROR("No name defined by this plugin, aborting.");
 }
 

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -24,7 +24,7 @@ class BedrockPlugin {
     virtual STable getInfo();
 
     // Returns a short, descriptive name of this plugin
-    virtual string getName();
+    virtual const string& getName() const;
 
     // Return a command, or a null pointer if this plugin can't handle this request.
     virtual unique_ptr<BedrockCommand> getCommand(SQLiteCommand&& baseCommand) = 0;

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -7,7 +7,6 @@ class BedrockPlugin {
   public:
     // We use these sizes to make sure the storage engine does not silently truncate data. We throw an exception
     // instead.
-    static constexpr int64_t MAX_SIZE_NONCOLUMN = 1024 * 1024 * 1024;
     static constexpr int64_t MAX_SIZE_QUERY = 1024 * 1024;
     static constexpr int64_t MAX_SIZE_BLOB = 1024 * 1024;
     static constexpr int64_t MAX_SIZE_SMALL = 255;
@@ -27,20 +26,8 @@ class BedrockPlugin {
     // Returns a short, descriptive name of this plugin
     virtual string getName();
 
-    // Called to attempt to handle a command in a read-only fashion. Should return true if the command has been
-    // completely handled and a response has been written into `command.response`, which can be returned to the client.
-    // Should return `false` if the command needs to write to the database or otherwise could not be finished in a
-    // read-only fashion (i.e., it opened an HTTPS request and is waiting for the response).
-    virtual bool peekCommand(SQLite& db, BedrockCommand& command);
-
-    // Called after a command has returned `false` to peek, and will attempt to commit and distribute a transaction
-    // with any changes to the DB made by this plugin.
-    virtual bool processCommand(SQLite& db, BedrockCommand& command);
-
-    // Bedrock will call this before each or `processCommand` (note: not `peekCommand`) for each plugin to allow it to
-    // enable query rewriting. If a plugin would like to enable query rewriting, this should return true, and it should
-    // set the rewriteHandler it would like to use.
-    virtual bool shouldEnableQueryRewriting(const SQLite& db, const BedrockCommand& command, bool (**rewriteHandler)(int, const char*, string&));
+    // Return a command, or a null pointer if this plugin can't handle this request.
+    virtual unique_ptr<BedrockCommand> getCommand(SData&& request) = 0;
 
     // Called at some point during initiation to allow the plugin to verify/change the database schema.
     virtual void upgradeDatabase(SQLite& db);
@@ -70,14 +57,7 @@ class BedrockPlugin {
     // s        Optional socket from which this request was received
     virtual void onPortRequestComplete(const BedrockCommand& command, STCPManager::Socket* s) { }
 
-    // Set to true if we don't want to log timeout alerts, and let the caller deal with it.
-    virtual bool shouldSuppressTimeoutWarnings();
-
     virtual bool preventAttach();
-
-    // A plugin can optionally handle a command for which the reply to the caller was undeliverable.
-    // Note that it gets no reference to the DB, this happens after the transaction is already complete.
-    virtual void handleFailedReply(const BedrockCommand& command);
 
     // Map of plugin names to functions that will return a new plugin of the given type.
     static map<string, function<BedrockPlugin*(BedrockServer&)>> g_registeredPluginList;

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -27,7 +27,7 @@ class BedrockPlugin {
     virtual string getName();
 
     // Return a command, or a null pointer if this plugin can't handle this request.
-    virtual unique_ptr<BedrockCommand> getCommand(SData&& request) = 0;
+    virtual unique_ptr<BedrockCommand> getCommand(SQLiteCommand&& baseCommand) = 0;
 
     // Called at some point during initiation to allow the plugin to verify/change the database schema.
     virtual void upgradeDatabase(SQLite& db);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -949,7 +949,7 @@ void BedrockServer::worker(const SData& args,
                     // We check `onlyProcessOnSyncThread` here, rather than before processing the command, because it's
                     // not set at creation time, it's set in `peek`, so we need to wait at least until after peek is
                     // called to check it.
-                    if (command->onlyProcessOnSyncThread || !canWriteParallel) {
+                    if (command->onlyProcessOnSyncThread() || !canWriteParallel) {
                         // Roll back the transaction, it'll get re-run in the sync thread.
                         core.rollback();
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1661,14 +1661,9 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
         }
 
         // Is a plugin handling this command? If so, it gets to send the response.
-        try {
-            // If there's no plugin name, we'll jump right to the catch block. We throw explicitly if there's an empty
-            // value here.
-            const string& pluginName = command->request.nameValueMap.at("plugin");
-            if (pluginName.empty()) {
-                throw (out_of_range("plugin name empty."));
-            }
+        const string& pluginName = command->request["plugin"];
 
+        if (!pluginName.empty()) {
             // Let the plugin handle it
             SINFO("Plugin '" << pluginName << "' handling response '" << command->response.methodLine
                   << "' to request '" << command->request.methodLine << "'");
@@ -1678,7 +1673,7 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
             } else {
                 SERROR("Couldn't find plugin '" << pluginName << ".");
             }
-        } catch (const out_of_range& e) {
+        } else {
             // Otherwise we send the standard response.
             socketIt->second->send(command->response.serialize());
         }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1632,7 +1632,7 @@ unique_ptr<BedrockCommand> BedrockServer::getCommandFromPlugins(SQLiteCommand&& 
     for (auto pair : plugins) {
         auto command = pair.second->getCommand(move(baseCommand));
         if (command) {
-            SINFO("Plugin " << pair.first << " handling command " << command->request.methodLine);
+            SDEBUG("Plugin " << pair.first << " handling command " << command->request.methodLine);
             return command;
         }
     }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1634,7 +1634,7 @@ unique_ptr<BedrockCommand> BedrockServer::getCommandFromPlugins(SQLiteCommand&& 
             return command;
         }
     }
-    return make_unique<UnhandledBedrockCommand>(move(baseCommand));
+    return make_unique<BedrockCommand>(move(baseCommand), nullptr);
 }
 
 void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -352,6 +352,10 @@ class BedrockServer : public SQLiteServer {
     // This stars the server shutting down.
     void _beginShutdown(const string& reason, bool detach = false);
 
+    // See if there's a plugin that can turn this request into a command.
+    // If not, we'll create a command that returns `430 Unrecognized command`.
+    unique_ptr<BedrockCommand> getCommandFromPlugins(SData&& request);
+
     // This is a map of commit counts in the future to commands that depend on them. We can receive a command that
     // depends on a future commit if we're a follower that's behind leader, and a client makes two requests, one to a node
     // more current than ourselves, and a following request to us. We'll move these commands to this special map until

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -355,6 +355,7 @@ class BedrockServer : public SQLiteServer {
     // See if there's a plugin that can turn this request into a command.
     // If not, we'll create a command that returns `430 Unrecognized command`.
     unique_ptr<BedrockCommand> getCommandFromPlugins(SData&& request);
+    unique_ptr<BedrockCommand> getCommandFromPlugins(SQLiteCommand&& baseCommand);
 
     // This is a map of commit counts in the future to commands that depend on them. We can receive a command that
     // depends on a future commit if we're a follower that's behind leader, and a client makes two requests, one to a node

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -460,7 +460,7 @@ class BedrockServer : public SQLiteServer {
     // Generate a CRASH_COMMAND command for a given bad command.
     static SData _generateCrashMessage(const unique_ptr<BedrockCommand>& command);
 
-    static void _addRequestID(SData& request);
+    static void _addRequestID(const SData& request);
 
     // The number of seconds to wait between forcing a command to QUORUM.
     uint64_t _quorumCheckpointSeconds;

--- a/main.cpp
+++ b/main.cpp
@@ -84,7 +84,7 @@ set<string> loadPlugins(SData& args) {
     BedrockPlugin::g_registeredPluginList.emplace(make_pair("DB", [](BedrockServer& s){return new BedrockPlugin_DB(s);}));
     BedrockPlugin::g_registeredPluginList.emplace(make_pair("JOBS", [](BedrockServer& s){return new BedrockPlugin_Jobs(s);}));
     BedrockPlugin::g_registeredPluginList.emplace(make_pair("CACHE", [](BedrockServer& s){return new BedrockPlugin_Cache(s);}));
-    //BedrockPlugin::g_registeredPluginList.emplace(make_pair("MYSQL", [](BedrockServer& s){return new BedrockPlugin_MySQL(s);}));
+    BedrockPlugin::g_registeredPluginList.emplace(make_pair("MYSQL", [](BedrockServer& s){return new BedrockPlugin_MySQL(s);}));
 
     for (string pluginName : plugins) {
         // If it's one of our standard plugins, just move on to the next one.

--- a/main.cpp
+++ b/main.cpp
@@ -84,7 +84,7 @@ set<string> loadPlugins(SData& args) {
     BedrockPlugin::g_registeredPluginList.emplace(make_pair("DB", [](BedrockServer& s){return new BedrockPlugin_DB(s);}));
     BedrockPlugin::g_registeredPluginList.emplace(make_pair("JOBS", [](BedrockServer& s){return new BedrockPlugin_Jobs(s);}));
     BedrockPlugin::g_registeredPluginList.emplace(make_pair("CACHE", [](BedrockServer& s){return new BedrockPlugin_Cache(s);}));
-    BedrockPlugin::g_registeredPluginList.emplace(make_pair("MYSQL", [](BedrockServer& s){return new BedrockPlugin_MySQL(s);}));
+    //BedrockPlugin::g_registeredPluginList.emplace(make_pair("MYSQL", [](BedrockServer& s){return new BedrockPlugin_MySQL(s);}));
 
     for (string pluginName : plugins) {
         // If it's one of our standard plugins, just move on to the next one.

--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -6,8 +6,8 @@ const string& BedrockCacheCommand::getName() {
     return name;
 }
 
-BedrockCacheCommand::BedrockCacheCommand(BedrockPlugin_Cache& _plugin, SData&& _request) :
-  BedrockCommand(move(_request)),
+BedrockCacheCommand::BedrockCacheCommand(BedrockPlugin_Cache& _plugin, SQLiteCommand&& baseCommand) :
+  BedrockCommand(move(baseCommand)),
   plugin(_plugin)
 {
 }
@@ -17,9 +17,9 @@ const set<string, STableComp> BedrockPlugin_Cache::supportedRequestVerbs = {
     "WriteCache",
 };
 
-unique_ptr<BedrockCommand> BedrockPlugin_Cache::getCommand(SData&& request) {
-    if (supportedRequestVerbs.count(request.getVerb())) {
-        return make_unique<BedrockCacheCommand>(*this, move(request));
+unique_ptr<BedrockCommand> BedrockPlugin_Cache::getCommand(SQLiteCommand&& baseCommand) {
+    if (supportedRequestVerbs.count(baseCommand.request.getVerb())) {
+        return make_unique<BedrockCacheCommand>(*this, move(baseCommand));
     }
     return unique_ptr<BedrockCommand>(nullptr);
 }

--- a/plugins/Cache.h
+++ b/plugins/Cache.h
@@ -12,7 +12,7 @@ class BedrockPlugin_Cache : public BedrockPlugin {
     virtual string getName() { return "Cache"; }
     virtual void upgradeDatabase(SQLite& db);
 
-    virtual unique_ptr<BedrockCommand> getCommand(SData&& request);
+    virtual unique_ptr<BedrockCommand> getCommand(SQLiteCommand&& baseCommand);
 
     // Bedrock Cache LRU map
     class LRUMap {
@@ -55,7 +55,7 @@ class BedrockPlugin_Cache : public BedrockPlugin {
 
 class BedrockCacheCommand : public BedrockCommand {
   public:
-    BedrockCacheCommand(BedrockPlugin_Cache& _plugin, SData&& _request);
+    BedrockCacheCommand(BedrockPlugin_Cache& _plugin, SQLiteCommand&& baseCommand);
     virtual bool peek(SQLite& db);
     virtual void process(SQLite& db);
     virtual const string& getName();

--- a/plugins/Cache.h
+++ b/plugins/Cache.h
@@ -11,10 +11,9 @@ class BedrockPlugin_Cache : public BedrockPlugin {
     // Implement base class interface
     virtual string getName() { return "Cache"; }
     virtual void upgradeDatabase(SQLite& db);
-    virtual bool peekCommand(SQLite& db, BedrockCommand& command);
-    virtual bool processCommand(SQLite& db, BedrockCommand& command);
 
-  private:
+    virtual unique_ptr<BedrockCommand> getCommand(SData&& request);
+
     // Bedrock Cache LRU map
     class LRUMap {
       public:
@@ -46,7 +45,21 @@ class BedrockPlugin_Cache : public BedrockPlugin {
         map<string, Entry*> _lruMap;
     };
 
+    static int64_t initCacheSize(string cacheString);
+
     // Constants
     const int64_t _maxCacheSize;
     LRUMap _lruMap;
+    static const set<string, STableComp> supportedRequestVerbs;
+};
+
+class BedrockCacheCommand : public BedrockCommand {
+  public:
+    BedrockCacheCommand(BedrockPlugin_Cache& _plugin, SData&& _request);
+    virtual bool peek(SQLite& db);
+    virtual void process(SQLite& db);
+    virtual const string& getName();
+  private:
+    static const string name;
+    BedrockPlugin_Cache& plugin;
 };

--- a/plugins/Cache.h
+++ b/plugins/Cache.h
@@ -9,10 +9,10 @@ class BedrockPlugin_Cache : public BedrockPlugin {
     ~BedrockPlugin_Cache();
 
     // Implement base class interface
-    virtual string getName() { return "Cache"; }
+    virtual const string& getName() const;
     virtual void upgradeDatabase(SQLite& db);
-
     virtual unique_ptr<BedrockCommand> getCommand(SQLiteCommand&& baseCommand);
+    static const string name;
 
     // Bedrock Cache LRU map
     class LRUMap {
@@ -55,11 +55,10 @@ class BedrockPlugin_Cache : public BedrockPlugin {
 
 class BedrockCacheCommand : public BedrockCommand {
   public:
-    BedrockCacheCommand(BedrockPlugin_Cache& _plugin, SQLiteCommand&& baseCommand);
+    BedrockCacheCommand(SQLiteCommand&& baseCommand, BedrockPlugin_Cache* plugin);
     virtual bool peek(SQLite& db);
     virtual void process(SQLite& db);
-    virtual const string& getName();
+
   private:
-    static const string name;
-    BedrockPlugin_Cache& plugin;
+    BedrockPlugin_Cache& plugin() { return static_cast<BedrockPlugin_Cache&>(*_plugin); }
 };

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -13,14 +13,14 @@ BedrockPlugin_DB::BedrockPlugin_DB(BedrockServer& s) : BedrockPlugin(s)
 {
 }
 
-BedrockDBCommand::BedrockDBCommand(SData&& _request) :
-  BedrockCommand(move(_request))
+BedrockDBCommand::BedrockDBCommand(SQLiteCommand&& baseCommand) :
+  BedrockCommand(move(baseCommand))
 {
 }
 
-unique_ptr<BedrockCommand> BedrockPlugin_DB::getCommand(SData&& request) {
-    if (SStartsWith(request.methodLine, "query:") || SIEquals(request.getVerb(), "Query")) {
-        return make_unique<BedrockDBCommand>(move(request));
+unique_ptr<BedrockCommand> BedrockPlugin_DB::getCommand(SQLiteCommand&& baseCommand) {
+    if (SStartsWith(baseCommand.request.methodLine, "query:") || SIEquals(baseCommand.request.getVerb(), "Query")) {
+        return make_unique<BedrockDBCommand>(move(baseCommand));
     }
     return unique_ptr<BedrockCommand>(nullptr);
 }

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -4,8 +4,8 @@
 #undef SLOGPREFIX
 #define SLOGPREFIX "{" << getName() << "} "
 
-const string BedrockDBCommand::name = "DB";
-const string& BedrockDBCommand::getName() {
+const string BedrockPlugin_DB::name("DB");
+const string& BedrockPlugin_DB::getName() const {
     return name;
 }
 
@@ -13,16 +13,16 @@ BedrockPlugin_DB::BedrockPlugin_DB(BedrockServer& s) : BedrockPlugin(s)
 {
 }
 
-BedrockDBCommand::BedrockDBCommand(SQLiteCommand&& baseCommand) :
-  BedrockCommand(move(baseCommand))
+BedrockDBCommand::BedrockDBCommand(SQLiteCommand&& baseCommand, BedrockPlugin_DB* plugin) :
+  BedrockCommand(move(baseCommand), plugin)
 {
 }
 
 unique_ptr<BedrockCommand> BedrockPlugin_DB::getCommand(SQLiteCommand&& baseCommand) {
     if (SStartsWith(baseCommand.request.methodLine, "query:") || SIEquals(baseCommand.request.getVerb(), "Query")) {
-        return make_unique<BedrockDBCommand>(move(baseCommand));
+        return make_unique<BedrockDBCommand>(move(baseCommand), this);
     }
-    return unique_ptr<BedrockCommand>(nullptr);
+    return nullptr;
 }
 
 bool BedrockDBCommand::peek(SQLite& db) {

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -41,8 +41,8 @@ bool BedrockDBCommand::peek(SQLite& db) {
     if (SStartsWith(SToLower(request.methodLine), "query:")) {
         //  Just take everything after that and put into the query param
         SINFO("Rewriting command: " << request.methodLine);
-        request["query"] = request.methodLine.substr(strlen("query:"));
-        request.methodLine = "Query";
+        const_cast<SData&>(request)["query"] = request.methodLine.substr(strlen("query:"));
+        const_cast<SData&>(request).methodLine = "Query";
     }
 
     // ----------------------------------------------------------------------

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -26,7 +26,6 @@ unique_ptr<BedrockCommand> BedrockPlugin_DB::getCommand(SQLiteCommand&& baseComm
 }
 
 bool BedrockDBCommand::peek(SQLite& db) {
-    // ----------------------------------------------------------------------
     // The "full" syntax of a query request is:
     //
     //      Query
@@ -45,7 +44,6 @@ bool BedrockDBCommand::peek(SQLite& db) {
         const_cast<SData&>(request).methodLine = "Query";
     }
 
-    // ----------------------------------------------------------------------
     if (SIEquals(request.getVerb(), "Query")) {
         // - Query( query )
         //

--- a/plugins/DB.h
+++ b/plugins/DB.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <libstuff/libstuff.h>
 #include "../BedrockPlugin.h"
 

--- a/plugins/DB.h
+++ b/plugins/DB.h
@@ -5,7 +5,7 @@
 
 class BedrockDBCommand : public BedrockCommand {
   public:
-    BedrockDBCommand(SData&& _request);
+    BedrockDBCommand(SQLiteCommand&& baseCommand);
     virtual bool peek(SQLite& db);
     virtual void process(SQLite& db);
     virtual const string& getName();
@@ -17,5 +17,5 @@ class BedrockPlugin_DB : public BedrockPlugin {
   public:
     BedrockPlugin_DB(BedrockServer& s);
     virtual string getName() { return "DB"; }
-    virtual unique_ptr<BedrockCommand> getCommand(SData&& request);
+    virtual unique_ptr<BedrockCommand> getCommand(SQLiteCommand&& baseCommand);
 };

--- a/plugins/DB.h
+++ b/plugins/DB.h
@@ -2,10 +2,20 @@
 #include "../BedrockPlugin.h"
 
 // Declare the class we're going to implement below
+
+class BedrockDBCommand : public BedrockCommand {
+  public:
+    BedrockDBCommand(SData&& _request);
+    virtual bool peek(SQLite& db);
+    virtual void process(SQLite& db);
+    virtual const string& getName();
+  private:
+    static const string name;
+};
+
 class BedrockPlugin_DB : public BedrockPlugin {
   public:
     BedrockPlugin_DB(BedrockServer& s);
     virtual string getName() { return "DB"; }
-    virtual bool peekCommand(SQLite& db, BedrockCommand& command);
-    virtual bool processCommand(SQLite& db, BedrockCommand& command);
+    virtual unique_ptr<BedrockCommand> getCommand(SData&& request);
 };

--- a/plugins/DB.h
+++ b/plugins/DB.h
@@ -1,21 +1,17 @@
 #include <libstuff/libstuff.h>
 #include "../BedrockPlugin.h"
 
-// Declare the class we're going to implement below
-
-class BedrockDBCommand : public BedrockCommand {
-  public:
-    BedrockDBCommand(SQLiteCommand&& baseCommand);
-    virtual bool peek(SQLite& db);
-    virtual void process(SQLite& db);
-    virtual const string& getName();
-  private:
-    static const string name;
-};
-
 class BedrockPlugin_DB : public BedrockPlugin {
   public:
     BedrockPlugin_DB(BedrockServer& s);
-    virtual string getName() { return "DB"; }
+    virtual const string& getName() const;
     virtual unique_ptr<BedrockCommand> getCommand(SQLiteCommand&& baseCommand);
+    static const string name;
+};
+
+class BedrockDBCommand : public BedrockCommand {
+  public:
+    BedrockDBCommand(SQLiteCommand&& baseCommand, BedrockPlugin_DB* plugin);
+    virtual bool peek(SQLite& db);
+    virtual void process(SQLite& db);
 };

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -144,7 +144,7 @@ bool BedrockJobsCommand::peek(SQLite& db) {
         //     - 303 - Timeout
         //     - 404 - No jobs found
         //
-        BedrockPlugin_Jobs::verifyAttributeSize(request, "name", 1, BedrockPlugin_Jobs::MAX_SIZE_NAME);
+        BedrockPlugin::verifyAttributeSize(request, "name", 1, BedrockPlugin_Jobs::MAX_SIZE_NAME);
         if (SIEquals(requestVerb, "GetJobs") != request.isSet("numResults")) {
             if (SIEquals(requestVerb, "GetJobs")) {
                 STHROW("402 Missing numResults");
@@ -182,7 +182,7 @@ bool BedrockJobsCommand::peek(SQLite& db) {
         //         . data - JSON data associated with this job
         //     - 404 - No jobs found
         //
-        BedrockPlugin_Jobs::verifyAttributeInt64(request, "jobID", 1);
+        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
 
         // Verify there is a job like this
         SQResult result;
@@ -212,7 +212,7 @@ bool BedrockJobsCommand::peek(SQLite& db) {
     else if (SIEquals(requestVerb, "CreateJob") || SIEquals(requestVerb, "CreateJobs")) {
         list<STable> jsonJobs;
         if (SIEquals(requestVerb, "CreateJob")) {
-            BedrockPlugin_Jobs::verifyAttributeSize(request, "name", 1, BedrockPlugin_Jobs::MAX_SIZE_SMALL);
+            BedrockPlugin::verifyAttributeSize(request, "name", 1, BedrockPlugin_Jobs::MAX_SIZE_SMALL);
             jsonJobs.push_back(request.nameValueMap);
         } else {
             list<string> multipleJobs;
@@ -332,7 +332,7 @@ bool BedrockJobsCommand::peek(SQLite& db) {
         //     - 200 - OK
         //     - 402 - Cannot cancel jobs that are running
         //
-        BedrockPlugin_Jobs::verifyAttributeInt64(request, "jobID", 1);
+        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
         int64_t jobID = request.calc64("jobID");
 
         SQResult result;
@@ -838,8 +838,8 @@ void BedrockJobsCommand::process(SQLite& db) {
         //     - repeat - A description of how to repeat (optional)
         //     - jobPriority - The priority of the job (optional)
         //
-        BedrockPlugin_Jobs::verifyAttributeInt64(request, "jobID", 1);
-        BedrockPlugin_Jobs::verifyAttributeSize(request, "data", 1, BedrockPlugin_Jobs::MAX_SIZE_BLOB);
+        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
+        BedrockPlugin::verifyAttributeSize(request, "data", 1, BedrockPlugin_Jobs::MAX_SIZE_BLOB);
 
         // If a repeat is provided, validate it
         if (request.isSet("repeat")) {
@@ -923,7 +923,7 @@ void BedrockJobsCommand::process(SQLite& db) {
         //     - jobID  - ID of the job to finish
         //     - data   - Data to associate with this finsihed job
         //
-        BedrockPlugin_Jobs::verifyAttributeInt64(request, "jobID", 1);
+        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
         int64_t jobID = request.calc64("jobID");
 
         // Verify there is a job like this and it's running
@@ -1145,7 +1145,7 @@ void BedrockJobsCommand::process(SQLite& db) {
         //     - jobID - ID of the job to fail
         //     - data  - Data to associate with this failed job
         //
-        BedrockPlugin_Jobs::verifyAttributeInt64(request, "jobID", 1);
+        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
 
         // Verify there is a job like this and it's running
         SQResult result;
@@ -1195,7 +1195,7 @@ void BedrockJobsCommand::process(SQLite& db) {
         //     Parameters:
         //     - jobID - ID of the job to delete
         //
-        BedrockPlugin_Jobs::verifyAttributeInt64(request, "jobID", 1);
+        BedrockPlugin::verifyAttributeInt64(request, "jobID", 1);
 
         // Verify there is a job like this and it's not running
         SQResult result;

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -4,8 +4,7 @@
 #undef SLOGPREFIX
 #define SLOGPREFIX "{" << getName() << "} "
 
-#define JOBS_DEFAULT_PRIORITY 500
-
+const int64_t BedrockPlugin_Jobs::JOBS_DEFAULT_PRIORITY = 500;
 const string BedrockPlugin_Jobs::name("Jobs");
 const string& BedrockPlugin_Jobs::getName() const {
     return name;
@@ -239,7 +238,7 @@ bool BedrockJobsCommand::peek(SQLite& db) {
 
         for (auto& job : jsonJobs) {
             // If no priority set, set it
-            int64_t priority = SContains(job, "jobPriority") ? SToInt(job["jobPriority"]) : JOBS_DEFAULT_PRIORITY;
+            int64_t priority = SContains(job, "jobPriority") ? SToInt(job["jobPriority"]) : BedrockPlugin_Jobs::JOBS_DEFAULT_PRIORITY;
 
             // We'd initially intended for any value to be allowable here, but for
             // performance reasons, we currently will only allow specific values to
@@ -534,7 +533,7 @@ void BedrockJobsCommand::process(SQLite& db) {
             }
 
             // If no priority set, set it
-            int64_t priority = SContains(job, "jobPriority") ? SToInt(job["jobPriority"]) : (SContains(job, "priority") ? SToInt(job["priority"]) : JOBS_DEFAULT_PRIORITY);
+            int64_t priority = SContains(job, "jobPriority") ? SToInt(job["jobPriority"]) : (SContains(job, "priority") ? SToInt(job["priority"]) : BedrockPlugin_Jobs::JOBS_DEFAULT_PRIORITY);
 
             // Validate the priority passed in
             _validatePriority(priority);

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -112,7 +112,7 @@ bool BedrockJobsCommand::peek(SQLite& db) {
 
     // If this command is a Jobs command, we disable the crash prevention by using a random number as part of the crash
     // command criteria. This is because otherwise we would blanket blacklist every command with the same name.
-    request["crashID"] = to_string(SRandom::rand64());
+    const_cast<SData&>(request)["crashID"] = to_string(SRandom::rand64());
     crashIdentifyingValues.insert("crashID");
 
     // Reset the content object. It could have been written by a previous call to this function that conflicted in
@@ -285,10 +285,10 @@ bool BedrockJobsCommand::peek(SQLite& db) {
                 bool childIsMocked = request.isSet("mockRequest");
 
                 if (parentIsMocked && !childIsMocked) {
-                    request["mockRequest"] = "true";
+                    const_cast<SData&>(request)["mockRequest"] = "true";
                     SINFO("Setting child job to mocked to match parent.");
                 } else if (!parentIsMocked && childIsMocked) {
-                    request.erase("mockRequest");
+                    const_cast<SData&>(request).erase("mockRequest");
                     SINFO("Setting child job to non-mocked to match parent.");
                 }
             }
@@ -847,7 +847,7 @@ void BedrockJobsCommand::process(SQLite& db) {
             if (request["repeat"].empty()) {
                 SWARN("Repeat is set in UpdateJob, but is set to the empty string. jobID: "
                       << request["jobID"] << ", removing attribute.");
-                request.erase("repeat");
+                const_cast<SData&>(request).erase("repeat");
             } else if (!_validateRepeat(request["repeat"])) {
                 STHROW("402 Malformed repeat");
             }

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -19,6 +19,7 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
   private:
     static int64_t getNextID(SQLite& db);
     static const string name;
+    static const int64_t JOBS_DEFAULT_PRIORITY;
 };
 
 class BedrockJobsCommand : public BedrockCommand {

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -1,32 +1,13 @@
 #include <libstuff/libstuff.h>
 #include "../BedrockPlugin.h"
 
-// Declare the class we're going to implement below
 class BedrockPlugin_Jobs : public BedrockPlugin {
-
-    class Command : public BedrockCommand {
-      public:
-        Command(BedrockPlugin_Jobs& _plugin, SQLiteCommand&& baseCommand);
-        virtual bool peek(SQLite& db);
-        virtual void process(SQLite& db);
-        virtual void handleFailedReply();
-        virtual const string& getName() { return pluginName; }
-
-      private:
-        // Helper functions
-        bool _isValidSQLiteDateModifier(const string& modifier);
-        string _constructNextRunDATETIME(const string& lastScheduled, const string& lastRun, const string& repeat);
-        bool _validateRepeat(const string& repeat) { return !_constructNextRunDATETIME("", "", repeat).empty(); }
-        bool _hasPendingChildJobs(SQLite& db, int64_t jobID);
-        void _validatePriority(const int64_t priority);
-        BedrockPlugin_Jobs& plugin;
-    };
-
+  friend class BedrockJobsCommand;
   public:
     BedrockPlugin_Jobs(BedrockServer& s);
-
-    // Return a new command.
     virtual unique_ptr<BedrockCommand> getCommand(SQLiteCommand&& baseCommand);
+    virtual const string& getName() const;
+    virtual void upgradeDatabase(SQLite& db);
 
     // We were using MAX_SIZE_SMALL in GetJob to check the job name, but now GetJobs accepts more than one job name,
     // because of that, we need to increase the size of the param to be able to accept around 50 job names.
@@ -35,11 +16,23 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     // Set of supported verbs for jobs with case-insensitive matching.
     static const set<string,STableComp>supportedRequestVerbs;
 
-    // Implement base class interface
-    virtual string getName() { return pluginName; }
-    virtual void upgradeDatabase(SQLite& db);
-
   private:
     static int64_t getNextID(SQLite& db);
-    static const string pluginName;
+    static const string name;
+};
+
+class BedrockJobsCommand : public BedrockCommand {
+  public:
+    BedrockJobsCommand(SQLiteCommand&& baseCommand, BedrockPlugin_Jobs* plugin);
+    virtual bool peek(SQLite& db);
+    virtual void process(SQLite& db);
+    virtual void handleFailedReply();
+
+  private:
+    // Helper functions
+    bool _isValidSQLiteDateModifier(const string& modifier);
+    string _constructNextRunDATETIME(const string& lastScheduled, const string& lastRun, const string& repeat);
+    bool _validateRepeat(const string& repeat) { return !_constructNextRunDATETIME("", "", repeat).empty(); }
+    bool _hasPendingChildJobs(SQLite& db, int64_t jobID);
+    void _validatePriority(const int64_t priority);
 };

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -4,13 +4,13 @@
 // Declare the class we're going to implement below
 class BedrockPlugin_Jobs : public BedrockPlugin {
 
-    class BedrockJobsCommand : public BedrockCommand {
+    class Command : public BedrockCommand {
       public:
-        BedrockJobsCommand(BedrockPlugin_Jobs& _plugin, SData&& _request);
+        Command(BedrockPlugin_Jobs& _plugin, SQLiteCommand&& baseCommand);
         virtual bool peek(SQLite& db);
         virtual void process(SQLite& db);
         virtual void handleFailedReply();
-        virtual const string& getName() { return BedrockPlugin_Jobs::pluginName; }
+        virtual const string& getName() { return pluginName; }
 
       private:
         // Helper functions
@@ -25,7 +25,7 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     BedrockPlugin_Jobs(BedrockServer& s);
 
     // Return a new command.
-    virtual unique_ptr<BedrockCommand> getCommand(SData&& request);
+    virtual unique_ptr<BedrockCommand> getCommand(SQLiteCommand&& baseCommand);
 
     // We were using MAX_SIZE_SMALL in GetJob to check the job name, but now GetJobs accepts more than one job name,
     // because of that, we need to increase the size of the param to be able to accept around 50 job names.
@@ -35,7 +35,7 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     static const set<string,STableComp>supportedRequestVerbs;
 
     // Implement base class interface
-    virtual string getName() { return "Jobs"; }
+    virtual string getName() { return pluginName; }
     virtual void upgradeDatabase(SQLite& db);
 
   private:

--- a/plugins/MySQL.cpp
+++ b/plugins/MySQL.cpp
@@ -4,6 +4,11 @@
 #undef SLOGPREFIX
 #define SLOGPREFIX "{" << getName() << "} "
 
+const string BedrockPlugin_MySQL::name("MySQL");
+const string& BedrockPlugin_MySQL::getName() const {
+    return name;
+}
+
 MySQLPacket::MySQLPacket() {
     // Initialize
     sequenceID = 0;
@@ -222,7 +227,7 @@ string MySQLPacket::serializeERR(int sequenceID, uint16_t code, const string& me
     return err.serialize();
 }
 
-BedrockPlugin_MySQL::BedrockPlugin_MySQL(BedrockServer& s) : BedrockPlugin(s)
+BedrockPlugin_MySQL::BedrockPlugin_MySQL(BedrockServer& s) : BedrockPlugin_DB(s)
 {
 }
 
@@ -316,10 +321,10 @@ void BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
                 s->send(MySQLPacket::serializeOK(packet.sequenceID));
             } else {
                 // Transform this into an internal request
-                request.methodLine = "Query";
-                request["format"] = "json";
-                request["sequenceID"] = SToStr(packet.sequenceID);
-                request["query"] = query;
+                const_cast<SData&>(request).methodLine = "Query";
+                const_cast<SData&>(request)["format"] = "json";
+                const_cast<SData&>(request)["sequenceID"] = SToStr(packet.sequenceID);
+                const_cast<SData&>(request)["query"] = query;
             }
             break;
         }

--- a/plugins/MySQL.h
+++ b/plugins/MySQL.h
@@ -1,5 +1,6 @@
+#pragma once
 #include <libstuff/libstuff.h>
-#include "../BedrockPlugin.h"
+#include "DB.h"
 
 #define MYSQL_NUM_VARIABLES 292
 extern const char* g_MySQLVariables[MYSQL_NUM_VARIABLES][2];
@@ -90,11 +91,10 @@ struct MySQLPacket {
 /**
  * Declare the class we're going to implement below
  */
-class BedrockPlugin_MySQL : public BedrockPlugin {
+class BedrockPlugin_MySQL : public BedrockPlugin_DB {
   public:
     BedrockPlugin_MySQL(BedrockServer& s);
-    // Indicate which functions we are implementing
-    virtual string getName() { return "MySQL"; }
+    virtual const string& getName() const;
     virtual void initialize(const SData& args, BedrockServer& server) { _args = args; }
     virtual string getPort() {
         return _args.isSet("-mysql.host") ? _args["-mysql.host"] : "localhost:3306";
@@ -106,4 +106,5 @@ class BedrockPlugin_MySQL : public BedrockPlugin {
   private:
     // Attributes
     SData _args;
+    static const string name;
 };

--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -30,7 +30,7 @@ SQLiteCommand::SQLiteCommand(SData&& _request) :
 
     // If the request doesn't specify an execution time, default to right now.
     if (!request.isSet("commandExecuteTime")) {
-        request["commandExecuteTime"] = to_string(STimeNow());
+        const_cast<SData&>(request)["commandExecuteTime"] = to_string(STimeNow());
     }
 }
 

--- a/sqlitecluster/SQLiteCommand.h
+++ b/sqlitecluster/SQLiteCommand.h
@@ -27,8 +27,8 @@ class SQLiteCommand {
     // Used inside SQLiteNode
     SData transaction;
 
-    // Original request
-    SData request;
+    // Original request, immutable.
+    const SData request;
 
     // Accumulated response content
     STable jsonContent;

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -17,7 +17,7 @@ BedrockPlugin_TestPlugin::~BedrockPlugin_TestPlugin()
     delete httpsManager;
 }
 
-unique_ptr<BedrockCommand> BedrockPlugin_TestPlugin::getCommand(SData&& request) {
+unique_ptr<BedrockCommand> BedrockPlugin_TestPlugin::getCommand(SQLiteCommand&& baseCommand) {
     static set<string> supportedCommands = {
         "testcommand",
         "broadcastwithtimeouts",
@@ -38,8 +38,8 @@ unique_ptr<BedrockCommand> BedrockPlugin_TestPlugin::getCommand(SData&& request)
         "slowprocessquery",
     };
     for (auto& cmdName : supportedCommands) {
-        if (SStartsWith(request.methodLine, cmdName)) {
-            return make_unique<TestPluginCommand>(*this, move(request));
+        if (SStartsWith(baseCommand.request.methodLine, cmdName)) {
+            return make_unique<TestPluginCommand>(*this, move(baseCommand));
         }
     }
     return unique_ptr<BedrockCommand>(nullptr);
@@ -51,8 +51,8 @@ const string& TestPluginCommand::getName() {
     return name;
 }
 
-TestPluginCommand::TestPluginCommand(BedrockPlugin_TestPlugin& _plugin, SData&& _request) :
-  BedrockCommand(move(_request)),
+TestPluginCommand::TestPluginCommand(BedrockPlugin_TestPlugin& _plugin, SQLiteCommand&& baseCommand) :
+  BedrockCommand(move(baseCommand)),
   plugin(_plugin)
 {
 }

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -17,83 +17,123 @@ BedrockPlugin_TestPlugin::~BedrockPlugin_TestPlugin()
     delete httpsManager;
 }
 
+unique_ptr<BedrockCommand> BedrockPlugin_TestPlugin::getCommand(SData&& request) {
+    static set<string> supportedCommands = {
+        "testcommand",
+        "broadcastwithtimeouts",
+        "storeboradcasttimeouts",
+        "getbroadcasttimeouts",
+        "sendrequest",
+        "slowquery",
+        "httpstimeout",
+        "exceptioninpeek",
+        "generatesegfaultpeek",
+        "generateassertpeek",
+        "preventattach",
+        "chainedrequest",
+        "ineffectiveUpdate",
+        "exceptioninprocess",
+        "generatesegfaultprocess",
+        "idcollision",
+        "slowprocessquery",
+    };
+    for (auto& cmdName : supportedCommands) {
+        if (SStartsWith(request.methodLine, cmdName)) {
+            return make_unique<TestPluginCommand>(*this, move(request));
+        }
+    }
+    return unique_ptr<BedrockCommand>(nullptr);
+}
+
+const string TestPluginCommand::name("TestPlugin");
+
+const string& TestPluginCommand::getName() {
+    return name;
+}
+
+TestPluginCommand::TestPluginCommand(BedrockPlugin_TestPlugin& _plugin, SData&& _request) :
+  BedrockCommand(move(_request)),
+  plugin(_plugin)
+{
+}
+
 bool BedrockPlugin_TestPlugin::preventAttach() {
     return shouldPreventAttach;
 }
 
-bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) {
+bool TestPluginCommand::peek(SQLite& db) {
     // Always blacklist on userID.
-    command.crashIdentifyingValues.insert("userID");
+    crashIdentifyingValues.insert("userID");
 
     // Now that we've blacklisted, mutate the command and see if things break!
-    if (command.request.isSet("userID")) {
-        command.request["userID"] = to_string(stoll(command.request["userID"]) + 1000);
+    if (request.isSet("userID")) {
+        request["userID"] = to_string(stoll(request["userID"]) + 1000);
     }
 
     // Sleep if requested.
-    if (command.request.calc("PeekSleep")) {
-        usleep(command.request.calc("PeekSleep") * 1000);
+    if (request.calc("PeekSleep")) {
+        usleep(request.calc("PeekSleep") * 1000);
     }
 
-    if (SStartsWith(command.request.methodLine,"testcommand")) {
-        if (!command.request["response"].empty()) {
-            command.response.methodLine = command.request["response"];
+    if (SStartsWith(request.methodLine,"testcommand")) {
+        if (!request["response"].empty()) {
+            response.methodLine = request["response"];
         } else {
-            command.response.methodLine = "200 OK";
+            response.methodLine = "200 OK";
         }
-        command.response.content = "this is a test response";
+        response.content = "this is a test response";
         return true;
-    } else if (SStartsWith(command.request.methodLine, "broadcastwithtimeouts")) {
+    } else if (SStartsWith(request.methodLine, "broadcastwithtimeouts")) {
         // First, send a `broadcastwithtimeouts` which will generate a new command and broadcast that to peers.
         SData subCommand("storeboradcasttimeouts");
         subCommand["processTimeout"] = to_string(5001);
         subCommand["timeout"] = to_string(5002);
         subCommand["not_special"] = "whatever";
-        server.broadcastCommand(subCommand);
+        plugin.server.broadcastCommand(subCommand);
         return true;
-    } else if (SStartsWith(command.request.methodLine, "storeboradcasttimeouts")) {
+    } else if (SStartsWith(request.methodLine, "storeboradcasttimeouts")) {
         // This is the command that will be broadcast to peers, it will store some data.
-        lock_guard<mutex> lock(dataLock);
-        arbitraryData["timeout"] = command.request["timeout"];
-        arbitraryData["processTimeout"] = command.request["processTimeout"];
-        arbitraryData["commandExecuteTime"] = command.request["commandExecuteTime"];
-        arbitraryData["not_special"] = command.request["not_special"];
+        lock_guard<mutex> lock(plugin.dataLock);
+        plugin.arbitraryData["timeout"] = request["timeout"];
+        plugin.arbitraryData["processTimeout"] = request["processTimeout"];
+        plugin.arbitraryData["commandExecuteTime"] = request["commandExecuteTime"];
+        plugin.arbitraryData["not_special"] = request["not_special"];
         return true;
-    } else if (SStartsWith(command.request.methodLine, "getbroadcasttimeouts")) {
+    } else if (SStartsWith(request.methodLine, "getbroadcasttimeouts")) {
         // Finally, the caller can send this command to the peers to make sure they received the correct timeout data.
-        lock_guard<mutex> lock(dataLock);
-        command.response["stored_timeout"] = arbitraryData["timeout"];
-        command.response["stored_processTimeout"] = arbitraryData["processTimeout"];
-        command.response["stored_commandExecuteTime"] = arbitraryData["commandExecuteTime"];
-        command.response["stored_not_special"] = arbitraryData["not_special"];
+        lock_guard<mutex> lock(plugin.dataLock);
+        response["stored_timeout"] = plugin.arbitraryData["timeout"];
+        response["stored_processTimeout"] = plugin.arbitraryData["processTimeout"];
+        response["stored_commandExecuteTime"] = plugin.arbitraryData["commandExecuteTime"];
+        response["stored_not_special"] = plugin.arbitraryData["not_special"];
         return true;
-    } else if (SStartsWith(command.request.methodLine, "sendrequest")) {
-        if (server.getState() != SQLiteNode::LEADING && server.getState() != SQLiteNode::STANDINGDOWN) {
+    } else if (SStartsWith(request.methodLine, "sendrequest")) {
+        if (plugin.server.getState() != SQLiteNode::LEADING && plugin.server.getState() != SQLiteNode::STANDINGDOWN) {
             // Only start HTTPS requests on leader, otherwise, we'll escalate.
             return false;
         }
         int requestCount = 1;
-        if (command.request.isSet("httpsRequestCount")) {
-            requestCount = max(command.request.calc("httpsRequestCount"), 1);
+        if (request.isSet("httpsRequestCount")) {
+            requestCount = max(request.calc("httpsRequestCount"), 1);
         }
         for (int i = 0; i < requestCount; i++) {
-            SData request("GET / HTTP/1.1");
-            string host = command.request["Host"];
+            SData newRequest("GET / HTTP/1.1");
+            string host = request["Host"];
             if (host.empty()) {
                 host = "www.google.com";
             }
-            request["Host"] = host;
-            command.httpsRequests.push_back(httpsManager->send("https://" + host + "/", request));
+            newRequest["Host"] = host;
+            httpsRequests.push_back(plugin.httpsManager->send("https://" + host + "/", newRequest));
         }
         return false; // Not complete.
-    } else if (SStartsWith(command.request.methodLine, "slowquery")) {
+    } else if (SStartsWith(request.methodLine, "slowquery")) {
         int size = 100000000;
         int count = 1;
-        if (command.request.isSet("size")) {
-            size = SToInt(command.request["size"]);
+        if (request.isSet("size")) {
+            size = SToInt(request["size"]);
         }
-        if (command.request.isSet("count")) {
-            count = SToInt(command.request["count"]);
+        if (request.isSet("count")) {
+            count = SToInt(request["count"]);
         }
         for (int i = 0; i < count; i++) {
             string query = "WITH RECURSIVE cnt(x) AS ( SELECT random() UNION ALL SELECT x+1 FROM cnt LIMIT " + SQ(size) + ") SELECT MAX(x) FROM cnt;";
@@ -101,73 +141,75 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
             db.read(query, result);
         }
         return true;
-    } else if (SStartsWith(command.request.methodLine, "httpstimeout")) {
+    } else if (SStartsWith(request.methodLine, "httpstimeout")) {
         // This command doesn't actually make the connection for 35 seconds, allowing us to use it to test what happens
         // when there's a blocking command and leader needs to stand down, to verify the timeout for that works.
         // It *does* eventually connect and return, so that we can also verify that the leftover command gets cleaned
         // up correctly on the former leader.
-        SData request("GET / HTTP/1.1");
-        request["Host"] = "www.google.com";
-        auto transaction = httpsManager->httpsDontSend("https://www.google.com/", request);
-        command.httpsRequests.push_back(transaction);
-        if (command.request["neversend"].empty()) {
-            thread([transaction, request](){
+        SData newRequest("GET / HTTP/1.1");
+        newRequest["Host"] = "www.google.com";
+        auto transaction = plugin.httpsManager->httpsDontSend("https://www.google.com/", newRequest);
+        httpsRequests.push_back(transaction);
+        if (request["neversend"].empty()) {
+            thread([transaction, newRequest](){
                 SINFO("Sleeping 35 seconds for httpstimeout");
                 sleep(35);
                 SINFO("Done Sleeping 35 seconds for httpstimeout");
-                transaction->s->send(request.serialize());
+                transaction->s->send(newRequest.serialize());
             }).detach();
         }
-    } else if (SStartsWith(command.request.methodLine, "exceptioninpeek")) {
+    } else if (SStartsWith(request.methodLine, "exceptioninpeek")) {
         throw 1;
-    } else if (SStartsWith(command.request.methodLine, "generatesegfaultpeek")) {
+    } else if (SStartsWith(request.methodLine, "generatesegfaultpeek")) {
         int* i = 0;
         int x = *i;
-        command.response["invalid"] = to_string(x);
-    } else if (SStartsWith(command.request.methodLine, "generateassertpeek")) {
+        response["invalid"] = to_string(x);
+    } else if (SStartsWith(request.methodLine, "generateassertpeek")) {
         SASSERT(0);
-        command.response["invalid"] = "nope";
-    } else if (SStartsWith(command.request.methodLine, "preventattach")) {
+        response["invalid"] = "nope";
+    } else if (SStartsWith(request.methodLine, "preventattach")) {
         // We do all of this work in a thread because plugins don't poll in detached
         // mode, so the tester will send this command to the plugin, then detach BedrockServer,
         // then the tester will try to attach, sleep, then try again.
-        thread([this](){
+        // The command will be gone by the time the sleep finishes, so pass a pointer to the plugin.
+        BedrockPlugin_TestPlugin* pluginPtr = &plugin;
+        thread([pluginPtr](){
             // Have this plugin block attaching
-            shouldPreventAttach = true;
+            pluginPtr->shouldPreventAttach = true;
 
             // Wait for the tester to try to attach
             sleep(5);
 
             // Reset so the tester can attach this time.
-            shouldPreventAttach = false;
+            pluginPtr->shouldPreventAttach = false;
         }).detach();
         return true;
-    } else if (SStartsWith(command.request.methodLine, "chainedrequest")) {
+    } else if (SStartsWith(request.methodLine, "chainedrequest")) {
         // Let's see what the user wanted to request.
-        if (command.request.test("pendingResult")) {
-            if (command.httpsRequests.empty()) {
+        if (request.test("pendingResult")) {
+            if (httpsRequests.empty()) {
                 STHROW("Pending Result flag set but no requests!");
             }
             // There was a previous request, let's record it's result.
-            command.response.content += command.httpsRequests.back()->fullRequest["Host"] + ":" + to_string(command.httpsRequests.back()->response) + "\n";
+            response.content += httpsRequests.back()->fullRequest["Host"] + ":" + to_string(httpsRequests.back()->response) + "\n";
         }
-        list<string> remainingURLs = SParseList(command.request["urls"]);
+        list<string> remainingURLs = SParseList(request["urls"]);
         if (remainingURLs.size()) {
-            SData request("GET / HTTP/1.1");
+            SData newRequest("GET / HTTP/1.1");
             string host = remainingURLs.front();
-            request["Host"] = host;
-            command.httpsRequests.push_back(httpsManager->send("https://" + host + "/", request));
+            newRequest["Host"] = host;
+            httpsRequests.push_back(plugin.httpsManager->send("https://" + host + "/", newRequest));
 
             // Indicate there will be a result waiting next time `peek` is called, and that we need to peek again.
-            command.request["pendingResult"] = "true";
-            command.repeek = true;
+            request["pendingResult"] = "true";
+            repeek = true;
 
             // re-write the URL list for the next iteration.
             remainingURLs.pop_front();
-            command.request["urls"] = SComposeList(remainingURLs);
+            request["urls"] = SComposeList(remainingURLs);
         } else {
             // There are no URLs left.
-            command.repeek = false;
+            repeek = false;
 
             // But we still want to call `process`. We make this explicit for clarity, even though its the fall-through
             // case
@@ -178,35 +220,35 @@ bool BedrockPlugin_TestPlugin::peekCommand(SQLite& db, BedrockCommand& command) 
     return false;
 }
 
-bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& command) {
-    if (command.request.calc("ProcessSleep")) {
-        usleep(command.request.calc("ProcessSleep") * 1000);
+void TestPluginCommand::process(SQLite& db) {
+    if (request.calc("ProcessSleep")) {
+        usleep(request.calc("ProcessSleep") * 1000);
     }
-    if (SStartsWith(command.request.methodLine, "sendrequest")) {
+    if (SStartsWith(request.methodLine, "sendrequest")) {
         // This flag makes us pass through the response we got from the server, rather than returning 200 if every
         // response we got from the server was < 400. I.e., if the server returns 202, or 304, or anything less than
         // 400, we return 200 except when this flag is set.
-        if (command.request.test("passthrough")) {
-            command.response.methodLine = command.httpsRequests.front()->fullResponse.methodLine;
-            if (command.httpsRequests.front()->response >= 500 && command.httpsRequests.front()->response <= 503) {
+        if (request.test("passthrough")) {
+            response.methodLine = httpsRequests.front()->fullResponse.methodLine;
+            if (httpsRequests.front()->response >= 500 && httpsRequests.front()->response <= 503) {
                 // Error transaction, couldn't send.
-                command.response.methodLine = "NO_RESPONSE";
+                response.methodLine = "NO_RESPONSE";
             }
-            command.response["Host"] = command.httpsRequests.front()->fullRequest["Host"];
+            response["Host"] = httpsRequests.front()->fullRequest["Host"];
         } else {
             // Assert if we got here with no requests.
-            if (command.httpsRequests.empty()) {
-                SINFO ("Calling process with no https request: " << command.request.methodLine);
+            if (httpsRequests.empty()) {
+                SINFO ("Calling process with no https request: " << request.methodLine);
                 SASSERT(false);
             }
             // If any of our responses were bad, we want to know that.
             bool allGoodResponses = true;
-            for (auto& request : command.httpsRequests) {
+            for (auto& request : httpsRequests) {
                 // If we're calling `process` on a command with a https request, it had better be finished.
                 SASSERT(request->response);
 
                 // Concatenate all of our responses into the body.
-                command.response.content += to_string(request->response) + "\n";
+                response.content += to_string(request->response) + "\n";
 
                 // If our response is an error, store that.
                 if (request->response >= 400) {
@@ -215,10 +257,10 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
             }
 
             // Update the response method line.
-            if (!command.request["response"].empty() && allGoodResponses) {
-                command.response.methodLine = command.request["response"];
+            if (!request["response"].empty() && allGoodResponses) {
+                response.methodLine = request["response"];
             } else {
-                command.response.methodLine = "200 OK";
+                response.methodLine = "200 OK";
             }
 
             // Update the DB so we can test conflicts.
@@ -226,27 +268,27 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
             db.read("SELECT MAX(id) FROM test", result);
             SASSERT(result.size());
             int nextID = SToInt(result[0][0]) + 1;
-            SASSERT(db.write("INSERT INTO TEST VALUES(" + SQ(nextID) + ", " + SQ(command.request["value"]) + ");"));
+            SASSERT(db.write("INSERT INTO TEST VALUES(" + SQ(nextID) + ", " + SQ(request["value"]) + ");"));
         }
 
         // Done.
-        return true;
+        return;
     }
-    else if (SStartsWith(command.request.methodLine, "idcollision")) {
+    else if (SStartsWith(request.methodLine, "idcollision")) {
         SQResult result;
         db.read("SELECT MAX(id) FROM test", result);
         SASSERT(result.size());
         int nextID = SToInt(result[0][0]) + 1;
-        SASSERT(db.write("INSERT INTO TEST VALUES(" + SQ(nextID) + ", " + SQ(command.request["value"]) + ");"));
+        SASSERT(db.write("INSERT INTO TEST VALUES(" + SQ(nextID) + ", " + SQ(request["value"]) + ");"));
 
-        if (!command.request["response"].empty()) {
-            command.response.methodLine = command.request["response"];
+        if (!request["response"].empty()) {
+            response.methodLine = request["response"];
         } else {
-            command.response.methodLine = "200 OK";
+            response.methodLine = "200 OK";
         }
 
-        return true;
-    } else if (SStartsWith(command.request.methodLine, "slowprocessquery")) {
+        return;
+    } else if (SStartsWith(request.methodLine, "slowprocessquery")) {
         SQResult result;
         db.read("SELECT MAX(id) FROM test", result);
         SASSERT(result.size());
@@ -254,11 +296,11 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
 
         int size = 1;
         int count = 1;
-        if (command.request.isSet("size")) {
-            size = SToInt(command.request["size"]);
+        if (request.isSet("size")) {
+            size = SToInt(request["size"]);
         }
-        if (command.request.isSet("count")) {
-            count = SToInt(command.request["count"]);
+        if (request.isSet("count")) {
+            count = SToInt(request["count"]);
         }
 
         for (int i = 0; i < count; i++) {
@@ -273,20 +315,19 @@ bool BedrockPlugin_TestPlugin::processCommand(SQLite& db, BedrockCommand& comman
             query += ";";
             db.read(query, result);
         }
-    } else if (SStartsWith(command.request.methodLine, "exceptioninprocess")) {
+    } else if (SStartsWith(request.methodLine, "exceptioninprocess")) {
         throw 2;
-    } else if (SStartsWith(command.request.methodLine, "generatesegfaultprocess")) {
+    } else if (SStartsWith(request.methodLine, "generatesegfaultprocess")) {
         int* i = 0;
         int x = *i;
-        command.response["invalid"] = to_string(x);
-    } else if (SStartsWith(command.request.methodLine, "ineffectiveUpdate")) {
+        response["invalid"] = to_string(x);
+    } else if (SStartsWith(request.methodLine, "ineffectiveUpdate")) {
         // This command does nothing on purpose so that we can run it in 10x mode and verify it replicates OK.
-        return true;
-    } else if (SStartsWith(command.request.methodLine, "chainedrequest")) {
+        return;
+    } else if (SStartsWith(request.methodLine, "chainedrequest")) {
         // Note that we eventually got to process, though we write nothing to the DB.
-        command.response.content += "PROCESSED\n";
+        response.content += "PROCESSED\n";
     }
-    return false;
 }
 
 void BedrockPlugin_TestPlugin::upgradeDatabase(SQLite& db) {

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -65,7 +65,7 @@ bool TestPluginCommand::peek(SQLite& db) {
 
     // Now that we've blacklisted, mutate the command and see if things break!
     if (request.isSet("userID")) {
-        request["userID"] = to_string(stoll(request["userID"]) + 1000);
+        const_cast<SData&>(request)["userID"] = to_string(stoll(request["userID"]) + 1000);
     }
 
     // Sleep if requested.
@@ -199,12 +199,12 @@ bool TestPluginCommand::peek(SQLite& db) {
             httpsRequests.push_back(plugin().httpsManager->send("https://" + host + "/", newRequest));
 
             // Indicate there will be a result waiting next time `peek` is called, and that we need to peek again.
-            request["pendingResult"] = "true";
+            const_cast<SData&>(request)["pendingResult"] = "true";
             repeek = true;
 
             // re-write the URL list for the next iteration.
             remainingURLs.pop_front();
-            request["urls"] = SComposeList(remainingURLs);
+            const_cast<SData&>(request)["urls"] = SComposeList(remainingURLs);
         } else {
             // There are no URLs left.
             repeek = false;

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -19,7 +19,8 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
     BedrockPlugin_TestPlugin(BedrockServer& s);
     ~BedrockPlugin_TestPlugin();
     void upgradeDatabase(SQLite& db);
-    virtual string getName() { return "TestPlugin"; }
+    virtual const string& getName() const;
+    static const string name;
     virtual bool preventAttach();
 
     virtual unique_ptr<BedrockCommand> getCommand(SQLiteCommand&& baseCommand);
@@ -35,12 +36,10 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
 
 class TestPluginCommand : public BedrockCommand {
   public:
-    TestPluginCommand(BedrockPlugin_TestPlugin& _plugin, SQLiteCommand&& baseCommand);
+    TestPluginCommand(SQLiteCommand&& baseCommand, BedrockPlugin_TestPlugin* plugin);
     virtual bool peek(SQLite& db);
     virtual void process(SQLite& db);
-    virtual const string& getName();
 
   private:
-    BedrockPlugin_TestPlugin& plugin;
-    static const string name;
+    BedrockPlugin_TestPlugin& plugin() { return static_cast<BedrockPlugin_TestPlugin&>(*_plugin); }
 };

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -22,7 +22,7 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
     virtual string getName() { return "TestPlugin"; }
     virtual bool preventAttach();
 
-    virtual unique_ptr<BedrockCommand> getCommand(SData&& request);
+    virtual unique_ptr<BedrockCommand> getCommand(SQLiteCommand&& baseCommand);
 
     TestHTTPSManager* httpsManager;
     bool shouldPreventAttach = false;
@@ -35,7 +35,7 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
 
 class TestPluginCommand : public BedrockCommand {
   public:
-    TestPluginCommand(BedrockPlugin_TestPlugin& _plugin, SData&& _request);
+    TestPluginCommand(BedrockPlugin_TestPlugin& _plugin, SQLiteCommand&& baseCommand);
     virtual bool peek(SQLite& db);
     virtual void process(SQLite& db);
     virtual const string& getName();

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -21,10 +21,9 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
     void upgradeDatabase(SQLite& db);
     virtual string getName() { return "TestPlugin"; }
     virtual bool preventAttach();
-    bool peekCommand(SQLite& db, BedrockCommand& command);
-    bool processCommand(SQLite& db, BedrockCommand& command);
 
-  private:
+    virtual unique_ptr<BedrockCommand> getCommand(SData&& request);
+
     TestHTTPSManager* httpsManager;
     bool shouldPreventAttach = false;
 
@@ -32,4 +31,16 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
     // of one command from another, even if the first command never sends a response.
     static mutex dataLock;
     static map<string, string> arbitraryData;
+};
+
+class TestPluginCommand : public BedrockCommand {
+  public:
+    TestPluginCommand(BedrockPlugin_TestPlugin& _plugin, SData&& _request);
+    virtual bool peek(SQLite& db);
+    virtual void process(SQLite& db);
+    virtual const string& getName();
+
+  private:
+    BedrockPlugin_TestPlugin& plugin;
+    static const string name;
 };


### PR DESCRIPTION
This moves to using polymorphic command types in Bedrock. it makes command requests `const` (except, for now, it mostly handles places they were modified with `const_cast`) which prevents whole categories of bugs we've seen where commands have had their requests modified and then been escalated or re-processed after a conflict.

This allows for an individual command to store its own state, without requiring special mechanisms inside of `BedrockCommand` that will hold onto a `void*` for the caller, for example.