### PR TITLE
Fix atomicity in write cache

### DIFF
--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -252,9 +252,7 @@ bool BedrockPlugin_Cache::processCommand(SQLite& db, BedrockCommand& command) {
         while (SToInt64(db.read("SELECT size FROM cacheSize;")) + contentSize > _maxCacheSize) {
             // Find the least recently used (LRU) item if there is one.  (If the server was recently restarted,
             // its LRU might not be fully populated.)
-
             auto popResult = _lruMap.popLRU();
-
             const string& name = (popResult.second ? popResult.first : db.read("SELECT name FROM cache LIMIT 1"));
             SASSERT(!name.empty());
 

--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -18,14 +18,14 @@ BedrockPlugin_Cache::LRUMap::~LRUMap() {
 // ==========================================================================
 bool BedrockPlugin_Cache::LRUMap::empty() {
     // Both the map and list are the same size, so check either
-    SAUTOLOCK(_mutex);
+    lock_guard<decltype(_mutex)> lock(_mutex);
     return _lruList.empty();
 }
 
 // ==========================================================================
 void BedrockPlugin_Cache::LRUMap::pushMRU(const string& name) {
     // See if if it's already there
-    SAUTOLOCK(_mutex);
+    lock_guard<decltype(_mutex)> lock(_mutex);
     map<string, Entry*>::iterator mapIt = _lruMap.find(name);
     if (mapIt == _lruMap.end()) {
         // Not in the map -- add a new entry
@@ -44,23 +44,24 @@ void BedrockPlugin_Cache::LRUMap::pushMRU(const string& name) {
 }
 
 // ==========================================================================
-string BedrockPlugin_Cache::LRUMap::popLRU() {
+pair<string, bool> BedrockPlugin_Cache::LRUMap::popLRU() {
     // Make sure we're not empty
-    SAUTOLOCK(_mutex);
-    SASSERT(!empty());
-
+    lock_guard<decltype(_mutex)> lock(_mutex);
+    if (empty()) {
+        return make_pair("", false);
+    }
     // Take the first item off the list
     Entry* entry = _lruList.front();
     _lruList.erase(entry->listIt);
     _lruMap.erase(entry->mapIt);
     string nameCopy = entry->name;
     delete entry;
-    return nameCopy;
+    return make_pair(nameCopy, true);
 }
 
 // ==========================================================================
 BedrockPlugin_Cache::BedrockPlugin_Cache(BedrockServer& s)
-    : BedrockPlugin(s), _maxCacheSize(0) // Will be set inside initialize()
+    : BedrockPlugin(s), _maxCacheSize(0)
 {
     // Check the configuration
     const string& maxCache = SToUpper(server.args["-cache.max"]);
@@ -204,7 +205,7 @@ bool BedrockPlugin_Cache::processCommand(SQLite& db, BedrockCommand& command) {
         //
         //     Parameters:
         //     - name           - An arbitrary string identifier (case insensitive)
-        //     - value          - Raw data to associate with this value, as a request header (1MB max) or content body
+        //     - value          - Raw data to associate with this name, as a request header (1MB max) or content body
         //     (64MB max)
         //     - invalidateName - A name pattern to erase from the cache (optional)
         //
@@ -248,20 +249,25 @@ bool BedrockPlugin_Cache::processCommand(SQLite& db, BedrockCommand& command) {
         while (SToInt64(db.read("SELECT size FROM cacheSize;")) + contentSize > _maxCacheSize) {
             // Find the least recently used (LRU) item if there is one.  (If the server was recently restarted,
             // its LRU might not be fully populated.)
-            const string& name = (_lruMap.empty() ? db.read("SELECT name FROM cache LIMIT 1") : _lruMap.popLRU());
+
+            auto popResult = _lruMap.popLRU();
+
+            const string& name = (popResult.second ? popResult.first : db.read("SELECT name FROM cache LIMIT 1"));
             SASSERT(!name.empty());
 
             // Delete it
-            if (!db.write("DELETE FROM cache WHERE name=" + SQ(name) + ";"))
+            if (!db.write("DELETE FROM cache WHERE name=" + SQ(name) + ";")) {
                 STHROW("502 Query failed (deleting)");
+            }
         }
 
         // Insert the new entry
         const string& safeValue = SQ(valueHeader.empty() ? request.content : valueHeader);
         if (!db.write("INSERT OR REPLACE INTO cache ( name, value ) "
                       "VALUES( " +
-                      SQ(name) + ", " + safeValue + " );"))
-            STHROW("502 Query failed (inserting)");
+                      SQ(name) + ", " + safeValue + " );")) {
+                          STHROW("502 Query failed (inserting)");
+                      }
 
         // Writing is a form of "use", so this is the new MRU.  Note that we're
         // adding it to the MRU, even before we commit.  So if this transaction

--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -44,6 +44,9 @@ void BedrockPlugin_Cache::LRUMap::pushMRU(const string& name) {
 }
 
 // ==========================================================================
+// This returns a pair which is made of up of the LRU item in the cache and
+// a bool of whether or not the cache was empty when we tried to pop. If the
+// cache is empty, the LRU item will be an empty string and the bool will be false.
 pair<string, bool> BedrockPlugin_Cache::LRUMap::popLRU() {
     // Make sure we're not empty
     lock_guard<decltype(_mutex)> lock(_mutex);

--- a/plugins/Cache.h
+++ b/plugins/Cache.h
@@ -29,7 +29,7 @@ class BedrockPlugin_Cache : public BedrockPlugin {
         void pushMRU(const string& name);
 
         // Remove the name that is the least recently used (LRU)
-        string popLRU();
+        pair<string, bool> popLRU();
 
       private:
         // A single entry being tracked


### PR DESCRIPTION
@tylerkaraszewski This fixes an atomicity problem in `WriteCache`.

If two threads run `WriteCache` at same time with one entry in the cache, this line:
```
const string& name = (_lruMap.empty() ? db.read("SELECT name FROM cache LIMIT 1") : _lruMap.popLRU());
```
Will have `_lruMap.empty()` return false in both threads, then the first thread will call `_lruMap.popLRU()`, delete the last entry in the cache. Then the second thread calls `_lruMap.popLRU()` which causes us to try to pop a now empty cache hitting the assert:
`SASSERT(!empty());`.

This makes this operation atomic by checking for empty and doing the pop inside a single mutex lock.

I also did some style changes.

