### PR TITLE
[WIP] Log sync total from freshest

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1347,6 +1347,9 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 _changeState(SEARCHING);
             } else {
                 // Otherwise, more to go
+                if (_syncPeer->calcU64("CommitCount") < _freshestPeer->calcU64("CommitCount")) {
+                    peerCommitCount = _freshestPeer->calcU64("CommitCount");
+                }
                 SINFO("Synchronization underway, at commitCount #"
                       << _db.getCommitCount() << " (" << _db.getCommittedHash() << "), "
                       << peerCommitCount - _db.getCommitCount() << " to go.");

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -118,6 +118,9 @@ class SQLiteNode : public STCPNode {
     // commitCount that we do, this will return null.
     void _updateSyncPeer();
     Peer* _syncPeer;
+    
+    // Track the freshest peer, so we can calculate our commit status relative to the rest of the cluster
+    Peer* _freshestPeer;
 
     // Store the ID of the last transaction that we replicated to peers. Whenever we do an update, we will try and send
     // any new committed transactions to peers, and update this value.


### PR DESCRIPTION
There are periodic circumstances where we can see "to go" commit totals that are wildly off. AFAIK, this only happens after a network partition when a node and its neighbor are both restoring from backup, and one chooses the other as its `_syncPeer`. In this case, a node can be ~ "1000 commits to go" for an hour or more. Seems like we can do better. Not sure this is a great solution. By creating an internal `_freshestPeer` variable, we solve the problem, but we introduce a new set of "freshest peer" calculations that are separate from the ones done under the `SEARCHING` state. Even though they're functionally distinct, that seems like it's introducing confusion into the codebase, so I'd appreciate any suggestions on whether this makes sense.

Also, it wasn't immediately obvious to me how to do a proper test of this in a low-latency environment like a cluster in a dev vm where choosing the _syncPeer is going to be more or less random. Any ideas there would be appreciated as well.

Tests: ran `Bedrock/test` and `Bedrock/test/clustertest -repeatCount 3` with no errors