### PR TITLE
Better interrupt error handling

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -206,8 +206,6 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
                     SALERT("Command " << command->request.methodLine << " timed out after " << e.time()/1000 << "ms.");
                 }
                 STHROW("555 Timeout processing command");
-            } catch (const SQLite::checkpoint_required_error& e) {
-                SINFO("[checkpoint] Command " << command->request.methodLine << " abandoned (process) for checkpoint");
             }
         }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -563,7 +563,7 @@ bool SQLite::read(const string& query, SQResult& result) {
 void SQLite::_checkInterruptErrors(const string& error) {
 
     // Local error code.
-    int error = 0;
+    int errorCode = 0;
     uint64_t time = 0;
 
     // First check timeout. we want this to overide the others, so we can't get stuck in an endless loop where we do
@@ -587,7 +587,7 @@ void SQLite::_checkInterruptErrors(const string& error) {
                 _autoRolledBack = true;
             }
 
-            error = 1;
+            errorCode = 1;
         }
     }
 
@@ -604,15 +604,15 @@ void SQLite::_checkInterruptErrors(const string& error) {
 
         // Reset this and throw the appropriate exception.
         throw checkpoint_required_error();
-        error = 2;
+        errorCode = 2;
     }
 
     // Reset this regardless of which error (or both) occurred. If we handled a timeout, this is still done.
     _abandonForCheckpoint = false;
 
-    if (error == 1) {
+    if (errorCode == 1) {
         throw timeout_error("timeout in "s + error, time);
-    } else if (error = 2) {
+    } else if (errorCode == 2) {
         throw checkpoint_required_error();
     }
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -396,15 +396,9 @@ class SQLite {
     uint64_t _timeoutError;
     bool _abandonForCheckpoint;
 
-    // Check the timing of the current query and throw if the limit's exceeded.
-    void _checkTiming(const string& error);
-
-    // Check if we need to abandon a query for a checkpoint.
-    void _checkAbandon();
-
     // Check out various error cases that can interrupt a query.
     // We check them all together because we need to make sure we atomically pick a single one to handle.
-    void _checkInterruptErrors();
+    void _checkInterruptErrors(const string& error);
 
     // Called internally by _sqliteAuthorizerCallback to authorize columns for a query.
     int _authorize(int actionCode, const char* detail1, const char* detail2, const char* detail3, const char* detail4);

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -402,6 +402,10 @@ class SQLite {
     // Check if we need to abandon a query for a checkpoint.
     void _checkAbandon();
 
+    // Check out various error cases that can interrupt a query.
+    // We check them all together because we need to make sure we atomically pick a single one to handle.
+    void _checkInterruptErrors();
+
     // Called internally by _sqliteAuthorizerCallback to authorize columns for a query.
     int _authorize(int actionCode, const char* detail1, const char* detail2, const char* detail3, const char* detail4);
 


### PR DESCRIPTION
cc @cead22 

Fixes:
https://github.com/Expensify/Expensify/issues/128133

We had a bug before where we could throw a `timeout` error at the same time as a `checkpoint_required` error. 

This almost worked OK, except that when we finished up all of our exception handling, we'd run this code:

```
    // Reset, we can write now.
    while (true) {
        try {
            _db.read("PRAGMA query_only = false;");
            break;
        } catch (const SQLite::checkpoint_required_error& e) {
            // just try again
        }
    }
```

We have this loop because we can throw `checkpoint_required` from the `PRAGMA` query. However in the odd case where we timed out *and* needed to checkpoint at the *same time* we could have set the `_abandonForCheckpoint` flag which would trigger this loop to repeat once. This would clear the `_abandonForCheckpoint` but it would set `_autoRolledBack` so that we wouldn't do a  real `rollback` the next time it was called.

This meant that next time the thread did a rollback, it was a "fake" rollback because we thought it had been automatically done inside the error handler.

Then what would happen is we'd still be inside a transaction when the next one started, and that would throw a `501 Failed to begin concurrent transaction` and the thread would be broken from then on.

This change does a couple things to try and rectify this:

1. It explicitly resets the `_abandonForCheckpoint` and `_autoRolledBack` flags at the beginning of a transaction (there's no reason not to).
2. It combines the two methods for handling interrupt errors into a single method that can reset state for all of the errors on any of the errors so that it can reset `_abandonForCheckpoint` even on a timeout error (the transaction's done anyway, we don't need to abandon it any longer).
3. It adds a check for `_insideTransaction` to where we set `_autoRolledBack`. If we're not inside a transaction (like when we do the above `PRAGMA` query, then there's nothing to roll back.