### PR TITLE
use db.verifyIndex on start for Jobs plugin

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1238,7 +1238,7 @@ void BedrockJobsCommand::process(SQLite& db) {
     else if (SIEquals(requestVerb, "RequeueJobs")) {
         SINFO("Requeueing jobs with IDs: " << request["jobIDs"]);
         list<int64_t> jobIDs = SParseIntegerList(request["jobIDs"]);
-        
+
         if (jobIDs.size()) {
             const string& name = request["name"];
             string nameQuery = name.empty() ? "" : ", name = " + SQ(name) + "";

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -103,27 +103,9 @@ void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
     // These indexes are not used by the Bedrock::Jobs plugin, but provided for easy analysis
     // using the Bedrock::DB plugin.
     // TODO: we can't set isProductionServer by calling BedrockPlugin_Auth::isLiveServer() since this is bedrock jobs
-    SASSERT(db.verifyIndex(
-                "jobsName",         // index name
-                "jobs",             // table name
-                "( name )",         // index criteria
-                false,              // is unique?
-                false
-    ));
-    SASSERT(db.verifyIndex(
-            "jobsParentJobIDState",
-            "jobs",
-            "( parentJobID, state ) WHERE parentJobID != 0",
-            false,
-            !BedrockPlugin_Jobs::isLive
-    ));
-    SASSERT(db.verifyIndex(
-            "jobsStatePriorityNextRunName",
-            "jobs",
-            "( state, priority, nextRun, name )",
-            false,
-            !BedrockPlugin_Jobs::isLive
-    ));
+    SASSERT(db.verifyIndex("jobsName", "jobs", "( name )", false, !BedrockPlugin_Jobs::isLive));
+    SASSERT(db.verifyIndex("jobsParentJobIDState", "jobs", "( parentJobID, state ) WHERE parentJobID != 0", false, !BedrockPlugin_Jobs::isLive));
+    SASSERT(db.verifyIndex("jobsStatePriorityNextRunName", "jobs", "( state, priority, nextRun, name )", false, !BedrockPlugin_Jobs::isLive));
 }
 
 // ==========================================================================

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -99,8 +99,7 @@ void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
                                "parentJobID INTEGER NOT NULL DEFAULT 0, "
                                "retryAfter  TEXT NOT NULL DEFAULT \"\")",
                            ignore));
-
-    // These indexes are not used by the Bedrock::Jobs plugin, but provided for easy analysis using the Bedrock::DB plugin.
+    // verify and conditionally create indexes
     SASSERT(db.verifyIndex("jobsName", "jobs", "( name )", false, !BedrockPlugin_Jobs::isLive));
     SASSERT(db.verifyIndex("jobsParentJobIDState", "jobs", "( parentJobID, state ) WHERE parentJobID != 0", false, !BedrockPlugin_Jobs::isLive));
     SASSERT(db.verifyIndex("jobsStatePriorityNextRunName", "jobs", "( state, priority, nextRun, name )", false, !BedrockPlugin_Jobs::isLive));

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -100,9 +100,7 @@ void BedrockPlugin_Jobs::upgradeDatabase(SQLite& db) {
                                "retryAfter  TEXT NOT NULL DEFAULT \"\")",
                            ignore));
 
-    // These indexes are not used by the Bedrock::Jobs plugin, but provided for easy analysis
-    // using the Bedrock::DB plugin.
-    // TODO: we can't set isProductionServer by calling BedrockPlugin_Auth::isLiveServer() since this is bedrock jobs
+    // These indexes are not used by the Bedrock::Jobs plugin, but provided for easy analysis using the Bedrock::DB plugin.
     SASSERT(db.verifyIndex("jobsName", "jobs", "( name )", false, !BedrockPlugin_Jobs::isLive));
     SASSERT(db.verifyIndex("jobsParentJobIDState", "jobs", "( parentJobID, state ) WHERE parentJobID != 0", false, !BedrockPlugin_Jobs::isLive));
     SASSERT(db.verifyIndex("jobsStatePriorityNextRunName", "jobs", "( state, priority, nextRun, name )", false, !BedrockPlugin_Jobs::isLive));

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -16,6 +16,8 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
     // Set of supported verbs for jobs with case-insensitive matching.
     static const set<string,STableComp>supportedRequestVerbs;
 
+    const bool isLive;
+
   private:
     static int64_t getNextID(SQLite& db);
     static const string name;


### PR DESCRIPTION
Update `Jobs` plugin to use `db.verifyIndex()` instead of `CREATE INDEX IF NOT EXISTS`.

Part of https://github.com/Expensify/Expensify/issues/99832

No more remaining "CREATE INDEX IF NOT" instances in the Bedrock code:

```
phs@MBP-PhiSmi2020 ~/Expensidev/Bedrock [phs_verify_index_on_start] $ grep -RH 'CREATE INDEX IF NOT' *
phs@MBP-PhiSmi2020 ~/Expensidev/Bedrock [phs_verify_index_on_start] $
```

## Tests

<details>
<summary>Server logs; running without -live</summary>

Server startup detects missing index and creates it (with `-live` missing from args).

![image](https://user-images.githubusercontent.com/139959/87495486-e05ef380-c694-11ea-8778-03fe429da087.png)

</details>

<details>
<summary>Server logs; running with -live</summary>

Server startup fails due to `-live` parameter (assertion fails).

![image](https://user-images.githubusercontent.com/139959/87502910-4142f780-c6a6-11ea-9319-34e1f96c05c7.png)

</details>