### PR TITLE
Update SToJSON to handle floats and doubles (with 6 point precision)

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1191,8 +1191,13 @@ extern const char* _SParseJSONValue(const char* ptr, const char* end, string& va
 
 string SToJSON(const string& value, const bool forceString) {
     // Is it an integer?
-    if (SToStr(SToInt64(value.c_str())) == value)
+    if (SToStr(SToInt64(value.c_str())) == value) {
         return value;
+    }
+    // Is it a float?
+    if (SToStr(SToFloat(value.c_str())) == value) {
+        return value;
+    }
 
     // Is it boolean?
     if (SIEquals(value, "true"))

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -26,6 +26,7 @@
 #include <cctype>
 #include <chrono>
 #include <condition_variable>
+#include <iomanip>
 #include <iostream>
 #include <list>
 #include <map>
@@ -378,7 +379,7 @@ string SHexStringFromBase32(const string& buffer);
 // **NOTE: Use 'ostringstream' because 'stringstream' leaks on VS2005
 template <class T> inline string SToStr(const T& t) {
     ostringstream ss;
-    ss << t;
+    ss << fixed << showpoint << setprecision(6) << t;
     return ss.str();
 }
 

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -62,9 +62,16 @@ struct LibStuff : tpunit::TestFixture {
 
     void testJSON() {
         // Floating point value tests
-        ASSERT_EQUAL(SToJSON("{\"imAFloat\":1.2}"), "{\"imAFloat\":1.2}");
+        ASSERT_EQUAL(SToJSON("{\"imAFloat\":0.0000}"), "{\"imAFloat\":0.0000}");
         ASSERT_EQUAL(SToJSON("{\"imAFloat\":-0.23456789}"), "{\"imAFloat\":-0.23456789}");
         ASSERT_EQUAL(SToJSON("{\"imAFloat\":-123456789.23456789}"), "{\"imAFloat\":-123456789.23456789}");
+        ASSERT_EQUAL(SToJSON("{\"object\":{\"imAFloat\":1.00}}"), "{\"object\":{\"imAFloat\":1.00}}");
+
+        STable test;
+        test["imAFloat"] = (double)0.0000;
+        string returnVal = SComposeJSONObject(test);
+        cout << "returnVal: " << returnVal << endl;
+        ASSERT_EQUAL(returnVal, "{\"imAFloat\":0.0000}");
 
         // Scientific notation tests
         ASSERT_EQUAL(SToJSON("{\"science\":1.5e-8}"), "{\"science\":1.5e-8}");

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -67,11 +67,10 @@ struct LibStuff : tpunit::TestFixture {
         ASSERT_EQUAL(SToJSON("{\"imAFloat\":-123456789.23456789}"), "{\"imAFloat\":-123456789.23456789}");
         ASSERT_EQUAL(SToJSON("{\"object\":{\"imAFloat\":1.00}}"), "{\"object\":{\"imAFloat\":1.00}}");
 
-        STable test;
-        test["imAFloat"] = (double)0.0000;
-        string returnVal = SComposeJSONObject(test);
-        cout << "returnVal: " << returnVal << endl;
-        ASSERT_EQUAL(returnVal, "{\"imAFloat\":0.0000}");
+        STable testFloats;
+        testFloats["imAFloat"] = (double)0.000;
+        string returnVal = SComposeJSONObject(testFloats);
+        ASSERT_EQUAL(returnVal, "{\"imAFloat\":0.000000}");
 
         // Scientific notation tests
         ASSERT_EQUAL(SToJSON("{\"science\":1.5e-8}"), "{\"science\":1.5e-8}");


### PR DESCRIPTION
@tylerkaraszewski please review
cc @cead22 @pecanoro 

Fixes bug seen here: https://github.com/Expensify/Server-Expensify/pull/4523/files#r430434543

Added tests that reflect the fix, which were failing before the fix (see first commit) 