### PR TITLE
Remove master/slave references

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -321,7 +321,6 @@ class BedrockServer : public SQLiteServer {
     void _reply(unique_ptr<BedrockCommand>& command);
 
     // The following are constants used as methodlines by status command requests.
-    static constexpr auto STATUS_IS_SLAVE          = "GET /status/isSlave HTTP/1.1";
     static constexpr auto STATUS_IS_FOLLOWER       = "GET /status/isFollower HTTP/1.1";
     static constexpr auto STATUS_HANDLING_COMMANDS = "GET /status/handlingCommands HTTP/1.1";
     static constexpr auto STATUS_PING              = "Ping";

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -22,8 +22,6 @@ STCPNode::~STCPNode() {
 }
 
 const string& STCPNode::stateName(STCPNode::State state) {
-    // This returns the legacy names MASTERING/SLAVING until all nodes have been updated to be able to
-    // understand the new LEADING/FOLLOWING names.
     static string placeholder = "";
     static map<State, string> lookup = {
         {UNKNOWN, "UNKNOWN"},
@@ -31,10 +29,10 @@ const string& STCPNode::stateName(STCPNode::State state) {
         {SYNCHRONIZING, "SYNCHRONIZING"},
         {WAITING, "WAITING"},
         {STANDINGUP, "STANDINGUP"},
-        {LEADING, "MASTERING"},
+        {LEADING, "LEADING"},
         {STANDINGDOWN, "STANDINGDOWN"},
         {SUBSCRIBING, "SUBSCRIBING"},
-        {FOLLOWING, "SLAVING"},
+        {FOLLOWING, "FOLLOWING"},
     };
     auto it = lookup.find(state);
     if (it == lookup.end()) {
@@ -54,11 +52,9 @@ STCPNode::State STCPNode::stateFromName(const string& name) {
         {"WAITING", WAITING},
         {"STANDINGUP", STANDINGUP},
         {"LEADING", LEADING},
-        {"MASTERING", LEADING},
         {"STANDINGDOWN", STANDINGDOWN},
         {"SUBSCRIBING", SUBSCRIBING},
         {"FOLLOWING", FOLLOWING},
-        {"SLAVING", FOLLOWING},
     };
     auto it = lookup.find(normalizedName);
     if (it == lookup.end()) {

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -46,15 +46,18 @@ STCPNode::State STCPNode::stateFromName(const string& name) {
     string normalizedName = SToUpper(name);
 
     // Accept both old and new state names, but map them all to the new states.
+    // We can delete the old names once the entire cluster is using the new names.
     static map<string, State> lookup = {
         {"SEARCHING", SEARCHING},
         {"SYNCHRONIZING", SYNCHRONIZING},
         {"WAITING", WAITING},
         {"STANDINGUP", STANDINGUP},
         {"LEADING", LEADING},
+        {"MASTERING", LEADING},
         {"STANDINGDOWN", STANDINGDOWN},
         {"SUBSCRIBING", SUBSCRIBING},
         {"FOLLOWING", FOLLOWING},
+        {"SLAVING", FOLLOWING},
     };
     auto it = lookup.find(normalizedName);
     if (it == lookup.end()) {

--- a/test/clustertest/tests/BadCommandTest.cpp
+++ b/test/clustertest/tests/BadCommandTest.cpp
@@ -75,7 +75,7 @@ struct BadCommandTest : tpunit::TestFixture {
 
             // Bring leader back up.
             leader.startServer();
-            ASSERT_TRUE(leader.waitForStates({"LEADING", "MASTERING"}));
+            ASSERT_TRUE(leader.waitForState("LEADING"));
         }
     }
 

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -102,7 +102,7 @@ struct GracefulFailoverTest : tpunit::TestFixture {
     }
 
     void test() {
-        ASSERT_TRUE(tester->getTester(0).waitForStates({"LEADING", "MASTERING"}));
+        ASSERT_TRUE(tester->getTester(0).waitForState("LEADING"));
 
         // Step 1: everything is already up and running. Let's start spamming.
         list<thread>* threads = new list<thread>();
@@ -122,14 +122,14 @@ struct GracefulFailoverTest : tpunit::TestFixture {
         tester->stopNode(0);
 
         // Wait for node 1 to be leader.
-        ASSERT_TRUE(tester->getTester(1).waitForStates({"LEADING", "MASTERING"}));
+        ASSERT_TRUE(tester->getTester(1).waitForState("LEADING"));
 
         // Let the spammers keep spamming on the new leader.
         sleep(3);
 
         // Bring leader back up.
         tester->getTester(0).startServer();
-        ASSERT_TRUE(tester->getTester(0).waitForStates({"LEADING", "MASTERING"}));
+        ASSERT_TRUE(tester->getTester(0).waitForState("LEADING"));
         sleep(15);
 
         // Now let's  stop a follower and make sure everything keeps working.
@@ -159,7 +159,7 @@ struct GracefulFailoverTest : tpunit::TestFixture {
 
         // And bring it back up.
         tester->getTester(2).startServer();
-        ASSERT_TRUE(tester->getTester(2).waitForStates({"FOLLOWING", "SLAVING"}));
+        ASSERT_TRUE(tester->getTester(2).waitForState("FOLLOWING"));
 
         // We're done, let spammers finish.
         done.store(true);
@@ -188,12 +188,12 @@ struct GracefulFailoverTest : tpunit::TestFixture {
         tester->getTester(0).stopServer(SIGKILL);
 
         // Wait for node 1 to be leader.
-        ASSERT_TRUE(tester->getTester(1).waitForStates({"LEADING", "MASTERING"}));
+        ASSERT_TRUE(tester->getTester(1).waitForState("LEADING"));
 
         // Now bring leader back up.
         sleep(2);
         tester->getTester(0).startServer();
-        ASSERT_TRUE(tester->getTester(0).waitForStates({"LEADING", "MASTERING"}));
+        ASSERT_TRUE(tester->getTester(0).waitForState("LEADING"));
 
         // Blow up a follower.
         sleep(2);
@@ -202,7 +202,7 @@ struct GracefulFailoverTest : tpunit::TestFixture {
         // And bring it back up.
         sleep(2);
         tester->getTester(2).startServer();
-        ASSERT_TRUE(tester->getTester(2).waitForStates({"FOLLOWING", "SLAVING"}));
+        ASSERT_TRUE(tester->getTester(2).waitForState("FOLLOWING"));
 
         // We're really done, let everything finish a last time.
         done.store(true);

--- a/test/clustertest/tests/JobIDTest.cpp
+++ b/test/clustertest/tests/JobIDTest.cpp
@@ -43,7 +43,7 @@ struct JobIDTest : tpunit::TestFixture {
             SData cmd("Status");
             string response = follower.executeWaitVerifyContent(cmd);
             STable json = SParseJSONObject(response);
-            if (json["state"] == "LEADING" || json["state"] == "MASTERING") {
+            if (json["isLeading"] == "true") {
                 success = true;
                 break;
             }
@@ -67,7 +67,7 @@ struct JobIDTest : tpunit::TestFixture {
             SData cmd("Status");
             string response = leader.executeWaitVerifyContent(cmd);
             STable json = SParseJSONObject(response);
-            if (json["state"] == "LEADING" || json["state"] == "MASTERING") {
+            if (json["isLeading"] == "true") {
                 success = true;
                 break;
             }

--- a/test/clustertest/tests/JobIDTest.cpp
+++ b/test/clustertest/tests/JobIDTest.cpp
@@ -43,7 +43,7 @@ struct JobIDTest : tpunit::TestFixture {
             SData cmd("Status");
             string response = follower.executeWaitVerifyContent(cmd);
             STable json = SParseJSONObject(response);
-            if (json["isLeading"] == "true") {
+            if (json["isLeader"] == "true") {
                 success = true;
                 break;
             }
@@ -67,7 +67,7 @@ struct JobIDTest : tpunit::TestFixture {
             SData cmd("Status");
             string response = leader.executeWaitVerifyContent(cmd);
             STable json = SParseJSONObject(response);
-            if (json["isLeading"] == "true") {
+            if (json["isLeader"] == "true") {
                 success = true;
                 break;
             }

--- a/test/clustertest/tests/LeadingTest.cpp
+++ b/test/clustertest/tests/LeadingTest.cpp
@@ -40,9 +40,9 @@ struct MasteringTest : tpunit::TestFixture {
                 results[i] = json["state"];
             }
 
-            if ((results[0] == "LEADING" || results[0] == "MASTERING") &&
-                (results[1] == "FOLLOWING" || results[1] == "SLAVING") &&
-                (results[2] == "FOLLOWING" || results[2] == "SLAVING"))
+            if (results[0] == "LEADING" &&
+                results[1] == "FOLLOWING" &&
+                results[2] == "FOLLOWING")
             {
                 success = true;
                 break;


### PR DESCRIPTION
@coleaeason @righdforsa 

Replaces: https://github.com/Expensify/Bedrock/pull/656

Related issue: https://github.com/Expensify/Expensify/issues/104378

This removes (almost) all remaining references to MASTER/SLAVE in Bedrock. There's a single exception in `STCPNode::stateFromName` where we'll still recognize these names when sent by a peer, because existing peers still send the old names and we want to recognize them during the upgrade away from these names.

HOLD for: https://github.com/Expensify/Salt/pull/6783
HOLD for: https://github.com/Expensify/Server-Expensify/pull/4331

The S-E change above must be deployed before or concurrent with this change or EBM will break.

Existing tests all pass.
