### PR TITLE
Add SuppressCommandPort and ClearCommandPort as non-secure control commands

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2060,12 +2060,7 @@ bool BedrockServer::_isControlCommand(const unique_ptr<BedrockCommand>& command)
 
 bool BedrockServer::_isNonSecureControlCommand(const unique_ptr<BedrockCommand>& command) {
     // A list of non-secure control commands that can be run from another host
-    if (SIEquals(command->request.methodLine, "SuppressCommandPort") ||
-        SIEquals(command->request.methodLine, "ClearCommandPort")
-        ) {
-        return true;
-    }
-    return false;
+    return SIEquals(command->request.methodLine, "SuppressCommandPort") || SIEquals(command->request.methodLine, "ClearCommandPort");
 }
 
 void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -350,6 +350,7 @@ class BedrockServer : public SQLiteServer {
     bool _isStatusCommand(const unique_ptr<BedrockCommand>& command);
     void _status(unique_ptr<BedrockCommand>& command);
     bool _isControlCommand(const unique_ptr<BedrockCommand>& command);
+    bool _isNonSecureControlCommand(const unique_ptr<BedrockCommand>& command);
     void _control(unique_ptr<BedrockCommand>& command);
 
     // Accepts any sockets pending on our listening ports. We do this both after `poll()`, and before shutting down


### PR DESCRIPTION
Thanks for the review! The `SuppressCommandPort`, `ClearCommandPort` control commands should be permitted to be run from other hosts, at least for now.

## Tests
- Ensure other existing control commands e.g. `BeginBackup` are still restricted from being run through other hosts AND still can be successfully run from localhost.
- Ensure `SuppressCommandPort` and `ClearCommandPort` can be run from from localhost and external hosts.