### PR TITLE
Add flag to enable parallel replication

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -195,7 +195,7 @@ void BedrockServer::sync(const SData& args,
     // Initialize the shared pointer to our sync node object.
     server._syncNode = make_shared<SQLiteNode>(server, dbPool, args["-nodeName"], args["-nodeHost"],
                                                args["-peerList"], args.calc("-priority"), firstTimeout,
-                                               server._version);
+                                               server._version, args.test("-parallelReplication"));
 
     // This should be empty anyway, but let's make sure.
     if (server._completedCommands.size()) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -38,7 +38,7 @@ atomic<int64_t> SQLiteNode::_currentCommandThreadID(0);
 
 SQLiteNode::SQLiteNode(SQLiteServer& server, SQLitePool& dbPool, const string& name,
                        const string& host, const string& peerList, int priority, uint64_t firstTimeout,
-                       const string& version)
+                       const string& version, const bool useParallelReplication)
     : STCPNode(name, host, max(SQL_NODE_DEFAULT_RECV_TIMEOUT, SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT)),
       _dbPool(dbPool),
       _db(_dbPool.getBase()),
@@ -48,7 +48,8 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, SQLitePool& dbPool, const string& n
       _lastNetStatTime(chrono::steady_clock::now()),
       _handledCommitCount(0),
       _replicationThreadsShouldExit(false),
-      _replicationThreadCount(0)
+      _replicationThreadCount(0),
+      _useParallelReplication(useParallelReplication)
     {
 
     SASSERT(priority >= 0);
@@ -1574,13 +1575,23 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             throw e;
         }
     } else if (SIEquals(message.methodLine, "BEGIN_TRANSACTION") || SIEquals(message.methodLine, "COMMIT_TRANSACTION") || SIEquals(message.methodLine, "ROLLBACK_TRANSACTION")) {
-        if (_replicationThreadsShouldExit) {
-            SINFO("Discarding replication message, stopping FOLLOWING");
+        if (_useParallelReplication) {
+            if (_replicationThreadsShouldExit) {
+                SINFO("Discarding replication message, stopping FOLLOWING");
+            } else {
+                auto threadID = _replicationThreadCount.fetch_add(1);
+                SINFO("Spawning concurrent replicate thread (blocks until DB handle available): " << threadID);
+                thread(replicate, ref(*this), peer, message, ref(_dbPool.get())).detach();
+                SINFO("Done spawning concurrent replicate thread: " << threadID);
+            }
         } else {
-            auto threadID = _replicationThreadCount.fetch_add(1);
-            SINFO("Spawning concurrent replicate thread (blocks until DB handle available): " << threadID);
-            thread(replicate, ref(*this), peer, message, ref(_dbPool.get())).detach();
-            SINFO("Done spawning concurrent replicate thread: " << threadID);
+            if (SIEquals(message.methodLine, "BEGIN_TRANSACTION")) {
+                handleSerialBeginTransaction(peer, message);
+            } else if (SIEquals(message.methodLine, "COMMIT_TRANSACTION")) {
+                handleSerialCommitTransaction(peer, message);
+            } else if (SIEquals(message.methodLine, "ROLLBACK_TRANSACTION")) {
+                handleSerialRollbackTransaction(peer, message);
+            }
         }
     } else if (SIEquals(message.methodLine, "APPROVE_TRANSACTION") || SIEquals(message.methodLine, "DENY_TRANSACTION")) {
         // APPROVE_TRANSACTION: Sent to the leader by a follower when it confirms it was able to begin a transaction and
@@ -2535,3 +2546,169 @@ SQLiteNode::State SQLiteNode::leaderState() const {
     }
     return State::UNKNOWN;
 }
+
+
+void SQLiteNode::handleSerialBeginTransaction(Peer* peer, const SData& message) {
+    AutoScopedWallClockTimer timer(_syncTimer);
+
+    // BEGIN_TRANSACTION: Sent by the LEADER to all subscribed followers to begin a new distributed transaction. Each
+    // follower begins a local transaction with this query and responds APPROVE_TRANSACTION. If the follower cannot start
+    // the transaction for any reason, it is broken somehow -- disconnect from the leader.
+    // **FIXME**: What happens if LEADER steps down before sending BEGIN?
+    // **FIXME**: What happens if LEADER steps down or disconnects after BEGIN?
+    bool success = true;
+    uint64_t leaderSentTimestamp = message.calcU64("leaderSendTime");
+    uint64_t followerDequeueTimestamp = STimeNow();
+    if (!message.isSet("ID")) {
+        STHROW("missing ID");
+    }
+    if (!message.isSet("NewCount")) {
+        STHROW("missing NewCount");
+    }
+    if (!message.isSet("NewHash")) {
+        STHROW("missing NewHash");
+    }
+    if (_state != FOLLOWING) {
+        STHROW("not following");
+    }
+    if (!_leadPeer) {
+        STHROW("no leader?");
+    }
+    if (!_db.getUncommittedHash().empty()) {
+        STHROW("already in a transaction");
+    }
+    if (_db.getCommitCount() + 1 != message.calcU64("NewCount")) {
+        STHROW("commit count mismatch. Expected: " + message["NewCount"] + ", but would actually be: " + to_string(_db.getCommitCount() + 1));
+    }
+
+    // This block repeats until we successfully commit, or error out of it.
+    // This allows us to retry in the event we're interrupted for a checkpoint. This should only happen once,
+    // because the second try will be blocked on the checkpoint.
+    while (true) {
+        try {
+            _db.waitForCheckpoint();
+            if (!_db.beginTransaction()) {
+                STHROW("failed to begin transaction");
+            }
+
+            // Inside transaction; get ready to back out on error
+            if (!_db.writeUnmodified(message.content)) {
+                STHROW("failed to write transaction");
+            }
+            if (!_db.prepare()) {
+                STHROW("failed to prepare transaction");
+            }
+
+            // Successful commit; we in the right state?
+            if (_db.getUncommittedHash() != message["NewHash"]) {
+                // Something is screwed up
+                PWARN("New hash mismatch: command='" << message["Command"] << "', commitCount=#" << _db.getCommitCount()
+                      << "', committedHash='" << _db.getCommittedHash() << "', uncommittedHash='"
+                      << _db.getUncommittedHash() << "', messageHash='" << message["NewHash"] << "', uncommittedQuery='"
+                      << _db.getUncommittedQuery() << "'");
+                STHROW("new hash mismatch");
+            }
+
+            // Done, break out of `while (true)`.
+            break;
+        } catch (const SException& e) {
+            // Something caused a write failure.
+            success = false;
+            _db.rollback();
+
+            // This is a fatal error case.
+            break;
+        } catch (const SQLite::checkpoint_required_error& e) {
+            _db.rollback();
+            SINFO("[checkpoint] Retrying beginTransaction after checkpoint.");
+        }
+    }
+
+    // Are we participating in quorum?
+    if (_priority) {
+        // If the ID is /ASYNC_\d+/, no need to respond, leader will ignore it anyway.
+        string verb = success ? "APPROVE_TRANSACTION" : "DENY_TRANSACTION";
+        if (!SStartsWith(message["ID"], "ASYNC_")) {
+            // Not a permafollower, approve the transaction
+            PINFO(verb << " #" << _db.getCommitCount() + 1 << " (" << message["NewHash"] << ").");
+            SData response(verb);
+            response["NewCount"] = SToStr(_db.getCommitCount() + 1);
+            response["NewHash"] = success ? _db.getUncommittedHash() : message["NewHash"];
+            response["ID"] = message["ID"];
+            _sendToPeer(_leadPeer, response);
+        } else {
+            PINFO("Skipping " << verb << " for ASYNC command.");
+        }
+    } else {
+        PINFO("Would approve/deny transaction #" << _db.getCommitCount() + 1 << " (" << _db.getUncommittedHash()
+              << ") for command '" << message["Command"] << "', but a permafollower -- keeping quiet.");
+    }
+
+    uint64_t transitTimeUS = followerDequeueTimestamp - leaderSentTimestamp;
+    uint64_t applyTimeUS = STimeNow() - followerDequeueTimestamp;
+    float transitTimeMS = (float)transitTimeUS / 1000.0;
+    float applyTimeMS = (float)applyTimeUS / 1000.0;
+    PINFO("Replicated transaction " << message.calcU64("NewCount") << ", sent by leader at " << leaderSentTimestamp
+          << ", transit/dequeue time: " << transitTimeMS << "ms, applied in: " << applyTimeMS << "ms, should COMMIT next.");
+}
+
+void SQLiteNode::handleSerialCommitTransaction(Peer* peer, const SData& message) {
+    AutoScopedWallClockTimer timer(_syncTimer);
+
+    // COMMIT_TRANSACTION: Sent to all subscribed followers by the leader when it determines that the current
+    // outstanding transaction should be committed to the database. This completes a given distributed transaction.
+    if (_state != FOLLOWING) {
+        STHROW("not following");
+    }
+    if (_db.getUncommittedHash().empty()) {
+        STHROW("no outstanding transaction");
+    }
+    if (message.calcU64("CommitCount") != _db.getCommitCount() + 1) {
+        STHROW("commit count mismatch. Expected: " + message["CommitCount"] + ", but would actually be: "
+              + to_string(_db.getCommitCount() + 1));
+    }
+    if (message["Hash"] != _db.getUncommittedHash()) {
+        STHROW("hash mismatch");
+    }
+
+    SDEBUG("Committing current transaction because COMMIT_TRANSACTION: " << _db.getUncommittedQuery());
+    _db.commit();
+
+    // Clear the list of committed transactions. We're following, so we don't need to send these.
+    _db.getCommittedTransactions();
+
+    // Log timing info.
+    // TODO: This is obsolete and replaced by timing info in BedrockCommand. This should be removed.
+    uint64_t beginElapsed, readElapsed, writeElapsed, prepareElapsed, commitElapsed, rollbackElapsed;
+    uint64_t totalElapsed = _db.getLastTransactionTiming(beginElapsed, readElapsed, writeElapsed, prepareElapsed,
+                                                         commitElapsed, rollbackElapsed);
+    SINFO("Committed follower transaction #" << message["CommitCount"] << " (" << message["Hash"] << ") in "
+          << totalElapsed / 1000 << " ms (" << beginElapsed / 1000 << "+"
+          << readElapsed / 1000 << "+" << writeElapsed / 1000 << "+"
+          << prepareElapsed / 1000 << "+" << commitElapsed / 1000 << "+"
+          << rollbackElapsed / 1000 << "ms)");
+
+    _handledCommitCount++;
+    if (_handledCommitCount % 5000 == 0) {
+        // Log how much time we've spent handling 5000 commits.
+        auto timingInfo = _syncTimer.getStatsAndReset();
+        SINFO("Over the last 5000 commits, (total: " << _handledCommitCount << ") " << timingInfo.second.count() << "/" << timingInfo.first.count() << "ms spent in replication");
+    }
+}
+
+void SQLiteNode::handleSerialRollbackTransaction(Peer* peer, const SData& message) {
+    AutoScopedWallClockTimer timer(_syncTimer);
+    // ROLLBACK_TRANSACTION: Sent to all subscribed followers by the leader when it determines that the current
+    // outstanding transaction should be rolled back. This completes a given distributed transaction.
+    if (!message.isSet("ID")) {
+        STHROW("missing ID");
+    }
+    if (_state != FOLLOWING) {
+        STHROW("not following");
+    }
+    if (_db.getUncommittedHash().empty()) {
+        SINFO("Received ROLLBACK_TRANSACTION with no outstanding transaction.");
+    }
+    _db.rollback();
+}
+

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -38,7 +38,7 @@ class SQLiteNode : public STCPNode {
 
     // Constructor/Destructor
     SQLiteNode(SQLiteServer& server, SQLitePool& dbPool, const string& name, const string& host,
-               const string& peerList, int priority, uint64_t firstTimeout, const string& version);
+               const string& peerList, int priority, uint64_t firstTimeout, const string& version, const bool useParallelReplication = false);
     ~SQLiteNode();
 
     // Simple Getters. See property definitions for details.
@@ -220,6 +220,11 @@ class SQLiteNode : public STCPNode {
     void handlePrepareTransaction(SQLite& db, Peer* peer, const SData& message);
     int handleCommitTransaction(SQLite& db, Peer* peer, const uint64_t commandCommitCount, const string& commandCommitHash);
     void handleRollbackTransaction(SQLite& db, Peer* peer, const SData& message);
+    
+    // Legacy versions of the above functions for serial replication.
+    void handleSerialBeginTransaction(Peer* peer, const SData& message);
+    void handleSerialCommitTransaction(Peer* peer, const SData& message);
+    void handleSerialRollbackTransaction(Peer* peer, const SData& message);
 
     WallClockTimer _syncTimer;
     atomic<uint64_t> _handledCommitCount;
@@ -252,6 +257,9 @@ class SQLiteNode : public STCPNode {
     // Counter of the total number of currently active replication threads. This is used to let us know when all
     // threads have finished.
     atomic<int64_t> _replicationThreadCount;
+
+    // Indicates whether this node is configured for parallel replication.
+    const bool _useParallelReplication;
 
     // Monotonically increasing thread counter, used for thread IDs for logging purposes.
     static atomic<int64_t> _currentCommandThreadID;


### PR DESCRIPTION
This adds back the old versions of `handleBeginTransaction`, `handleRollbackTransaction` and `handleCommitTransaction` and adds a command line flag to enable parallel replication.

It does *not* hide any of the other changes required to use parallel replication behind this flag, except for actually doing replication in parallel.

## Tests
Existing tests.