### PR TITLE
Tweak some log lines for ES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ libstuff.a
 sqlitecluster/sqlitecluster
 libstuff/libstuff.d
 libstuff/libstuff.h.gch
+.idea

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -223,7 +223,7 @@ void BedrockCommand::finalizeTimingInfo() {
     }
 
     // Log all this info.
-    SINFO("[performance] command '" << request.methodLine << "' timing info (ms): "
+    SINFO("command '" << request.methodLine << "' timing info (ms): "
           << peekTotal/1000 << " (" << peekCount << "), "
           << processTotal/1000 << " (" << processCount << "), "
           << commitWorkerTotal/1000 << ", "

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -101,7 +101,7 @@ bool BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command) {
 
                 // Try to peek the command.
                 if (plugin.second->peekCommand(_db, *command)) {
-                    SINFO("Plugin '" << plugin.second->getName() << "' peeked command '" << request.methodLine << "'");
+                    SDEBUG("Plugin '" << plugin.second->getName() << "' peeked command '" << request.methodLine << "'");
                     command->peekedBy = plugin.second;
                     pluginPeeked = true;
                     break;
@@ -213,7 +213,7 @@ bool BedrockCore::processCommand(unique_ptr<BedrockCommand>& command) {
             AutoScopeRewrite rewrite(enable, _db, handler);
             try {
                 if (plugin.second->processCommand(_db, *command)) {
-                    SINFO("Plugin '" << plugin.second->getName() << "' processed command '" << request.methodLine << "'");
+                    SDEBUG("Plugin '" << plugin.second->getName() << "' processed command '" << request.methodLine << "'");
                     pluginProcessed = true;
                     command->processedBy = plugin.second;
                     break;


### PR DESCRIPTION
Related to https://github.com/Expensify/Salt/pull/7334

This makes some log lines be debug and removes `performace` from another one so that it is parsed by ES