### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+FROM phusion/baseimage:0.11 AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y software-properties-common \
+  && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+  && apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y gcc-9 g++-9 libpcre3-dev libpcre++-dev zlib1g-dev make gdb git \
+  && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
+
+RUN adduser --disabled-password --gecos "" build \
+  && adduser build build \
+  && chgrp build /lib \
+  && chmod 775 /lib
+
+RUN mkdir /src
+COPY ./ /src
+
+RUN chown -R build:build /src
+
+USER build
+WORKDIR /src
+
+ARG CC=gcc-9
+ARG GXX=g++-9 
+
+# prevent stray build artifacts from the COPY stopping a clean build
+RUN make clean
+RUN make -j8
+
+# tests
+
+WORKDIR /src/test
+RUN ./test -threads 8
+WORKDIR /src/test/clustertest
+RUN ./clustertest -threads 8
+
+#### build complete, now to make run image
+
+FROM phusion/baseimage:0.11
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# GCC-9 needs to be installed to run dynamically linked libstdc++ binaries like BedrockDB
+RUN apt-get update && apt-get install -y software-properties-common \
+  && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+  && apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y gcc-9 g++-9 libpcre3 libpcre++ zlib1g \
+  && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
+
+COPY --from=builder /src/bedrock /usr/local/bin/
+RUN mkdir -p /etc/service/bedrock/
+COPY --from=builder /src/bedrock.sh /etc/service/bedrock/run
+RUN chmod +x /etc/service/bedrock/run
+
+RUN adduser --disabled-password --gecos "" bedrock \
+  && adduser bedrock bedrock \
+  && mkdir /db \
+  && chown -R bedrock:bedrock /db
+
+CMD ["/sbin/my_init"]
+

--- a/bedrock.sh
+++ b/bedrock.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+# Requires bash 4.2 or greater because of use of `-v` for testing variables being set
+# Returns 1 if version doesn't match
+function bashVersionCheck()
+{
+  [ -z $BASH_VERSIO ] && return 1
+
+  # If it's set, check the version
+  case $BASH_VERSIO in
+    5.*) return 0 ;;
+    4.1) return 1 ;;
+    4.0) return 1 ;;
+    4.*) return 0 ;;
+    ?) return 1;;
+  esac
+}
+
+if [ $(bashVersionCheck) ]; then
+  echo "Requires bash 4.2 or greater"
+  exit -1
+fi
+
+NO_ARG_PARAMS=("VERBOSE" "QUIET" "CLEAN")
+ONE_ARG_PARAMS=("DB" "SERVER_HOST" "NODE_NAME" "NODE_HOST" "PEER_LIST" "PRIORITY" "PLUGINS" "CACHE_SIZE" "WORKER_THREADS" "QUERY_LOG" "MAX_JOURNAL_SIZE" "SYNCHRONOUS")
+
+
+function toLowerCase()
+{
+  echo "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+function toSnakeCase()
+{
+  lowered=$(toLowerCase $1)
+  arr=(${lowered//_/ })
+  printf -v ccase %s "${arr[@]^}"
+  echo "${lowered:0:1}${ccase:1}"
+}
+
+PARAMS=""
+
+for i in "${NO_ARG_PARAMS[@]}"
+do
+  :
+  if [ -v "$i" ]; then
+    export PARAMS="$PARAMS -$(toLowerCase ${i:0:1})"
+  fi
+done
+
+for i in "${ONE_ARG_PARAMS[@]}"
+do
+  :
+  if [ -v "$i" ]; then
+    export PARAMS="$PARAMS -$(toSnakeCase ${i}) ${!i}"
+  fi
+done
+
+exec /sbin/setuser bedrock /usr/local/bin/bedrock $PARAMS >> /var/log/bedrock.log 2>&1


### PR DESCRIPTION
Creates a Dockerfile for Bedrock.

This is using `phusion/baseimage` because it's ubuntu xenial to match travis and syslogd built in, which Bedrock uses for logging.

Example usage:
```bash
mkdir -p db
touch db/bedrock.db
docker run --env DB=/db/bedrock.db --env SERVER_HOST=0.0.0.0:8888 -v `pwd`/db:/db -p 8888:8888 -p 3306:3306 dinedal/bedrockdb:latest
```

The env vars to command line args is a bit clever for my tastes, even, however it does allow flexibility.