### PR TITLE
Add onAttach handler, move resetServer to the proper location

### DIFF
--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -65,6 +65,11 @@ class BedrockPlugin {
     // multiple times. The subsequent calls should be a no-op.
     virtual void onDetach() {}
 
+    // Called when a client or plugin requests that the BedrockServer re-attache to the database.
+    // If a plugin makes it's own connections to the database, it should use this function to
+    // re-open those connections if not handled elsewhere in the plugin.
+    virtual void onAttach() {}
+
     // Map of plugin names to functions that will return a new plugin of the given type.
     static map<string, function<BedrockPlugin*(BedrockServer&)>> g_registeredPluginList;
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -128,8 +128,8 @@ void BedrockServer::syncWrapper(const SData& args,
                 sleep(1);
             }
             SINFO("Bedrock server entering attached state.");
+            server._resetServer();
         }
-        server._resetServer();
         sync(args, replicationState, upgradeInProgress, leaderVersion, syncNodeQueuedCommands, server);
 
         // Now that we've run the sync thread, we can exit if it hasn't set _detach again.
@@ -1178,6 +1178,11 @@ void BedrockServer::_resetServer() {
     _commandPort = nullptr;
     _gracefulShutdownTimeout.alarmDuration = 0;
     _pluginsDetached = false;
+
+    // Tell any plugins that they can attach now
+    for (auto plugin : plugins) {
+        plugin.second->onAttach();
+    }
 }
 
 BedrockServer::BedrockServer(SQLiteNode::State state, const SData& args_) : SQLiteServer(""), args(args_), _replicationState(SQLiteNode::LEADING)


### PR DESCRIPTION
@tylerkaraszewski Please review.

This adds an onAttach handler for plugins so that they can perform any necessary functions when the Bedrock gets an `Attach` control command. 

I also moved the reset server call into the re-attach block, otherwise we reset the server variables before they are actually set, which seems unnecessary. This was causing us to call onAttach before a detach was ever called.