### PR TITLE
Check for new exception in SQLiteNode

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1952,21 +1952,36 @@ void SQLiteNode::_recvSynchronize(Peer* peer, const SData& message) {
             SALERT("Synchronized blank query");
         if (commit.calcU64("CommitIndex") != _db.getCommitCount() + 1)
             STHROW("commit index mismatch");
-        _db.waitForCheckpoint();
-        if (!_db.beginTransaction())
-            STHROW("failed to begin transaction");
-        try {
-            // Inside a transaction; get ready to back out if an error
-            if (!_db.writeUnmodified(commit.content))
-                STHROW("failed to write transaction");
-            if (!_db.prepare())
-                STHROW("failed to prepare transaction");
-        } catch (const SException& e) {
-            // Transaction failed, clean up
-            SERROR("Can't synchronize (" << e.what() << "); shutting down.");
-            // **FIXME: Remove the above line once we can automatically handle?
-            _db.rollback();
-            throw e;
+
+        // This block repeats until we successfully commit, or throw out of it.
+        // This allows us to retry in the event we're interrupted for a checkpoint. This should only happen once,
+        // because the second try will be blocked on the checkpoint.
+        while (true) {
+            try {
+                _db.waitForCheckpoint();
+                if (!_db.beginTransaction()) {
+                    STHROW("failed to begin transaction");
+                }
+
+                // Inside a transaction; get ready to back out if an error
+                if (!_db.writeUnmodified(commit.content)) {
+                    STHROW("failed to write transaction");
+                }
+                if (!_db.prepare()) {
+                    STHROW("failed to prepare transaction");
+                }
+
+                // Done, break out of `while (true)`.
+                break;
+            } catch (const SException& e) {
+                // Transaction failed, clean up
+                SERROR("Can't synchronize (" << e.what() << "); shutting down.");
+                // **FIXME: Remove the above line once we can automatically handle?
+                _db.rollback();
+                throw e;
+            } catch (const SQLite::checkpoint_required_error& e) {
+                SINFO("[checkpoint] Retrying synchronize after checkpoint.");
+            }
         }
 
         // Transaction succeeded, commit and go to the next
@@ -2157,31 +2172,47 @@ void SQLiteNode::handleBeginTransaction(Peer* peer, const SData& message) {
     if (_db.getCommitCount() + 1 != message.calcU64("NewCount")) {
         STHROW("commit count mismatch. Expected: " + message["NewCount"] + ", but would actually be: " + to_string(_db.getCommitCount() + 1));
     }
-    _db.waitForCheckpoint();
-    if (!_db.beginTransaction()) {
-        STHROW("failed to begin transaction");
-    }
-    try {
-        // Inside transaction; get ready to back out on error
-        if (!_db.writeUnmodified(message.content)) {
-            STHROW("failed to write transaction");
+
+    // This block repeats until we successfully commit, or error out of it.
+    // This allows us to retry in the event we're interrupted for a checkpoint. This should only happen once,
+    // because the second try will be blocked on the checkpoint.
+    while (true) {
+        try {
+            _db.waitForCheckpoint();
+            if (!_db.beginTransaction()) {
+                STHROW("failed to begin transaction");
+            }
+
+            // Inside transaction; get ready to back out on error
+            if (!_db.writeUnmodified(message.content)) {
+                STHROW("failed to write transaction");
+            }
+            if (!_db.prepare()) {
+                STHROW("failed to prepare transaction");
+            }
+
+            // Successful commit; we in the right state?
+            if (_db.getUncommittedHash() != message["NewHash"]) {
+                // Something is screwed up
+                PWARN("New hash mismatch: command='" << message["Command"] << "', commitCount=#" << _db.getCommitCount()
+                      << "', committedHash='" << _db.getCommittedHash() << "', uncommittedHash='"
+                      << _db.getUncommittedHash() << "', messageHash='" << message["NewHash"] << "', uncommittedQuery='"
+                      << _db.getUncommittedQuery() << "'");
+                STHROW("new hash mismatch");
+            }
+
+            // Done, break out of `while (true)`.
+            break;
+        } catch (const SException& e) {
+            // Something caused a write failure.
+            success = false;
+            _db.rollback();
+
+            // This is a fatal error case.
+            break;
+        } catch (const SQLite::checkpoint_required_error& e) {
+            SINFO("[checkpoint] Retrying beginTransaction after checkpoint.");
         }
-        if (!_db.prepare()) {
-            STHROW("failed to prepare transaction");
-        }
-        // Successful commit; we in the right state?
-        if (_db.getUncommittedHash() != message["NewHash"]) {
-            // Something is screwed up
-            PWARN("New hash mismatch: command='" << message["Command"] << "', commitCount=#" << _db.getCommitCount()
-                  << "', committedHash='" << _db.getCommittedHash() << "', uncommittedHash='"
-                  << _db.getUncommittedHash() << "', messageHash='" << message["NewHash"] << "', uncommittedQuery='"
-                  << _db.getUncommittedQuery() << "'");
-            STHROW("new hash mismatch");
-        }
-    } catch (const SException& e) {
-        // Something caused a commit failure.
-        success = false;
-        _db.rollback();
     }
 
     // Are we participating in quorum?


### PR DESCRIPTION
@coleaeason @cead22 

This is the fix for the crash we saw at last night's deploy, that resulted in the following stack trace:

```
2020-03-31T01:06:52.582472+00:00 db2.rno bedrock: xxxxxx (SQLite.cpp:564) _checkAbandon [sync] [hmmm] Transaction automatically rolled back. Setting _autoRolledBack = true
2020-03-31T01:06:52.582582+00:00 db2.rno bedrock: xxxxxx (libstuff.cpp:2542) STerminateHandler [sync] [alrt] Terminating with uncaught exception 'SQLite::checkpoint_required_error'.
2020-03-31T01:06:52.583325+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:163) _SSignal_StackTrace [sync] [warn] Signal Aborted(6) caused crash, logging stack trace.
2020-03-31T01:06:52.583748+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn]
2020-03-31T01:06:52.583795+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] _SSignal_StackTrace(int, siginfo_t*, void*) [0x65f1ab]
2020-03-31T01:06:52.583839+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /lib/x86_64-linux-gnu/libpthread.so.0(+0x11390) [0x7ff84b7c6390]
2020-03-31T01:06:52.583880+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /lib/x86_64-linux-gnu/libc.so.6(gsignal+0x38) [0x7ff84ac0b428]
2020-03-31T01:06:52.583948+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /lib/x86_64-linux-gnu/libc.so.6(abort+0x16a) [0x7ff84ac0d02a]
2020-03-31T01:06:52.583987+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /usr/sbin/bedrock() [0x48c870]
2020-03-31T01:06:52.584027+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /usr/lib/x86_64-linux-gnu/libstdc++.so.6(+0xa54b6) [0x7ff84b25d4b6]
2020-03-31T01:06:52.584069+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /usr/lib/x86_64-linux-gnu/libstdc++.so.6(+0xa5521) [0x7ff84b25d521]
2020-03-31T01:06:52.584111+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /usr/lib/x86_64-linux-gnu/libstdc++.so.6(+0xa5775) [0x7ff84b25d775]
2020-03-31T01:06:52.584148+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /usr/sbin/bedrock() [0x472cc1]
2020-03-31T01:06:52.584189+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] SQLite::_writeIdempotent(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) [0x5c8479]
2020-03-31T01:06:52.584226+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] SQLiteNode::handleBeginTransaction(STCPNode::Peer*, SData const&) [0x5773dd]
2020-03-31T01:06:52.584263+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] SQLiteNode::_onMESSAGE(STCPNode::Peer*, SData const&) [0x5a93ba]
2020-03-31T01:06:52.584299+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] STCPNode::postPoll(std::map<int, pollfd, std::less<int>, std::allocator<std::pair<int const, pollfd> > >&, unsigned long&) [0x6437ab]
2020-03-31T01:06:52.584851+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] BedrockServer::sync(SData const&, std::atomic<STCPNode::State>&, std::atomic<bool>&, std::atomic<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&, BedrockTimeoutCommandQueue&, BedrockServer&) [0x4ce912]
2020-03-31T01:06:52.584998+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] BedrockServer::syncWrapper(SData const&, std::atomic<STCPNode::State>&, std::atomic<bool>&, std::atomic<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&, BedrockTimeoutCommandQueue&, BedrockServer&) [0x4d6470]
2020-03-31T01:06:52.585142+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /usr/lib/x86_64-linux-gnu/libstdc++.so.6(+0xd0840) [0x7ff84b288840]
2020-03-31T01:06:52.585272+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /lib/x86_64-linux-gnu/libpthread.so.0(+0x76ba) [0x7ff84b7bc6ba]
2020-03-31T01:06:52.585402+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:167) _SSignal_StackTrace [sync] [warn] /lib/x86_64-linux-gnu/libc.so.6(clone+0x6d) [0x7ff84acdd41d]
2020-03-31T01:06:52.585529+00:00 db2.rno bedrock: xxxxxx (SSignal.cpp:171) _SSignal_StackTrace [sync] [warn] Calling DIE function.
2020-03-31T01:07:01.216175+00:00 db2.rno sshd[53243]: Connection from 10.6.12.11 port 34638 on 10.5.102.12 port 22
```

In retrospect, this is a fairly obvious oversight. The new code can throw out of any transaction, and we handled all the "normal" cases, but overlooked synchronization/replication. This adds support for those cases.

I haven't been able to test this so far, it's hard to reproduce without production scale. I'm trying tp modify the tests to trigger this case. I'll update the PR if I can make it happen in tests.