### PR TITLE
Make command resetting a property of the base BedrockCommand class

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -112,6 +112,13 @@ bool BedrockCommand::areHttpsRequestsComplete() const {
     return true;
 }
 
+void BedrockCommand::reset(BedrockCommand::STAGE stage) {
+    if (stage == STAGE::PEEK) {
+        jsonContent.clear();
+        response.clear();
+    }
+}
+
 void BedrockCommand::finalizeTimingInfo() {
     uint64_t peekTotal = 0;
     uint64_t processTotal = 0;

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -90,6 +90,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
             _db.read("PRAGMA query_only = true;");
 
             // Peek.
+            command->reset(BedrockCommand::STAGE::PEEK);
             bool completed = command->peek(_db);
             SDEBUG("Plugin '" << command->getName() << "' peeked command '" << request.methodLine << "'");
 
@@ -199,6 +200,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
             bool enable = command->shouldEnableQueryRewriting(_db, &handler);
             AutoScopeRewrite rewrite(enable, _db, handler);
             try {
+                command->reset(BedrockCommand::STAGE::PROCESS);
                 command->process(_db);
                 SDEBUG("Plugin '" << command->getName() << "' processed command '" << request.methodLine << "'");
             } catch (const SQLite::timeout_error& e) {

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -117,12 +117,6 @@ bool BedrockJobsCommand::peek(SQLite& db) {
     // We can potentially change this, so we set it here.
     mockRequest = request.isSet("mockRequest");
 
-    // Reset the content object. It could have been written by a previous call to this function that conflicted in
-    // multi-write.
-    jsonContent.clear();
-    response.clear();
-
-    // ----------------------------------------------------------------------
     if (SIEquals(requestVerb, "GetJob") || SIEquals(requestVerb, "GetJobs")) {
         // - GetJob( name )
         // - GetJobs( name, numResults )
@@ -388,12 +382,6 @@ void BedrockJobsCommand::process(SQLite& db) {
     // Pull out some helpful variables
     const string& requestVerb = request.getVerb();
 
-    // Reset the content object. It could have been written by a previous call to this function that conflicted in
-    // multi-write.
-    jsonContent.clear();
-    response.clear();
-
-    // ----------------------------------------------------------------------
     if (SIEquals(requestVerb, "CreateJob") || SIEquals(requestVerb, "CreateJobs")) {
         // - CreateJob( name, [data], [firstRun], [repeat], [jobPriority], [unique], [parentJobID], [retryAfter] )
         //

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -39,10 +39,12 @@ class TestPluginCommand : public BedrockCommand {
     TestPluginCommand(SQLiteCommand&& baseCommand, BedrockPlugin_TestPlugin* plugin);
     virtual bool peek(SQLite& db);
     virtual void process(SQLite& db);
+    virtual void reset(BedrockCommand::STAGE stage) override;
 
   private:
     BedrockPlugin_TestPlugin& plugin() { return static_cast<BedrockPlugin_TestPlugin&>(*_plugin); }
 
     bool pendingResult;
+    string chainedHTTPResponseContent;
     string urls;
 };


### PR DESCRIPTION
This fixes a bug we found in FuzzyBot where we'd return a stale response after a conflict. This mirrors other bugs we've seen in Auth and Jobs, and so moves this functionality to the base BedrockCommand class so we can't forget to add this in new plugins or command types.

Followup PRs will address this for existing plugins that have extended functionality (like Auth).

## Fixed Issues
$ https://github.com/Expensify/Expensify/issues/128564

## Tests
Just existing tests verifying this doesn't break anything. The auth tests have also been run against this branch with no failures.
