### PR TITLE
PortMap needs to include libstuff or it doesn't compile. 

### DIFF
--- a/test/lib/PortMap.h
+++ b/test/lib/PortMap.h
@@ -1,3 +1,5 @@
+#include <libstuff/libstuff.h>
+
 // Track TCP ports to use with the tester.
 class PortMap {
   public:
@@ -24,4 +26,3 @@ class PortMap {
     set<uint16_t> _returned;
     mutex _m;
 };
-

--- a/test/lib/PortMap.h
+++ b/test/lib/PortMap.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <libstuff/libstuff.h>
 
 // Track TCP ports to use with the tester.


### PR DESCRIPTION
@righdforsa Please review. PortMap cannot be included without including libstuff, otherwise none of the types are defined. This only compiles other places out of luck of include orders.