### PR TITLE
Include file for cout

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -1,5 +1,6 @@
 #include "tpunit++.hpp"
 #include <string.h>
+#include <iostream>
 #include <regex>
 using namespace tpunit;
 


### PR DESCRIPTION
@coleaeason 

This should be here, it's included in other places so it "mostly" worked before, but keysplittertest fails to build in S-E because it's missing here.