### PR TITLE
make permafollower detection backwards compatible

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1070,10 +1070,10 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         if (!message.isSet("Version")) {
             STHROW("missing Version");
         }
-        if (peer->params["Permafollower"] == "true" && message["Permafollower"] != "true") {
+        if (peer->params["Permafollower"] == "true" && (message["Permafollower"] != "true" || message.calc("Priority") > 0)) {
             STHROW("you're supposed to be a 0-priority permafollower");
         }
-        if (peer->params["Permafollower"] != "true" && message["Permafollower"] == "true") {
+        if (peer->params["Permafollower"] != "true" && (message["Permafollower"] == "true" || message.calc("Priority") == 0)) {
             STHROW("you're *not* supposed to be a 0-priority permafollower");
         }
 


### PR DESCRIPTION
This avoids the permafollower dance introduced by https://github.com/Expensify/Bedrock/pull/766 which occurs if you are changing to the new permafollower code in a live cluster. Fixed by testing conditions available on both sides of the migration.

Historically, we treat "priority is 0" as the condition for what a permafollower is, and login messages contain "priority", not "permafollower" status.

As of https://github.com/Expensify/Bedrock/pull/766, we change that and tread "permafollower status is true" as the condition for what a permafollower is, and add permafollower status to the login messages, but we keep priority in the login message.

So, in a transition between those two versions, a permafollower sending login messages will get progressively more and more disconnected from the cluster, because the definition of permafollower in PR 766 is not satisfied. When the permafollower finally falls out because it gets disconnected from master, it will fall into a state of SEARCHING. When SEARCHING, a node that was previously FOLLOWING will not close its port, so it will hold onto requests expecting to eventually rejoin the cluster.

With this change, we will consider both the old (priority = 0) and new (permafollower = true) versions of what a permafollower is, and the permafollower won't get dropped out as we switch from one version to the other.

cc @Expensify/infra 