### PR TITLE
check for future times for leader commit msgs

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2259,6 +2259,11 @@ void SQLiteNode::handleBeginTransaction(Peer* peer, const SData& message) {
         commandIt->second->transaction = message;
     }
 
+    // calculate and log replication timers
+    if (leaderSentTimestamp > followerDequeueTimestamp) {
+        SWARN("Leader replication timestamp is " << (leaderSentTimestamp - followerDequeueTimestamp) << " usecs newer than our timestamp. Possible clock synchronization issue.");
+        leaderSentTimestamp = followerDequeueTimestamp;
+    }
     uint64_t transitTimeUS = followerDequeueTimestamp - leaderSentTimestamp;
     uint64_t applyTimeUS = STimeNow() - followerDequeueTimestamp;
     float transitTimeMS = (float)transitTimeUS / 1000.0;


### PR DESCRIPTION
We can sometimes get transactions from the leader that occur in the future, which indicates a somewhat concerning time difference between servers. Now that we know this can happen, we can check for it and warn. (and hopefully fix)

Tests:
- modified the dequeue timestamp in dev by making it "now - 10000", ran "clustertest" -> "MultipleLeaderSyncTest" and saw that my warning was in the logs.
- removed my modification and saw that my warning was not in the logs