### PR TITLE
Remove unnecessary delete

### DIFF
--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -19,7 +19,6 @@ BedrockPlugin(s), httpsManager(new TestHTTPSManager(*this))
 
 BedrockPlugin_TestPlugin::~BedrockPlugin_TestPlugin()
 {
-    delete httpsManager;
 }
 
 unique_ptr<BedrockCommand> BedrockPlugin_TestPlugin::getCommand(SQLiteCommand&& baseCommand) {


### PR DESCRIPTION
Calling `delete` here results in a double free error like:
```
*** Error in `../bedrock': double free or corruption (!prev): 0x0000000001842130 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7f02c97377e5]
/lib/x86_64-linux-gnu/libc.so.6(+0x8037a)[0x7f02c974037a]
/lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7f02c974453c]
../bedrock(_ZN13BedrockPluginD1Ev+0x37)[0x4ac5f7]
```

Because HTTPSManagers are automatically cleaned up here:
https://github.com/Expensify/Bedrock/blob/549daf1bc133c02f1c51f521b0a97d7bad7746f7/BedrockPlugin.cpp#L11-L13

## Tests
run `./test -only ChainedHTTP` and verify it succeeds with no error printed.