### PR TITLE
Upgrade to gcc9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 sudo: false
 env:
-    - GXX=g++-6 CC=gcc-6
+    - GXX=g++-9 CC=gcc-9
 addons:
     apt:
         sources:
             - ubuntu-toolchain-r-test
         packages:
-            - gcc-6
-            - g++-6
+            - gcc-9
+            - g++-9
 notifications:
     email:
         on_success: never

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # Set the compiler, if it's not set by the environment.
 ifndef GXX
-	GXX = g++-6
+	GXX = g++-9
 endif
 
 ifndef CC
-	CC = gcc-6
+	CC = gcc-9
 endif
 
 GIT_REVISION = $(shell git rev-parse --short HEAD)

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,25 +36,25 @@ You can build from scratch as follows:
 
     # Clone out this repo:
     git clone https://github.com/Expensify/Bedrock.git
-    
+
     # Install some dependencies
     sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     sudo apt-get update
-    sudo apt-get install gcc-6 g++-6 libpcre++-dev zlib1g-dev
-    
+    sudo apt-get install gcc-9 g++-9 libpcre++-dev zlib1g-dev
+
     # Build it
     cd Bedrock
     make
-    
+
     # Create an empty database (See: https://github.com/Expensify/Bedrock/issues/489)
     touch bedrock.db
-    
+
     # Run it (press Ctrl^C to quit, or use -fork to make it run in the backgroud)
     ./bedrock
-    
+
     # Connect to it in a different terminal using netcat
     nc localhost 8888
-    
+
     # Type "Status" and then enter twice to verify it's working
     # See here to use the default DB plugin: http://bedrockdb.com/db.html
 
@@ -82,34 +82,34 @@ You can build from scratch as follows:
 
     # Clone out this repo:
     git clone https://github.com/Expensify/Bedrock.git
-    
+
     # Install some dependencies with Brew (see: https://brew.sh/)
     brew update
     brew install gcc@6
-    
+
     # Configure PCRE to use C++17 and compile from source
     brew uninstall --ignore-dependencies pcre
     brew edit pcre
     # Add these to the end of the `system "./configure"` command:
     #     "--enable-cpp",
     #     "--enable-pcre64",
-    #     "CXX=/usr/local/bin/g++-6",
+    #     "CXX=/usr/local/bin/g++-9",
     #     "CXXFLAGS=--std=gnu++14"
     brew install --build-from-source pcre
-    
+
     # Build it
     cd Bedrock
     make
-    
+
     # Create an empty database (See: https://github.com/Expensify/Bedrock/issues/489)
     touch bedrock.db
-    
+
     # Run it (press Ctrl^C to quit, or use -fork to make it run in the backgroud)
     ./bedrock
-    
+
     # Connect to it in a different terminal using netcat
     nc localhost 8888
-    
+
     # Type "Status" and then enter twice to verify it's working
     # See here to use the default DB plugin: http://bedrockdb.com/db.html
 
@@ -124,7 +124,7 @@ That query can be any [SQLite-compatible query](http://sqlite.org/lang.html) -- 
 
     200 OK
     Content-Length: 16
-    
+
     foo | bar
     1 | 2
 
@@ -134,10 +134,10 @@ By default, Bedrock optimizes the output for human consumption.  If you are a ro
     Query
     query: SELECT 1 AS foo, 2 AS bar;
     format: json
-    
+
     200 OK
     Content-Length: 40
-    
+
     {"headers":["foo","bar"],"rows":[[1,2]]}
 
 Some people are creeped out by sockets, and prefer tools.  No problem: Bedrock supports the MySQL protocol, meaning you can continue using whatever MySQL client you prefer:
@@ -146,15 +146,15 @@ Some people are creeped out by sockets, and prefer tools.  No problem: Bedrock s
     Welcome to the MySQL monitor.  Commands end with ; or \g.
     Your MySQL connection id is 1
     Server version: bedrock 09b08f82e6eefe69f79bb8414882dd64182e3e8c
-    
+
     Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
-    
+
     Oracle is a registered trademark of Oracle Corporation and/or its
     affiliates. Other names may be trademarks of their respective
     owners.
-    
+
     Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
-    
+
     mysql> SELECT 1 AS foo, 2 AS bar;
     +------+------+
     | foo  | bar  |
@@ -162,8 +162,8 @@ Some people are creeped out by sockets, and prefer tools.  No problem: Bedrock s
     |    1 |    2 |
     +------+------+
     1 row in set (0.01 sec)
-    
-    mysql> 
+
+    mysql>
 
 That also means you can continue using whatever MySQL language binding you already know and love.  Alternatively, if you don't know or love any of them, Bedrock also provides a [PHP binding](https://github.com/Expensify/Bedrock-PHP) that looks something like this:
 
@@ -191,5 +191,3 @@ So many ways!
 * Submit a PR to [Bedrock's GitHub repo](https://github.com/Expensify/Bedrock)
 * Email David, the CEO of Expensify (and biggest Bedrock fanboy ever) directly: [dbarrett@expensify.com](mailto:dbarrett@expensify.com)
 * [Join Expensify](http://we.are.expensify.com) and you can work on Bedrock (and other, even cooler things) full time!
-
-

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -354,7 +354,7 @@ string SQLite::_getJournalTableName(int journalTableID) {
     if (journalTableID < 0) {
         return "journal";
     }
-    char buff[12] = {0};
+    char buff[27] = {0};
     sprintf(buff, "journal%04d", journalTableID);
     return buff;
 }

--- a/test/clustertest/testplugin/Makefile
+++ b/test/clustertest/testplugin/Makefile
@@ -1,10 +1,10 @@
 # # Set the compiler, if it's not set by the environment.
 ifndef GXX
-	GXX = g++-6
+	GXX = g++-9
 endif
 
 ifndef CC
-	CC = gcc-6
+	CC = gcc-9
 endif
 
 # We use our project directory as a search path so we don't need "../../../.." all over the place.
@@ -74,4 +74,3 @@ $(INTERMEDIATEDIR)/%.d: %.cpp
 $(INTERMEDIATEDIR)/%.o: %.cpp $(INTERMEDIATEDIR)/%.d
 	@mkdir -p $(dir $@)
 	$(GXX) $(CXXFLAGS) -MMD -MF $(INTERMEDIATEDIR)/$*.d -o $@ -c $<
-

--- a/travis.sh
+++ b/travis.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-export GXX=g++-6
-export CC=gcc-6
+export GXX=g++-9
+export CC=gcc-9
 
 ${CC} --version
 ${GXX} --version


### PR DESCRIPTION
@tylerkaraszewski Please review. Upgrades bedrock to work with gcc9

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/124560

# Tests
It compiles! Speed testing is in the issue.

