### PR TITLE
Remove const_cast everywhere

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -460,7 +460,7 @@ class BedrockServer : public SQLiteServer {
     // Generate a CRASH_COMMAND command for a given bad command.
     static SData _generateCrashMessage(const unique_ptr<BedrockCommand>& command);
 
-    static void _addRequestID(const SData& request);
+    static void _addRequestID(SData& request);
 
     // The number of seconds to wait between forcing a command to QUORUM.
     uint64_t _quorumCheckpointSeconds;

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -14,7 +14,17 @@ BedrockPlugin_DB::BedrockPlugin_DB(BedrockServer& s) : BedrockPlugin(s)
 }
 
 BedrockDBCommand::BedrockDBCommand(SQLiteCommand&& baseCommand, BedrockPlugin_DB* plugin) :
-  BedrockCommand(move(baseCommand), plugin)
+  BedrockCommand(move(baseCommand), plugin),
+    // The "full" syntax of a query request is:
+    //
+    //      Query
+    //      Query: ...sql...
+    //
+    // However, that's awfully redundant.  As shorthand, we'll accept the query
+    // in the method line as follows:
+    //
+    //      Query: ...sql...
+  query(SStartsWith(SToLower(request.methodLine), "query:") ? request.methodLine.substr(strlen("query:")) : request["query"])
 {
 }
 
@@ -26,126 +36,92 @@ unique_ptr<BedrockCommand> BedrockPlugin_DB::getCommand(SQLiteCommand&& baseComm
 }
 
 bool BedrockDBCommand::peek(SQLite& db) {
-    // The "full" syntax of a query request is:
+    if (query.size() < 1 || query.size() > BedrockPlugin::MAX_SIZE_QUERY) {
+        STHROW("402 Missing query");
+    }
+    BedrockPlugin::verifyAttributeBool(request, "nowhere",  false);
+
+    // See if it's read-only (and thus safely peekable) or read-write
+    // (and thus requires processing).
     //
-    //      Query
-    //      Query: ...sql...
-    //
-    // However, that's awfully redundant.  As shorthand, we'll accept the query
-    // in the method line as follows:
-    //
-    //      Query: ...sql...
-    //
-    // We do this by rewriting the request when it matches that pattern
-    if (SStartsWith(SToLower(request.methodLine), "query:")) {
-        //  Just take everything after that and put into the query param
-        SINFO("Rewriting command: " << request.methodLine);
-        const_cast<SData&>(request)["query"] = request.methodLine.substr(strlen("query:"));
-        const_cast<SData&>(request).methodLine = "Query";
+    // **NOTE: This isn't intended to be foolproof, and attempts to err on the
+    //         side of caution (eg, assuming read-write unless clearly read-
+    //         only).  A not-so-clever client could easily bypass this.  But
+    //         that same person could also easily wreck havoc in a bunch of
+    //         other ways, too.  That said, the worst-case scenario is that a
+    //         read-write command is mis-classified as read-only an executed in
+    //         the peek, but even then we'll detect it after the fact and shut
+    //         the node down.
+    const string& upperQuery = SToUpper(STrim(query));
+    bool shouldRequireWhere = !request.test("nowhere");
+
+    if (!SEndsWith(upperQuery, ";")) {
+        SALERT("Query aborted, query must end in ';'");
+        STHROW("502 Query aborted");
     }
 
-    if (SIEquals(request.getVerb(), "Query")) {
-        // - Query( query )
-        //
-        //     Executes a simple query
-        //
-        BedrockPlugin::verifyAttributeSize(request, "query", 1, BedrockPlugin::MAX_SIZE_QUERY);
-        BedrockPlugin::verifyAttributeBool(request, "nowhere",  false);
-
-        // See if it's read-only (and thus safely peekable) or read-write
-        // (and thus requires processing).
-        //
-        // **NOTE: This isn't intended to be foolproof, and attempts to err on the
-        //         side of caution (eg, assuming read-write unless clearly read-
-        //         only).  A not-so-clever client could easily bypass this.  But
-        //         that same person could also easily wreck havoc in a bunch of
-        //         other ways, too.  That said, the worst-case scenario is that a
-        //         read-write command is mis-classified as read-only an executed in
-        //         the peek, but even then we'll detect it after the fact and shut
-        //         the node down.
-        const string& query = request["query"];
-        const string& upperQuery = SToUpper(STrim(query));
-        bool shouldRequireWhere = !request.test("nowhere");
-
-        if (!SEndsWith(upperQuery, ";")) {
-            SALERT("Query aborted, query must end in ';'");
+    if (SStartsWith(upperQuery, "SELECT ")) {
+        // Seems to be read-only
+        SINFO("Query appears to be read-only, peeking.");
+    } else {
+        if (shouldRequireWhere &&
+           (SStartsWith(upperQuery, "UPDATE") || SStartsWith(upperQuery, "DELETE")) &&
+           !SContains(upperQuery, " WHERE ")) {
+            SALERT("Query aborted, it has no 'where' clause: '" << query << "'");
             STHROW("502 Query aborted");
         }
 
-        if (SStartsWith(upperQuery, "SELECT ")) {
-            // Seems to be read-only
-            SINFO("Query appears to be read-only, peeking.");
-        } else {
-            if (shouldRequireWhere &&
-               (SStartsWith(upperQuery, "UPDATE") || SStartsWith(upperQuery, "DELETE")) &&
-               !SContains(upperQuery, " WHERE ")) {
-                SALERT("Query aborted, it has no 'where' clause: '" << query << "'");
-                STHROW("502 Query aborted");
-            }
-
-            // Assume it's read/write
-            SINFO("Query appears to be read/write, queuing for processing.");
-            return false;
-        }
-
-        // Attempt the read-only query
-        SQResult result;
-        int preChangeCount = db.getChangeCount();
-        if (!db.read(query, result)) {
-            // Query failed
-            SALERT("Query failed: '" << query << "'");
-            response["error"] = db.getLastError();
-            STHROW("502 Query failed");
-        }
-
-        // Verify it didn't change anything -- assert because if we did, we did so
-        // outside of a replicated transaction and that's REALLY bad.
-        if (preChangeCount != db.getChangeCount()) {
-            // This database is fucked -- we made a change outside of a transaction
-            // so we can't roll back, and outside of a *distributed* transaction so
-            // now it's out of sync with the rest of the cluster.  This database
-            // needs to be destroyed and recovered from a peer.
-            SERROR("Read query actually managed to write; database is corrupt "
-                   << "and must be recovered from backup or peer.  Offending query: '" << query << "'");
-        }
-
-        // Worked!  What format do we want the output?
-        response.content = result.serialize(request["Format"]);
-        return true; // Successfully peeked
+        // Assume it's read/write
+        SINFO("Query appears to be read/write, queuing for processing.");
+        return false;
     }
 
-    // Didn't recognize this command
-    return false;
+    // Attempt the read-only query
+    SQResult result;
+    int preChangeCount = db.getChangeCount();
+    if (!db.read(query, result)) {
+        // Query failed
+        SALERT("Query failed: '" << query << "'");
+        response["error"] = db.getLastError();
+        STHROW("502 Query failed");
+    }
+
+    // Verify it didn't change anything -- assert because if we did, we did so
+    // outside of a replicated transaction and that's REALLY bad.
+    if (preChangeCount != db.getChangeCount()) {
+        // This database is fucked -- we made a change outside of a transaction
+        // so we can't roll back, and outside of a *distributed* transaction so
+        // now it's out of sync with the rest of the cluster.  This database
+        // needs to be destroyed and recovered from a peer.
+        SERROR("Read query actually managed to write; database is corrupt "
+               << "and must be recovered from backup or peer.  Offending query: '" << query << "'");
+    }
+
+    // Worked!  What format do we want the output?
+    response.content = result.serialize(request["Format"]);
+    return true; // Successfully peeked
 }
 
 void BedrockDBCommand::process(SQLite& db) {
-    if (SIEquals(request.getVerb(), "Query")) {
-        if (db.getUpdateNoopMode()) {
-            SINFO("Query run in mocked request, just ignoring.");
-            return;
-        }
-        // - Query( query )
-        //
-        //     Executes a simple read/write query
-        //
-        BedrockPlugin::verifyAttributeSize(request, "query", 1, BedrockPlugin::MAX_SIZE_QUERY);
-
-        // Attempt the query
-        const string& query = request["query"] + ";";
-        if (!db.write(query)) {
-            // Query failed
-            SALERT("Query failed: '" << query << "'");
-            response["error"] = db.getLastError();
-            STHROW("502 Query failed");
-        }
-
-        // Worked!  Let's save the last inserted row id
-        const string& upperQuery = SToUpper(STrim(query));
-        if (SStartsWith(upperQuery, "INSERT ")) {
-            response["lastInsertRowID"] = SToStr(db.getLastInsertRowID());
-        }
-
-        // Successfully processed
+    if (db.getUpdateNoopMode()) {
+        SINFO("Query run in mocked request, just ignoring.");
         return;
     }
+
+    // Attempt the query
+    if (!db.write(query)) {
+        // Query failed
+        SALERT("Query failed: '" << query << "'");
+        response["error"] = db.getLastError();
+        STHROW("502 Query failed");
+    }
+
+    // Worked!  Let's save the last inserted row id
+    const string& upperQuery = SToUpper(STrim(query));
+    if (SStartsWith(upperQuery, "INSERT ")) {
+        response["lastInsertRowID"] = SToStr(db.getLastInsertRowID());
+    }
+
+    // Successfully processed
+    return;
 }

--- a/plugins/DB.h
+++ b/plugins/DB.h
@@ -15,4 +15,7 @@ class BedrockDBCommand : public BedrockCommand {
     BedrockDBCommand(SQLiteCommand&& baseCommand, BedrockPlugin_DB* plugin);
     virtual bool peek(SQLite& db);
     virtual void process(SQLite& db);
+
+  private:
+    const string query;
 };

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -35,4 +35,6 @@ class BedrockJobsCommand : public BedrockCommand {
     bool _validateRepeat(const string& repeat) { return !_constructNextRunDATETIME("", "", repeat).empty(); }
     bool _hasPendingChildJobs(SQLite& db, int64_t jobID);
     void _validatePriority(const int64_t priority);
+
+    bool mockRequest;
 };

--- a/plugins/MySQL.cpp
+++ b/plugins/MySQL.cpp
@@ -321,10 +321,10 @@ void BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
                 s->send(MySQLPacket::serializeOK(packet.sequenceID));
             } else {
                 // Transform this into an internal request
-                const_cast<SData&>(request).methodLine = "Query";
-                const_cast<SData&>(request)["format"] = "json";
-                const_cast<SData&>(request)["sequenceID"] = SToStr(packet.sequenceID);
-                const_cast<SData&>(request)["query"] = query;
+                request.methodLine = "Query";
+                request["format"] = "json";
+                request["sequenceID"] = SToStr(packet.sequenceID);
+                request["query"] = query;
             }
             break;
         }

--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -1,12 +1,12 @@
 #include <libstuff/libstuff.h>
 #include "SQLiteCommand.h"
 
-SData&& SQLiteCommand::preprocessRequest(SData&& request) {
+SData SQLiteCommand::preprocessRequest(SData&& request) {
     // If the request doesn't specify an execution time, default to right now.
     if (!request.isSet("commandExecuteTime")) {
         request["commandExecuteTime"] = to_string(STimeNow());
     }
-    return move(request);
+    return request;
 }
 
 SQLiteCommand::SQLiteCommand(SData&& _request) : 

--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -1,10 +1,18 @@
 #include <libstuff/libstuff.h>
 #include "SQLiteCommand.h"
 
+SData&& SQLiteCommand::preprocessRequest(SData&& request) {
+    // If the request doesn't specify an execution time, default to right now.
+    if (!request.isSet("commandExecuteTime")) {
+        request["commandExecuteTime"] = to_string(STimeNow());
+    }
+    return move(request);
+}
+
 SQLiteCommand::SQLiteCommand(SData&& _request) : 
     initiatingPeerID(0),
     initiatingClientID(0),
-    request(move(_request)),
+    request(preprocessRequest(move(_request))),
     writeConsistency(SQLiteNode::ASYNC),
     complete(false),
     escalationTimeUS(0),
@@ -26,11 +34,6 @@ SQLiteCommand::SQLiteCommand(SData&& _request) :
                 writeConsistency = SQLiteNode::ASYNC;
                 break;
         }
-    }
-
-    // If the request doesn't specify an execution time, default to right now.
-    if (!request.isSet("commandExecuteTime")) {
-        const_cast<SData&>(request)["commandExecuteTime"] = to_string(STimeNow());
     }
 }
 

--- a/sqlitecluster/SQLiteCommand.h
+++ b/sqlitecluster/SQLiteCommand.h
@@ -5,7 +5,7 @@ class SQLiteCommand {
   public:
 
     // This allows for modifying a request passed into the constructor such that we can store it as `const`.
-    static SData&& preprocessRequest(SData&& request);
+    static SData preprocessRequest(SData&& request);
 
     // If this command was created via an escalation from a peer, this value will point to that peer object. As such,
     // this should only ever be set on leader nodes, though it does not *need* to be set on leader nodes, as they can

--- a/sqlitecluster/SQLiteCommand.h
+++ b/sqlitecluster/SQLiteCommand.h
@@ -3,6 +3,10 @@
 
 class SQLiteCommand {
   public:
+
+    // This allows for modifying a request passed into the constructor such that we can store it as `const`.
+    static SData&& preprocessRequest(SData&& request);
+
     // If this command was created via an escalation from a peer, this value will point to that peer object. As such,
     // this should only ever be set on leader nodes, though it does not *need* to be set on leader nodes, as they can
     // also accept connections directly from clients.

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -42,4 +42,7 @@ class TestPluginCommand : public BedrockCommand {
 
   private:
     BedrockPlugin_TestPlugin& plugin() { return static_cast<BedrockPlugin_TestPlugin&>(*_plugin); }
+
+    bool pendingResult;
+    string urls;
 };


### PR DESCRIPTION
Cleans up leftover temporary usages of `const_cast` everywhere. Worth a bit of a careful look, though much of this is straightforward. I added one new test to make sure that timing out a command with a future commit count works (the existing check to remove `commitCount` from the request seems entirely unnecessary) and I ran the auth test suite against the change as well.

Tests:
Existing tests pass.