### PR TITLE
Add flag for making commands uninterruptable by checkpoints

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -240,7 +240,7 @@ int SQLite::_progressHandlerCallback(void* arg) {
             sqlite->_abandonForCheckpoint = true;
             return 2;
         } else {
-            SINFO("[checkpoint] Not unblocking transaction for checkpoint because _enableCheckpointInterrupt disabled.");
+            SHMMM("[checkpoint] Not unblocking transaction for checkpoint because _enableCheckpointInterrupt disabled.");
         }
     }
     return 0;


### PR DESCRIPTION
cc @flodnv 

This is designed to be the simplest solution to this problem that we can deploy before the next billing cycle. There will be a companion change in S-E.

Related: https://github.com/Expensify/Expensify/issues/132696

Testing it is actually pretty hard.

I made the following changes to SQLite.cpp to force the checkpoints to run in the tests:
```
diff --git a/sqlitecluster/SQLite.cpp b/sqlitecluster/SQLite.cpp
index cacd954..1968a38 100644
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -221,7 +221,7 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints

     // I tested and found that we could set about 10,000,000 and the number of steps to run and get a callback once a
     // second. This is set to be a bit more granular than that, which is probably adequate.
-    sqlite3_progress_handler(_db, 1'000'000, _progressHandlerCallback, this);
+    sqlite3_progress_handler(_db, 1'000, _progressHandlerCallback, this);
 }

 int SQLite::_progressHandlerCallback(void* arg) {
@@ -262,7 +262,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int
     object->_sharedData->_currentPageCount.store(pageCount);
     // Try a passive checkpoint if full checkpoints aren't enabled, *or* if the page count is less than the required
     // size for a full checkpoint.
-    if (!object->_enableFullCheckpoints || pageCount < fullCheckpointPageMin.load()) {
+    if (false && (!object->_enableFullCheckpoints || pageCount < fullCheckpointPageMin.load())) {
         int passive = passiveCheckpointPageMin.load();
```

And I hacked up `test/clustertest/tests/ConflictSpamTest.cpp` to send commands that were slow enough to get interrupted, and verified we logged the right thing:
```
...
2020-07-23T20:32:54.498084+00:00 expensidev bedrock10001: NaQRpb (SQLite.cpp:243) _progressHandlerCallback [worker6] [info] [checkpoint] Not unblocking transaction for checkpoint because _enableCheckpointInterrupt disabled.
2020-07-23T20:32:54.501049+00:00 expensidev bedrock10001: PJ2XEI (SQLite.cpp:243) _progressHandlerCallback [worker4] [info] [checkpoint] Not unblocking transaction for checkpoint because _enableCheckpointInterrupt disabled.
2020-07-23T20:32:54.524210+00:00 expensidev bedrock10001: qfKNNM (SQLite.cpp:243) _progressHandlerCallback [blockingCommit] [info] [checkpoint] Not unblocking transaction for checkpoint because _enableCheckpointInterrupt disabled.
...
```

I think this is about as good as we can do here.

