### PR TITLE
Upgrade mbedtls to get rid of gcc9 warnings, use more cores for compiliation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean:
 mbedtls/library/libmbedcrypto.a mbedtls/library/libmbedtls.a mbedtls/library/libmbedx509.a:
 	git submodule init
 	git submodule update
-	cd mbedtls && git checkout -q c49b808ae490f03d665df5faae457f613aa31aaf
+	cd mbedtls && git checkout -q 04a049bda1ceca48060b57bc4bcf5203ce591421
 	cd mbedtls && $(MAKE) no_test && touch library/libmbedcrypto.a && touch library/libmbedtls.a && touch library/libmbedx509.a
 
 # Ok, that's the end of our magic PCH code. The only other mention of it is in the build line where we include it.

--- a/travis.sh
+++ b/travis.sh
@@ -41,11 +41,9 @@ travis_fold() {
   echo -en "travis_fold:${action}:${name}\r${ANSI_CLEAR}"
 }
 
-CORES=4
-
 travis_fold start build_bedrock
 travis_time_start
-make
+make -j8
 travis_time_finish
 travis_fold end build_bedrock
 


### PR DESCRIPTION
@tylerkaraszewski Please review. After wasting 45 minutes chasing a problem that doesn't exist, here is the final set of changes for gcc9 in this repo. This removes two warnings from building mbedtls buy upgrading to the latest release. It also gets rid of an unused variable and builds with more cores.