### PR TITLE
Force results to strings

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -791,7 +791,7 @@ int SQLite::commit() {
         if (_currentTransactionAttemptCount != -1) {
             string logLine = SWHEREAMI + "[row-level-locking] transaction attempt:" +
                              to_string(_currentTransactionAttemptCount) + " committed. report: " +
-                             sqlite3_begin_concurrent_report(_db);
+                             string(sqlite3_begin_concurrent_report(_db));
             syslog(LOG_DEBUG, "%s", logLine.c_str());
         }
         _commitElapsed += STimeNow() - before;
@@ -874,7 +874,7 @@ void SQLite::rollback() {
         if (_currentTransactionAttemptCount != -1) {
             string logLine = SWHEREAMI + "[row-level-locking] transaction attempt:" +
                              to_string(_currentTransactionAttemptCount) + " rolled back. report: " +
-                             sqlite3_begin_concurrent_report(_db);
+                             string(sqlite3_begin_concurrent_report(_db));
             syslog(LOG_DEBUG, "%s", logLine.c_str());
         }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -789,9 +789,10 @@ int SQLite::commit() {
     SASSERT(result == SQLITE_OK || result == SQLITE_BUSY_SNAPSHOT);
     if (result == SQLITE_OK) {
         if (_currentTransactionAttemptCount != -1) {
+            const char* report = sqlite3_begin_concurrent_report(_db);
             string logLine = SWHEREAMI + "[row-level-locking] transaction attempt:" +
                              to_string(_currentTransactionAttemptCount) + " committed. report: " +
-                             string(sqlite3_begin_concurrent_report(_db));
+                             (report ? string(report) : "null"s);
             syslog(LOG_DEBUG, "%s", logLine.c_str());
         }
         _commitElapsed += STimeNow() - before;
@@ -872,9 +873,10 @@ void SQLite::rollback() {
         }
 
         if (_currentTransactionAttemptCount != -1) {
+            const char* report = sqlite3_begin_concurrent_report(_db);
             string logLine = SWHEREAMI + "[row-level-locking] transaction attempt:" +
                              to_string(_currentTransactionAttemptCount) + " rolled back. report: " +
-                             string(sqlite3_begin_concurrent_report(_db));
+                             (report ? string(report) : "null"s);
             syslog(LOG_DEBUG, "%s", logLine.c_str());
         }
 


### PR DESCRIPTION
The `+` operator has right-to-left associativity, meaning:

`string + char* + char*` adds the `char*`s together before it adds the string to anything.

This was tested by adding:
```
{"-pageLogging", "true"},
```
To the standard BedrockTester arguments in BedrockClusterTester.h, and watching that the `row-level-locking` loglines are recorded.