### PR TITLE
Need to rollback to notify checkpoint thread it can do something

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1980,6 +1980,7 @@ void SQLiteNode::_recvSynchronize(Peer* peer, const SData& message) {
                 _db.rollback();
                 throw e;
             } catch (const SQLite::checkpoint_required_error& e) {
+                _db.rollback();
                 SINFO("[checkpoint] Retrying synchronize after checkpoint.");
             }
         }
@@ -2211,6 +2212,7 @@ void SQLiteNode::handleBeginTransaction(Peer* peer, const SData& message) {
             // This is a fatal error case.
             break;
         } catch (const SQLite::checkpoint_required_error& e) {
+            _db.rollback();
             SINFO("[checkpoint] Retrying beginTransaction after checkpoint.");
         }
     }


### PR DESCRIPTION
@coleaeason @cead22 

Rollback when we catch an error.

This will make this line run:
https://github.com/Expensify/Bedrock/blob/d52e9a42af07f09eb51436f734dc69b4eddbe05f/sqlitecluster/SQLite.cpp#L853

Which will trigger this and unblock the checkpoint thread:
https://github.com/Expensify/Bedrock/blob/d52e9a42af07f09eb51436f734dc69b4eddbe05f/sqlitecluster/SQLite.cpp#L339

Testing this by making the `ConflictSpam` cluster test run a slow query in readdb.sh seems to work.