### PR TITLE
Add an onDetach handler for plugins

### DIFF
--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -64,6 +64,9 @@ class BedrockPlugin {
     // close those connections.
     virtual void onDetach() {}
 
+    // Is this plugin detached? By default we assume yes
+    virtual bool isDetached() { return true; };
+
     // Map of plugin names to functions that will return a new plugin of the given type.
     static map<string, function<BedrockPlugin*(BedrockServer&)>> g_registeredPluginList;
 

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -61,11 +61,9 @@ class BedrockPlugin {
 
     // Called when a client or plugin requests that the BedrockServer detaches from the database.
     // If a plugin makes it's own connections to the database, it should use this function to
-    // close those connections.
+    // close those connections. A plugin that implements this should expect it will be called
+    // multiple times. The subsequent calls should be a no-op.
     virtual void onDetach() {}
-
-    // Is this plugin detached? By default we assume yes
-    virtual bool isDetached() { return true; };
 
     // Map of plugin names to functions that will return a new plugin of the given type.
     static map<string, function<BedrockPlugin*(BedrockServer&)>> g_registeredPluginList;

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -59,6 +59,11 @@ class BedrockPlugin {
 
     virtual bool preventAttach();
 
+    // Called when a client or plugin requests that the BedrockServer detaches from the database.
+    // If a plugin makes it's own connections to the database, it should use this function to
+    // close those connections.
+    virtual void onDetach() {}
+
     // Map of plugin names to functions that will return a new plugin of the given type.
     static map<string, function<BedrockPlugin*(BedrockServer&)>> g_registeredPluginList;
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -112,12 +112,13 @@ void BedrockServer::syncWrapper(const SData& args,
             // If we're set detached, we assume we'll be re-attached eventually, and then be `RUNNING`.
             SINFO("Bedrock server entering detached state.");
             server._shutdownState.store(RUNNING);
+
+            // Detach any plugins now
+            for (auto plugin : server.plugins) {
+                plugin.second->onDetach();
+            }
+
             while (server._detach) {
-                for (auto plugin : server.plugins) {
-                    if (!plugin.second->isDetached()) {
-                        plugin.second->onDetach();
-                    }
-                }
                 if (server.shutdownWhileDetached) {
                     SINFO("Bedrock server exiting from detached state.");
                     return;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1791,6 +1791,11 @@ list<STable> BedrockServer::getPeerInfo() {
 void BedrockServer::setDetach(bool detach) {
     if (detach) {
         _beginShutdown("Detach", true);
+
+        // Tell all of our plugins to detach as well
+        for (auto plugin : plugins) {
+            plugin.second->onDetach();
+        }
     } else {
         _detach = false;
     }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -468,4 +468,7 @@ class BedrockServer : public SQLiteServer {
     // We keep a queue of completed commands that workers will insert into when they've successfully finished a command
     // that just needs to be returned to a peer.
     BedrockTimeoutCommandQueue _completedCommands;
+
+    // Whether or not all plugins are detached
+    bool _pluginsDetached;
 };


### PR DESCRIPTION
@tylerkaraszewski Please review.

This adds an onDetach handler for plugins, to allow them to close any database handles they are holding when BedrockServer is told to `detach`. 

Related to https://github.com/Expensify/Expensify/issues/124381