### PR TITLE
Polymorphic commands second try

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -29,9 +29,7 @@ BedrockCommand::~BedrockCommand() {
     for (auto request : httpsRequests) {
         request->manager.closeTransaction(request);
     }
-    if (countCommand) {
-        _commandCount--;
-    }
+    _commandCount--;
     if (deallocator && peekData) {
         deallocator(peekData);
     }
@@ -50,39 +48,9 @@ BedrockCommand::BedrockCommand(SQLiteCommand&& from, int dontCount) :
     peekData(nullptr),
     deallocator(nullptr),
     _inProgressTiming(INVALID, 0, 0),
-    _timeout(_getTimeout(request)),
-    countCommand(dontCount != DONT_COUNT)
+    _timeout(_getTimeout(request))
 {
     _init();
-    if (countCommand) {
-        _commandCount++;
-    }
-}
-
-BedrockCommand::BedrockCommand(BedrockCommand&& from) :
-    SQLiteCommand(move(from)),
-    httpsRequests(move(from.httpsRequests)),
-    priority(from.priority),
-    peekCount(from.peekCount),
-    processCount(from.processCount),
-    peekedBy(from.peekedBy),
-    processedBy(from.processedBy),
-    repeek(from.repeek),
-    timingInfo(from.timingInfo),
-    onlyProcessOnSyncThread(from.onlyProcessOnSyncThread),
-    crashIdentifyingValues(*this, move(from.crashIdentifyingValues)),
-    peekData(from.peekData),
-    deallocator(from.deallocator),
-    _inProgressTiming(from._inProgressTiming),
-    _timeout(from._timeout),
-    countCommand(true)
-{
-    // The move constructor (and likewise, the move assignment operator), don't simply copy these pointer values, but
-    // they clear them from the old object, so that when its destructor is called, the HTTPS transactions aren't
-    // closed.
-    from.httpsRequests.clear();
-    from.peekData = nullptr;
-    from.deallocator = nullptr;
     _commandCount++;
 }
 
@@ -99,8 +67,7 @@ BedrockCommand::BedrockCommand(SData&& _request) :
     peekData(nullptr),
     deallocator(nullptr),
     _inProgressTiming(INVALID, 0, 0),
-    _timeout(_getTimeout(request)),
-    countCommand(true)
+    _timeout(_getTimeout(request))
 {
     _init();
     _commandCount++;
@@ -119,66 +86,10 @@ BedrockCommand::BedrockCommand(SData _request) :
     peekData(nullptr),
     deallocator(nullptr),
     _inProgressTiming(INVALID, 0, 0),
-    _timeout(_getTimeout(request)),
-    countCommand(true)
+    _timeout(_getTimeout(request))
 {
     _init();
     _commandCount++;
-}
-
-BedrockCommand& BedrockCommand::operator=(BedrockCommand&& from) {
-    if (this != &from) {
-        // The current incarnation of this object is going away, if it had an httpsRequest, we'll need to destroy it,
-        // or it will leak and never get cleaned up.
-        for (auto request : httpsRequests) {
-            if (!request->response) {
-                SWARN("Closing unfinished httpRequest by assigning over it. This was probably a mistake.");
-            }
-            request->manager.closeTransaction(request);
-        }
-        httpsRequests = move(from.httpsRequests);
-        from.httpsRequests.clear();
-
-        // Same here, deallocate current data.
-        if (deallocator && peekData) {
-            deallocator(peekData);
-        }
-
-        // Update our other properties.
-        peekCount = from.peekCount;
-        processCount = from.processCount;
-        peekedBy = from.peekedBy;
-        processedBy = from.processedBy;
-        repeek = from.repeek;
-        priority = from.priority;
-        timingInfo = from.timingInfo;
-        onlyProcessOnSyncThread = from.onlyProcessOnSyncThread;
-        crashIdentifyingValues = move(from.crashIdentifyingValues);
-        peekData = move(from.peekData);
-        deallocator = move(from.deallocator);
-        _inProgressTiming = from._inProgressTiming;
-        _timeout = from._timeout;
-
-        // If countCommand is changing, update the count.
-        if (countCommand && !from.countCommand) {
-            // this command is no longer counted.
-            _commandCount--;
-        } else if (!countCommand && from.countCommand) {
-            // We need to start counting this command.
-            _commandCount++;
-        }
-        // Now set to match the existing command.
-        countCommand = from.countCommand;
-
-        // Don't delete when the old object is destroyed.
-        from.peekData = nullptr;
-        from.deallocator = nullptr;
-
-        // And call the base class's move constructor as well.
-        SQLiteCommand::operator=(move(from));
-    }
-
-    return *this;
 }
 
 void BedrockCommand::_init() {
@@ -338,24 +249,24 @@ void BedrockCommand::finalizeTimingInfo() {
 
 // pop and push specializations for SSynchronizedQueue that record timing info.
 template<>
-BedrockCommand SSynchronizedQueue<BedrockCommand>::pop() {
+unique_ptr<BedrockCommand> SSynchronizedQueue<unique_ptr<BedrockCommand>>::pop() {
     SAUTOLOCK(_queueMutex);
     if (!_queue.empty()) {
-        BedrockCommand item = move(_queue.front());
+        unique_ptr<BedrockCommand> item = move(_queue.front());
         _queue.pop_front();
-        item.stopTiming(BedrockCommand::QUEUE_SYNC);
+        item->stopTiming(BedrockCommand::QUEUE_SYNC);
         return item;
     }
     throw out_of_range("No commands");
 }
 
 template<>
-void SSynchronizedQueue<BedrockCommand>::push(BedrockCommand&& cmd) {
+void SSynchronizedQueue<unique_ptr<BedrockCommand>>::push(unique_ptr<BedrockCommand>&& cmd) {
     SAUTOLOCK(_queueMutex);
-    SINFO("Enqueuing command '" << cmd.request.methodLine << "', with " << _queue.size() << " commands already queued.");
+    SINFO("Enqueuing command '" << cmd->request.methodLine << "', with " << _queue.size() << " commands already queued.");
     // Just add to the queue
     _queue.push_back(move(cmd));
-    _queue.back().startTiming(BedrockCommand::QUEUE_SYNC);
+    _queue.back()->startTiming(BedrockCommand::QUEUE_SYNC);
 
     // Write arbitrary buffer to the pipe so any subscribers will be awoken.
     // **NOTE: 1 byte so write is atomic.

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -249,10 +249,10 @@ void BedrockCommand::finalizeTimingInfo() {
 
 // pop and push specializations for SSynchronizedQueue that record timing info.
 template<>
-unique_ptr<BedrockCommand> SSynchronizedQueue<unique_ptr<BedrockCommand>>::pop() {
+BedrockCommandPtr SSynchronizedQueue<BedrockCommandPtr>::pop() {
     SAUTOLOCK(_queueMutex);
     if (!_queue.empty()) {
-        unique_ptr<BedrockCommand> item = move(_queue.front());
+        BedrockCommandPtr item = move(_queue.front());
         _queue.pop_front();
         item->stopTiming(BedrockCommand::QUEUE_SYNC);
         return item;
@@ -261,7 +261,7 @@ unique_ptr<BedrockCommand> SSynchronizedQueue<unique_ptr<BedrockCommand>>::pop()
 }
 
 template<>
-void SSynchronizedQueue<unique_ptr<BedrockCommand>>::push(unique_ptr<BedrockCommand>&& cmd) {
+void SSynchronizedQueue<BedrockCommandPtr>::push(BedrockCommandPtr&& cmd) {
     SAUTOLOCK(_queueMutex);
     SINFO("Enqueuing command '" << cmd->request.methodLine << "', with " << _queue.size() << " commands already queued.");
     // Just add to the queue

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -139,3 +139,32 @@ class BedrockCommand : public SQLiteCommand {
 
     static atomic<size_t> _commandCount;
 };
+
+#include <BedrockCommand.h>
+
+class checkedUniquePtr_BedrockCommand : public unique_ptr<BedrockCommand> {
+  public:
+
+    // Constructors.
+    checkedUniquePtr_BedrockCommand(unique_ptr<BedrockCommand>&& other) {
+        unique_ptr<BedrockCommand>::operator=(move(other));
+    }
+    checkedUniquePtr_BedrockCommand(BedrockCommand* other) : unique_ptr<BedrockCommand>(other) { }
+    checkedUniquePtr_BedrockCommand(nullptr_t np) : unique_ptr<BedrockCommand>(np) {}
+
+    // Copy by calling parent copy assignment operator.
+    checkedUniquePtr_BedrockCommand& operator=(unique_ptr<BedrockCommand>&& other) {
+        unique_ptr<BedrockCommand>::operator=(move(other));
+        return *this;
+    }
+
+    BedrockCommand* operator->() const {
+        if (get() == nullptr) {
+            STHROW_STACK("Dereferencing null pointer");
+        }
+        return get();
+    }
+};
+
+typedef checkedUniquePtr_BedrockCommand BedrockCommandPtr;
+

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -23,9 +23,6 @@ class BedrockCommand : public SQLiteCommand {
         QUEUE_SYNC,
     };
 
-    // used to create commands that don't count towards the total number of commands.
-    static constexpr int DONT_COUNT = 1;
-
     // Times in *milliseconds*.
     static const uint64_t DEFAULT_TIMEOUT = 290'000; // 290 seconds, so clients can have a 5 minute timeout.
     static const uint64_t DEFAULT_TIMEOUT_FORGET = 60'000 * 60; // 1 hour for `connection: forget` commands.
@@ -33,9 +30,6 @@ class BedrockCommand : public SQLiteCommand {
 
     // Constructor to convert from an existing SQLiteCommand (by move).
     BedrockCommand(SQLiteCommand&& from, int dontCount = 0);
-
-    // Move constructor.
-    BedrockCommand(BedrockCommand&& from);
 
     // Constructor to initialize via a request object (by move).
     BedrockCommand(SData&& _request);
@@ -45,9 +39,6 @@ class BedrockCommand : public SQLiteCommand {
 
     // Destructor.
     ~BedrockCommand();
-
-    // Move assignment operator.
-    BedrockCommand& operator=(BedrockCommand&& from);
 
     // Start recording time for a given action type.
     void startTiming(TIMING_INFO type);
@@ -147,6 +138,4 @@ class BedrockCommand : public SQLiteCommand {
     uint64_t _timeout;
 
     static atomic<size_t> _commandCount;
-
-    bool countCommand;
 };

--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -1,15 +1,15 @@
 #include <BedrockCommandQueue.h>
 
-void BedrockCommandQueue::startTiming(BedrockCommand& command) {
-    command.startTiming(BedrockCommand::QUEUE_WORKER);
+void BedrockCommandQueue::startTiming(unique_ptr<BedrockCommand>& command) {
+    command->startTiming(BedrockCommand::QUEUE_WORKER);
 }
 
-void BedrockCommandQueue::stopTiming(BedrockCommand& command) {
-    command.stopTiming(BedrockCommand::QUEUE_WORKER);
+void BedrockCommandQueue::stopTiming(unique_ptr<BedrockCommand>& command) {
+    command->stopTiming(BedrockCommand::QUEUE_WORKER);
 }
 
 BedrockCommandQueue::BedrockCommandQueue() :
-  SScheduledPriorityQueue<BedrockCommand>(function<void(BedrockCommand&)>(startTiming), function<void(BedrockCommand&)>(stopTiming))
+  SScheduledPriorityQueue<unique_ptr<BedrockCommand>>(function<void(unique_ptr<BedrockCommand>&)>(startTiming), function<void(unique_ptr<BedrockCommand>&)>(stopTiming))
 { }
 
 list<string> BedrockCommandQueue::getRequestMethodLines() {
@@ -17,7 +17,7 @@ list<string> BedrockCommandQueue::getRequestMethodLines() {
     SAUTOLOCK(_queueMutex);
     for (auto& queue : _queue) {
         for (auto& entry : queue.second) {
-            returnVal.push_back(entry.second.item.request.methodLine);
+            returnVal.push_back(entry.second.item->request.methodLine);
         }
     }
     return returnVal;
@@ -64,9 +64,9 @@ void BedrockCommandQueue::abandonFutureCommands(int msInFuture) {
     }
 }
 
-void BedrockCommandQueue::push(BedrockCommand&& command) {
-    BedrockCommand::Priority priority = command.priority;
-    uint64_t executionTime = command.request.calcU64("commandExecuteTime");
-    uint64_t timeout = command.timeout();
-    SScheduledPriorityQueue<BedrockCommand>::push(move(command), priority, executionTime, timeout);
+void BedrockCommandQueue::push(unique_ptr<BedrockCommand>&& command) {
+    BedrockCommand::Priority priority = command->priority;
+    uint64_t executionTime = command->request.calcU64("commandExecuteTime");
+    uint64_t timeout = command->timeout();
+    SScheduledPriorityQueue<unique_ptr<BedrockCommand>>::push(move(command), priority, executionTime, timeout);
 }

--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -1,15 +1,15 @@
 #include <BedrockCommandQueue.h>
 
-void BedrockCommandQueue::startTiming(unique_ptr<BedrockCommand>& command) {
+void BedrockCommandQueue::startTiming(BedrockCommandPtr& command) {
     command->startTiming(BedrockCommand::QUEUE_WORKER);
 }
 
-void BedrockCommandQueue::stopTiming(unique_ptr<BedrockCommand>& command) {
+void BedrockCommandQueue::stopTiming(BedrockCommandPtr& command) {
     command->stopTiming(BedrockCommand::QUEUE_WORKER);
 }
 
 BedrockCommandQueue::BedrockCommandQueue() :
-  SScheduledPriorityQueue<unique_ptr<BedrockCommand>>(function<void(unique_ptr<BedrockCommand>&)>(startTiming), function<void(unique_ptr<BedrockCommand>&)>(stopTiming))
+  SScheduledPriorityQueue<BedrockCommandPtr>(function<void(BedrockCommandPtr&)>(startTiming), function<void(BedrockCommandPtr&)>(stopTiming))
 { }
 
 list<string> BedrockCommandQueue::getRequestMethodLines() {
@@ -64,9 +64,9 @@ void BedrockCommandQueue::abandonFutureCommands(int msInFuture) {
     }
 }
 
-void BedrockCommandQueue::push(unique_ptr<BedrockCommand>&& command) {
+void BedrockCommandQueue::push(BedrockCommandPtr&& command) {
     BedrockCommand::Priority priority = command->priority;
     uint64_t executionTime = command->request.calcU64("commandExecuteTime");
     uint64_t timeout = command->timeout();
-    SScheduledPriorityQueue<unique_ptr<BedrockCommand>>::push(move(command), priority, executionTime, timeout);
+    SScheduledPriorityQueue<BedrockCommandPtr>::push(move(command), priority, executionTime, timeout);
 }

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -3,13 +3,13 @@
 #include <libstuff/SScheduledPriorityQueue.h>
 #include "BedrockCommand.h"
 
-class BedrockCommandQueue : public SScheduledPriorityQueue<unique_ptr<BedrockCommand>> {
+class BedrockCommandQueue : public SScheduledPriorityQueue<BedrockCommandPtr> {
   public:
     BedrockCommandQueue();
 
     // Functions to start and stop timing on the commands when they're inserted/removed from the queue.
-    static void startTiming(unique_ptr<BedrockCommand>& command);
-    static void stopTiming(unique_ptr<BedrockCommand>& command);
+    static void startTiming(BedrockCommandPtr& command);
+    static void stopTiming(BedrockCommandPtr& command);
     
     // Returns a list of all the method lines for all the requests currently queued. This function exists for state
     // reporting, and is called by BedrockServer when we receive a `Status` command.
@@ -19,5 +19,5 @@ class BedrockCommandQueue : public SScheduledPriorityQueue<unique_ptr<BedrockCom
     void abandonFutureCommands(int msInFuture);
 
     // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
-    void push(unique_ptr<BedrockCommand>&& command);
+    void push(BedrockCommandPtr&& command);
 };

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -3,13 +3,13 @@
 #include <libstuff/SScheduledPriorityQueue.h>
 #include "BedrockCommand.h"
 
-class BedrockCommandQueue : public SScheduledPriorityQueue<BedrockCommand> {
+class BedrockCommandQueue : public SScheduledPriorityQueue<unique_ptr<BedrockCommand>> {
   public:
     BedrockCommandQueue();
 
     // Functions to start and stop timing on the commands when they're inserted/removed from the queue.
-    static void startTiming(BedrockCommand& command);
-    static void stopTiming(BedrockCommand& command);
+    static void startTiming(unique_ptr<BedrockCommand>& command);
+    static void stopTiming(unique_ptr<BedrockCommand>& command);
     
     // Returns a list of all the method lines for all the requests currently queued. This function exists for state
     // reporting, and is called by BedrockServer when we receive a `Status` command.
@@ -19,5 +19,5 @@ class BedrockCommandQueue : public SScheduledPriorityQueue<BedrockCommand> {
     void abandonFutureCommands(int msInFuture);
 
     // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
-    void push(BedrockCommand&& command);
+    void push(unique_ptr<BedrockCommand>&& command);
 };

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -29,7 +29,7 @@ class AutoScopeRewrite {
     bool (*_handler)(int, const char*, string&);
 };
 
-uint64_t BedrockCore::_getRemainingTime(const unique_ptr<BedrockCommand>& command) {
+uint64_t BedrockCore::_getRemainingTime(const BedrockCommandPtr& command) {
     int64_t timeout = command->timeout();
     int64_t now = STimeNow();
 
@@ -53,7 +53,7 @@ uint64_t BedrockCore::_getRemainingTime(const unique_ptr<BedrockCommand>& comman
     return min(processTimeout, adjustedTimeout);
 }
 
-bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command) {
+bool BedrockCore::isTimedOut(BedrockCommandPtr& command) {
     try {
         _getRemainingTime(command);
     } catch (const SException& e) {
@@ -65,7 +65,7 @@ bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command) {
     return false;
 }
 
-bool BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command) {
+bool BedrockCore::peekCommand(BedrockCommandPtr& command) {
     AutoTimer timer(command, BedrockCommand::PEEK);
     // Convenience references to commonly used properties.
     SData& request = command->request;
@@ -177,7 +177,7 @@ bool BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command) {
     return true;
 }
 
-bool BedrockCore::processCommand(unique_ptr<BedrockCommand>& command) {
+bool BedrockCore::processCommand(BedrockCommandPtr& command) {
     AutoTimer timer(command, BedrockCommand::PROCESS);
 
     // Convenience references to commonly used properties.
@@ -278,7 +278,7 @@ bool BedrockCore::processCommand(unique_ptr<BedrockCommand>& command) {
     return needsCommit;
 }
 
-void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e) {
+void BedrockCore::_handleCommandException(BedrockCommandPtr& command, const SException& e) {
     const string& msg = "Error processing command '" + command->request.methodLine + "' (" + e.what() + "), ignoring.";
     if (SContains(e.what(), "_ALERT_")) {
         SALERT(msg);

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -29,23 +29,23 @@ class AutoScopeRewrite {
     bool (*_handler)(int, const char*, string&);
 };
 
-uint64_t BedrockCore::_getRemainingTime(const BedrockCommand& command) {
-    int64_t timeout = command.timeout();
+uint64_t BedrockCore::_getRemainingTime(const unique_ptr<BedrockCommand>& command) {
+    int64_t timeout = command->timeout();
     int64_t now = STimeNow();
 
     // This is what's left for the "absolute" time. If it's negative, we've already timed out.
     int64_t adjustedTimeout = timeout - now;
 
     // We also want to know the processTimeout, because we'll return early if we get stuck processing for too long.
-    int64_t processTimeout = command.request.isSet("processTimeout") ? command.request.calc("processTimeout") : BedrockCommand::DEFAULT_PROCESS_TIMEOUT;
+    int64_t processTimeout = command->request.isSet("processTimeout") ? command->request.calc("processTimeout") : BedrockCommand::DEFAULT_PROCESS_TIMEOUT;
 
     // Since timeouts are specified in ms, we convert to us.
     processTimeout *= 1000;
 
     // Already expired.
     if (adjustedTimeout <= 0 || processTimeout <= 0) {
-        SALERT("Command " << command.request.methodLine << " timed out after "
-               << ((now - command.request.calc64("commandExecuteTime")) / 1000) << "ms.");
+        SALERT("Command " << command->request.methodLine << " timed out after "
+               << ((now - command->request.calc64("commandExecuteTime")) / 1000) << "ms.");
         STHROW("555 Timeout");
     }
 
@@ -53,30 +53,30 @@ uint64_t BedrockCore::_getRemainingTime(const BedrockCommand& command) {
     return min(processTimeout, adjustedTimeout);
 }
 
-bool BedrockCore::isTimedOut(BedrockCommand& command) {
+bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command) {
     try {
         _getRemainingTime(command);
     } catch (const SException& e) {
         // Yep, timed out.
         _handleCommandException(command, e);
-        command.complete = true;
+        command->complete = true;
         return true;
     }
     return false;
 }
 
-bool BedrockCore::peekCommand(BedrockCommand& command) {
+bool BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command) {
     AutoTimer timer(command, BedrockCommand::PEEK);
     // Convenience references to commonly used properties.
-    SData& request = command.request;
-    SData& response = command.response;
-    STable& content = command.jsonContent;
+    SData& request = command->request;
+    SData& response = command->response;
+    STable& content = command->jsonContent;
 
     // We catch any exception and handle in `_handleCommandException`.
     try {
-        SDEBUG("Peeking at '" << request.methodLine << "' with priority: " << command.priority);
+        SDEBUG("Peeking at '" << request.methodLine << "' with priority: " << command->priority);
         uint64_t timeout = _getRemainingTime(command);
-        command.peekCount++;
+        command->peekCount++;
 
         _db.startTiming(timeout);
         // We start a transaction in `peekCommand` because we want to support having atomic transactions from peek
@@ -88,7 +88,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
         bool shouldSuppressTimeoutWarnings = false;
 
         try {
-            if (!_db.beginConcurrentTransaction(true, command.request.methodLine)) {
+            if (!_db.beginConcurrentTransaction(true, command->request.methodLine)) {
                 STHROW("501 Failed to begin concurrent transaction");
             }
 
@@ -100,9 +100,9 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
                 shouldSuppressTimeoutWarnings = plugin.second->shouldSuppressTimeoutWarnings();
 
                 // Try to peek the command.
-                if (plugin.second->peekCommand(_db, command)) {
+                if (plugin.second->peekCommand(_db, *command)) {
                     SINFO("Plugin '" << plugin.second->getName() << "' peeked command '" << request.methodLine << "'");
-                    command.peekedBy = plugin.second;
+                    command->peekedBy = plugin.second;
                     pluginPeeked = true;
                     break;
                 }
@@ -112,7 +112,7 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
             _db.read("PRAGMA query_only = false;");
         } catch (const SQLite::timeout_error& e) {
             if (!shouldSuppressTimeoutWarnings) {
-                SALERT("Command " << command.request.methodLine << " timed out after " << e.time()/1000 << "ms.");
+                SALERT("Command " << command->request.methodLine << " timed out after " << e.time()/1000 << "ms.");
             }
             STHROW("555 Timeout peeking command");
         }
@@ -147,27 +147,27 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
             }
         }
     } catch (const SException& e) {
-        command.repeek = false;
+        command->repeek = false;
         _db.resetTiming();
         _db.read("PRAGMA query_only = false;");
         _handleCommandException(command, e);
     } catch (const SHTTPSManager::NotLeading& e) {
-        command.repeek = false;
+        command->repeek = false;
         _db.rollback();
         _db.read("PRAGMA query_only = false;");
         _db.resetTiming();
         SINFO("Command '" << request.methodLine << "' wants to make HTTPS request, queuing for processing.");
         return false;
     } catch (...) {
-        command.repeek = false;
+        command->repeek = false;
         _db.resetTiming();
         _db.read("PRAGMA query_only = false;");
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
-        command.response.methodLine = "500 Unhandled Exception";
+        command->response.methodLine = "500 Unhandled Exception";
     }
 
     // If we get here, it means the command is fully completed.
-    command.complete = true;
+    command->complete = true;
 
     // Back out of the current transaction, it doesn't need to do anything.
     _db.rollback();
@@ -177,27 +177,27 @@ bool BedrockCore::peekCommand(BedrockCommand& command) {
     return true;
 }
 
-bool BedrockCore::processCommand(BedrockCommand& command) {
+bool BedrockCore::processCommand(unique_ptr<BedrockCommand>& command) {
     AutoTimer timer(command, BedrockCommand::PROCESS);
 
     // Convenience references to commonly used properties.
-    SData& request = command.request;
-    SData& response = command.response;
-    STable& content = command.jsonContent;
+    SData& request = command->request;
+    SData& response = command->response;
+    STable& content = command->jsonContent;
 
     // Keep track of whether we've modified the database and need to perform a `commit`.
     bool needsCommit = false;
     try {
         SDEBUG("Processing '" << request.methodLine << "'");
         uint64_t timeout = _getRemainingTime(command);
-        command.processCount++;
+        command->processCount++;
 
         // Time in US.
         _db.startTiming(timeout);
         // If a transaction was already begun in `peek`, then this is a no-op. We call it here to support the case where
         // peek created a httpsRequest and closed it's first transaction until the httpsRequest was complete, in which
         // case we need to open a new transaction.
-        if (!_db.insideTransaction() && !_db.beginConcurrentTransaction(true, command.request.methodLine)) {
+        if (!_db.insideTransaction() && !_db.beginConcurrentTransaction(true, command->request.methodLine)) {
             STHROW("501 Failed to begin concurrent transaction");
         }
 
@@ -205,21 +205,21 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         bool pluginProcessed = false;
 
         // If the command is mocked, turn on UpdateNoopMode.
-        _db.setUpdateNoopMode(command.request.isSet("mockRequest"));
+        _db.setUpdateNoopMode(command->request.isSet("mockRequest"));
         for (auto plugin : _server.plugins) {
             // Try to process the command.
             bool (*handler)(int, const char*, string&) = nullptr;
-            bool enable = plugin.second->shouldEnableQueryRewriting(_db, command, &handler);
+            bool enable = plugin.second->shouldEnableQueryRewriting(_db, *command, &handler);
             AutoScopeRewrite rewrite(enable, _db, handler);
             try {
-                if (plugin.second->processCommand(_db, command)) {
+                if (plugin.second->processCommand(_db, *command)) {
                     SINFO("Plugin '" << plugin.second->getName() << "' processed command '" << request.methodLine << "'");
                     pluginProcessed = true;
-                    command.processedBy = plugin.second;
+                    command->processedBy = plugin.second;
                     break;
                 }
             } catch (const SQLite::timeout_error& e) {
-                SALERT("Command " << command.request.methodLine << " timed out after " << e.time()/1000 << "ms.");
+                SALERT("Command " << command->request.methodLine << " timed out after " << e.time()/1000 << "ms.");
                 STHROW("555 Timeout processing command");
             }
         }
@@ -262,7 +262,7 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
         needsCommit = false;
     } catch(...) {
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
-        command.response.methodLine = "500 Unhandled Exception";
+        command->response.methodLine = "500 Unhandled Exception";
         _db.rollback();
         needsCommit = false;
     }
@@ -274,12 +274,12 @@ bool BedrockCore::processCommand(BedrockCommand& command) {
     _db.resetTiming();
 
     // Done, return whether or not we need the parent to commit our transaction.
-    command.complete = !needsCommit;
+    command->complete = !needsCommit;
     return needsCommit;
 }
 
-void BedrockCore::_handleCommandException(BedrockCommand& command, const SException& e) {
-    const string& msg = "Error processing command '" + command.request.methodLine + "' (" + e.what() + "), ignoring.";
+void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e) {
+    const string& msg = "Error processing command '" + command->request.methodLine + "' (" + e.what() + "), ignoring.";
     if (SContains(e.what(), "_ALERT_")) {
         SALERT(msg);
     } else if (SContains(e.what(), "_WARN_")) {
@@ -294,15 +294,15 @@ void BedrockCore::_handleCommandException(BedrockCommand& command, const SExcept
 
     // Set the response to the values from the exception, if set.
     if (!e.method.empty()) {
-        command.response.methodLine = e.method;
+        command->response.methodLine = e.method;
     }
     if (!e.headers.empty()) {
-        command.response.nameValueMap = e.headers;
+        command->response.nameValueMap = e.headers;
     }
     if (!e.body.empty()) {
-        command.response.content = e.body;
+        command->response.content = e.body;
     }
 
     // Add the commitCount header to the response.
-    command.response["commitCount"] = to_string(_db.getCommitCount());
+    command->response["commitCount"] = to_string(_db.getCommitCount());
 }

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -10,13 +10,13 @@ class BedrockCore : public SQLiteCore {
     // Automatic timing class that records an entry corresponding to its lifespan.
     class AutoTimer {
       public:
-        AutoTimer(BedrockCommand& command, BedrockCommand::TIMING_INFO type) :
+        AutoTimer(unique_ptr<BedrockCommand>& command, BedrockCommand::TIMING_INFO type) :
         _command(command), _type(type), _start(STimeNow()) { }
         ~AutoTimer() {
-            _command.timingInfo.emplace_back(make_tuple(_type, _start, STimeNow()));
+            _command->timingInfo.emplace_back(make_tuple(_type, _start, STimeNow()));
         }
       private:
-        BedrockCommand& _command;
+        unique_ptr<BedrockCommand>& _command;
         BedrockCommand::TIMING_INFO _type;
         uint64_t _start;
     };
@@ -24,7 +24,7 @@ class BedrockCore : public SQLiteCore {
     // Checks if a command has already timed out. Like `peekCommand` without doing any work. Returns `true` and sets
     // the same command state as `peekCommand` would if the command has timed out. Returns `false` and does nothing if
     // the command hasn't timed out.
-    bool isTimedOut(BedrockCommand& command);
+    bool isTimedOut(unique_ptr<BedrockCommand>& command);
 
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same
     // command, and it *may be called multiple times*. Preventing duplicate actions on calling peek multiple times is
@@ -33,7 +33,7 @@ class BedrockCore : public SQLiteCore {
     // should be considered an error to modify the DB from inside `peek`.
     // Returns a boolean value of `true` if the command is complete and its `response` field can be returned to the
     // caller. Returns `false` if the command will need to be passed to `process` to complete handling the command.
-    bool peekCommand(BedrockCommand& command);
+    bool peekCommand(unique_ptr<BedrockCommand>& command);
 
     // Process is the follow-up to `peek` if `peek` was insufficient to handle the command. It will only ever be called
     // on the leader node, and should always be able to resolve the command completely. When a command is passed to
@@ -45,7 +45,7 @@ class BedrockCore : public SQLiteCore {
     // replicate the transaction to follower nodes. Upon being returned `true`, the caller will attempt to perform a
     // `COMMIT` and replicate the transaction to follower nodes. It's allowable for this `COMMIT` to fail, in which case
     // this command *will be passed to process again in the future to retry*.
-    bool processCommand(BedrockCommand& command);
+    bool processCommand(unique_ptr<BedrockCommand>& command);
 
   private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.
@@ -54,8 +54,8 @@ class BedrockCore : public SQLiteCore {
     // Gets the amount of time remaining until this command times out. This is the difference between the command's
     // 'timeout' value (or the default timeout, if not set) and the time the command was initially scheduled to run. If
     // this time is already expired, this throws `555 Timeout`
-    uint64_t _getRemainingTime(const BedrockCommand& command);
+    uint64_t _getRemainingTime(const unique_ptr<BedrockCommand>& command);
 
-    void _handleCommandException(BedrockCommand& command, const SException& e);
+    void _handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e);
     const BedrockServer& _server;
 };

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -10,13 +10,13 @@ class BedrockCore : public SQLiteCore {
     // Automatic timing class that records an entry corresponding to its lifespan.
     class AutoTimer {
       public:
-        AutoTimer(unique_ptr<BedrockCommand>& command, BedrockCommand::TIMING_INFO type) :
+        AutoTimer(BedrockCommandPtr& command, BedrockCommand::TIMING_INFO type) :
         _command(command), _type(type), _start(STimeNow()) { }
         ~AutoTimer() {
             _command->timingInfo.emplace_back(make_tuple(_type, _start, STimeNow()));
         }
       private:
-        unique_ptr<BedrockCommand>& _command;
+        BedrockCommandPtr& _command;
         BedrockCommand::TIMING_INFO _type;
         uint64_t _start;
     };
@@ -24,7 +24,7 @@ class BedrockCore : public SQLiteCore {
     // Checks if a command has already timed out. Like `peekCommand` without doing any work. Returns `true` and sets
     // the same command state as `peekCommand` would if the command has timed out. Returns `false` and does nothing if
     // the command hasn't timed out.
-    bool isTimedOut(unique_ptr<BedrockCommand>& command);
+    bool isTimedOut(BedrockCommandPtr& command);
 
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same
     // command, and it *may be called multiple times*. Preventing duplicate actions on calling peek multiple times is
@@ -33,7 +33,7 @@ class BedrockCore : public SQLiteCore {
     // should be considered an error to modify the DB from inside `peek`.
     // Returns a boolean value of `true` if the command is complete and its `response` field can be returned to the
     // caller. Returns `false` if the command will need to be passed to `process` to complete handling the command.
-    bool peekCommand(unique_ptr<BedrockCommand>& command);
+    bool peekCommand(BedrockCommandPtr& command);
 
     // Process is the follow-up to `peek` if `peek` was insufficient to handle the command. It will only ever be called
     // on the leader node, and should always be able to resolve the command completely. When a command is passed to
@@ -45,7 +45,7 @@ class BedrockCore : public SQLiteCore {
     // replicate the transaction to follower nodes. Upon being returned `true`, the caller will attempt to perform a
     // `COMMIT` and replicate the transaction to follower nodes. It's allowable for this `COMMIT` to fail, in which case
     // this command *will be passed to process again in the future to retry*.
-    bool processCommand(unique_ptr<BedrockCommand>& command);
+    bool processCommand(BedrockCommandPtr& command);
 
   private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.
@@ -54,8 +54,8 @@ class BedrockCore : public SQLiteCore {
     // Gets the amount of time remaining until this command times out. This is the difference between the command's
     // 'timeout' value (or the default timeout, if not set) and the time the command was initially scheduled to run. If
     // this time is already expired, this throws `555 Timeout`
-    uint64_t _getRemainingTime(const unique_ptr<BedrockCommand>& command);
+    uint64_t _getRemainingTime(const BedrockCommandPtr& command);
 
-    void _handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e);
+    void _handleCommandException(BedrockCommandPtr& command, const SException& e);
     const BedrockServer& _server;
 };

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -26,25 +26,25 @@ void BedrockServer::acceptCommand(SQLiteCommand&& command, bool isNew) {
         }
         SALERT("Blacklisting command (now have " << totalCount << " blacklisted commands): " << request.serialize());
     } else {
-        BedrockCommand newCommand(move(command));
-        if (SIEquals(newCommand.request.methodLine, "BROADCAST_COMMAND")) {
+        unique_ptr<BedrockCommand> newCommand = make_unique<BedrockCommand>(move(command));
+        if (SIEquals(newCommand->request.methodLine, "BROADCAST_COMMAND")) {
             SData newRequest;
-            newRequest.deserialize(newCommand.request.content);
-            newCommand = BedrockCommand(newRequest);
-            newCommand.initiatingClientID = -1;
-            newCommand.initiatingPeerID = 0;
+            newRequest.deserialize(newCommand->request.content);
+            newCommand = make_unique<BedrockCommand>(newRequest);
+            newCommand->initiatingClientID = -1;
+            newCommand->initiatingPeerID = 0;
         }
         // Add a request ID if one was missing.
-        _addRequestID(newCommand.request);
-        SAUTOPREFIX(newCommand.request);
-        if (newCommand.writeConsistency != SQLiteNode::QUORUM
-            && _syncCommands.find(newCommand.request.methodLine) != _syncCommands.end()) {
+        _addRequestID(newCommand->request);
+        SAUTOPREFIX(newCommand->request);
+        if (newCommand->writeConsistency != SQLiteNode::QUORUM
+            && _syncCommands.find(newCommand->request.methodLine) != _syncCommands.end()) {
 
-            newCommand.writeConsistency = SQLiteNode::QUORUM;
+            newCommand->writeConsistency = SQLiteNode::QUORUM;
             _lastQuorumCommandTime = STimeNow();
-            SINFO("Forcing QUORUM consistency for command " << newCommand.request.methodLine);
+            SINFO("Forcing QUORUM consistency for command " << newCommand->request.methodLine);
         }
-        SINFO("Queued new '" << newCommand.request.methodLine << "' command from bedrock node, with " << _commandQueue.size()
+        SINFO("Queued new '" << newCommand->request.methodLine << "' command from bedrock node, with " << _commandQueue.size()
               << " commands already queued.");
 
         _commandQueue.push(move(newCommand));
@@ -193,7 +193,7 @@ void BedrockServer::sync(const SData& args,
 
     // Now we jump into our main command processing loop.
     uint64_t nextActivity = STimeNow();
-    BedrockCommand command(move(SQLiteCommand(SData())), BedrockCommand::DONT_COUNT);
+    unique_ptr<BedrockCommand> command(nullptr);
     bool committingCommand = false;
 
     // We hold a lock here around all operations on `syncNode`, because `SQLiteNode` isn't thread-safe, but we need
@@ -204,7 +204,9 @@ void BedrockServer::sync(const SData& args,
     server._syncMutex.lock();
     do {
         // Make sure the existing command prefix is still valid since they're reset when SAUTOPREFIX goes out of scope.
-        SAUTOPREFIX(command.request);
+        if (command) {
+            SAUTOPREFIX(command->request);
+        }
 
         // If there were commands waiting on our commit count to come up-to-date, we'll move them back to the main
         // command queue here. There's no place in particular that's best to do this, so we do it at the top of this
@@ -224,13 +226,13 @@ void BedrockServer::sync(const SData& args,
                     auto itPair =  server._futureCommitCommands.equal_range(it->second);
                     for (auto cmdIt = itPair.first; cmdIt != itPair.second; cmdIt++) {
                         // Check for one with this timeout.
-                        if (cmdIt->second.timeout() == it->first) {
+                        if (cmdIt->second->timeout() == it->first) {
                             // This command has the right commit count *and* timeout, return it.
-                            SINFO("Returning command (" << cmdIt->second.request.methodLine << ") waiting on commit " << cmdIt->first
+                            SINFO("Returning command (" << cmdIt->second->request.methodLine << ") waiting on commit " << cmdIt->first
                                   << " to queue, timed out at: " << now << ", timeout was: " << it->first << ".");
 
                             // Remove the commit count requirement so this can get timed out.
-                            cmdIt->second.request.erase("commitCount");
+                            cmdIt->second->request.erase("commitCount");
                             server._commandQueue.push(move(cmdIt->second));
 
                             // And delete it, it's gone.
@@ -254,12 +256,12 @@ void BedrockServer::sync(const SData& args,
                 uint64_t commitCount = db.getCommitCount();
                 auto it = server._futureCommitCommands.begin();
                 while (it != server._futureCommitCommands.end() && (it->first <= commitCount || server._shutdownState.load() != RUNNING)) {
-                    SINFO("Returning command (" << it->second.request.methodLine << ") waiting on commit " << it->first
+                    SINFO("Returning command (" << it->second->request.methodLine << ") waiting on commit " << it->first
                           << " to queue, now have commit " << commitCount);
                     server._commandQueue.push(move(it->second));
 
                     // Remove it from the timed out list as well.
-                    auto itPair = server._futureCommitCommandTimeouts.equal_range(it->second.timeout());
+                    auto itPair = server._futureCommitCommandTimeouts.equal_range(it->second->timeout());
                     for (auto timeoutIt = itPair.first; timeoutIt != itPair.second; timeoutIt++) {
                         if (timeoutIt->second == it->first) {
                              server._futureCommitCommandTimeouts.erase(timeoutIt);
@@ -396,9 +398,9 @@ void BedrockServer::sync(const SData& args,
             try {
                 while (true) {
                     // Reset this to blank. This releases the existing command and allows it to get cleaned up.
-                    command = BedrockCommand(move(SQLiteCommand(SData())), BedrockCommand::DONT_COUNT);
+                    command = nullptr;
                     command = syncNodeQueuedCommands.pop();
-                    if (command.initiatingClientID) {
+                    if (command->initiatingClientID) {
                         // This one came from a local client, so we can save it for later.
                         server._commandQueue.push(move(command));
                     }
@@ -411,8 +413,10 @@ void BedrockServer::sync(const SData& args,
         // If we started a commit, and one's not in progress, then we've finished it and we'll take that command and
         // stick it back in the appropriate queue.
         if (committingCommand && !server._syncNode->commitInProgress()) {
-            // Record the time spent.
-            command.stopTiming(BedrockCommand::COMMIT_SYNC);
+            // Record the time spent, unless we were upgrading, in which case, there's no command to write to.
+            if (command) {
+                command->stopTiming(BedrockCommand::COMMIT_SYNC);
+            }
 
             // We're done with the commit, we unlock our mutex and decrement our counter.
             server._syncThreadCommitMutex.unlock();
@@ -424,12 +428,12 @@ void BedrockServer::sync(const SData& args,
                     server._suppressMultiWrite.store(false);
                     continue;
                 }
-                SINFO("[performance] Sync thread finished committing command " << command.request.methodLine);
+                SINFO("[performance] Sync thread finished committing command " << command->request.methodLine);
 
                 // Otherwise, save the commit count, mark this command as complete, and reply.
-                command.response["commitCount"] = to_string(db.getCommitCount());
-                command.complete = true;
-                if (command.initiatingPeerID) {
+                command->response["commitCount"] = to_string(db.getCommitCount());
+                command->complete = true;
+                if (command->initiatingPeerID) {
                     // This is a command that came from a peer. Have the sync node send the response back to the peer.
                     server._finishPeerCommand(command);
                 } else {
@@ -443,14 +447,14 @@ void BedrockServer::sync(const SData& args,
                 // state, because this loop is skipped except when LEADING, FOLLOWING, or STANDINGDOWN. It's also
                 // theoretically feasible for this to happen if a follower fails to commit a transaction, but that
                 // probably indicates a bug (or a follower disk failure).
-                SINFO("requeueing command " << command.request.methodLine
+                SINFO("requeueing command " << command->request.methodLine
                       << " after failed sync commit. Sync thread has " << syncNodeQueuedCommands.size()
                       << " queued commands.");
                 syncNodeQueuedCommands.push(move(command));
             }
 
             // Prevent the requestID from a finished command from being used.
-            command.request.clear();
+            command->request.clear();
         }
 
         // We're either leading, standing down, or following. There could be a commit in progress on `command`, but
@@ -460,11 +464,11 @@ void BedrockServer::sync(const SData& args,
             // If there are any completed commands to respond to, we'll do that first.
             try {
                 while (true) {
-                    BedrockCommand completedCommand = server._completedCommands.pop();
-                    SAUTOPREFIX(completedCommand.request);
-                    SASSERT(completedCommand.complete);
-                    SASSERT(completedCommand.initiatingPeerID);
-                    SASSERT(!completedCommand.initiatingClientID);
+                    unique_ptr<BedrockCommand> completedCommand = server._completedCommands.pop();
+                    SAUTOPREFIX(completedCommand->request);
+                    SASSERT(completedCommand->complete);
+                    SASSERT(completedCommand->initiatingPeerID);
+                    SASSERT(!completedCommand->initiatingClientID);
                     server._finishPeerCommand(completedCommand);
                 }
             } catch (const out_of_range& e) {
@@ -477,18 +481,18 @@ void BedrockServer::sync(const SData& args,
             }
 
             // Reset this to blank. This releases the existing command and allows it to get cleaned up.
-            command = BedrockCommand(move(SQLiteCommand(SData())), BedrockCommand::DONT_COUNT);
+            command = nullptr;
 
             // Get the next sync node command to work on.
             command = syncNodeQueuedCommands.pop();
 
             // We got a command to work on! Set our log prefix to the request ID.
-            SAUTOPREFIX(command.request);
-            SINFO("Sync thread dequeued command " << command.request.methodLine << ". Sync thread has "
+            SAUTOPREFIX(command->request);
+            SINFO("Sync thread dequeued command " << command->request.methodLine << ". Sync thread has "
                   << syncNodeQueuedCommands.size() << " queued commands.");
 
-            if (command.timeout() < STimeNow()) {
-                SINFO("Command '" << command.request.methodLine << "' timed out in sync thread queue, sending back to main queue.");
+            if (command->timeout() < STimeNow()) {
+                SINFO("Command '" << command->request.methodLine << "' timed out in sync thread queue, sending back to main queue.");
                 server._commandQueue.push(move(command));
                 continue;
             }
@@ -497,7 +501,7 @@ void BedrockServer::sync(const SData& args,
             // like a segfault. Note that it's possible we're in the middle of sending a message to peers when we call
             // this, which would probably make this message malformed. This is the best we can do.
             SSetSignalHandlerDieFunc([&](){
-                server._syncNode->broadcast(_generateCrashMessage(&command));
+                server._syncNode->broadcast(_generateCrashMessage(command));
             });
 
             // And now we'll decide how to handle it.
@@ -522,7 +526,7 @@ void BedrockServer::sync(const SData& args,
                 // IMPORTANT: This check is omitted for commands with an HTTPS request object, because we don't want to
                 // risk duplicating that request. If your command creates an HTTPS request, it needs to explicitly
                 // re-verify that any checks made in peek are still valid in process.
-                if (!command.httpsRequests.size()) {
+                if (!command->httpsRequests.size()) {
                     if (core.peekCommand(command)) {
 
                         // Finished with this.
@@ -530,8 +534,8 @@ void BedrockServer::sync(const SData& args,
 
                         // This command completed in peek, respond to it appropriately, either directly or by sending it
                         // back to the sync thread.
-                        SASSERT(command.complete);
-                        if (command.initiatingPeerID) {
+                        SASSERT(command->complete);
+                        if (command->initiatingPeerID) {
                             server._finishPeerCommand(command);
                         } else {
                             server._reply(command);
@@ -540,7 +544,7 @@ void BedrockServer::sync(const SData& args,
                     }
 
                     // If we just started a new HTTPS request, save it for later.
-                    if (command.httpsRequests.size()) {
+                    if (command->httpsRequests.size()) {
                         server.waitForHTTPS(move(command));
 
                         // Move on to the next command until this one finishes.
@@ -553,10 +557,10 @@ void BedrockServer::sync(const SData& args,
                 if (core.processCommand(command)) {
                     // The processor says we need to commit this, so let's start that process.
                     committingCommand = true;
-                    SINFO("[performance] Sync thread beginning committing command " << command.request.methodLine);
+                    SINFO("[performance] Sync thread beginning committing command " << command->request.methodLine);
                     // START TIMING.
-                    command.startTiming(BedrockCommand::COMMIT_SYNC);
-                    server._syncNode->startCommit(command.writeConsistency);
+                    command->startTiming(BedrockCommand::COMMIT_SYNC);
+                    server._syncNode->startCommit(command->writeConsistency);
 
                     // And we'll start the next main loop.
                     // NOTE: This will cause us to read from the network again. This, in theory, is fine, but we saw
@@ -572,7 +576,7 @@ void BedrockServer::sync(const SData& args,
                     // Otherwise, the command doesn't need a commit (maybe it was an error, or it didn't have any work
                     // to do). We'll just respond.
                     server._syncThreadCommitMutex.unlock();
-                    if (command.initiatingPeerID) {
+                    if (command->initiatingPeerID) {
                         server._finishPeerCommand(command);
                     } else {
                         server._reply(command);
@@ -582,16 +586,18 @@ void BedrockServer::sync(const SData& args,
                 // If we're following, we just escalate directly to leader without peeking. We can only get an incomplete
                 // command on the follower sync thread if a follower worker thread peeked it unsuccessfully, so we don't
                 // bother peeking it again.
-                auto it = command.request.nameValueMap.find("Connection");
-                bool forget = it != command.request.nameValueMap.end() && SIEquals(it->second, "forget");
-                server._syncNode->escalateCommand(move(command), forget);
+                auto it = command->request.nameValueMap.find("Connection");
+                bool forget = it != command->request.nameValueMap.end() && SIEquals(it->second, "forget");
+                server._syncNode->escalateCommand(move(*command), forget);
                 if (forget) {
                     // Command is no longer in progress.
                 }
             }
         } catch (const out_of_range& e) {
             // Prevent the requestID from a finished command from being used.
-            command.request.clear();
+            if (command) {
+                command->request.clear();
+            }
 
             // syncNodeQueuedCommands had no commands to work on, we'll need to re-poll for some.
             continue;
@@ -676,7 +682,7 @@ void BedrockServer::worker(const SData& args,
     BedrockCore core(db, server);
 
     // Command to work on. This default command is replaced when we find work to do.
-    BedrockCommand command(move(SQLiteCommand(SData())), BedrockCommand::DONT_COUNT);
+    unique_ptr<BedrockCommand> command(nullptr);
 
     // Which command queue do we use? The blockingCommit thread special and does blocking commits from the blocking queue.
     BedrockCommandQueue& commandQueue = threadId ? server._commandQueue : server._blockingCommandQueue;
@@ -691,20 +697,20 @@ void BedrockServer::worker(const SData& args,
             });
 
             // Reset this to blank. This releases the existing command and allows it to get cleaned up.
-            command = BedrockCommand(move(SQLiteCommand(SData())), BedrockCommand::DONT_COUNT);
+            command = nullptr;
 
             // And get another one.
             command = commandQueue.get(1000000);
 
-            SAUTOPREFIX(command.request);
-            SINFO("Dequeued command " << command.request.methodLine << " in worker, "
+            SAUTOPREFIX(command->request);
+            SINFO("Dequeued command " << command->request.methodLine << " in worker, "
                   << commandQueue.size() << " commands in " << (threadId ? "" : "blocking") << " queue.");
 
             // Set the function that lets the signal handler know which command caused a problem, in case that happens.
             // If a signal is caught on this thread, which should only happen for unrecoverable, yet synchronous
             // signals, like SIGSEGV, this function will be called.
             SSetSignalHandlerDieFunc([&](){
-                server._syncNode->broadcast(_generateCrashMessage(&command));
+                server._syncNode->broadcast(_generateCrashMessage(command));
             });
 
             // If we dequeue a status or control command, handle it immediately.
@@ -719,7 +725,7 @@ void BedrockServer::worker(const SData& args,
             // because the commands already had a HTTPS request attached, and then they were immediately re-sent to the
             // sync queue, because of the QUORUM consistency requirement, resulting in an endless loop.
             if (core.isTimedOut(command)) {
-                if (command.initiatingPeerID) {
+                if (command->initiatingPeerID) {
                     // Escalated command. Give it back to the sync thread to respond.
                     syncNodeCompletedCommands.push(move(command));
                 } else {
@@ -731,10 +737,10 @@ void BedrockServer::worker(const SData& args,
             // Check if this command would be likely to cause a crash
             if (server._wouldCrash(command)) {
                 // If so, make a lot of noise, and respond 500 without processing it.
-                SALERT("CRASH-INDUCING COMMAND FOUND: " << command.request.methodLine);
-                command.response.methodLine = "500 Refused";
-                command.complete = true;
-                if (command.initiatingPeerID) {
+                SALERT("CRASH-INDUCING COMMAND FOUND: " << command->request.methodLine);
+                command->response.methodLine = "500 Refused";
+                command->complete = true;
+                if (command->initiatingPeerID) {
                     // Escalated command. Give it back to the sync thread to respond.
                     syncNodeCompletedCommands.push(move(command));
                 } else {
@@ -745,7 +751,7 @@ void BedrockServer::worker(const SData& args,
 
             // If this was a command initiated by a peer as part of a cluster operation, then we process it separately
             // and respond immediately. This allows SQLiteNode to offload read-only operations to worker threads.
-            if (SQLiteNode::peekPeerCommand(server._syncNode.get(), db, command)) {
+            if (SQLiteNode::peekPeerCommand(server._syncNode.get(), db, *command)) {
                 // Move on to the next command.
                 continue;
             }
@@ -759,7 +765,7 @@ void BedrockServer::worker(const SData& args,
                 // Make sure that the node isn't shutting down, leaving us in an endless loop.
                 if (server._shutdownState.load() != RUNNING) {
                     SWARN("Sync thread shut down while were waiting for it to come up. Discarding command '"
-                          << command.request.methodLine << "'.");
+                          << command->request.methodLine << "'.");
                     return;
                 }
 
@@ -774,13 +780,13 @@ void BedrockServer::worker(const SData& args,
             // finishes its update loop, it will re-queue any of these commands that are no longer blocked on our
             // updated commit count.
             uint64_t commitCount = db.getCommitCount();
-            uint64_t commandCommitCount = command.request.calcU64("commitCount");
+            uint64_t commandCommitCount = command->request.calcU64("commitCount");
             if (commandCommitCount > commitCount) {
                 SAUTOLOCK(server._futureCommitCommandMutex);
                 auto newQueueSize = server._futureCommitCommands.size() + 1;
-                SINFO("Command (" << command.request.methodLine << ") depends on future commit (" << commandCommitCount
+                SINFO("Command (" << command->request.methodLine << ") depends on future commit (" << commandCommitCount
                       << "), Currently at: " << commitCount << ", storing for later. Queue size: " << newQueueSize);
-                server._futureCommitCommandTimeouts.insert(make_pair(command.timeout(), commandCommitCount));
+                server._futureCommitCommandTimeouts.insert(make_pair(command->timeout(), commandCommitCount));
                 server._futureCommitCommands.insert(make_pair(commandCommitCount, move(command)));
 
                 // Don't count this as `in progress`, it's just sitting there.
@@ -803,13 +809,13 @@ void BedrockServer::worker(const SData& args,
             // original caller will need to re-send the request. This can happen if we're leading, and receive a
             // request from a peer, but then we stand down from leading. The SQLiteNode should have already told its
             // peers that their outstanding requests were being canceled at this point.
-            if (command.initiatingPeerID && !(state == SQLiteNode::LEADING || state == SQLiteNode::STANDINGDOWN)) {
-                SWARN("Found " << (command.complete ? "" : "in") << "complete " << "command "
-                      << command.request.methodLine << " from peer, but not leading. Too late for it, discarding.");
+            if (command->initiatingPeerID && !(state == SQLiteNode::LEADING || state == SQLiteNode::STANDINGDOWN)) {
+                SWARN("Found " << (command->complete ? "" : "in") << "complete " << "command "
+                      << command->request.methodLine << " from peer, but not leading. Too late for it, discarding.");
 
                 // If the command was processed, tell the plugin we couldn't send the response.
-                if (command.processedBy) {
-                    command.processedBy->handleFailedReply(command);
+                if (command->processedBy) {
+                    command->processedBy->handleFailedReply(*command);
                 }
 
                 continue;
@@ -818,23 +824,23 @@ void BedrockServer::worker(const SData& args,
             // If this command is already complete, then we should be a follower, and the sync node got a response back
             // from a command that had been escalated to leader, and queued it for a worker to respond to. We'll send
             // that response now.
-            if (command.complete) {
+            if (command->complete) {
                 // If this command is already complete, we can return it to the caller.
                 // If it has an initiator, it should have been returned to a peer by a sync node instead, but if we've
                 // just switched states out of leading, we might have an old command in the queue. All we can do here
                 // is note that and discard it, as we have nobody to deliver it to.
-                if (command.initiatingPeerID) {
+                if (command->initiatingPeerID) {
                     // Let's note how old this command is.
-                    uint64_t ageSeconds = (STimeNow() - command.creationTime) / STIME_US_PER_S;
-                    SWARN("Found unexpected complete command " << command.request.methodLine
+                    uint64_t ageSeconds = (STimeNow() - command->creationTime) / STIME_US_PER_S;
+                    SWARN("Found unexpected complete command " << command->request.methodLine
                           << " from peer in worker thread. Discarding (command was " << ageSeconds << "s old).");
                     continue;
                 }
 
                 // Make sure we have an initiatingClientID at this point. If we do, but it's negative, it's for a
                 // client that we can't respond to, so we don't bother sending the response.
-                SASSERT(command.initiatingClientID);
-                if (command.initiatingClientID > 0) {
+                SASSERT(command->initiatingClientID);
+                if (command->initiatingClientID > 0) {
                     server._reply(command);
                 }
 
@@ -842,8 +848,8 @@ void BedrockServer::worker(const SData& args,
                 continue;
             }
 
-            if (command.request.isSet("mockRequest")) {
-                SINFO("mockRequest set for command '" << command.request.methodLine << "'.");
+            if (command->request.isSet("mockRequest")) {
+                SINFO("mockRequest set for command '" << command->request.methodLine << "'.");
             }
 
             // See if this is a feasible command to write parallel. If not, then be ready to forward it to the sync
@@ -853,22 +859,22 @@ void BedrockServer::worker(const SData& args,
                 // If multi-write is enabled, then we need to make sure the command isn't blacklisted.
                 shared_lock<decltype(_blacklistedParallelCommandMutex)> lock(_blacklistedParallelCommandMutex);
                 canWriteParallel =
-                    (_blacklistedParallelCommands.find(command.request.methodLine) == _blacklistedParallelCommands.end());
+                    (_blacklistedParallelCommands.find(command->request.methodLine) == _blacklistedParallelCommands.end());
             }
 
             // More checks for parallel writing.
             canWriteParallel = canWriteParallel && !server._suppressMultiWrite.load();
             canWriteParallel = canWriteParallel && (state == SQLiteNode::LEADING);
-            canWriteParallel = canWriteParallel && (command.writeConsistency == SQLiteNode::ASYNC);
+            canWriteParallel = canWriteParallel && (command->writeConsistency == SQLiteNode::ASYNC);
 
             // If all the other checks have passed, and we haven't sent a quorum command to the sync thread in a while,
             // auto-promote one.
             if (canWriteParallel) {
                 uint64_t now = STimeNow();
                 if (now > (server._lastQuorumCommandTime + (server._quorumCheckpointSeconds * 1'000'000))) {
-                    SINFO("Forcing QUORUM for command '" << command.request.methodLine << "'.");
+                    SINFO("Forcing QUORUM for command '" << command->request.methodLine << "'.");
                     server._lastQuorumCommandTime = now;
-                    command.writeConsistency = SQLiteNode::QUORUM;
+                    command->writeConsistency = SQLiteNode::QUORUM;
                     canWriteParallel = false;
                 }
             }
@@ -893,7 +899,7 @@ void BedrockServer::worker(const SData& args,
                 // If peek succeeds, then it's finished, and all we need to do is respond to the command at the bottom.
                 bool calledPeek = false;
                 bool peekResult = false;
-                if (command.repeek || !command.httpsRequests.size()) {
+                if (command->repeek || !command->httpsRequests.size()) {
                     peekResult = core.peekCommand(command);
                     calledPeek = true;
                 }
@@ -902,31 +908,31 @@ void BedrockServer::worker(const SData& args,
                     // We've just unsuccessfully peeked a command, which means we're in a state where we might want to
                     // write it. We'll flag that here, to keep the node from falling out of LEADING/STANDINGDOWN
                     // until we're finished with this command.
-                    if (command.httpsRequests.size()) {
+                    if (command->httpsRequests.size()) {
                         // This *should* be impossible, but previous bugs have existed where it's feasible that we call
                         // `peekCommand` while leading, and by the time we're done, we're FOLLOWING, so we check just
                         // in case we ever introduce another similar bug.
                         if (state != SQLiteNode::LEADING && state != SQLiteNode::STANDINGDOWN) {
                             SALERT("Not leading or standing down (" << SQLiteNode::stateName(state)
-                                   << ") but have outstanding HTTPS command: " << command.request.methodLine
+                                   << ") but have outstanding HTTPS command: " << command->request.methodLine
                                    << ", returning 500.");
-                            command.response.methodLine = "500 STANDDOWN TIMEOUT";
+                            command->response.methodLine = "500 STANDDOWN TIMEOUT";
                             server._reply(command);
                             core.rollback();
                             break;
                         }
 
                         // If the command isn't complete, we'll re-queue it.
-                        if (command.repeek || !command.areHttpsRequestsComplete()) {
+                        if (command->repeek || !command->areHttpsRequestsComplete()) {
                             // Roll back the existing transaction, but only if we are inside an transaction
                             if (calledPeek) {
                                 core.rollback();
                             }
 
-                            if (!command.areHttpsRequestsComplete()) {
+                            if (!command->areHttpsRequestsComplete()) {
                                 // If it has outstanding HTTPS requests, we'll wait for them.
                                 server.waitForHTTPS(move(command));
-                            } else if (command.repeek) {
+                            } else if (command->repeek) {
                                 // Otherwise, it needs to be re-peeked, but had no outstanding requests, so it goes
                                 // back in the main queue.
                                 commandQueue.push(move(command));
@@ -941,12 +947,12 @@ void BedrockServer::worker(const SData& args,
                     // We check `onlyProcessOnSyncThread` here, rather than before processing the command, because it's
                     // not set at creation time, it's set in `peek`, so we need to wait at least until after peek is
                     // called to check it.
-                    if (command.onlyProcessOnSyncThread || !canWriteParallel) {
+                    if (command->onlyProcessOnSyncThread || !canWriteParallel) {
                         // Roll back the transaction, it'll get re-run in the sync thread.
                         core.rollback();
 
                         // We're not handling a writable command anymore.
-                        SINFO("Sending non-parallel command " << command.request.methodLine
+                        SINFO("Sending non-parallel command " << command->request.methodLine
                               << " to sync thread. Sync thread has " << syncNodeQueuedCommands.size()
                               << " queued commands.");
                         syncNodeQueuedCommands.push(move(command));
@@ -1001,14 +1007,14 @@ void BedrockServer::worker(const SData& args,
                             }
                         }
                         if (commitSuccess) {
-                            SINFO("Successfully committed " << command.request.methodLine << " on worker thread. blocking: "
+                            SINFO("Successfully committed " << command->request.methodLine << " on worker thread. blocking: "
                                   << (threadId ? "false" : "true"));
                             // So we must still be leading, and at this point our commit has succeeded, let's
                             // mark it as complete. We add the currentCommit count here as well.
-                            command.response["commitCount"] = to_string(db.getCommitCount());
-                            command.complete = true;
+                            command->response["commitCount"] = to_string(db.getCommitCount());
+                            command->complete = true;
                         } else {
-                            SINFO("Conflict or state change committing " << command.request.methodLine
+                            SINFO("Conflict or state change committing " << command->request.methodLine
                                   << " on worker thread with " << retry << " retries remaining.");
                         }
                     }
@@ -1016,8 +1022,8 @@ void BedrockServer::worker(const SData& args,
 
                 // If the command was completed above, then we'll go ahead and respond. Otherwise there must have been
                 // a conflict, and we'll retry.
-                if (command.complete) {
-                    if (command.initiatingPeerID) {
+                if (command->complete) {
+                    if (command->initiatingPeerID) {
                         // Escalated command. Send it back to the peer.
                         server._finishPeerCommand(command);
                     } else {
@@ -1032,7 +1038,7 @@ void BedrockServer::worker(const SData& args,
                 --retry;
 
                 if (!retry) {
-                    SINFO("Max retries hit in worker, sending '" << command.request.methodLine << "' to blocking queue.");
+                    SINFO("Max retries hit in worker, sending '" << command->request.methodLine << "' to blocking queue.");
                    server._blockingCommandQueue.push(move(command));
                 }
             }
@@ -1053,19 +1059,19 @@ void BedrockServer::worker(const SData& args,
     }
 }
 
-bool BedrockServer::_handleIfStatusOrControlCommand(BedrockCommand& command) {
+bool BedrockServer::_handleIfStatusOrControlCommand(unique_ptr<BedrockCommand>& command) {
     if (_isStatusCommand(command)) {
         _status(command);
         _reply(command);
         return true;
     } else if (_isControlCommand(command)) {
         // Control commands can only come from localhost (and thus have an empty `_source`).
-        if (command.request["_source"].empty()) {
+        if (command->request["_source"].empty()) {
             _control(command);
         } else {
-            SWARN("Got control command " << command.request.methodLine << " on non-localhost socket ("
-                  << command.request["_source"] << "). Ignoring.");
-            command.response.methodLine = "401 Unauthorized";
+            SWARN("Got control command " << command->request.methodLine << " on non-localhost socket ("
+                  << command->request["_source"] << "). Ignoring.");
+            command->response.methodLine = "401 Unauthorized";
         }
         _reply(command);
         return true;
@@ -1073,12 +1079,12 @@ bool BedrockServer::_handleIfStatusOrControlCommand(BedrockCommand& command) {
     return false;
 }
 
-bool BedrockServer::_wouldCrash(const BedrockCommand& command) {
+bool BedrockServer::_wouldCrash(const unique_ptr<BedrockCommand>& command) {
     // Get a shared lock so that all the workers can look at this map simultaneously.
     shared_lock<decltype(_crashCommandMutex)> lock(_crashCommandMutex);
 
     // Typically, this map is empty and this returns no results.
-    auto commandIt = _crashCommands.find(command.request.methodLine);
+    auto commandIt = _crashCommands.find(command->request.methodLine);
     if (commandIt == _crashCommands.end()) {
         return false;
     }
@@ -1095,8 +1101,8 @@ bool BedrockServer::_wouldCrash(const BedrockCommand& command) {
             }
 
             // See if our current command even has the blacklisted key.
-            auto it = command.request.nameValueMap.find(pair.first);
-            if (it ==  command.request.nameValueMap.end()) {
+            auto it = command->request.nameValueMap.find(pair.first);
+            if (it ==  command->request.nameValueMap.end()) {
                 // If we didn't find it, the command's not sufficiently similar, and is not blacklisted.
                 isMatch = false;
                 break;
@@ -1508,31 +1514,31 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                     }
 
                     // Create a command.
-                    BedrockCommand command(request);
+                    unique_ptr<BedrockCommand> command = make_unique<BedrockCommand>(request);
 
                     // Get the source ip of the command.
                     char *ip = inet_ntoa(s->addr.sin_addr);
                     if (ip != "127.0.0.1"s) {
                         // We only add this if it's not localhost because existing code expects commands that come from
                         // localhost to have it blank.
-                        command.request["_source"] = ip;
+                        command->request["_source"] = ip;
                     }
 
-                    if (command.writeConsistency != SQLiteNode::QUORUM
-                        && _syncCommands.find(command.request.methodLine) != _syncCommands.end()) {
+                    if (command->writeConsistency != SQLiteNode::QUORUM
+                        && _syncCommands.find(command->request.methodLine) != _syncCommands.end()) {
 
-                        command.writeConsistency = SQLiteNode::QUORUM;
+                        command->writeConsistency = SQLiteNode::QUORUM;
                         _lastQuorumCommandTime = STimeNow();
-                        SINFO("Forcing QUORUM consistency for command " << command.request.methodLine);
+                        SINFO("Forcing QUORUM consistency for command " << command->request.methodLine);
                     }
 
                     // This is important! All commands passed through the entire cluster must have unique IDs, or they
                     // won't get routed properly from follower to leader and back.
-                    command.id = args["-nodeName"] + "#" + to_string(_requestCount++);
+                    command->id = args["-nodeName"] + "#" + to_string(_requestCount++);
 
                     // And we and keep track of the client that initiated this command, so we can respond later, except
                     // if we received connection:forget in which case we don't respond later
-                    command.initiatingClientID = SIEquals(request["Connection"], "forget") ? -1 : s->id;
+                    command->initiatingClientID = SIEquals(request["Connection"], "forget") ? -1 : s->id;
 
                     // If it's a status or control command, we handle it specially there. If not, we'll queue it for
                     // later processing.
@@ -1541,7 +1547,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                         if (_syncNodeCopy && _syncNodeCopy->getState() == SQLiteNode::STANDINGDOWN) {
                             _standDownQueue.push(move(command));
                         } else {
-                            SINFO("Queued new '" << command.request.methodLine << "' command from local client, with "
+                            SINFO("Queued new '" << command->request.methodLine << "' command from local client, with "
                                   << _commandQueue.size() << " commands already queued.");
                             _commandQueue.push(move(command));
                         }
@@ -1614,60 +1620,60 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     }
 }
 
-void BedrockServer::_reply(BedrockCommand& command) {
+void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
     SAUTOLOCK(_socketIDMutex);
 
     // Finalize timing info even for commands we won't respond to (this makes this data available in logs).
-    command.finalizeTimingInfo();
+    command->finalizeTimingInfo();
 
     // Don't reply to commands with pseudo-clients (i.e., commands that we generated by other commands).
-    if (command.initiatingClientID < 0) {
+    if (command->initiatingClientID < 0) {
         return;
     }
 
     // Do we have a socket for this command?
-    auto socketIt = _socketIDMap.find(command.initiatingClientID);
+    auto socketIt = _socketIDMap.find(command->initiatingClientID);
     if (socketIt != _socketIDMap.end()) {
-        command.response["nodeName"] = args["-nodeName"];
+        command->response["nodeName"] = args["-nodeName"];
 
         // Is a plugin handling this command? If so, it gets to send the response.
-        string& pluginName = command.request["plugin"];
+        string& pluginName = command->request["plugin"];
 
         // If we're shutting down, tell the caller to close the connection.
         if (_shutdownState.load() != RUNNING) {
-            command.response["Connection"] = "close";
+            command->response["Connection"] = "close";
         }
 
         if (!pluginName.empty()) {
             // Let the plugin handle it
-            SINFO("Plugin '" << pluginName << "' handling response '" << command.response.methodLine
-                  << "' to request '" << command.request.methodLine << "'");
+            SINFO("Plugin '" << pluginName << "' handling response '" << command->response.methodLine
+                  << "' to request '" << command->request.methodLine << "'");
             auto it = plugins.find(pluginName);
             if (it != plugins.end()) {
-                it->second->onPortRequestComplete(command, socketIt->second);
+                it->second->onPortRequestComplete(*command, socketIt->second);
             } else {
                 SERROR("Couldn't find plugin '" << pluginName << ".");
             }
         } else {
             // Otherwise we send the standard response.
-            socketIt->second->send(command.response.serialize());
+            socketIt->second->send(command->response.serialize());
         }
 
         // If `Connection: close` was set, shut down the socket, in case the caller ignores us.
-        if (SIEquals(command.request["Connection"], "close") || _shutdownState.load() != RUNNING) {
+        if (SIEquals(command->request["Connection"], "close") || _shutdownState.load() != RUNNING) {
             shutdownSocket(socketIt->second, SHUT_RDWR);
         }
 
         // We only keep track of sockets with pending commands.
         _socketIDMap.erase(socketIt);
     } else {
-        if (!SIEquals(command.request["Connection"], "forget")) {
-            SINFO("No socket to reply for: '" << command.request.methodLine << "' #" << command.initiatingClientID);
+        if (!SIEquals(command->request["Connection"], "forget")) {
+            SINFO("No socket to reply for: '" << command->request.methodLine << "' #" << command->initiatingClientID);
         }
 
         // If the command was processed, tell the plugin we couldn't send the response.
-        if (command.processedBy) {
-            command.processedBy->handleFailedReply(command);
+        if (command->processedBy) {
+            command->processedBy->handleFailedReply(*command);
         }
     }
 }
@@ -1699,14 +1705,14 @@ void BedrockServer::suppressCommandPort(const string& reason, bool suppress, boo
     }
 }
 
-bool BedrockServer::_isStatusCommand(BedrockCommand& command) {
-    if (SIEquals(command.request.methodLine, STATUS_IS_SLAVE)          ||
-        SIEquals(command.request.methodLine, STATUS_IS_FOLLOWER)       ||
-        SIEquals(command.request.methodLine, STATUS_HANDLING_COMMANDS) ||
-        SIEquals(command.request.methodLine, STATUS_PING)              ||
-        SIEquals(command.request.methodLine, STATUS_STATUS)            ||
-        SIEquals(command.request.methodLine, STATUS_BLACKLIST)         ||
-        SIEquals(command.request.methodLine, STATUS_MULTIWRITE)) {
+bool BedrockServer::_isStatusCommand(const unique_ptr<BedrockCommand>& command) {
+    if (SIEquals(command->request.methodLine, STATUS_IS_SLAVE)          ||
+        SIEquals(command->request.methodLine, STATUS_IS_FOLLOWER)       ||
+        SIEquals(command->request.methodLine, STATUS_HANDLING_COMMANDS) ||
+        SIEquals(command->request.methodLine, STATUS_PING)              ||
+        SIEquals(command->request.methodLine, STATUS_STATUS)            ||
+        SIEquals(command->request.methodLine, STATUS_BLACKLIST)         ||
+        SIEquals(command->request.methodLine, STATUS_MULTIWRITE)) {
         return true;
     }
     return false;
@@ -1751,9 +1757,9 @@ bool BedrockServer::isDetached() {
     return _detach && _syncThreadComplete;
 }
 
-void BedrockServer::_status(BedrockCommand& command) {
-    SData& request  = command.request;
-    SData& response = command.response;
+void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
+    SData& request  = command->request;
+    SData& response = command->response;
 
     // We'll return whether or not this server is following.
     if (SIEquals(request.methodLine, STATUS_IS_SLAVE) || SIEquals(request.methodLine, STATUS_IS_FOLLOWER)) {
@@ -1867,7 +1873,7 @@ void BedrockServer::_status(BedrockCommand& command) {
         // `_syncNodeQueuedCommands`.
         list<string> syncNodeQueuedMethods;
         _syncNodeQueuedCommands.each([&syncNodeQueuedMethods](auto& item){
-            syncNodeQueuedMethods.push_back(item.request.methodLine);
+            syncNodeQueuedMethods.push_back(item->request.methodLine);
         });
         content["peerList"]                    = SComposeJSONArray(peerList);
         content["queuedCommandList"]           = SComposeJSONArray(_commandQueue.getRequestMethodLines());
@@ -1909,39 +1915,39 @@ void BedrockServer::_status(BedrockCommand& command) {
     }
 }
 
-bool BedrockServer::_isControlCommand(BedrockCommand& command) {
-    if (SIEquals(command.request.methodLine, "BeginBackup")            ||
-        SIEquals(command.request.methodLine, "SuppressCommandPort")    ||
-        SIEquals(command.request.methodLine, "ClearCommandPort")       ||
-        SIEquals(command.request.methodLine, "ClearCrashCommands")     ||
-        SIEquals(command.request.methodLine, "Detach")                 ||
-        SIEquals(command.request.methodLine, "Attach")                 ||
-        SIEquals(command.request.methodLine, "SetConflictParams")      ||
-        SIEquals(command.request.methodLine, "SetCheckpointIntervals") ||
-        SIEquals(command.request.methodLine, "EnableSQLTracing")
+bool BedrockServer::_isControlCommand(const unique_ptr<BedrockCommand>& command) {
+    if (SIEquals(command->request.methodLine, "BeginBackup")            ||
+        SIEquals(command->request.methodLine, "SuppressCommandPort")    ||
+        SIEquals(command->request.methodLine, "ClearCommandPort")       ||
+        SIEquals(command->request.methodLine, "ClearCrashCommands")     ||
+        SIEquals(command->request.methodLine, "Detach")                 ||
+        SIEquals(command->request.methodLine, "Attach")                 ||
+        SIEquals(command->request.methodLine, "SetConflictParams")      ||
+        SIEquals(command->request.methodLine, "SetCheckpointIntervals") ||
+        SIEquals(command->request.methodLine, "EnableSQLTracing")
         ) {
         return true;
     }
     return false;
 }
 
-void BedrockServer::_control(BedrockCommand& command) {
-    SData& response = command.response;
+void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
+    SData& response = command->response;
     response.methodLine = "200 OK";
-    if (SIEquals(command.request.methodLine, "BeginBackup")) {
+    if (SIEquals(command->request.methodLine, "BeginBackup")) {
         _shouldBackup = true;
         _beginShutdown("Detach", true);
-    } else if (SIEquals(command.request.methodLine, "SuppressCommandPort")) {
+    } else if (SIEquals(command->request.methodLine, "SuppressCommandPort")) {
         suppressCommandPort("SuppressCommandPort", true, true);
-    } else if (SIEquals(command.request.methodLine, "ClearCommandPort")) {
+    } else if (SIEquals(command->request.methodLine, "ClearCommandPort")) {
         suppressCommandPort("ClearCommandPort", false, true);
-    } else if (SIEquals(command.request.methodLine, "ClearCrashCommands")) {
+    } else if (SIEquals(command->request.methodLine, "ClearCrashCommands")) {
         unique_lock<decltype(_crashCommandMutex)> lock(_crashCommandMutex);
         _crashCommands.clear();
-    } else if (SIEquals(command.request.methodLine, "Detach")) {
+    } else if (SIEquals(command->request.methodLine, "Detach")) {
         response.methodLine = "203 DETACHING";
         _beginShutdown("Detach", true);
-    } else if (SIEquals(command.request.methodLine, "Attach")) {
+    } else if (SIEquals(command->request.methodLine, "Attach")) {
         // Ensure none of our plugins are blocking attaching
         list<string> blockingPlugins;
         for (auto plugin : plugins) {
@@ -1955,26 +1961,26 @@ void BedrockServer::_control(BedrockCommand& command) {
             response.methodLine = "204 ATTACHING";
             _detach = false;
         }
-    } else if (SIEquals(command.request.methodLine, "SetCheckpointIntervals")) {
+    } else if (SIEquals(command->request.methodLine, "SetCheckpointIntervals")) {
         response["passiveCheckpointPageMin"] = to_string(SQLite::passiveCheckpointPageMin.load());
         response["fullCheckpointPageMin"] = to_string(SQLite::fullCheckpointPageMin.load());
-        if (command.request.isSet("passiveCheckpointPageMin")) {
-            SQLite::passiveCheckpointPageMin.store(command.request.calc("passiveCheckpointPageMin"));
+        if (command->request.isSet("passiveCheckpointPageMin")) {
+            SQLite::passiveCheckpointPageMin.store(command->request.calc("passiveCheckpointPageMin"));
         }
-        if (command.request.isSet("fullCheckpointPageMin")) {
-            SQLite::fullCheckpointPageMin.store(command.request.calc("fullCheckpointPageMin"));
+        if (command->request.isSet("fullCheckpointPageMin")) {
+            SQLite::fullCheckpointPageMin.store(command->request.calc("fullCheckpointPageMin"));
         }
-        if (command.request.isSet("MaxConflictRetries")) {
-            int retries = command.request.calc("MaxConflictRetries");
+        if (command->request.isSet("MaxConflictRetries")) {
+            int retries = command->request.calc("MaxConflictRetries");
             if (retries > 0 && retries <= 100) {
                 SINFO("Updating _maxConflictRetries to: " << retries);
                 _maxConflictRetries.store(retries);
             }
         }
-    } else if (SIEquals(command.request.methodLine, "EnableSQLTracing")) {
+    } else if (SIEquals(command->request.methodLine, "EnableSQLTracing")) {
         response["oldValue"] = SQLite::enableTrace ? "true" : "false";
-        if (command.request.isSet("enable")) {
-            SQLite::enableTrace.store(command.request.test("enable"));
+        if (command->request.isSet("enable")) {
+            SQLite::enableTrace.store(command->request.test("enable"));
             response["newValue"] = SQLite::enableTrace ? "true" : "false";
         }
     }
@@ -2070,7 +2076,7 @@ bool BedrockServer::shouldBackup() {
     return _shouldBackup;
 }
 
-SData BedrockServer::_generateCrashMessage(const BedrockCommand* command) {
+SData BedrockServer::_generateCrashMessage(const unique_ptr<BedrockCommand>& command) {
     SData message("CRASH_COMMAND");
     SData subMessage(command->request.methodLine);
     for (auto& pair : command->crashIdentifyingValues) {
@@ -2098,29 +2104,29 @@ void BedrockServer::onNodeLogin(SQLiteNode::Peer* peer)
             SALERT("Sending crash command " << p.first << " to node " << peer->name << " on login");
             SData command(p.first);
             command.nameValueMap = table;
-            BedrockCommand cmd(command);
+            unique_ptr<BedrockCommand> cmd = make_unique<BedrockCommand>(command);
             for (const auto& fields : command.nameValueMap) {
-                cmd.crashIdentifyingValues.insert(fields.first);
+                cmd->crashIdentifyingValues.insert(fields.first);
             }
             auto _syncNodeCopy = _syncNode;
             if (_syncNodeCopy) {
-                _syncNodeCopy->broadcast(_generateCrashMessage(&cmd), peer);
+                _syncNodeCopy->broadcast(_generateCrashMessage(cmd), peer);
             }
         }
     }
 }
 
-void BedrockServer::_finishPeerCommand(BedrockCommand& command) {
+void BedrockServer::_finishPeerCommand(unique_ptr<BedrockCommand>& command) {
     // See if we're supposed to forget this command (because the follower is not listening for a response).
-    auto it = command.request.nameValueMap.find("Connection");
-    bool forget = it != command.request.nameValueMap.end() && SIEquals(it->second, "forget");
-    command.finalizeTimingInfo();
+    auto it = command->request.nameValueMap.find("Connection");
+    bool forget = it != command->request.nameValueMap.end() && SIEquals(it->second, "forget");
+    command->finalizeTimingInfo();
     if (forget) {
-        SINFO("Not responding to 'forget' command '" << command.request.methodLine << "' from follower.");
+        SINFO("Not responding to 'forget' command '" << command->request.methodLine << "' from follower.");
     } else {
         auto _syncNodeCopy = _syncNode;
         if (_syncNodeCopy) {
-            _syncNodeCopy->sendResponse(command);
+            _syncNodeCopy->sendResponse(*command);
         }
     }
 }
@@ -2142,16 +2148,16 @@ void BedrockServer::_acceptSockets() {
     }
 }
 
-void BedrockServer::waitForHTTPS(BedrockCommand&& command) {
+void BedrockServer::waitForHTTPS(unique_ptr<BedrockCommand>&& command) {
     lock_guard<mutex> lock(_httpsCommandMutex);
 
-    // Create a new BedrockCommand on the head via moving from our existing command. This is the one we'll store.
-    BedrockCommand* commandPtr = new BedrockCommand(move(command));
+    // Un-uniquify the unique_ptr. I don't love this, but it works better with the code we've already got.
+    BedrockCommand* commandPtr = command.get();
+    command.release();
 
     // And we keep it in a set of all commands with outstanding HTTPS requests.
     _outstandingHTTPSCommands.insert(commandPtr);
 
-    // Insert each request pointing at the given object.
     for (auto request : commandPtr->httpsRequests) {
         if (!request->response) {
             _outstandingHTTPSRequests.emplace(make_pair(request, commandPtr));
@@ -2179,9 +2185,8 @@ int BedrockServer::finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& comp
             // I guess it's still here! Is it done?
             if (commandPtr->areHttpsRequestsComplete()) {
                 // If so, add it back to the main queue, erase its entry in _outstandingHTTPSCommands, and delete it.
-                _commandQueue.push(move(*commandPtr));
+                _commandQueue.push(unique_ptr<BedrockCommand>(commandPtr));
                 _outstandingHTTPSCommands.erase(commandPtrIt);
-                delete commandPtr;
                 commandsCompleted++;
             }
         }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -318,7 +318,7 @@ class BedrockServer : public SQLiteServer {
 
     // Send a reply for a completed command back to the initiating client. If the `originator` of the command is set,
     // then this is an error, as the command should have been sent back to a peer.
-    void _reply(unique_ptr<BedrockCommand>& command);
+    void _reply(BedrockCommandPtr& command);
 
     // The following are constants used as methodlines by status command requests.
     static constexpr auto STATUS_IS_SLAVE          = "GET /status/isSlave HTTP/1.1";
@@ -340,10 +340,10 @@ class BedrockServer : public SQLiteServer {
     recursive_timed_mutex _syncMutex;
 
     // Functions for checking for and responding to status and control commands.
-    bool _isStatusCommand(const unique_ptr<BedrockCommand>& command);
-    void _status(unique_ptr<BedrockCommand>& command);
-    bool _isControlCommand(const unique_ptr<BedrockCommand>& command);
-    void _control(unique_ptr<BedrockCommand>& command);
+    bool _isStatusCommand(const BedrockCommandPtr& command);
+    void _status(BedrockCommandPtr& command);
+    bool _isControlCommand(const BedrockCommandPtr& command);
+    void _control(BedrockCommandPtr& command);
 
     // Accepts any sockets pending on our listening ports. We do this both after `poll()`, and before shutting down
     // those ports.
@@ -356,7 +356,7 @@ class BedrockServer : public SQLiteServer {
     // depends on a future commit if we're a follower that's behind leader, and a client makes two requests, one to a node
     // more current than ourselves, and a following request to us. We'll move these commands to this special map until
     // we catch up, and then move them back to the regular command queue.
-    multimap<uint64_t, unique_ptr<BedrockCommand>> _futureCommitCommands;
+    multimap<uint64_t, BedrockCommandPtr> _futureCommitCommands;
 
     // Map of command timeouts to the indexes into _futureCommitCommands where those commands live.
     multimap<uint64_t, uint64_t> _futureCommitCommandTimeouts;
@@ -418,14 +418,14 @@ class BedrockServer : public SQLiteServer {
 
     // Takes a command that has an outstanding HTTPS request and saves it in _outstandingHTTPSCommands until its HTTPS
     // requests are complete.
-    void waitForHTTPS(unique_ptr<BedrockCommand>&& command);
+    void waitForHTTPS(BedrockCommandPtr&& command);
 
     // Takes a list of completed HTTPS requests, and move those commands back to the main queue (as long as they don't
     // have any other incomplete requests).
     int finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& completedHTTPSRequests);
 
     // Send a reply to a command that was escalated to us from a peer, rather than a locally-connected client.
-    void _finishPeerCommand(unique_ptr<BedrockCommand>& command);
+    void _finishPeerCommand(BedrockCommandPtr& command);
 
     // When we're standing down, we temporarily dump newly received commands here (this lets all existing
     // partially-completed commands, like commands with HTTPS requests) finish without risking getting caught in an
@@ -447,13 +447,13 @@ class BedrockServer : public SQLiteServer {
 
     // Returns whether or not the command was a status or control command. If it was, it will have already been handled
     // and responded to upon return
-    bool _handleIfStatusOrControlCommand(unique_ptr<BedrockCommand>& command);
+    bool _handleIfStatusOrControlCommand(BedrockCommandPtr& command);
 
     // Check a command against the list of crash commands, and return whether we think the command would crash.
-    bool _wouldCrash(const unique_ptr<BedrockCommand>& command);
+    bool _wouldCrash(const BedrockCommandPtr& command);
 
     // Generate a CRASH_COMMAND command for a given bad command.
-    static SData _generateCrashMessage(const unique_ptr<BedrockCommand>& command);
+    static SData _generateCrashMessage(const BedrockCommandPtr& command);
 
     static void _addRequestID(SData& request);
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -318,7 +318,7 @@ class BedrockServer : public SQLiteServer {
 
     // Send a reply for a completed command back to the initiating client. If the `originator` of the command is set,
     // then this is an error, as the command should have been sent back to a peer.
-    void _reply(BedrockCommand&);
+    void _reply(unique_ptr<BedrockCommand>& command);
 
     // The following are constants used as methodlines by status command requests.
     static constexpr auto STATUS_IS_SLAVE          = "GET /status/isSlave HTTP/1.1";
@@ -340,10 +340,10 @@ class BedrockServer : public SQLiteServer {
     recursive_timed_mutex _syncMutex;
 
     // Functions for checking for and responding to status and control commands.
-    bool _isStatusCommand(BedrockCommand& command);
-    void _status(BedrockCommand& command);
-    bool _isControlCommand(BedrockCommand& command);
-    void _control(BedrockCommand& command);
+    bool _isStatusCommand(const unique_ptr<BedrockCommand>& command);
+    void _status(unique_ptr<BedrockCommand>& command);
+    bool _isControlCommand(const unique_ptr<BedrockCommand>& command);
+    void _control(unique_ptr<BedrockCommand>& command);
 
     // Accepts any sockets pending on our listening ports. We do this both after `poll()`, and before shutting down
     // those ports.
@@ -356,7 +356,7 @@ class BedrockServer : public SQLiteServer {
     // depends on a future commit if we're a follower that's behind leader, and a client makes two requests, one to a node
     // more current than ourselves, and a following request to us. We'll move these commands to this special map until
     // we catch up, and then move them back to the regular command queue.
-    multimap<uint64_t, BedrockCommand> _futureCommitCommands;
+    multimap<uint64_t, unique_ptr<BedrockCommand>> _futureCommitCommands;
 
     // Map of command timeouts to the indexes into _futureCommitCommands where those commands live.
     multimap<uint64_t, uint64_t> _futureCommitCommandTimeouts;
@@ -418,14 +418,14 @@ class BedrockServer : public SQLiteServer {
 
     // Takes a command that has an outstanding HTTPS request and saves it in _outstandingHTTPSCommands until its HTTPS
     // requests are complete.
-    void waitForHTTPS(BedrockCommand&& command);
+    void waitForHTTPS(unique_ptr<BedrockCommand>&& command);
 
     // Takes a list of completed HTTPS requests, and move those commands back to the main queue (as long as they don't
     // have any other incomplete requests).
     int finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& completedHTTPSRequests);
 
     // Send a reply to a command that was escalated to us from a peer, rather than a locally-connected client.
-    void _finishPeerCommand(BedrockCommand& command);
+    void _finishPeerCommand(unique_ptr<BedrockCommand>& command);
 
     // When we're standing down, we temporarily dump newly received commands here (this lets all existing
     // partially-completed commands, like commands with HTTPS requests) finish without risking getting caught in an
@@ -447,13 +447,13 @@ class BedrockServer : public SQLiteServer {
 
     // Returns whether or not the command was a status or control command. If it was, it will have already been handled
     // and responded to upon return
-    bool _handleIfStatusOrControlCommand(BedrockCommand& command);
+    bool _handleIfStatusOrControlCommand(unique_ptr<BedrockCommand>& command);
 
     // Check a command against the list of crash commands, and return whether we think the command would crash.
-    bool _wouldCrash(const BedrockCommand& command);
+    bool _wouldCrash(const unique_ptr<BedrockCommand>& command);
 
     // Generate a CRASH_COMMAND command for a given bad command.
-    static SData _generateCrashMessage(const BedrockCommand* command);
+    static SData _generateCrashMessage(const unique_ptr<BedrockCommand>& command);
 
     static void _addRequestID(SData& request);
 

--- a/BedrockTimeoutCommandQueue.cpp
+++ b/BedrockTimeoutCommandQueue.cpp
@@ -1,6 +1,6 @@
 #include <BedrockTimeoutCommandQueue.h>
 
-const BedrockCommand& BedrockTimeoutCommandQueue::front() const {
+const unique_ptr<BedrockCommand>& BedrockTimeoutCommandQueue::front() const {
     lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     if (_queue.empty()) {
         throw out_of_range("No commands");
@@ -14,7 +14,7 @@ const BedrockCommand& BedrockTimeoutCommandQueue::front() const {
     return _queue.front();
 }
 
-void BedrockTimeoutCommandQueue::push(BedrockCommand&& rhs) {
+void BedrockTimeoutCommandQueue::push(unique_ptr<BedrockCommand>&& rhs) {
     lock_guard<decltype(_queueMutex)> lock(_queueMutex);
 
     // Add to the queue and timeout map.
@@ -23,20 +23,20 @@ void BedrockTimeoutCommandQueue::push(BedrockCommand&& rhs) {
     // This is past-the-end, so we decrement it to point to the last element.
     auto lastIt = _queue.end();
     lastIt--;
-    _timeoutMap.insert(make_pair(lastIt->timeout(), lastIt));
+    _timeoutMap.insert(make_pair((*lastIt)->timeout(), lastIt));
 
     // Write arbitrary buffer to the pipe so any subscribers will be awoken.
     // **NOTE: 1 byte so write is atomic.
     SASSERT(write(_pipeFD[1], "A", 1));
 }
 
-BedrockCommand BedrockTimeoutCommandQueue::pop() {
+unique_ptr<BedrockCommand> BedrockTimeoutCommandQueue::pop() {
     lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     if (_queue.empty()) {
         throw out_of_range("No commands");
     }
     if (_timeoutMap.begin()->first < STimeNow()) {
-        BedrockCommand item = move(*(_timeoutMap.begin()->second));
+        unique_ptr<BedrockCommand> item = move(*(_timeoutMap.begin()->second));
         _queue.erase(_timeoutMap.begin()->second);
         _timeoutMap.erase(_timeoutMap.begin());
         return item;
@@ -44,7 +44,7 @@ BedrockCommand BedrockTimeoutCommandQueue::pop() {
 
     // We need to remove the reference in the timeout map for this item as well.
     auto firstCommandIt = _queue.begin();
-    auto itPair = _timeoutMap.equal_range(firstCommandIt->timeout());
+    auto itPair = _timeoutMap.equal_range((*firstCommandIt)->timeout());
     for (auto it = itPair.first; it != itPair.second; it++) {
         if (it->second == firstCommandIt) {
             // This one points at this command, remove it.
@@ -52,7 +52,7 @@ BedrockCommand BedrockTimeoutCommandQueue::pop() {
             break;
         }
     }
-    BedrockCommand item = move(*firstCommandIt);
+    unique_ptr<BedrockCommand> item = move(*firstCommandIt);
     _queue.pop_front();
     return item;
 }

--- a/BedrockTimeoutCommandQueue.h
+++ b/BedrockTimeoutCommandQueue.h
@@ -1,15 +1,15 @@
 #include <libstuff/libstuff.h>
 #include <BedrockCommand.h>
 
-class BedrockTimeoutCommandQueue : public SSynchronizedQueue<BedrockCommand> {
+class BedrockTimeoutCommandQueue : public SSynchronizedQueue<unique_ptr<BedrockCommand>> {
   public:
     // Override the base class to account for timeouts.
-    const BedrockCommand& front() const;
-    void push(BedrockCommand&& rhs);
-    BedrockCommand pop();
+    const unique_ptr<BedrockCommand>& front() const;
+    void push(unique_ptr<BedrockCommand>&& rhs);
+    unique_ptr<BedrockCommand> pop();
 
   private:
     // Map of timeouts to commands in the queue. Because the queue is a std::list, we can store iterators into it and
     // they stay valid as we manipulate the list, avoiding walking the list to re-locate them.
-    multimap<uint64_t, list<BedrockCommand>::iterator> _timeoutMap;
+    multimap<uint64_t, list<unique_ptr<BedrockCommand>>::iterator> _timeoutMap;
 };

--- a/BedrockTimeoutCommandQueue.h
+++ b/BedrockTimeoutCommandQueue.h
@@ -1,15 +1,15 @@
 #include <libstuff/libstuff.h>
 #include <BedrockCommand.h>
 
-class BedrockTimeoutCommandQueue : public SSynchronizedQueue<unique_ptr<BedrockCommand>> {
+class BedrockTimeoutCommandQueue : public SSynchronizedQueue<BedrockCommandPtr> {
   public:
     // Override the base class to account for timeouts.
-    const unique_ptr<BedrockCommand>& front() const;
-    void push(unique_ptr<BedrockCommand>&& rhs);
-    unique_ptr<BedrockCommand> pop();
+    const BedrockCommandPtr& front() const;
+    void push(BedrockCommandPtr&& rhs);
+    BedrockCommandPtr pop();
 
   private:
     // Map of timeouts to commands in the queue. Because the queue is a std::list, we can store iterators into it and
     // they stay valid as we manipulate the list, avoiding walking the list to re-locate them.
-    multimap<uint64_t, list<unique_ptr<BedrockCommand>>::iterator> _timeoutMap;
+    multimap<uint64_t, list<BedrockCommandPtr>::iterator> _timeoutMap;
 };

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -10,8 +10,8 @@ void SLogStackTrace() {
     // Output the symbols to the log
     void* callstack[100];
     int depth = backtrace(callstack, 100);
-    char** symbols = backtrace_symbols(callstack, depth);
-    for (int c = 0; c < depth; ++c) {
-        SWARN(symbols[c]);
+    vector<string> stack = SGetCallstack(depth, callstack);
+    for (const auto& frame : stack) {
+        SWARN(frame);
     }
 }

--- a/libstuff/SSignal.cpp
+++ b/libstuff/SSignal.cpp
@@ -162,38 +162,9 @@ void _SSignal_StackTrace(int signum, siginfo_t *info, void *ucontext) {
             // also might not do what we hope.
             SWARN("Signal " << strsignal(_SSignal_threadCaughtSignalNumber) << "(" << _SSignal_threadCaughtSignalNumber
                   << ") caused crash, logging stack trace.");
-            char** symbols = backtrace_symbols(callstack, depth);
-
-            vector<string> details(depth + 1);
-            int status = 0;
-            for (int i = 0; i < depth; i++) {
-                // Demangle them if possible.
-                string temp = symbols[i];
-                size_t start = temp.find_first_of('(');
-                size_t end = temp.find_first_of('+', start);
-                temp = temp.substr(start + 1, end - start - 1);
-                char* demangled = abi::__cxa_demangle(temp.c_str(), 0, 0, &status);
-
-                // If the status is OK, we'll see if we can pull the address from the original string.
-                // If so, we concatenate that on the end of the demangled line. If we can't pull it out, we'll fall back to the
-                // original line, as we'd rather have mangled names with potential offsets than demangled names but lost
-                // offsets.
-                if (status == 0) {
-                    string symbolsStr = string(symbols[i]);
-                    size_t addressOffset = symbolsStr.find_last_of('[');
-                    if (addressOffset != string::npos) {
-                        details[i + 1] = string(demangled) + " " + symbolsStr.substr(addressOffset);
-                    } else {
-                        details[i + 1] = symbols[i];
-                    }
-                } else {
-                    details[i + 1] = symbols[i];
-                }
-                free(demangled);
-            }
-
-            for (int c = 0; c < depth; ++c) {
-                SWARN(details[c]);
+            vector<string> stack = SGetCallstack(depth, callstack);
+            for (const auto& frame : stack) {
+                SWARN(frame);
             }
 
             // Call our die function and then reset it.

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -117,8 +117,19 @@ vector<string> SException::details() const noexcept {
         size_t end = temp.find_first_of('+', start);
         temp = temp.substr(start + 1, end - start - 1);
         char* demangled = abi::__cxa_demangle(temp.c_str(), 0, 0, &status);
+
+        // If the status is OK, we'll see if we can pull the address from the original string.
+        // If so, we concatenate that on the end of the demangled line. If we can't pull it out, we'll fall back to the
+        // original line, as we'd rather have mangled names with potential offsets than demangled names but lost
+        // offsets.
         if (status == 0) {
-            details[i + 1] = demangled;
+            string symbolsStr = string(symbols[i]);
+            size_t addressOffset = symbolsStr.find_last_of('[');
+            if (addressOffset != string::npos) {
+                details[i + 1] = string(demangled) + " " + symbolsStr.substr(addressOffset);
+            } else {
+                details[i + 1] = symbols[i];
+            }
         } else {
             details[i + 1] = symbols[i];
         }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -101,16 +101,14 @@ const char* SException::what() const noexcept {
     return method.c_str();
 }
 
-vector<string> SException::details() const noexcept {
+vector<string> SGetCallstack(int depth, void* const* callstack) noexcept {
     // Symbols for each stack frame.
     char** symbols = nullptr;
-    if (_depth) {
-        symbols = backtrace_symbols(_callstack, _depth);
-    }
-    vector<string> details(_depth + 1);
-    details[0] = string("Initially thrown from: ") + basename((char*)_file.c_str()) + ":" + to_string(_line);
+    symbols = backtrace_symbols(callstack, depth);
+
+    vector<string> details(depth + 1);
     int status = 0;
-    for (int i = 0; i < _depth; i++) {
+    for (int i = 0; i < depth; i++) {
         // Demangle them if possible.
         string temp = symbols[i];
         size_t start = temp.find_first_of('(');
@@ -136,6 +134,12 @@ vector<string> SException::details() const noexcept {
         free(demangled);
     }
     return details;
+}
+
+vector<string> SException::details() const noexcept {
+    vector<string> stack = SGetCallstack(_depth, _callstack);
+    stack.push_back(string("Initially thrown from: ") + basename((char*)_file.c_str()) + ":" + to_string(_line));
+    return stack;
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -170,6 +170,9 @@ class SException : public exception {
     const string body;
 };
 
+// Utility function for generating pretty callstacks.
+vector<string> SGetCallstack(int depth = 0, void* const* callstack = nullptr) noexcept;
+
 // --------------------------------------------------------------------------
 // A very simple HTTP-like structure consisting of a method line, a table,
 // and a content body.


### PR DESCRIPTION
This un-reverts the previous PR and adds a wrapper class that traps null dereferences to see if we can track down where it was crashing before. It also adds some fixes for failures that can happen if we fail while upgrading, which should only happen on leader.

See here for description:
https://github.com/Expensify/Bedrock/pull/692