### PR TITLE
Add replication time logging.

### DIFF
--- a/WallClockTimer.cpp
+++ b/WallClockTimer.cpp
@@ -1,0 +1,61 @@
+#include "WallClockTimer.h"
+
+WallClockTimer::WallClockTimer() :
+  _count(0),
+  _currentStart(),
+  _absoluteStart(),
+  _elapsedRecorded(chrono::milliseconds::zero())
+{
+}
+
+void WallClockTimer::start() {
+    lock_guard<mutex> lock(_m);
+
+    // If the timer isn't running, start it.
+    if (!_count) {
+        _currentStart = chrono::steady_clock::now();
+    }
+    _count++;
+    
+    // If we've never started this timer before, mark this as its absolute beginning.
+    if (_absoluteStart.time_since_epoch() == chrono::milliseconds::zero()) {
+        _absoluteStart = _currentStart;
+    }
+}
+
+void WallClockTimer::stop() {
+    lock_guard<mutex> lock(_m);
+
+    // If we're about to decrement to zero, record the time.
+    if (_count == 1) {
+        // No longer timing, record the length of time that we were.
+        _elapsedRecorded += chrono::duration_cast<std::chrono::milliseconds>(chrono::steady_clock::now() - _currentStart);
+    } else if (_count == 0) {
+        SWARN("Stopped timer that wasn't running. Resetting.");
+        _count = 0;
+        _absoluteStart = chrono::steady_clock::time_point();
+        _currentStart = chrono::steady_clock::time_point();
+        _elapsedRecorded = chrono::milliseconds::zero();
+    }
+    _count--;
+}
+
+pair<chrono::milliseconds, chrono::milliseconds> WallClockTimer::getStatsAndReset() {
+    lock_guard<mutex> lock(_m);
+
+    // Figure out how much time it's been.
+    auto now = chrono::steady_clock::now();
+    auto startTime = _absoluteStart;
+    auto recorded = _elapsedRecorded;
+    if (_count) {
+        recorded += chrono::duration_cast<std::chrono::milliseconds>(now - _currentStart);
+    }
+
+    // reset our counters.
+    _currentStart = now;
+    _absoluteStart = now;
+    _elapsedRecorded = chrono::milliseconds::zero();
+
+    // Return our result.
+    return make_pair(chrono::duration_cast<std::chrono::milliseconds>(now - startTime), recorded);
+}

--- a/WallClockTimer.h
+++ b/WallClockTimer.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// A WallClockTimer is a class that can be used by multiple threads to count wall clock time that some task is
+// occurring. This won't double-count the same wall clock time for two different threads that are working in parallel.
+class WallClockTimer {
+  public:
+    // Create a new WallClockTimer.
+    WallClockTimer();
+
+    // Start counting time. Has no effect if another thread is already counting time.
+    void start();
+
+    // Stop counting time. Has no effect if another thread is still counting time.
+    void stop();
+
+    // Return to time periods, the first being total wall clock time elapsed, and the second being the time that the
+    // timer was actually running. Resets both these values upon call.
+    // That is to say, if you call 'getStatsAndReset' every 10s, you should see pairs where the first value is always
+    // approximately 10s, and the second value is always in the range 0-10s.
+    pair<chrono::milliseconds, chrono::milliseconds> getStatsAndReset();
+
+  private:
+    mutex _m;
+    uint64_t _count;
+    chrono::steady_clock::time_point _currentStart;
+    chrono::steady_clock::time_point _absoluteStart;
+    chrono::milliseconds _elapsedRecorded;
+};
+
+class AutoScopedWallClockTimer {
+  public:
+    AutoScopedWallClockTimer(WallClockTimer& timer) :
+        _timer(timer)
+    {
+        _timer.start();
+    }
+
+    ~AutoScopedWallClockTimer() {
+        _timer.stop();
+    }
+
+  private:
+    WallClockTimer& _timer;
+};

--- a/WallClockTimer.h
+++ b/WallClockTimer.h
@@ -27,6 +27,10 @@ class WallClockTimer {
     chrono::milliseconds _elapsedRecorded;
 };
 
+// You can use an AutoScopedWallClockTimer to start timing with a WallClockTimer and have timing stop automatically
+// when the AutoScopedWallClockTimer goes out of scope. This allows you not not worry about doing `timer.stop()` in
+// multiple return statement locations in a function or to worry about what happens if an exception is thrown while
+// your timer is running.
 class AutoScopedWallClockTimer {
   public:
     AutoScopedWallClockTimer(WallClockTimer& timer) :

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -39,9 +39,6 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, SQLite& db, const string& name, con
     : STCPNode(name, host, max(SQL_NODE_DEFAULT_RECV_TIMEOUT, SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT)),
       _db(db), _commitState(CommitState::UNINITIALIZED), _server(server), _stateChangeCount(0),
       _lastNetStatTime(chrono::steady_clock::now()),
-      _replicationPool(_db, "repl", true, 8),
-      _receivedCommitCount(_db.getCommitCount()),
-      _completedCommitCount(_db.getCommitCount()),
       _handledCommitCount(0)
     {
     SASSERT(priority >= 0);
@@ -2309,98 +2306,3 @@ void SQLiteNode::handleRollbackTransaction(Peer* peer, const SData& message) {
         commandIt->second.transaction = message;
     }
 }
-
-#undef SLOGPREFIX
-#define SLOGPREFIX "{replication} "
-
-// This is the function that will be called by the replication pool.
-void SQLiteNode::handleTransactionMessage(sqlite3* db, void* data) {
-    // TODO: I don't know where these are allocated or deleted.
-    // We can probably just allocate them where we pass them to this function and delete them at the end of this
-    // function, as we don't depend on their results.
-    SQLiteNode& node = static_cast<TransactionInfo*>(data)->node;
-    const SData& message = static_cast<TransactionInfo*>(data)->message;
-
-    // These apply to all three types of messages we handle here:
-    // BEGIN_TRANSACTION, COMMIT_TRANSACTION, ROLLBACK_TRANSACTION
-    // So we only check them once.
-    bool isAsync = SStartsWith(message["ID"], "ASYNC_");
-    uint64_t transactionID = stoull(isAsync ? message["ID"].substr(6) : message["ID"]);
-
-    // If we're supposed to start a transaction, let's do so.
-    if (message.methodLine == "BEGIN_TRANSACTION") {
-
-         // We'll loop here, we may need to run this transaction more than once in the case of a conflict.
-         while (true) {
-            // db.write(); // This is a placeholder for actually running the transaction.
-            
-            // Now we need to see if we can run the commit.
-            unique_lock<mutex> lock(node._replicationMutex);
-
-            // We can commit as soon as LEADER sends a message saying that we can, and as soon as everyone else before
-            // us has committed.
-            bool canCommit = (node._receivedCommitCount >= transactionID) && (node._completedCommitCount == transactionID - 1);
-            while (!canCommit) {
-                // Wait for the next iteration, and then check again.
-                node._replicationCV.wait(lock);
-                canCommit = (node._receivedCommitCount >= transactionID) && (node._completedCommitCount == transactionID - 1);
-            }
-
-            // Now we know we're ready to commit.
-            // bool result = db.commit(); // placeholder for actually committing.
-            if (1/*result == conflict*/) {
-                // Rollback and we'll retry on the next loop.
-                // db.rollback();
-            } else {
-                // We've finished! Increment node._completedCommitCount while we're still holding the lock from when we
-                // finished the commit to avoid race conditions.
-                node._completedCommitCount = transactionID;
-
-                // And now we can release the lock and drop out of the loop.
-                break;
-            }
-        }
-
-        // Now we've committed, so we can notify anyone else that might have been waiting.
-        node._replicationCV.notify_all();
-    } else if (message.methodLine == "COMMIT_TRANSACTION") {
-        //We lock here, because even though these messages always arrive in order, there's no guarantee that they're
-        //handled in order.
-        bool shouldNotify = false;
-        {
-            unique_lock<mutex> lock(node._replicationMutex);
-            if (node._receivedCommitCount < transactionID) {
-                node._receivedCommitCount = transactionID;
-                shouldNotify = true;
-            }
-        }
-        // Now that we've unlocked, if we changed the value, we want to notify anyone who's waiting.
-        if (shouldNotify) {
-            node._replicationCV.notify_all();
-        }
-
-        // Discussion: Assuming we have at least 2 threads, do we always complete transactions here?
-        // If we had only one thread, it could start a `BEGIN_TRANSACTION` message, and it would wait.
-        // The corresponding `COMMIT_TRANSACTION` would be in queue for the next available thread, but there never
-        // would be one, so it would never finish.
-        // On the other hand, messages from LEADER are always delivered in order, with a COMMIT (or potentially
-        // ROLLBACK) following each BEGIN.
-        // So, if thread 0 was waiting on a `COMMIT_TRANSACTION`, thread 1 would have to dequeue the following
-        // `COMMIT_TRANSACTION`, and this handling does not wait, so must succeed, thus unblocking thread 0. Because
-        // `BEGIN` and `END` messages alternate in the queue, then as long as you have two threads, and `END` is never
-        // blocked, you should never get stuck. Once thread 1 handles the END message that thread 0 is waiting for,
-        // thread 0 unsticks, even if thread 1 has since dequeued the next BEGIN, and thus thread 0 can handle the next
-        // END.
-    } else if (message.methodLine == "ROLLBACK_TRANSACTION") {
-        // This probably needs to set another variable that the BEGIN_TRANSACTION block above checks. These aren't
-        // expected to be common, and definitely aren't sequential (in fact, in practice they never happen, but we have
-        // handling for them *just in case*, such that in the event one ever does happen, it doesn't have the entire
-        // cluster crashing. I'm not actually that sure that this works correctly, though, as it never happens. We
-        // should add a test for it). We could have a list<uint64_t> rollbackTransactionIDs, and similar to checking if
-        // the commit count is up-to-date, we can check if rollbackTransactionIDs contains the current transaction.
-        SERROR("Add handling for replication ROLLBACK_TRANSACTION");
-    } else {
-        SERROR("Unhandled replication message " << message.methodLine);
-    }
-}
-

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2125,13 +2125,6 @@ bool SQLiteNode::peekPeerCommand(SQLiteNode* node, SQLite& db, SQLiteCommand& co
     return false;
 }
 
-// Temporary
-class TransactionInfo {
-  public:
-    SQLiteNode& node;
-    const SData& message;
-};
-
 void SQLiteNode::handleBeginTransaction(Peer* peer, const SData& message) {
     AutoScopedWallClockTimer timer(_syncTimer);
 

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "SQLite.h"
-#include "SQLiteThreadPool.h"
 #include "WallClockTimer.h"
 class SQLiteCommand;
 class SQLiteServer;
@@ -198,19 +197,10 @@ class SQLiteNode : public STCPNode {
     // Last time we recorded network stats.
     chrono::steady_clock::time_point _lastNetStatTime;
 
-    // Requirements for replication in separate threads. We also need enough DB handles to use.
-    SQLiteThreadPool _replicationPool;
-
     // Handler for transaction messages.
     void handleBeginTransaction(Peer* peer, const SData& message);
     void handleCommitTransaction(Peer* peer, const SData& message);
     void handleRollbackTransaction(Peer* peer, const SData& message);
-
-    static void handleTransactionMessage(sqlite3* db, void* data);
-    mutex _replicationMutex;
-    condition_variable _replicationCV;
-    atomic<uint64_t> _receivedCommitCount;
-    atomic<uint64_t> _completedCommitCount;
 
     WallClockTimer _syncTimer;
     uint64_t _handledCommitCount;


### PR DESCRIPTION
This adds a new timer class for counting only the fraction of *wall clock* time that something (in this case, replication) was busy, such that we can compare how close we are to saturating our ability to handle replicated transactions, both currently, and in a future change for parallel replication.

This code is actually pulled from this WIP PR for parallel replication:
https://github.com/Expensify/Bedrock/pull/729

The only functional change here is to add a logline. Everything else is refactoring to make this change simpler, and prepare for a future parallel replication change. We can easily back all this out if it turns out that we're not saturating our ability to handle replication.

Tests:
Existing tests.