### PR TITLE
Preserve Derived Command Instances Through Escalation

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -162,6 +162,9 @@ class BedrockServer : public SQLiteServer {
     // `isNew` will be set to true if this command has never been seen before, and false if this is an existing command
     // being returned to the command queue (such as one that was previously escalated).
     // SQLiteNode API.
+    void acceptCommand(unique_ptr<SQLiteCommand>&& command, bool isNew = true);
+
+    // Backwards-compatible version of the above method for plugins that already used it.
     void acceptCommand(SQLiteCommand&& command, bool isNew = true);
 
     // Cancel a command.
@@ -214,7 +217,7 @@ class BedrockServer : public SQLiteServer {
     // See if there's a plugin that can turn this request into a command.
     // If not, we'll create a command that returns `430 Unrecognized command`.
     unique_ptr<BedrockCommand> getCommandFromPlugins(SData&& request);
-    unique_ptr<BedrockCommand> getCommandFromPlugins(SQLiteCommand&& baseCommand);
+    unique_ptr<BedrockCommand> getCommandFromPlugins(unique_ptr<SQLiteCommand>&& baseCommand);
 
     // If you want to exit from the detached state, set this to true and the server will exit after the next loop.
     // It has no effect when not detached (except that it will cause the server to exit immediately upon becoming

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1336,8 +1336,8 @@ void BedrockJobsCommand::handleFailedReply() {
 
         // Keep the request ID so we'll be able to associate these in the logs.
         requeue["requestID"] = request["requestID"];
-        SQLiteCommand cmd(move(requeue));
-        cmd.initiatingClientID = -1;
+        auto cmd = make_unique<SQLiteCommand>(move(requeue));
+        cmd->initiatingClientID = -1;
         _plugin->server.acceptCommand(move(cmd));
     }
 }

--- a/sqlitecluster/SQLiteCommand.h
+++ b/sqlitecluster/SQLiteCommand.h
@@ -69,5 +69,5 @@ class SQLiteCommand {
     SQLiteCommand& operator=(SQLiteCommand&& from) = default;
 
     // Destructor.
-    ~SQLiteCommand() {}
+    virtual ~SQLiteCommand() {}
 };

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -135,8 +135,8 @@ bool SQLiteNode::shutdownComplete() {
         if (_escalatedCommandMap.size()) {
             SWARN("Abandoned " << _escalatedCommandMap.size() << " escalated commands.");
             for (auto& commandPair : _escalatedCommandMap) {
-                commandPair.second.response.methodLine = "500 Abandoned";
-                commandPair.second.complete = true;
+                commandPair.second->response.methodLine = "500 Abandoned";
+                commandPair.second->complete = true;
                 _server.acceptCommand(move(commandPair.second), false);
             }
             _escalatedCommandMap.clear();
@@ -157,12 +157,12 @@ bool SQLiteNode::shutdownComplete() {
         if (!_escalatedCommandMap.empty()) {
             for (auto& cmd : _escalatedCommandMap) {
                 string name = cmd.first;
-                SQLiteCommand& command = cmd.second;
-                int64_t created = command.request.calcU64("commandExecuteTime");
+                unique_ptr<SQLiteCommand>& command = cmd.second;
+                int64_t created = command->request.calcU64("commandExecuteTime");
                 int64_t elapsed = STimeNow() - created;
                 double elapsedSeconds = (double)elapsed / STIME_US_PER_S;
-                SINFO("Escalated command remaining at shutdown(" << name << "): " << command.request.methodLine
-                      << ". Created: " << command.request["commandExecuteTime"] << " (" << elapsedSeconds << "s ago)");
+                SINFO("Escalated command remaining at shutdown(" << name << "): " << command->request.methodLine
+                      << ". Created: " << command->request["commandExecuteTime"] << " (" << elapsedSeconds << "s ago)");
             }
         }
         return false;
@@ -228,7 +228,7 @@ void SQLiteNode::_sendOutstandingTransactions() {
     unsentTransactions.store(false);
 }
 
-void SQLiteNode::escalateCommand(SQLiteCommand&& command, bool forget) {
+void SQLiteNode::escalateCommand(unique_ptr<SQLiteCommand>&& command, bool forget) {
     // If the leader is currently standing down, we won't escalate, we'll give the command back to the caller.
     if(_leadPeer->state == STANDINGDOWN) {
         SINFO("Asked to escalate command but leader standing down, letting server retry.");
@@ -239,21 +239,21 @@ void SQLiteNode::escalateCommand(SQLiteCommand&& command, bool forget) {
     // Send this to the leader
     SASSERT(_leadPeer);
     SASSERTEQUALS(_leadPeer->state, LEADING);
-    uint64_t elapsed = STimeNow() - command.request.calcU64("commandExecuteTime");
-    SINFO("Escalating '" << command.request.methodLine << "' (" << command.id << ") to leader '" << _leadPeer->name
+    uint64_t elapsed = STimeNow() - command->request.calcU64("commandExecuteTime");
+    SINFO("Escalating '" << command->request.methodLine << "' (" << command->id << ") to leader '" << _leadPeer->name
           << "' after " << elapsed / 1000 << " ms");
 
     // Create a command to send to our leader.
     SData escalate("ESCALATE");
-    escalate["ID"] = command.id;
-    escalate.content = command.request.serialize();
+    escalate["ID"] = command->id;
+    escalate.content = command->request.serialize();
 
     // Store the command as escalated, unless we intend to forget about it anyway.
     if (forget) {
-        SINFO("Firing and forgetting command '" << command.request.methodLine << "' to leader.");
+        SINFO("Firing and forgetting command '" << command->request.methodLine << "' to leader.");
     } else {
-        command.escalationTimeUS = STimeNow();
-        _escalatedCommandMap.emplace(command.id, move(command));
+        command->escalationTimeUS = STimeNow();
+        _escalatedCommandMap.emplace(command->id, move(command));
     }
 
     // And send to leader.
@@ -263,7 +263,7 @@ void SQLiteNode::escalateCommand(SQLiteCommand&& command, bool forget) {
 list<string> SQLiteNode::getEscalatedCommandRequestMethodLines() {
     list<string> returnList;
     for (auto& commandPair : _escalatedCommandMap) {
-        returnList.push_back(commandPair.second.request.methodLine);
+        returnList.push_back(commandPair.second->request.methodLine);
     }
     return returnList;
 }
@@ -1296,8 +1296,8 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             request["peerName"] = peer->name;
 
             // Create a command from this request and pass it on to the server to handle.
-            SQLiteCommand command(move(request));
-            command.initiatingPeerID = peer->id;
+            auto command = make_unique<SQLiteCommand>(move(request));
+            command->initiatingPeerID = peer->id;
             _server.acceptCommand(move(command), true);
         } else {
             // Otherwise we handle them immediately, as the server doesn't deliver commands to workers until we've
@@ -1504,9 +1504,9 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             PINFO("Received ESCALATE command for '" << message["ID"] << "' (" << request.methodLine << ")");
 
             // Create a new Command and send to the server.
-            SQLiteCommand command(move(request));
-            command.initiatingPeerID = peer->id;
-            command.id = message["ID"];
+            auto command = make_unique<SQLiteCommand>(move(request));
+            command->initiatingPeerID = peer->id;
+            command->id = message["ID"];
             _server.acceptCommand(move(command), true);
         }
     } else if (SIEquals(message.methodLine, "ESCALATE_CANCEL")) {
@@ -1558,14 +1558,14 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         auto commandIt = _escalatedCommandMap.find(message["ID"]);
         if (commandIt != _escalatedCommandMap.end()) {
             // Process the escalated command response
-            SQLiteCommand& command = commandIt->second;
-            if (command.escalationTimeUS) {
-                command.escalationTimeUS = STimeNow() - command.escalationTimeUS;
-                SINFO("Total escalation time for command " << command.request.methodLine << " was "
-                      << command.escalationTimeUS/1000 << "ms.");
+            unique_ptr<SQLiteCommand>& command = commandIt->second;
+            if (command->escalationTimeUS) {
+                command->escalationTimeUS = STimeNow() - command->escalationTimeUS;
+                SINFO("Total escalation time for command " << command->request.methodLine << " was "
+                      << command->escalationTimeUS/1000 << "ms.");
             }
-            command.response = response;
-            command.complete = true;
+            command->response = response;
+            command->complete = true;
             _server.acceptCommand(move(command), false);
             _escalatedCommandMap.erase(commandIt);
         } else {
@@ -1585,9 +1585,9 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         auto commandIt = _escalatedCommandMap.find(message["ID"]);
         if (commandIt != _escalatedCommandMap.end()) {
             // Re-queue this
-            SQLiteCommand& command = commandIt->second;
-            PINFO("Re-queueing command '" << message["ID"] << "' (" << command.request.methodLine << ") ("
-                  << command.id << ")");
+            unique_ptr<SQLiteCommand>& command = commandIt->second;
+            PINFO("Re-queueing command '" << message["ID"] << "' (" << command->request.methodLine << ") ("
+                  << command->id << ")");
             _server.acceptCommand(move(command), false);
             _escalatedCommandMap.erase(commandIt);
         } else
@@ -1596,7 +1596,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         // Create a new Command and send to the server.
         SData messageCopy = message;
         PINFO("Received " << message.methodLine << " command, forwarding to server.");
-        _server.acceptCommand(SQLiteCommand(move(messageCopy)), true);
+        _server.acceptCommand(make_unique<SQLiteCommand>(move(messageCopy)), true);
     } else {
         STHROW("unrecognized message");
     }
@@ -1658,11 +1658,11 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
         // progress when the leader died, in which case we say they completed with a 500 Error.
         for (auto& cmd : _escalatedCommandMap) {
             // If this isn't set, the leader hadn't actually started processing this, and we can re-queue it.
-            if (!cmd.second.transaction.methodLine.empty()) {
-                PWARN("Aborting escalated command '" << cmd.second.request.methodLine << "' (" << cmd.second.id
-                      << ") in transaction state '" << cmd.second.transaction.methodLine << "'");
-                cmd.second.complete = true;
-                cmd.second.response.methodLine = "500 Aborted";
+            if (!cmd.second->transaction.methodLine.empty()) {
+                PWARN("Aborting escalated command '" << cmd.second->request.methodLine << "' (" << cmd.second->id
+                      << ") in transaction state '" << cmd.second->transaction.methodLine << "'");
+                cmd.second->complete = true;
+                cmd.second->response.methodLine = "500 Aborted";
             }
             _server.acceptCommand(move(cmd.second), false);
         }
@@ -2244,7 +2244,7 @@ void SQLiteNode::handleBeginTransaction(Peer* peer, const SData& message) {
         // so we know that this command might be corrupted if the leader
         // crashes.
         SINFO("Leader is processing our command " << message["ID"] << " (" << message["Command"] << ")");
-        commandIt->second.transaction = message;
+        commandIt->second->transaction = message;
     }
 
     uint64_t transitTimeUS = followerDequeueTimestamp - leaderSentTimestamp;
@@ -2297,7 +2297,7 @@ void SQLiteNode::handleCommitTransaction(Peer* peer, const SData& message) {
         // We're starting the transaction for a given command; note this so we know that this command might be
         // corrupted if the leader crashes.
         SINFO("Leader has committed in response to our command " << message["ID"]);
-        commandIt->second.transaction = message;
+        commandIt->second->transaction = message;
     }
 
     _handledCommitCount++;
@@ -2329,6 +2329,6 @@ void SQLiteNode::handleRollbackTransaction(Peer* peer, const SData& message) {
         // We're starting the transaction for a given command; note this so we know that this command might be
         // corrupted if the leader crashes.
         SINFO("Leader has rolled back in response to our command " << message["ID"]);
-        commandIt->second.transaction = message;
+        commandIt->second->transaction = message;
     }
 }

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -75,7 +75,7 @@ class SQLiteNode : public STCPNode {
     // takes ownership of the command until it receives a response from the follower. When the command completes, it will
     // be re-queued in the SQLiteServer (_server), but its `complete` field will be set to true.
     // If the 'forget' flag is set, we will not expect a response from leader for this command.
-    void escalateCommand(SQLiteCommand&& command, bool forget = false);
+    void escalateCommand(unique_ptr<SQLiteCommand>&& command, bool forget = false);
 
     // This takes a completed command and sends the response back to the originating peer. If we're not the leader
     // node, or if this command doesn't have an `initiatingPeerID`, then calling this function is an error.
@@ -181,7 +181,7 @@ class SQLiteNode : public STCPNode {
 
     // When we're a follower, we can escalate a command to the leader. When we do so, we store that command in the
     // following map of commandID to Command until the follower responds.
-    map<string, SQLiteCommand> _escalatedCommandMap;
+    map<string, unique_ptr<SQLiteCommand>> _escalatedCommandMap;
 
     // Replicates any transactions that have been made on our database by other threads to peers.
     void _sendOutstandingTransactions();

--- a/sqlitecluster/SQLiteServer.h
+++ b/sqlitecluster/SQLiteServer.h
@@ -11,7 +11,7 @@ class SQLiteServer : public STCPServer {
     // An SQLiteNode will call this to pass a command to a server for processing. The isNew flag is set if this is the
     // first time this command has been sent to this server, as opposed to being an existing command, such as one that
     // was previously escalated.
-    virtual void acceptCommand(SQLiteCommand&& command, bool isNew) = 0;
+    virtual void acceptCommand(unique_ptr<SQLiteCommand>&& command, bool isNew) = 0;
 
     // An SQLiteNode will call this to cancel a command that a peer has escalated but no longer wants a response to.
     // The command may or may not be canceled, depending on whether it's already been processed.

--- a/test/clustertest/testplugin/Makefile
+++ b/test/clustertest/testplugin/Makefile
@@ -41,7 +41,7 @@ clean:
 
 # Ok, that's the end of our magic PCH code. The only other mention of it is in the build line where we include it.
 # We're going to build a shared library from every CPP file in this directory or it's children.
-CPP = TestPlugin.cpp
+CPP = TestPlugin.cpp ../../lib/BedrockTester.cpp
 OBJ = $(CPP:%.cpp=$(INTERMEDIATEDIR)/%.o)
 DEP = $(CPP:%.cpp=$(INTERMEDIATEDIR)/%.d)
 

--- a/test/clustertest/testplugin/Makefile
+++ b/test/clustertest/testplugin/Makefile
@@ -41,7 +41,7 @@ clean:
 
 # Ok, that's the end of our magic PCH code. The only other mention of it is in the build line where we include it.
 # We're going to build a shared library from every CPP file in this directory or it's children.
-CPP = TestPlugin.cpp ../../lib/BedrockTester.cpp
+CPP = TestPlugin.cpp
 OBJ = $(CPP:%.cpp=$(INTERMEDIATEDIR)/%.o)
 DEP = $(CPP:%.cpp=$(INTERMEDIATEDIR)/%.d)
 

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -71,12 +71,12 @@ TestPluginCommand::~TestPluginCommand()
             string fileContents = SFileLoad(request["tempFile"]);
             SFileDelete(request["tempFile"]);
 
-            // Verifiy this all happened in the right order.
-            if (fileContents != "Peeking testescalate (FOLLOWING)\n"
-                                "Peeking testescalate (LEADING)\n"
-                                "Processing testescalate (LEADING)\n"
-                                "Destroying testescalate (LEADING)\n"
-                                "Destroying testescalate (FOLLOWING)\n") {
+            // Verifiy this all happened in the right order. We're running this on the follower, but it's feasible the
+            // destructor on the leader hasn't happened yet. We verify everything up to the first destruction.
+            if (!SStartsWith(fileContents, "Peeking testescalate (FOLLOWING)\n"
+                                           "Peeking testescalate (LEADING)\n"
+                                           "Processing testescalate (LEADING)\n"
+                                           "Destroying testescalate")) {
                 cout << "Crashing the server on purpose, execution order is wrong: " << endl;
                 cout << fileContents;
                 SASSERT(false);

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -37,6 +37,7 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
 class TestPluginCommand : public BedrockCommand {
   public:
     TestPluginCommand(SQLiteCommand&& baseCommand, BedrockPlugin_TestPlugin* plugin);
+    ~TestPluginCommand();
     virtual bool peek(SQLite& db);
     virtual void process(SQLite& db);
     virtual void reset(BedrockCommand::STAGE stage) override;

--- a/test/clustertest/tests/EscalateTest.cpp
+++ b/test/clustertest/tests/EscalateTest.cpp
@@ -3,6 +3,10 @@
 struct EscalateTest : tpunit::TestFixture {
     EscalateTest() : tpunit::TestFixture("EscalateTest", TEST(EscalateTest::test)) { }
 
+    // NOTE: This test relies on two processes (the leader and follower Bedrock nodes) both writing to the same temp
+    // file at potentially the same time. It's not impossible that these two writes step on each other and this test
+    // fails because the file ends up in a corrupt state. If we see intermittent failures in this test, we may want to
+    // add some sort of file locking to the reading/writing from this file.
     void test()
     {
         BedrockClusterTester tester;

--- a/test/clustertest/tests/EscalateTest.cpp
+++ b/test/clustertest/tests/EscalateTest.cpp
@@ -13,6 +13,7 @@ struct EscalateTest : tpunit::TestFixture {
         BedrockTester& brtester = tester.getTester(1);
         SData cmd("testescalate");
         cmd["writeConsistency"] = "ASYNC";
+        cmd["tempFile"] = BedrockTester::getTempFileName("escalate_test");
         brtester.executeWaitMultipleData({cmd});
 
         // Because the way the above escalation is verified is in the destructor for the command, we send another request to
@@ -23,4 +24,3 @@ struct EscalateTest : tpunit::TestFixture {
         ASSERT_EQUAL(results[0].methodLine, "200 OK");
     }
 } __EscalateTest;
-

--- a/test/clustertest/tests/EscalateTest.cpp
+++ b/test/clustertest/tests/EscalateTest.cpp
@@ -1,9 +1,7 @@
-
 #include "../BedrockClusterTester.h"
 
 struct EscalateTest : tpunit::TestFixture {
-    EscalateTest()
-        : tpunit::TestFixture("EscalateTest", TEST(EscalateTest::test)) { }
+    EscalateTest() : tpunit::TestFixture("EscalateTest", TEST(EscalateTest::test)) { }
 
     void test()
     {

--- a/test/clustertest/tests/EscalateTest.cpp
+++ b/test/clustertest/tests/EscalateTest.cpp
@@ -1,0 +1,26 @@
+
+#include "../BedrockClusterTester.h"
+
+struct EscalateTest : tpunit::TestFixture {
+    EscalateTest()
+        : tpunit::TestFixture("EscalateTest", TEST(EscalateTest::test)) { }
+
+    void test()
+    {
+        BedrockClusterTester tester;
+
+        // We're going to send a command to a follower.
+        BedrockTester& brtester = tester.getTester(1);
+        SData cmd("testescalate");
+        cmd["writeConsistency"] = "ASYNC";
+        brtester.executeWaitMultipleData({cmd});
+
+        // Because the way the above escalation is verified is in the destructor for the command, we send another request to
+        // verify the server hasn't crashed.
+        SData status("Status");
+        auto results = brtester.executeWaitMultipleData({status});
+        ASSERT_EQUAL(results.size(), 1);
+        ASSERT_EQUAL(results[0].methodLine, "200 OK");
+    }
+} __EscalateTest;
+

--- a/test/clustertest/tests/TimingTest.cpp
+++ b/test/clustertest/tests/TimingTest.cpp
@@ -52,7 +52,7 @@ struct TimingTest : tpunit::TestFixture {
             uint64_t processTime = SToUInt64(result["processTime"]);
             uint64_t totalTime = SToUInt64(result["totalTime"]);
 
-            // Only leader is expected to have these set.
+            // Leader should have peek and process times, followers only peek.
             if (i == 0) {
                 if (peekTime <= 0 || processTime <= 0) {
                     cout << "peekTime: " << peekTime << endl;
@@ -63,7 +63,7 @@ struct TimingTest : tpunit::TestFixture {
                 ASSERT_GREATER_THAN(peekTime, 0);
                 ASSERT_GREATER_THAN(processTime, 0);
             } else {
-                ASSERT_EQUAL(peekTime, 0);
+                ASSERT_GREATER_THAN(peekTime, 0);
                 ASSERT_EQUAL(processTime, 0);
             }
 

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -19,7 +19,7 @@ class TestServer : public SQLiteServer {
   public:
     TestServer(const string& host) : SQLiteServer(host) { }
 
-    virtual void acceptCommand(SQLiteCommand&& command, bool isNew) { }
+    virtual void acceptCommand(unique_ptr<SQLiteCommand>&& command, bool isNew) { }
     virtual void cancelCommand(const string& commandID) { }
     virtual bool canStandDown() { return true; }
     virtual void onNodeLogin(SQLiteNode::Peer* peer) { }


### PR DESCRIPTION
This is a bit of an interesting change, and what it does it maybe not super straightforward.

In the work @joelbettner is doing here:
https://github.com/Expensify/Server-Expensify/pull/4384

He'll be fowarding new commands at the end of `peek`, where previously, we'd only forwarded commands after the end of `process`.

This exposed a shortcoming, or weirdness, in Bedrock, which I'll try to explain:

Throughout bedrock, we pass around `unique_ptr<BedrockCommand>` holding commands once they've been created, *except* for one glaring exception:

In `SQLiteNode.h` we have this:
```
     map<string, SQLiteCommand> _escalatedCommandMap;
```

This means that escalated commands are *not* stored as the original pointers to derived command classes, but rather, they're stored by copying the base class `SQLiteCommand` in to this map.

This means that the destructor for escalated commands will run once, when the command is escalated, and then again, when the response is returned from leader.  This, in theory, could cause destruction side-effects (like forwarding other commands) to happen twice. This doesn't actually happen though, because when we pass the `SQLiteCommand` back from the escalated command map to `BedrockServer`, it's lost all of the derived class state that's not in `SQLiteNode` (such as the ability to forward commands), and reconstructed from scratch.

It makes more logical sense to store the original `unique_ptr` to the derived command instance and just run the destructor once when the command is actually complete.

This also allows us to avoid re-converting `SQLiteCommand`s back into the appropriate `BedrockCommand`s as if they were new commands, which saves some lookup work.

I'm going to leave a few comments on my own PR here to explain what's going on.