### PR TITLE
Update pipe behavior in queues to prevent the pipe from filling.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -301,10 +301,6 @@ void BedrockServer::sync(const SData& args,
         // Pre-process any sockets the sync node is managing (i.e., communication with peer nodes).
         server._syncNode->prePoll(fdm);
 
-        // Add our command queues to our fd_map.
-        syncNodeQueuedCommands.prePoll(fdm);
-        server._completedCommands.prePoll(fdm);
-
         // Wait for activity on any of those FDs, up to a timeout.
         const uint64_t now = STimeNow();
 
@@ -326,8 +322,6 @@ void BedrockServer::sync(const SData& args,
             // Process any activity in our plugins.
             server._postPollPlugins(fdm, nextActivity);
             server._syncNode->postPoll(fdm, nextActivity);
-            syncNodeQueuedCommands.postPoll(fdm);
-            server._completedCommands.postPoll(fdm);
         }
 
         // Ok, let the sync node to it's updating for as many iterations as it requires. We'll update the replication

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -301,6 +301,10 @@ void BedrockServer::sync(const SData& args,
         // Pre-process any sockets the sync node is managing (i.e., communication with peer nodes).
         server._syncNode->prePoll(fdm);
 
+        // Add our command queues to our fd_map.
+        syncNodeQueuedCommands.prePoll(fdm);
+        server._completedCommands.prePoll(fdm);
+
         // Wait for activity on any of those FDs, up to a timeout.
         const uint64_t now = STimeNow();
 
@@ -322,6 +326,8 @@ void BedrockServer::sync(const SData& args,
             // Process any activity in our plugins.
             server._postPollPlugins(fdm, nextActivity);
             server._syncNode->postPoll(fdm, nextActivity);
+            syncNodeQueuedCommands.postPoll(fdm);
+            server._completedCommands.postPoll(fdm);
         }
 
         // Ok, let the sync node to it's updating for as many iterations as it requires. We'll update the replication

--- a/BedrockTimeoutCommandQueue.cpp
+++ b/BedrockTimeoutCommandQueue.cpp
@@ -25,6 +25,10 @@ void BedrockTimeoutCommandQueue::push(BedrockCommandPtr&& rhs) {
     auto lastIt = _queue.end();
     lastIt--;
     _timeoutMap.insert(make_pair((*lastIt)->timeout(), lastIt));
+
+    // Write arbitrary buffer to the pipe so any subscribers will be awoken.
+    // **NOTE: 1 byte so write is atomic.
+    SASSERT(write(_pipeFD[1], "A", 1));
 }
 
 BedrockCommandPtr BedrockTimeoutCommandQueue::pop() {

--- a/libstuff/SSynchronizedQueue.h
+++ b/libstuff/SSynchronizedQueue.h
@@ -78,8 +78,7 @@ void SSynchronizedQueue<T>::prePoll(fd_map& fdm) {
 
 template<typename T>
 void SSynchronizedQueue<T>::postPoll(fd_map& fdm) {
-    // Pipe should every actually have 1 item in it, since we are just using the pipe as a mechanism
-    // to communicate that work is available.
+    // Check if there is anything to read off of the pipe, if there is, empty it.
     if (SFDAnySet(fdm, _pipeFD[0], SREADEVTS)) {
         // Read until there is nothing left to read.
         while (true) {

--- a/libstuff/SSynchronizedQueue.h
+++ b/libstuff/SSynchronizedQueue.h
@@ -10,6 +10,11 @@ class SSynchronizedQueue {
     // Explicitly delete copy constructor so it can't accidentally get called.
     SSynchronizedQueue(const SSynchronizedQueue& other) = delete;
 
+    // This queue can be watched by a `poll` loop. These functions are called with an fd_map to prepare for/handle
+    // activity from polling.
+    void prePoll(fd_map& fdm);
+    void postPoll(fd_map& fdm);
+
     // Returns true if the queue is empty.
     bool empty() const;
 
@@ -32,14 +37,64 @@ class SSynchronizedQueue {
   protected:
     list<T> _queue;
     mutable recursive_mutex _queueMutex;
+
+    // You may be wondering why we use a pipe instead of a condition variable
+    // for alerting threads that work is available. That's because we are treating
+    // queue activity like network activity in BedrockServer. This means that we
+    // treat the queue as if it was a network socket and we use the pipe to know
+    // if there are "unread bytes on the socket" that is to say -- work available --
+    // in the queue.
+    // This is kind of weird but prevents threads from waiting for a the poll()
+    // timeout on network activity. Since queue activity also causes poll() to return
+    // if there is work in the queue.
+    int _pipeFD[2] = {-1, -1};
 };
 
 template<typename T>
 SSynchronizedQueue<T>::SSynchronizedQueue() {
+    // Open up a pipe for communication and set the non-blocking reads.
+    SASSERT(0 == pipe(_pipeFD));
+    int flags = fcntl(_pipeFD[0], F_GETFL, 0);
+    fcntl(_pipeFD[0], F_SETFL, flags | O_NONBLOCK);
 }
 
 template<typename T>
 SSynchronizedQueue<T>::~SSynchronizedQueue() {
+    if (_pipeFD[0] != -1) {
+        close(_pipeFD[0]);
+    }
+    if (_pipeFD[1] != -1) {
+        close(_pipeFD[1]);
+    }
+}
+
+template<typename T>
+void SSynchronizedQueue<T>::prePoll(fd_map& fdm) {
+    // Put the read-side of the pipe into the fd set.
+    // **NOTE: This is *not* synchronized.  All threads use the same pipes. All threads use *different* fd_maps, though
+    //         so we don't have to worry about contention inside FDSet.
+    SFDset(fdm, _pipeFD[0], SREADEVTS);
+}
+
+template<typename T>
+void SSynchronizedQueue<T>::postPoll(fd_map& fdm) {
+    // Pipe should every actually have 1 item in it, since we are just using the pipe as a mechanism
+    // to communicate that work is available.
+    if (SFDAnySet(fdm, _pipeFD[0], SREADEVTS)) {
+        // Read until there is nothing left to read.
+        while (true) {
+            char readbuffer[1];
+            int ret = read(_pipeFD[0], readbuffer, sizeof(readbuffer));
+
+            // Since the pipe is set to non-blocking reads, read() will return -1
+            // when there is no data to read or 0 when we have read it all
+            if (ret == 0) {
+                break;
+            } else if (ret == -1) {
+                STHROW("Failed to read from pipe");
+            }
+        }
+    }
 }
 
 template<typename T>
@@ -73,6 +128,10 @@ void SSynchronizedQueue<T>::push(T&& rhs) {
     lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     // Just add to the queue
     _queue.push_back(move(rhs));
+
+    // Write arbitrary buffer to the pipe so any subscribers will be awoken.
+    // **NOTE: 1 byte so write is atomic.
+    SASSERT(write(_pipeFD[1], "A", 1));
 }
 
 template<typename T>

--- a/libstuff/SSynchronizedQueue.h
+++ b/libstuff/SSynchronizedQueue.h
@@ -84,15 +84,14 @@ void SSynchronizedQueue<T>::postPoll(fd_map& fdm) {
         while (true) {
             char readbuffer[1];
             int ret = read(_pipeFD[0], readbuffer, sizeof(readbuffer));
-            SINFO("COLE read " << ret << " bytes from pipe.");
 
             // Since the pipe is set to non-blocking reads, read() will return -1
-            // when there is no data to read or 0 when we have read it all
-            if (ret == 0) {
-                SINFO("COLE breaking");
+            // when there is no data to read  and will set errno to EAGAIN/EWOULDBLOCK
+            // otherwise it will 0 when we have read it all
+            if (ret <= 0 && errno == EWOULDBLOCK) {
                 break;
             } else if (ret == -1) {
-                STHROW("COLE Failed to read from pipe");
+                STHROW("Failed to read from pipe");
             }
         }
     }

--- a/libstuff/SSynchronizedQueue.h
+++ b/libstuff/SSynchronizedQueue.h
@@ -10,11 +10,6 @@ class SSynchronizedQueue {
     // Explicitly delete copy constructor so it can't accidentally get called.
     SSynchronizedQueue(const SSynchronizedQueue& other) = delete;
 
-    // This queue can be watched by a `poll` loop. These functions are called with an fd_map to prepare for/handle
-    // activity from polling.
-    void prePoll(fd_map& fdm);
-    void postPoll(fd_map& fdm, int bytesToRead = 1);
-
     // Returns true if the queue is empty.
     bool empty() const;
 
@@ -37,56 +32,25 @@ class SSynchronizedQueue {
   protected:
     list<T> _queue;
     mutable recursive_mutex _queueMutex;
-    int _pipeFD[2] = {-1, -1};
 };
 
 template<typename T>
 SSynchronizedQueue<T>::SSynchronizedQueue() {
-    // Open up a pipe for communication and set the non-blocking reads.
-    SASSERT(0 == pipe(_pipeFD));
-    int flags = fcntl(_pipeFD[0], F_GETFL, 0);
-    fcntl(_pipeFD[0], F_SETFL, flags | O_NONBLOCK);
 }
 
 template<typename T>
 SSynchronizedQueue<T>::~SSynchronizedQueue() {
-    if (_pipeFD[0] != -1) {
-        close(_pipeFD[0]);
-    }
-    if (_pipeFD[1] != -1) {
-        close(_pipeFD[1]);
-    }
-}
-
-template<typename T>
-void SSynchronizedQueue<T>::prePoll(fd_map& fdm) {
-    // Put the read-side of the pipe into the fd set.
-    // **NOTE: This is *not* synchronized.  All threads use the same pipes. All threads use *different* fd_maps, though
-    //         so we don't have to worry about contention inside FDSet.
-    SFDset(fdm, _pipeFD[0], SREADEVTS);
-}
-
-template<typename T>
-void SSynchronizedQueue<T>::postPoll(fd_map& fdm, int bytesToRead) {
-    // Caller determines the bytes to read.  If a consumer can only process one item then it will only read 1 byte. If
-    // the pipe has more data to read it will continue to "fire" so other threads also subscribing will pick up work.
-    if (SFDAnySet(fdm, _pipeFD[0], SREADEVTS)) {
-        char readbuffer[bytesToRead];
-        if (read(_pipeFD[0], readbuffer, sizeof(readbuffer)) == -1) {
-            STHROW("Read from pipe failed.");
-        }
-    }
 }
 
 template<typename T>
 bool SSynchronizedQueue<T>::empty() const {
-    SAUTOLOCK(_queueMutex);
+    lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     return _queue.empty();
 }
 
 template<typename T>
 const T& SSynchronizedQueue<T>::front() const {
-    SAUTOLOCK(_queueMutex);
+    lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     if (!_queue.empty()) {
         return _queue.front();
     }
@@ -95,7 +59,7 @@ const T& SSynchronizedQueue<T>::front() const {
 
 template<typename T>
 T SSynchronizedQueue<T>::pop() {
-    SAUTOLOCK(_queueMutex);
+    lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     if (!_queue.empty()) {
         T item = move(_queue.front());
         _queue.pop_front();
@@ -106,23 +70,19 @@ T SSynchronizedQueue<T>::pop() {
 
 template<typename T>
 void SSynchronizedQueue<T>::push(T&& rhs) {
-    SAUTOLOCK(_queueMutex);
+    lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     // Just add to the queue
     _queue.push_back(move(rhs));
-
-    // Write arbitrary buffer to the pipe so any subscribers will be awoken.
-    // **NOTE: 1 byte so write is atomic.
-    SASSERT(write(_pipeFD[1], "A", 1));
 }
 
 template<typename T>
 size_t SSynchronizedQueue<T>::size() const {
-    SAUTOLOCK(_queueMutex);
+    lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     return _queue.size();
 }
 
 template<typename T>
 void SSynchronizedQueue<T>::each(const function<void (T&)> f) {
-    SAUTOLOCK(_queueMutex);
+    lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     for_each(_queue.begin(), _queue.end(), f);
 }


### PR DESCRIPTION
@tylerkaraszewski Please review.

We had a server hang this weekend because one of its queues backed up the MAX_PIPE_SIZE, 64k. This caused a complete halt of the process because the thread trying to add something to the PIPE was holding the lock that prevents reading from the PIPE as well. This writer was blocked because the PIPE was at the MAX_PIPE_SIZE; this meant the writer would never finish and the readers would never be able to pull off of the queue to allow the writer to be unblocked.

~This PR completely removes the pipes and the polling infrastructure because none of it is actually needed or in use anymore.~ This PR makes it so that every time we call postPoll on the queue the pipe is completely emptied, this will prevent it from filling all the way up. I also removed some unused code in BedrockCommand.cpp that was not used anywhere, and moved the timing portions of this code (the only reason I can tell it ever existed) into the BedrockTimeoutQueue.