### PR TITLE
Respond 200 to STATUS_HANDLING_COMMANDS if LEADING or STANDINGDOWN

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1807,6 +1807,10 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
 
         // Additional logic for some old states
         if (SWITHIN(LEADING, oldState, STANDINGDOWN) && !SWITHIN(LEADING, newState, STANDINGDOWN)) {
+            // If we stop leading, unset _leaderVersion from our own _version.
+            // It will get re-set to the version on the new leader.
+            _leaderVersion = "";
+
             // We are no longer leading.  Are we processing a command?
             if (commitInProgress()) {
                 // Abort this command

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -353,6 +353,7 @@ bool SQLiteNode::update() {
             // There are no peers, jump straight to leading
             SHMMM("No peers configured, jumping to LEADING");
             _changeState(LEADING);
+            _leaderVersion = _version;
             return true; // Re-update immediately
         }
 
@@ -580,7 +581,6 @@ bool SQLiteNode::update() {
                 peer->erase("StandupResponse");
             }
             _changeState(STANDINGUP);
-            _leaderVersion = _version;
             return true; // Re-update
         }
 
@@ -641,6 +641,7 @@ bool SQLiteNode::update() {
             // Complete standup
             SINFO("All peers approved standup, going LEADING.");
             _changeState(LEADING);
+            _leaderVersion = _version;
             return true; // Re-update
         }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -580,6 +580,7 @@ bool SQLiteNode::update() {
                 peer->erase("StandupResponse");
             }
             _changeState(STANDINGUP);
+            _leaderVersion = _version;
             return true; // Re-update
         }
 

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -49,7 +49,7 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture {
         // leader is brought back up, it will be STANDINGDOWN until it finishes
         thread slowQueryThread([this, &follower](){
             SData slow("slowquery");
-            slow["processTimeout"] = "3000"; // 3s
+            slow["processTimeout"] = "5000"; // 5s
             follower.executeWaitVerifyContent(slow, "555 Timeout peeking command");
         });
 

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -25,20 +25,22 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture {
         thread healthCheckThread([this, &results, &follower](){
             SData cmd("GET /status/handlingCommands HTTP/1.1");
             string result;
-            bool found0, found1, found2;
+            bool foundLeader = false;
+            bool foundFollower = false;
+            bool foundStandingdown = false;
             chrono::steady_clock::time_point start = chrono::steady_clock::now();
 
-            while (chrono::steady_clock::now() < start + 60s && (!found0 || !found1 || !found2)) {
+            while (chrono::steady_clock::now() < start + 60s && (!foundLeader || !foundFollower || !foundStandingdown)) {
                 result = follower.executeWaitMultipleData({cmd}, 1, false)[0].methodLine;
                 if (result == "HTTP/1.1 200 LEADING") {
                     results[0] = result;
-                    found0 = true;
+                    foundLeader = true;
                 } else if (result == "HTTP/1.1 200 FOLLOWING") {
                     results[1] = result;
-                    found1 = true;
+                    foundFollower = true;
                 } else if (result == "HTTP/1.1 200 STANDINGDOWN") {
                     results[2] = result;
-                    found2 = true;
+                    foundStandingdown = true;
                 }
             }
         });

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -29,20 +29,16 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture {
             bool found0, found1, found2;
 
             while (STimeNow() < start + 6'0000'000 && (!found0 || !found1 || !found2)) {
-                try {
-                    result = follower.executeWaitMultipleData({cmd}, 1, false)[0].methodLine;
-                    if (result == "HTTP/1.1 200 LEADING") {
-                        results[0] = result;
-                        found0 = true;
-                    } else if (result == "HTTP/1.1 200 FOLLOWING") {
-                        results[1] = result;
-                        found1 = true;
-                    } else if (result == "HTTP/1.1 200 STANDINGDOWN") {
-                        results[2] = result;
-                        found2 = true;
-                    }
-                } catch (...) {
-                    // Doesn't do anything, we'll fall through to the sleep and try again.
+                result = follower.executeWaitMultipleData({cmd}, 1, false)[0].methodLine;
+                if (result == "HTTP/1.1 200 LEADING") {
+                    results[0] = result;
+                    found0 = true;
+                } else if (result == "HTTP/1.1 200 FOLLOWING") {
+                    results[1] = result;
+                    found1 = true;
+                } else if (result == "HTTP/1.1 200 STANDINGDOWN") {
+                    results[2] = result;
+                    found2 = true;
                 }
             }
         });

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -1,0 +1,69 @@
+#include "../BedrockClusterTester.h"
+
+struct StatusHandlingCommandsTest : tpunit::TestFixture {
+    StatusHandlingCommandsTest()
+        : tpunit::TestFixture("StatusHandlingCommandsTest",
+                              BEFORE_CLASS(StatusHandlingCommandsTest::setup),
+                              AFTER_CLASS(StatusHandlingCommandsTest::teardown),
+                              TEST(StatusHandlingCommandsTest::test)) { }
+
+    BedrockClusterTester* tester;
+
+    void setup () {
+        tester = new BedrockClusterTester();
+    }
+
+    void teardown() {
+        delete tester;
+    }
+
+    void test() {
+        vector<string> results(3);
+        BedrockTester& leader = tester->getTester(0);
+        BedrockTester& follower = tester->getTester(1);
+
+        thread healthCheckThread([this, &results, &follower](){
+            SData cmd("GET /status/handlingCommands HTTP/1.1");
+            string result;
+            uint64_t start = STimeNow();
+            bool found0, found1, found2;
+
+            while (STimeNow() < start + 6'0000'000 && (!found0 || !found1 || !found2)) {
+                try {
+                    result = follower.executeWaitMultipleData({cmd}, 1, false)[0].methodLine;
+                    if (result == "HTTP/1.1 200 LEADING") {
+                        results[0] = result;
+                        found0 = true;
+                    } else if (result == "HTTP/1.1 200 FOLLOWING") {
+                        results[1] = result;
+                        found1 = true;
+                    } else if (result == "HTTP/1.1 200 STANDINGDOWN") {
+                        results[2] = result;
+                        found2 = true;
+                    }
+                } catch (...) {
+                    // Doesn't do anything, we'll fall through to the sleep and try again.
+                }
+            }
+        });
+
+        leader.stopServer();
+
+        // Execute a slow query while the follower is leading so when the
+        // leader is brought back up, it will be STANDINGDOWN until it finishes
+        thread slowQueryThread([this, &follower](){
+            SData slow("slowquery");
+            slow["processTimeout"] = "1000"; // 1s
+            follower.executeWaitVerifyContent(slow, "555 Timeout peeking command");
+        });
+
+        leader.startServer(true);
+        slowQueryThread.join();
+        healthCheckThread.join();
+
+        ASSERT_EQUAL(results[0], "HTTP/1.1 200 LEADING")
+        ASSERT_EQUAL(results[1], "HTTP/1.1 200 FOLLOWING")
+        ASSERT_EQUAL(results[2], "HTTP/1.1 200 STANDINGDOWN")
+    }
+
+} __StatusHandlingCommandsTest;

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -49,7 +49,7 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture {
         // leader is brought back up, it will be STANDINGDOWN until it finishes
         thread slowQueryThread([this, &follower](){
             SData slow("slowquery");
-            slow["processTimeout"] = "1000"; // 1s
+            slow["processTimeout"] = "3000"; // 3s
             follower.executeWaitVerifyContent(slow, "555 Timeout peeking command");
         });
 

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -9,7 +9,7 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture {
 
     BedrockClusterTester* tester;
 
-    void setup () {
+    void setup() {
         tester = new BedrockClusterTester();
     }
 
@@ -18,52 +18,67 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture {
     }
 
     void test() {
+        bool success = false;
+        int count = 0;
         vector<string> results(3);
         BedrockTester& leader = tester->getTester(0);
         BedrockTester& follower = tester->getTester(1);
 
-        thread healthCheckThread([this, &results, &follower](){
-            SData cmd("GET /status/handlingCommands HTTP/1.1");
-            string result;
-            bool found0, found1, found2;
-            chrono::steady_clock::time_point start = chrono::steady_clock::now();
+        while (count++ < 10) {
+            thread healthCheckThread([this, &results, &follower](){
+                SData cmd("GET /status/handlingCommands HTTP/1.1");
+                string result;
+                bool found0, found1, found2;
+                chrono::steady_clock::time_point start = chrono::steady_clock::now();
 
-            while (chrono::steady_clock::now() < start + 60s && (!found0 || !found1 || !found2)) {
-                result = follower.executeWaitMultipleData({cmd}, 1, false)[0].methodLine;
-                if (result == "HTTP/1.1 200 LEADING") {
-                    results[0] = result;
-                    found0 = true;
-                } else if (result == "HTTP/1.1 200 FOLLOWING") {
-                    results[1] = result;
-                    found1 = true;
-                } else if (result == "HTTP/1.1 200 STANDINGDOWN") {
-                    results[2] = result;
-                    found2 = true;
+                while (chrono::steady_clock::now() < start + 60s && (!found0 || !found1 || !found2)) {
+                    result = follower.executeWaitMultipleData({cmd}, 1, false)[0].methodLine;
+                    if (result == "HTTP/1.1 200 LEADING") {
+                        results[0] = result;
+                        found0 = true;
+                    } else if (result == "HTTP/1.1 200 FOLLOWING") {
+                        results[1] = result;
+                        found1 = true;
+                    } else if (result == "HTTP/1.1 200 STANDINGDOWN") {
+                        results[2] = result;
+                        found2 = true;
+                    }
                 }
+            });
+
+            leader.stopServer();
+
+            // Execute a slow query while the follower is leading so when the
+            // leader is brought back up, it will be STANDINGDOWN until it finishes
+            thread slowQueryThread([this, &follower](){
+                SData slow("slowquery");
+                slow["processTimeout"] = "5000"; // 5s
+                follower.executeWaitVerifyContent(slow, "555 Timeout peeking command");
+            });
+
+            leader.startServer(true);
+            slowQueryThread.join();
+            healthCheckThread.join();
+
+            if (results[0] ==  "HTTP/1.1 200 LEADING" &&
+                results[1] == "HTTP/1.1 200 FOLLOWING" &&
+                results[2] == "HTTP/1.1 200 STANDINGDOWN")
+            {
+                success = true;
+                break;
             }
-        });
 
-        leader.stopServer();
-
-        // Execute a slow query while the follower is leading so when the
-        // leader is brought back up, it will be STANDINGDOWN until it finishes
-        thread slowQueryThread([this, &follower](){
-            SData slow("slowquery");
-            slow["processTimeout"] = "5000"; // 5s
-            follower.executeWaitVerifyContent(slow, "555 Timeout peeking command");
-        });
-
-        leader.startServer(true);
-        slowQueryThread.join();
-        healthCheckThread.join();
-
-        for (auto &result : results) {
-            cerr << result << endl;
+            sleep(1);
         }
 
-        ASSERT_EQUAL(results[0], "HTTP/1.1 200 LEADING")
-        ASSERT_EQUAL(results[1], "HTTP/1.1 200 FOLLOWING")
-        ASSERT_EQUAL(results[2], "HTTP/1.1 200 STANDINGDOWN")
+        if (!success) {
+            for (auto &result : results) {
+                cerr << result << endl;
+            }
+        }
+
+
+        ASSERT_TRUE(success);
     }
 
 } __StatusHandlingCommandsTest;

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -57,6 +57,10 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture {
         slowQueryThread.join();
         healthCheckThread.join();
 
+        for (auto &result : results) {
+            cerr << result << endl;
+        }
+
         ASSERT_EQUAL(results[0], "HTTP/1.1 200 LEADING")
         ASSERT_EQUAL(results[1], "HTTP/1.1 200 FOLLOWING")
         ASSERT_EQUAL(results[2], "HTTP/1.1 200 STANDINGDOWN")

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -25,10 +25,10 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture {
         thread healthCheckThread([this, &results, &follower](){
             SData cmd("GET /status/handlingCommands HTTP/1.1");
             string result;
-            uint64_t start = STimeNow();
             bool found0, found1, found2;
+            chrono::steady_clock::time_point start = chrono::steady_clock::now();
 
-            while (STimeNow() < start + 6'0000'000 && (!found0 || !found1 || !found2)) {
+            while (chrono::steady_clock::now() < start + 60s && (!found0 || !found1 || !found2)) {
                 result = follower.executeWaitMultipleData({cmd}, 1, false)[0].methodLine;
                 if (result == "HTTP/1.1 200 LEADING") {
                     results[0] = result;

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -59,10 +59,6 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture {
         slowQueryThread.join();
         healthCheckThread.join();
 
-        for (auto &result : results) {
-            cerr << result << endl;
-        }
-
         ASSERT_EQUAL(results[0], "HTTP/1.1 200 LEADING")
         ASSERT_EQUAL(results[1], "HTTP/1.1 200 FOLLOWING")
         ASSERT_EQUAL(results[2], "HTTP/1.1 200 STANDINGDOWN")


### PR DESCRIPTION
In these states, the node is able to handle commands, so the response code to the healthcheck should reflect that by returning 200 for those states instead of 500.