### PR TITLE
Revert "check for future times for leader commit msgs"

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2259,11 +2259,6 @@ void SQLiteNode::handleBeginTransaction(Peer* peer, const SData& message) {
         commandIt->second->transaction = message;
     }
 
-    // calculate and log replication timers
-    if (leaderSentTimestamp > followerDequeueTimestamp) {
-        SWARN("Leader replication timestamp is " << (leaderSentTimestamp - followerDequeueTimestamp) << " usecs newer than our timestamp. Possible clock synchronization issue.");
-        leaderSentTimestamp = followerDequeueTimestamp;
-    }
     uint64_t transitTimeUS = followerDequeueTimestamp - leaderSentTimestamp;
     uint64_t applyTimeUS = STimeNow() - followerDequeueTimestamp;
     float transitTimeMS = (float)transitTimeUS / 1000.0;


### PR DESCRIPTION
Reverts Expensify/Bedrock#794, the log line being generated by this change is too noisy in our environment.