### PR TITLE
Move requestID addition into SQLiteCommand constructor

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -320,9 +320,8 @@ void BedrockServer::sync(const SData& args,
         // Process any network traffic that happened. Scope this so that we can change the log prefix and have it
         // auto-revert when we're finished.
         {
-            SData request = SData();
-            request["requestID"] = "xxxxxx";
-            SAUTOPREFIX(request);
+            // Set the default log prefix.
+            SAUTOPREFIX(SData());
 
             // Process any activity in our plugins.
             server._postPollPlugins(fdm, nextActivity);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -30,9 +30,6 @@ void BedrockServer::acceptCommand(SQLiteCommand&& command, bool isNew) {
         if (SIEquals(command.request.methodLine, "BROADCAST_COMMAND")) {
             SData newRequest;
             newRequest.deserialize(command.request.content);
-
-            // Add a request ID if one was missing.
-            _addRequestID(newRequest);
             newCommand = getCommandFromPlugins(move(newRequest));
             newCommand->initiatingClientID = -1;
             newCommand->initiatingPeerID = 0;
@@ -1490,8 +1487,6 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 // If we have a populated request, from either a plugin or our default handling, we'll queue up the
                 // command.
                 if (!request.empty()) {
-                    // If there's no ID for this request, let's add one.
-                    _addRequestID(request);
                     SAUTOPREFIX(request);
                     deserializedRequests++;
                     // Either shut down the socket or store it so we can eventually sync out the response.
@@ -2205,15 +2200,4 @@ int BedrockServer::finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& comp
         _outstandingHTTPSRequests.erase(transactionIt);
     }
     return commandsCompleted;
-}
-
-void BedrockServer::_addRequestID(SData& request) {
-    if (!request.isSet("requestID")) {
-        string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        string requestID;
-        for (int i = 0; i < 6; i++) {
-            requestID += chars[SRandom::rand64() % chars.size()];
-        }
-        request["requestID"] = requestID;
-    }
 }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -459,8 +459,6 @@ class BedrockServer : public SQLiteServer {
     // Generate a CRASH_COMMAND command for a given bad command.
     static SData _generateCrashMessage(const unique_ptr<BedrockCommand>& command);
 
-    static void _addRequestID(SData& request);
-
     // The number of seconds to wait between forcing a command to QUORUM.
     uint64_t _quorumCheckpointSeconds;
 

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -304,7 +304,8 @@ struct SAutoThreadPrefix {
     SAutoThreadPrefix(const SData& request) {
         // Retain the old prefix
         oldPrefix = SThreadLogPrefix;
-        SLogSetThreadPrefix(request["requestID"] + (request.isSet("logParam") ? " " + request["logParam"] : "") + " ");
+        const string requestID = request.isSet("requestID") ? request["requestID"] : "xxxxxx";
+        SLogSetThreadPrefix(requestID + (request.isSet("logParam") ? " " + request["logParam"] : "") + " ");
     }
     ~SAutoThreadPrefix() { SLogSetThreadPrefix(oldPrefix); }
 

--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -6,6 +6,16 @@ SData SQLiteCommand::preprocessRequest(SData&& request) {
     if (!request.isSet("commandExecuteTime")) {
         request["commandExecuteTime"] = to_string(STimeNow());
     }
+
+    // Add a request ID if one was missing.
+    if (!request.isSet("requestID")) {
+        string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        string requestID;
+        for (int i = 0; i < 6; i++) {
+            requestID += chars[SRandom::rand64() % chars.size()];
+        }
+        request["requestID"] = requestID;
+    }
     return request;
 }
 


### PR DESCRIPTION
We broke a certain special case of automatic `requestID` generation when we changed how we instantiate commands. 

See here:
https://github.com/Expensify/Bedrock/blob/0f8e3517ec9b91b609a785855ef332a4b7e9384f/BedrockServer.cpp#L30-L42

In the `if` block we do:
```
            // Add a request ID if one was missing.
            _addRequestID(newRequest);
```

But this is only for `BROADCAST_COMMAND`s, we don't do the same thing in the `else` block. 

This is usually not a problem, because we always add this for incoming requests from clients, but the edge case is for internally forwarded commands.

This PR changes where we add the request ID to be at construction of the command, rather than checking each place we make a command and adding it there. This is more straightforward anyway, and also has the effect of being a lot easier to maintain now that command requests are `const`.

Tests:
Run `./authtest -only Billing_BasicSuccessCase` and verify the `BillFund` command has `requestID`s:

```
Bedrock:$  tail -F /var/log/syslog | grep bedrock | grep BillFund
2020-04-03T16:00:36.288378+00:00 expensidev bedrock: 3sYpD3 (BillCustomers.cpp:160) peek [worker1] [info] [billing] accountID:1 has usage of $9.00 creating BillFund command. isDryBillingRun? 0
2020-04-03T16:00:36.288529+00:00 expensidev bedrock: 3sYpD3 (BillCustomers.cpp:46) getNextCommandTimestamp [worker1] [dbug] [billing] setting next Scheduled BillFund command 0ms from now.
2020-04-03T16:00:36.288569+00:00 expensidev bedrock: 3sYpD3 (Billing.cpp:72) queueBillFundCommand [worker1] [info] [billing] Sending BillFund command for accountID:1
2020-04-03T16:00:36.288913+00:00 expensidev bedrock: 3sYpD3 (BedrockServer.cpp:1630) getCommandFromPlugins [worker1] [dbug] Plugin Auth handling command BillFund
2020-04-03T16:00:36.288952+00:00 expensidev bedrock: 3sYpD3 (BedrockServer.cpp:38) acceptCommand [worker1] [info] Accepted command BillFund from plugin Auth
2020-04-03T16:00:36.289124+00:00 expensidev bedrock: 8bReX1 (BedrockServer.cpp:49) acceptCommand [worker1] [info] Queued new 'BillFund' command from bedrock node, with 0 commands already queued.
2020-04-03T16:00:36.289280+00:00 expensidev bedrock: 3sYpD3 (BillCustomers.cpp:180) peek [worker1] [info] [billing] BillCustomers 1 of 1 completed in 0.001212 total seconds (0.000702 seconds in Billing::calculateBill). 1 BillFund commands, created from 1 candidate accounts. 0 BillCustomers commands remaining.
2020-04-03T16:00:36.290065+00:00 expensidev bedrock: 8bReX1 (BedrockServer.cpp:709) worker [worker1] [info] Dequeued command BillFund in worker, 0 commands in  queue.
2020-04-03T16:00:36.290314+00:00 expensidev bedrock: 8bReX1 (BedrockCore.cpp:77) peekCommand [worker1] [dbug] Peeking at 'BillFund' with priority: 250
2020-04-03T16:00:36.290554+00:00 expensidev bedrock: 8bReX1 (AuthCommand.cpp:272) peekCommand [worker1] [dbug] Peeking at 'BillFund'
2020-04-03T16:00:36.291240+00:00 expensidev bedrock: 8bReX1 (BillFund.cpp:122) peek [worker1] [info] [billing] In BillFund::peek() for accountID:1 at timestamp: 1585929636.265225. isDryBillingRun? 0
2020-04-03T16:00:36.293333+00:00 expensidev bedrock: 8bReX1 (BillFund.cpp:268) peek [worker1] [info] [billing] Range error with private peronsalDetails.
2020-04-03T16:00:36.295715+00:00 expensidev bedrock: 8bReX1 (BillFund.cpp:313) peek [worker1] [info] [billing] Valid Expensify Card not found, using fund details
2020-04-03T16:00:36.297573+00:00 expensidev bedrock: 8bReX1 (BillFund.cpp:367) peek [worker1] [info] [billing] using idempotency key: 'auto1032020' for accountID:1 , fundAccountID:1.
2020-04-03T16:00:36.298129+00:00 expensidev bedrock: 8bReX1 (BillFund.cpp:467) peek [worker1] [info] [billing] Sending Stripe request. accountID:1, fundAccountID:1, amount: $9.00, Stripe customer ID: cus_H1vooGVMkSgcwh
2020-04-03T16:00:36.325157+00:00 expensidev bedrock: 8bReX1 (BedrockCore.cpp:93) peekCommand [worker1] [dbug] Plugin 'Auth' peeked command 'BillFund'
2020-04-03T16:00:36.325333+00:00 expensidev bedrock: 8bReX1 (BedrockCore.cpp:99) peekCommand [worker1] [info] Command 'BillFund' not finished in peek, re-queuing.
2020-04-03T16:00:36.325905+00:00 expensidev bedrock: 8bReX1 (SQLite.cpp:834) rollback [worker1] [info] Transaction rollback with 22 queries attempted, 5 served from cache for 'BillFund'.
2020-04-03T16:00:37.745851+00:00 expensidev bedrock: 8bReX1 (BedrockServer.cpp:709) worker [worker4] [info] Dequeued command BillFund in worker, 0 commands in  queue.
2020-04-03T16:00:37.746319+00:00 expensidev bedrock: 8bReX1 (BedrockCore.cpp:174) processCommand [worker4] [dbug] Processing 'BillFund'
2020-04-03T16:00:37.747273+00:00 expensidev bedrock: 8bReX1 (BillFund.cpp:517) process [worker4] [info] [billing] In BillFund::process() for accountID:1, fundAccountID:1.
2020-04-03T16:00:37.755714+00:00 expensidev bedrock: 8bReX1 (BillFund.cpp:660) process [worker4] [info] [billing] Received Stripe response: 200, accountID:1, fundAccountID: 1, amount: $9.00, Stripe transactionID: ch_1GTrwfKMVuTn5qYVIyad5Y6s
2020-04-03T16:00:37.758526+00:00 expensidev bedrock: 8bReX1 (BillFund.cpp:830) process [worker4] [info] [billing] Billing succeeded for accountID:1, fundAccountID:1. Total Usage: $9.00. $9.00 charged. $0.00 freebie credits used.
2020-04-03T16:00:37.759744+00:00 expensidev bedrock: 8bReX1 (BillFund.cpp:855) process [worker4] [info] [billing] BillFund complete for accountID:1, fundAccountID:1 in 1.488764 seconds.
2020-04-03T16:00:37.760208+00:00 expensidev bedrock: 8bReX1 (AuthCommand.cpp:367) processCommand [worker4] [info] Responding '200 OK' to 'BillFund'.
2020-04-03T16:00:37.760397+00:00 expensidev bedrock: 8bReX1 (BedrockCore.cpp:197) processCommand [worker4] [dbug] Plugin 'Auth' processed command 'BillFund'
2020-04-03T16:00:37.760446+00:00 expensidev bedrock: 8bReX1 (BedrockCore.cpp:219) processCommand [worker4] [info] Processed '200 OK' for 'BillFund'.
2020-04-03T16:00:37.761796+00:00 expensidev bedrock: 8bReX1 (SQLite.cpp:756) commit [worker4] [info] Transaction commit with 42 queries attempted, 2 served from cache for 'BillFund'.
2020-04-03T16:00:37.761970+00:00 expensidev bedrock: 8bReX1 (BedrockServer.cpp:1011) worker [worker4]
```