### PR TITLE
Remove temporary testing wrapper class

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -249,10 +249,10 @@ void BedrockCommand::finalizeTimingInfo() {
 
 // pop and push specializations for SSynchronizedQueue that record timing info.
 template<>
-BedrockCommandPtr SSynchronizedQueue<BedrockCommandPtr>::pop() {
+unique_ptr<BedrockCommand> SSynchronizedQueue<unique_ptr<BedrockCommand>>::pop() {
     SAUTOLOCK(_queueMutex);
     if (!_queue.empty()) {
-        BedrockCommandPtr item = move(_queue.front());
+        unique_ptr<BedrockCommand> item = move(_queue.front());
         _queue.pop_front();
         item->stopTiming(BedrockCommand::QUEUE_SYNC);
         return item;
@@ -261,7 +261,7 @@ BedrockCommandPtr SSynchronizedQueue<BedrockCommandPtr>::pop() {
 }
 
 template<>
-void SSynchronizedQueue<BedrockCommandPtr>::push(BedrockCommandPtr&& cmd) {
+void SSynchronizedQueue<unique_ptr<BedrockCommand>>::push(unique_ptr<BedrockCommand>&& cmd) {
     SAUTOLOCK(_queueMutex);
     SINFO("Enqueuing command '" << cmd->request.methodLine << "', with " << _queue.size() << " commands already queued.");
     // Just add to the queue

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -139,32 +139,3 @@ class BedrockCommand : public SQLiteCommand {
 
     static atomic<size_t> _commandCount;
 };
-
-#include <BedrockCommand.h>
-
-class checkedUniquePtr_BedrockCommand : public unique_ptr<BedrockCommand> {
-  public:
-
-    // Constructors.
-    checkedUniquePtr_BedrockCommand(unique_ptr<BedrockCommand>&& other) {
-        unique_ptr<BedrockCommand>::operator=(move(other));
-    }
-    checkedUniquePtr_BedrockCommand(BedrockCommand* other) : unique_ptr<BedrockCommand>(other) { }
-    checkedUniquePtr_BedrockCommand(nullptr_t np) : unique_ptr<BedrockCommand>(np) {}
-
-    // Copy by calling parent copy assignment operator.
-    checkedUniquePtr_BedrockCommand& operator=(unique_ptr<BedrockCommand>&& other) {
-        unique_ptr<BedrockCommand>::operator=(move(other));
-        return *this;
-    }
-
-    BedrockCommand* operator->() const {
-        if (get() == nullptr) {
-            STHROW_STACK("Dereferencing null pointer");
-        }
-        return get();
-    }
-};
-
-typedef checkedUniquePtr_BedrockCommand BedrockCommandPtr;
-

--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -1,15 +1,15 @@
 #include <BedrockCommandQueue.h>
 
-void BedrockCommandQueue::startTiming(BedrockCommandPtr& command) {
+void BedrockCommandQueue::startTiming(unique_ptr<BedrockCommand>& command) {
     command->startTiming(BedrockCommand::QUEUE_WORKER);
 }
 
-void BedrockCommandQueue::stopTiming(BedrockCommandPtr& command) {
+void BedrockCommandQueue::stopTiming(unique_ptr<BedrockCommand>& command) {
     command->stopTiming(BedrockCommand::QUEUE_WORKER);
 }
 
 BedrockCommandQueue::BedrockCommandQueue() :
-  SScheduledPriorityQueue<BedrockCommandPtr>(function<void(BedrockCommandPtr&)>(startTiming), function<void(BedrockCommandPtr&)>(stopTiming))
+  SScheduledPriorityQueue<unique_ptr<BedrockCommand>>(function<void(unique_ptr<BedrockCommand>&)>(startTiming), function<void(unique_ptr<BedrockCommand>&)>(stopTiming))
 { }
 
 list<string> BedrockCommandQueue::getRequestMethodLines() {
@@ -64,9 +64,9 @@ void BedrockCommandQueue::abandonFutureCommands(int msInFuture) {
     }
 }
 
-void BedrockCommandQueue::push(BedrockCommandPtr&& command) {
+void BedrockCommandQueue::push(unique_ptr<BedrockCommand>&& command) {
     BedrockCommand::Priority priority = command->priority;
     uint64_t executionTime = command->request.calcU64("commandExecuteTime");
     uint64_t timeout = command->timeout();
-    SScheduledPriorityQueue<BedrockCommandPtr>::push(move(command), priority, executionTime, timeout);
+    SScheduledPriorityQueue<unique_ptr<BedrockCommand>>::push(move(command), priority, executionTime, timeout);
 }

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -3,13 +3,13 @@
 #include <libstuff/SScheduledPriorityQueue.h>
 #include "BedrockCommand.h"
 
-class BedrockCommandQueue : public SScheduledPriorityQueue<BedrockCommandPtr> {
+class BedrockCommandQueue : public SScheduledPriorityQueue<unique_ptr<BedrockCommand>> {
   public:
     BedrockCommandQueue();
 
     // Functions to start and stop timing on the commands when they're inserted/removed from the queue.
-    static void startTiming(BedrockCommandPtr& command);
-    static void stopTiming(BedrockCommandPtr& command);
+    static void startTiming(unique_ptr<BedrockCommand>& command);
+    static void stopTiming(unique_ptr<BedrockCommand>& command);
     
     // Returns a list of all the method lines for all the requests currently queued. This function exists for state
     // reporting, and is called by BedrockServer when we receive a `Status` command.
@@ -19,5 +19,5 @@ class BedrockCommandQueue : public SScheduledPriorityQueue<BedrockCommandPtr> {
     void abandonFutureCommands(int msInFuture);
 
     // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
-    void push(BedrockCommandPtr&& command);
+    void push(unique_ptr<BedrockCommand>&& command);
 };

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -29,7 +29,7 @@ class AutoScopeRewrite {
     bool (*_handler)(int, const char*, string&);
 };
 
-uint64_t BedrockCore::_getRemainingTime(const BedrockCommandPtr& command) {
+uint64_t BedrockCore::_getRemainingTime(const unique_ptr<BedrockCommand>& command) {
     int64_t timeout = command->timeout();
     int64_t now = STimeNow();
 
@@ -53,7 +53,7 @@ uint64_t BedrockCore::_getRemainingTime(const BedrockCommandPtr& command) {
     return min(processTimeout, adjustedTimeout);
 }
 
-bool BedrockCore::isTimedOut(BedrockCommandPtr& command) {
+bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command) {
     try {
         _getRemainingTime(command);
     } catch (const SException& e) {
@@ -65,7 +65,7 @@ bool BedrockCore::isTimedOut(BedrockCommandPtr& command) {
     return false;
 }
 
-bool BedrockCore::peekCommand(BedrockCommandPtr& command) {
+bool BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command) {
     AutoTimer timer(command, BedrockCommand::PEEK);
     // Convenience references to commonly used properties.
     SData& request = command->request;
@@ -177,7 +177,7 @@ bool BedrockCore::peekCommand(BedrockCommandPtr& command) {
     return true;
 }
 
-bool BedrockCore::processCommand(BedrockCommandPtr& command) {
+bool BedrockCore::processCommand(unique_ptr<BedrockCommand>& command) {
     AutoTimer timer(command, BedrockCommand::PROCESS);
 
     // Convenience references to commonly used properties.
@@ -278,7 +278,7 @@ bool BedrockCore::processCommand(BedrockCommandPtr& command) {
     return needsCommit;
 }
 
-void BedrockCore::_handleCommandException(BedrockCommandPtr& command, const SException& e) {
+void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e) {
     const string& msg = "Error processing command '" + command->request.methodLine + "' (" + e.what() + "), ignoring.";
     if (SContains(e.what(), "_ALERT_")) {
         SALERT(msg);

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -10,13 +10,13 @@ class BedrockCore : public SQLiteCore {
     // Automatic timing class that records an entry corresponding to its lifespan.
     class AutoTimer {
       public:
-        AutoTimer(BedrockCommandPtr& command, BedrockCommand::TIMING_INFO type) :
+        AutoTimer(unique_ptr<BedrockCommand>& command, BedrockCommand::TIMING_INFO type) :
         _command(command), _type(type), _start(STimeNow()) { }
         ~AutoTimer() {
             _command->timingInfo.emplace_back(make_tuple(_type, _start, STimeNow()));
         }
       private:
-        BedrockCommandPtr& _command;
+        unique_ptr<BedrockCommand>& _command;
         BedrockCommand::TIMING_INFO _type;
         uint64_t _start;
     };
@@ -24,7 +24,7 @@ class BedrockCore : public SQLiteCore {
     // Checks if a command has already timed out. Like `peekCommand` without doing any work. Returns `true` and sets
     // the same command state as `peekCommand` would if the command has timed out. Returns `false` and does nothing if
     // the command hasn't timed out.
-    bool isTimedOut(BedrockCommandPtr& command);
+    bool isTimedOut(unique_ptr<BedrockCommand>& command);
 
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same
     // command, and it *may be called multiple times*. Preventing duplicate actions on calling peek multiple times is
@@ -33,7 +33,7 @@ class BedrockCore : public SQLiteCore {
     // should be considered an error to modify the DB from inside `peek`.
     // Returns a boolean value of `true` if the command is complete and its `response` field can be returned to the
     // caller. Returns `false` if the command will need to be passed to `process` to complete handling the command.
-    bool peekCommand(BedrockCommandPtr& command);
+    bool peekCommand(unique_ptr<BedrockCommand>& command);
 
     // Process is the follow-up to `peek` if `peek` was insufficient to handle the command. It will only ever be called
     // on the leader node, and should always be able to resolve the command completely. When a command is passed to
@@ -45,7 +45,7 @@ class BedrockCore : public SQLiteCore {
     // replicate the transaction to follower nodes. Upon being returned `true`, the caller will attempt to perform a
     // `COMMIT` and replicate the transaction to follower nodes. It's allowable for this `COMMIT` to fail, in which case
     // this command *will be passed to process again in the future to retry*.
-    bool processCommand(BedrockCommandPtr& command);
+    bool processCommand(unique_ptr<BedrockCommand>& command);
 
   private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.
@@ -54,8 +54,8 @@ class BedrockCore : public SQLiteCore {
     // Gets the amount of time remaining until this command times out. This is the difference between the command's
     // 'timeout' value (or the default timeout, if not set) and the time the command was initially scheduled to run. If
     // this time is already expired, this throws `555 Timeout`
-    uint64_t _getRemainingTime(const BedrockCommandPtr& command);
+    uint64_t _getRemainingTime(const unique_ptr<BedrockCommand>& command);
 
-    void _handleCommandException(BedrockCommandPtr& command, const SException& e);
+    void _handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e);
     const BedrockServer& _server;
 };

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -318,7 +318,7 @@ class BedrockServer : public SQLiteServer {
 
     // Send a reply for a completed command back to the initiating client. If the `originator` of the command is set,
     // then this is an error, as the command should have been sent back to a peer.
-    void _reply(BedrockCommandPtr& command);
+    void _reply(unique_ptr<BedrockCommand>& command);
 
     // The following are constants used as methodlines by status command requests.
     static constexpr auto STATUS_IS_SLAVE          = "GET /status/isSlave HTTP/1.1";
@@ -340,10 +340,10 @@ class BedrockServer : public SQLiteServer {
     recursive_timed_mutex _syncMutex;
 
     // Functions for checking for and responding to status and control commands.
-    bool _isStatusCommand(const BedrockCommandPtr& command);
-    void _status(BedrockCommandPtr& command);
-    bool _isControlCommand(const BedrockCommandPtr& command);
-    void _control(BedrockCommandPtr& command);
+    bool _isStatusCommand(const unique_ptr<BedrockCommand>& command);
+    void _status(unique_ptr<BedrockCommand>& command);
+    bool _isControlCommand(const unique_ptr<BedrockCommand>& command);
+    void _control(unique_ptr<BedrockCommand>& command);
 
     // Accepts any sockets pending on our listening ports. We do this both after `poll()`, and before shutting down
     // those ports.
@@ -356,7 +356,7 @@ class BedrockServer : public SQLiteServer {
     // depends on a future commit if we're a follower that's behind leader, and a client makes two requests, one to a node
     // more current than ourselves, and a following request to us. We'll move these commands to this special map until
     // we catch up, and then move them back to the regular command queue.
-    multimap<uint64_t, BedrockCommandPtr> _futureCommitCommands;
+    multimap<uint64_t, unique_ptr<BedrockCommand>> _futureCommitCommands;
 
     // Map of command timeouts to the indexes into _futureCommitCommands where those commands live.
     multimap<uint64_t, uint64_t> _futureCommitCommandTimeouts;
@@ -418,14 +418,14 @@ class BedrockServer : public SQLiteServer {
 
     // Takes a command that has an outstanding HTTPS request and saves it in _outstandingHTTPSCommands until its HTTPS
     // requests are complete.
-    void waitForHTTPS(BedrockCommandPtr&& command);
+    void waitForHTTPS(unique_ptr<BedrockCommand>&& command);
 
     // Takes a list of completed HTTPS requests, and move those commands back to the main queue (as long as they don't
     // have any other incomplete requests).
     int finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& completedHTTPSRequests);
 
     // Send a reply to a command that was escalated to us from a peer, rather than a locally-connected client.
-    void _finishPeerCommand(BedrockCommandPtr& command);
+    void _finishPeerCommand(unique_ptr<BedrockCommand>& command);
 
     // When we're standing down, we temporarily dump newly received commands here (this lets all existing
     // partially-completed commands, like commands with HTTPS requests) finish without risking getting caught in an
@@ -447,13 +447,13 @@ class BedrockServer : public SQLiteServer {
 
     // Returns whether or not the command was a status or control command. If it was, it will have already been handled
     // and responded to upon return
-    bool _handleIfStatusOrControlCommand(BedrockCommandPtr& command);
+    bool _handleIfStatusOrControlCommand(unique_ptr<BedrockCommand>& command);
 
     // Check a command against the list of crash commands, and return whether we think the command would crash.
-    bool _wouldCrash(const BedrockCommandPtr& command);
+    bool _wouldCrash(const unique_ptr<BedrockCommand>& command);
 
     // Generate a CRASH_COMMAND command for a given bad command.
-    static SData _generateCrashMessage(const BedrockCommandPtr& command);
+    static SData _generateCrashMessage(const unique_ptr<BedrockCommand>& command);
 
     static void _addRequestID(SData& request);
 

--- a/BedrockTimeoutCommandQueue.cpp
+++ b/BedrockTimeoutCommandQueue.cpp
@@ -1,6 +1,6 @@
 #include <BedrockTimeoutCommandQueue.h>
 
-const BedrockCommandPtr& BedrockTimeoutCommandQueue::front() const {
+const unique_ptr<BedrockCommand>& BedrockTimeoutCommandQueue::front() const {
     lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     if (_queue.empty()) {
         throw out_of_range("No commands");
@@ -14,7 +14,7 @@ const BedrockCommandPtr& BedrockTimeoutCommandQueue::front() const {
     return _queue.front();
 }
 
-void BedrockTimeoutCommandQueue::push(BedrockCommandPtr&& rhs) {
+void BedrockTimeoutCommandQueue::push(unique_ptr<BedrockCommand>&& rhs) {
     lock_guard<decltype(_queueMutex)> lock(_queueMutex);
 
     // Add to the queue and timeout map.
@@ -30,13 +30,13 @@ void BedrockTimeoutCommandQueue::push(BedrockCommandPtr&& rhs) {
     SASSERT(write(_pipeFD[1], "A", 1));
 }
 
-BedrockCommandPtr BedrockTimeoutCommandQueue::pop() {
+unique_ptr<BedrockCommand> BedrockTimeoutCommandQueue::pop() {
     lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     if (_queue.empty()) {
         throw out_of_range("No commands");
     }
     if (_timeoutMap.begin()->first < STimeNow()) {
-        BedrockCommandPtr item = move(*(_timeoutMap.begin()->second));
+        unique_ptr<BedrockCommand> item = move(*(_timeoutMap.begin()->second));
         _queue.erase(_timeoutMap.begin()->second);
         _timeoutMap.erase(_timeoutMap.begin());
         return item;
@@ -52,7 +52,7 @@ BedrockCommandPtr BedrockTimeoutCommandQueue::pop() {
             break;
         }
     }
-    BedrockCommandPtr item = move(*firstCommandIt);
+    unique_ptr<BedrockCommand> item = move(*firstCommandIt);
     _queue.pop_front();
     return item;
 }

--- a/BedrockTimeoutCommandQueue.h
+++ b/BedrockTimeoutCommandQueue.h
@@ -1,15 +1,15 @@
 #include <libstuff/libstuff.h>
 #include <BedrockCommand.h>
 
-class BedrockTimeoutCommandQueue : public SSynchronizedQueue<BedrockCommandPtr> {
+class BedrockTimeoutCommandQueue : public SSynchronizedQueue<unique_ptr<BedrockCommand>> {
   public:
     // Override the base class to account for timeouts.
-    const BedrockCommandPtr& front() const;
-    void push(BedrockCommandPtr&& rhs);
-    BedrockCommandPtr pop();
+    const unique_ptr<BedrockCommand>& front() const;
+    void push(unique_ptr<BedrockCommand>&& rhs);
+    unique_ptr<BedrockCommand> pop();
 
   private:
     // Map of timeouts to commands in the queue. Because the queue is a std::list, we can store iterators into it and
     // they stay valid as we manipulate the list, avoiding walking the list to re-locate them.
-    multimap<uint64_t, list<BedrockCommandPtr>::iterator> _timeoutMap;
+    multimap<uint64_t, list<unique_ptr<BedrockCommand>>::iterator> _timeoutMap;
 };


### PR DESCRIPTION
Looks like we no longer need this for testing.