### PR TITLE
Make SData constructor deserialize by default, clean up file

### DIFF
--- a/libstuff/SData.cpp
+++ b/libstuff/SData.cpp
@@ -6,20 +6,17 @@ SData::SData() {
     // Nothing to do here
 }
 
-// Initializes a new SData from a string.  If the string provided is not
-// an entire HTTPs like message, the string is used as the methodLine.
-SData::SData(const string& rhs) {
-    if(!SParseHTTP(rhs, methodLine, nameValueMap, content)){
-        methodLine = rhs;
+
+SData::SData(const string& fromString) {
+    if(!SParseHTTP(fromString, methodLine, nameValueMap, content)){
+        methodLine = fromString;
     }
 }
 
-// This version creates an entry, if necessary, and returns a reference
 string& SData::operator[](const string& name) {
     return nameValueMap[name];
 }
 
-// This version takes care not to create an entry if none is present
 const string& SData::operator[](const string& name) const {
     STable::const_iterator it = nameValueMap.find(name);
     if (it == nameValueMap.end()) {
@@ -29,45 +26,37 @@ const string& SData::operator[](const string& name) const {
     }
 }
 
-// Erase everything
 void SData::clear() {
     methodLine.clear();
     nameValueMap.clear();
     content.clear();
 }
 
-// Erase one value
 void SData::erase(const string& name) {
     nameValueMap.erase(name);
 }
 
-// Combine the name/value pairs from two datas
-void SData::merge(const STable& rhs) {
-    nameValueMap.insert(rhs.begin(), rhs.end());
+void SData::merge(const STable& table) {
+    nameValueMap.insert(table.begin(), table.end());
 }
 
-// Combine two SData into one
 void SData::merge(const SData& rhs) {
     // **FIXME: What do we do with the content?  Where do we use this?
     merge(rhs.nameValueMap);
 }
 
-// Returns whether or not this data is empty
 bool SData::empty() const {
     return (methodLine.empty() && nameValueMap.empty() && content.empty());
 }
 
-// Returns whether or not a particular value has been set
 bool SData::isSet(const string& name) const {
     return SContains(nameValueMap, name);
 }
 
-// Return as a 32-bit value.
 int SData::calc(const string& name) const {
     return min((long)calc64(name), (long)0x7fffffffL);
 }
 
-// Return as a 64-bit value
 int64_t SData::calc64(const string& name) const {
     STable::const_iterator it = nameValueMap.find(name);
     if (it == nameValueMap.end()) {
@@ -77,7 +66,6 @@ int64_t SData::calc64(const string& name) const {
     }
 }
 
-// Return as an unsigned 64-bit value
 uint64_t SData::calcU64(const string& name) const {
     STable::const_iterator it = nameValueMap.find(name);
     if (it == nameValueMap.end()) {
@@ -87,46 +75,36 @@ uint64_t SData::calcU64(const string& name) const {
     }
 }
 
-// Returns if the value evaluates to true
 bool SData::test(const string& name) const {
     const string& value = (*this)[name];
     return (SIEquals(value, "true") || calc(name) != 0);
 }
 
-// Gets the verb (eg "GET") from the method line
 string SData::getVerb() const {
     return methodLine.substr(0, methodLine.find(" "));
 }
 
-// Serializes this to an ostringstream
 void SData::serialize(ostringstream& out) const {
     out << SComposeHTTP(methodLine, nameValueMap, content);
 }
 
-// Serializes this to a string
 string SData::serialize() const {
-    // Serializes this to a string
     return SComposeHTTP(methodLine, nameValueMap, content);
 }
 
-// Deserializes from a string
-int SData::deserialize(const string& rhs) {
-    return (SParseHTTP(rhs, methodLine, nameValueMap, content));
+int SData::deserialize(const string& fromString) {
+    return (SParseHTTP(fromString, methodLine, nameValueMap, content));
 }
 
-// Deserializes from a buffer
 int SData::deserialize(const char* buffer, int length) {
     return (SParseHTTP(buffer, length, methodLine, nameValueMap, content));
 }
 
-// Initializes a new SData from a string.  If there is no content provided,
-// then use whatever data remains in the string as the content
-// **DEPRECATED** Use the constructor that handles this instead.
-SData SData::create(const string& rhs) {
+SData SData::create(const string& fromString) {
     SData data;
-    int header = data.deserialize(rhs);
+    int header = data.deserialize(fromString);
     if (header && data.content.empty()) {
-        data.content = rhs.substr(header);
+        data.content = fromString.substr(header);
     }
     return data;
 }

--- a/libstuff/SData.cpp
+++ b/libstuff/SData.cpp
@@ -53,7 +53,7 @@ bool SData::isSet(const string& name) const {
     return SContains(nameValueMap, name);
 }
 
-int32_t SData::calc(const string& name) const {
+int SData::calc(const string& name) const {
     return min((long)calc64(name), (long)0x7fffffffL);
 }
 

--- a/libstuff/SData.cpp
+++ b/libstuff/SData.cpp
@@ -1,26 +1,26 @@
 #include "libstuff.h"
 
 const string SData::placeholder;
-// --------------------------------------------------------------------------
+
 SData::SData() {
     // Nothing to do here
 }
 
-// --------------------------------------------------------------------------
-SData::SData(const string& method) {
-    // Initialize the method
-    methodLine = method;
+// Initializes a new SData from a string.  If the string provided is not
+// an entire HTTPs like message, the string is used as the methodLine.
+SData::SData(const string& rhs) {
+    if(!SParseHTTP(rhs, methodLine, nameValueMap, content)){
+        methodLine = rhs;
+    }
 }
 
-// --------------------------------------------------------------------------
+// This version creates an entry, if necessary, and returns a reference
 string& SData::operator[](const string& name) {
-    // This version creates an entry, if necessary, and returns a reference
     return nameValueMap[name];
 }
 
-// --------------------------------------------------------------------------
+// This version takes care not to create an entry if none is present
 const string& SData::operator[](const string& name) const {
-    // This version takes care not to create an entry if none is present
     STable::const_iterator it = nameValueMap.find(name);
     if (it == nameValueMap.end()) {
         return placeholder;
@@ -29,54 +29,46 @@ const string& SData::operator[](const string& name) const {
     }
 }
 
-// --------------------------------------------------------------------------
+// Erase everything
 void SData::clear() {
-    // Erase everything
     methodLine.clear();
     nameValueMap.clear();
     content.clear();
 }
 
-// --------------------------------------------------------------------------
+// Erase one value
 void SData::erase(const string& name) {
-    // Erase one value
     nameValueMap.erase(name);
 }
 
-// --------------------------------------------------------------------------
+// Combine the name/value pairs from two datas
 void SData::merge(const STable& rhs) {
-    // Combine the name/value pairs from two datas
     nameValueMap.insert(rhs.begin(), rhs.end());
 }
 
-// --------------------------------------------------------------------------
+// Combine two SData into one
 void SData::merge(const SData& rhs) {
-    // Combine two SData into one
     // **FIXME: What do we do with the content?  Where do we use this?
     merge(rhs.nameValueMap);
 }
 
-// --------------------------------------------------------------------------
+// Returns whether or not this data is empty
 bool SData::empty() const {
-    // Returns whether or not this data is empty
     return (methodLine.empty() && nameValueMap.empty() && content.empty());
 }
 
-// --------------------------------------------------------------------------
+// Returns whether or not a particular value has been set
 bool SData::isSet(const string& name) const {
-    // Returns whether or not a particular value has been set
     return SContains(nameValueMap, name);
 }
 
-// --------------------------------------------------------------------------
+// Return as a 32-bit value.
 int SData::calc(const string& name) const {
-    // Forcing 32 bitness here.
     return min((long)calc64(name), (long)0x7fffffffL);
 }
 
-// --------------------------------------------------------------------------
+// Return as a 64-bit value
 int64_t SData::calc64(const string& name) const {
-    // Return as a 64-bit value
     STable::const_iterator it = nameValueMap.find(name);
     if (it == nameValueMap.end()) {
         return 0;
@@ -85,9 +77,8 @@ int64_t SData::calc64(const string& name) const {
     }
 }
 
-// --------------------------------------------------------------------------
+// Return as an unsigned 64-bit value
 uint64_t SData::calcU64(const string& name) const {
-    // Return as an unsigned 64-bit value
     STable::const_iterator it = nameValueMap.find(name);
     if (it == nameValueMap.end()) {
         return 0;
@@ -96,47 +87,42 @@ uint64_t SData::calcU64(const string& name) const {
     }
 }
 
-// --------------------------------------------------------------------------
+// Returns if the value evaluates to true
 bool SData::test(const string& name) const {
-    // Returns if the value evaluates to true
     const string& value = (*this)[name];
     return (SIEquals(value, "true") || calc(name) != 0);
 }
 
-// --------------------------------------------------------------------------
+// Gets the verb (eg "GET") from the method line
 string SData::getVerb() const {
-    // Gets the verb (eg "GET") from the method line
     return methodLine.substr(0, methodLine.find(" "));
 }
 
-// --------------------------------------------------------------------------
+// Serializes this to an ostringstream
 void SData::serialize(ostringstream& out) const {
-    // Serializes this to an ostringstream
     out << SComposeHTTP(methodLine, nameValueMap, content);
 }
 
-// --------------------------------------------------------------------------
+// Serializes this to a string
 string SData::serialize() const {
     // Serializes this to a string
     return SComposeHTTP(methodLine, nameValueMap, content);
 }
 
-// --------------------------------------------------------------------------
+// Deserializes from a string
 int SData::deserialize(const string& rhs) {
-    // Deserializes from a string
     return (SParseHTTP(rhs, methodLine, nameValueMap, content));
 }
 
-// --------------------------------------------------------------------------
+// Deserializes from a buffer
 int SData::deserialize(const char* buffer, int length) {
-    // Deserializes from a buffer
     return (SParseHTTP(buffer, length, methodLine, nameValueMap, content));
 }
 
-// --------------------------------------------------------------------------
+// Initializes a new SData from a string.  If there is no content provided,
+// then use whatever data remains in the string as the content
+// **DEPRECATED** Use the constructor that handles this instead.
 SData SData::create(const string& rhs) {
-    // Initializes a new SData from a string.  If there is no content provided,
-    // then use whatever data remains in the string as the content
     SData data;
     int header = data.deserialize(rhs);
     if (header && data.content.empty()) {

--- a/libstuff/SData.cpp
+++ b/libstuff/SData.cpp
@@ -53,7 +53,7 @@ bool SData::isSet(const string& name) const {
     return SContains(nameValueMap, name);
 }
 
-int SData::calc(const string& name) const {
+int32_t SData::calc(const string& name) const {
     return min((long)calc64(name), (long)0x7fffffffL);
 }
 

--- a/libstuff/SData.h
+++ b/libstuff/SData.h
@@ -68,8 +68,8 @@ struct SData {
     // Returns whether or not a particular value has been set
     bool isSet(const string& name) const;
 
-    // Return as a 32-bit value.
-    int32_t calc(const string& name) const;
+    // Return as an int value.
+    int calc(const string& name) const;
 
     // Return as a 64-bit value
     int64_t calc64(const string& name) const;

--- a/libstuff/SData.h
+++ b/libstuff/SData.h
@@ -15,7 +15,7 @@ struct SData {
     // Constructors
     SData();
 
-    // Initializes a new SData from a string.  If the string provided is not
+    // Initializes a new SData from a string. If the string provided is not
     // an entire HTTPs like message, the string is used as the methodLine.
     SData(const string& fromString);
 
@@ -24,7 +24,6 @@ struct SData {
     pair<decltype(nameValueMap)::iterator, bool> emplace(Ts&&... args) {
         return nameValueMap.emplace(forward<Ts>(args)...);
     }
-
 
     // Operators
     // This version creates an entry, if necessary, and returns a reference
@@ -70,7 +69,7 @@ struct SData {
     bool isSet(const string& name) const;
 
     // Return as a 32-bit value.
-    int calc(const string& name) const;
+    int32_t calc(const string& name) const;
 
     // Return as a 64-bit value
     int64_t calc64(const string& name) const;
@@ -87,8 +86,8 @@ struct SData {
     // Serialization
     // Serializes this to an ostringstream
     void serialize(ostringstream& out) const;
-    // Serializes this to a string
 
+    // Serializes this to a string
     string serialize() const;
 
     // Deserializes from a string
@@ -97,7 +96,7 @@ struct SData {
     // Deserializes from a buffer
     int deserialize(const char* buffer, int length);
 
-    // Initializes a new SData from a string.  If there is no content provided,
+    // Initializes a new SData from a string. If there is no content provided,
     // then use whatever data remains in the string as the content
     // **DEPRECATED** Use the constructor that handles this instead.
     static SData create(const string& rhs);

--- a/libstuff/SData.h
+++ b/libstuff/SData.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "libstuff.h"
+
+// --------------------------------------------------------------------------
+// A very simple HTTP-like structure consisting of a method line, a table,
+// and a content body.
+// --------------------------------------------------------------------------
+struct SData {
+    // Public attributes
+    string methodLine;
+    STable nameValueMap;
+    string content;
+
+    // Constructors
+    SData();
+
+    // Initializes a new SData from a string.  If the string provided is not
+    // an entire HTTPs like message, the string is used as the methodLine.
+    SData(const string& fromString);
+
+    // Allow forwarding emplacements directly so SData can act like `std::map`.
+    template <typename... Ts>
+    pair<decltype(nameValueMap)::iterator, bool> emplace(Ts&&... args) {
+        return nameValueMap.emplace(forward<Ts>(args)...);
+    }
+
+
+    // Operators
+    // This version creates an entry, if necessary, and returns a reference
+    string& operator[](const string& name);
+
+    // This version takes care not to create an entry if none is present
+    const string& operator[](const string& name) const;
+
+    // Two templated versions of `set` are provided. One for arithmetic types, and one for other types (which must be
+    // convertible to 'string'). These allow you to do the following:
+    // SData.set("count", 7);
+    // SData.set("name", "Tyler");
+    // for all string and integer types.
+    template <typename T>
+    typename enable_if<is_arithmetic<T>::value, void>::type set(const string& key, const T item)
+    {
+        nameValueMap[key] = to_string(item);
+    }
+    template <typename T>
+    typename enable_if<!is_arithmetic<T>::value, void>::type set(const string& key, const T item)
+    {
+        nameValueMap[key] = item;
+    }
+
+    // Mutators
+    // Erase everything
+    void clear();
+
+    // Erase one value
+    void erase(const string& name);
+
+    // Combine the name/value pairs from two datas
+    void merge(const STable& table);
+
+    // Combine two SData into one
+    void merge(const SData& rhs);
+
+    // Accessors
+    // Returns whether or not this data is empty
+    bool empty() const;
+
+    // Returns whether or not a particular value has been set
+    bool isSet(const string& name) const;
+
+    // Return as a 32-bit value.
+    int calc(const string& name) const;
+
+    // Return as a 64-bit value
+    int64_t calc64(const string& name) const;
+
+    // Return as an unsigned 64-bit value
+    uint64_t calcU64(const string& name) const;
+
+    // Returns if the value evaluates to true
+    bool test(const string& name) const;
+
+    // Gets the verb (eg "GET") from the method line
+    string getVerb() const;
+
+    // Serialization
+    // Serializes this to an ostringstream
+    void serialize(ostringstream& out) const;
+    // Serializes this to a string
+
+    string serialize() const;
+
+    // Deserializes from a string
+    int deserialize(const string& rhs);
+
+    // Deserializes from a buffer
+    int deserialize(const char* buffer, int length);
+
+    // Initializes a new SData from a string.  If there is no content provided,
+    // then use whatever data remains in the string as the content
+    // **DEPRECATED** Use the constructor that handles this instead.
+    static SData create(const string& rhs);
+    static const string placeholder;
+};


### PR DESCRIPTION
@tylerkaraszewski Please review. This PR makes it so you can deserialize an entire message into an SData, ala the now deprecated `SData::create()` which should have just been a constructor to begin with. This makes creating const SDatas a lot easier. 

Sorry for the diff, cleaned up the file and all of the comments because it was driving me nuts. 