### PR TITLE
Wait for DB to match LEADER state hen replicating to FOLLOWERs

### DIFF
--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -195,7 +195,7 @@ class SQLite {
     // This atomically removes and returns committed transactions from our inflight list. SQLiteNode can call this, and
     // it will return a map of transaction IDs to pairs of (query, hash), so that those transactions can be replicated
     // out to peers.
-    map<uint64_t, pair<string,string>> getCommittedTransactions();
+    map<uint64_t, tuple<string,string, uint64_t>> getCommittedTransactions();
 
     // The whitelist is either nullptr, in which case the feature is disabled, or it's a map of table names to sets of
     // column names that are allowed for reading. Using whitelist at all put the database handle into a more
@@ -220,6 +220,9 @@ class SQLite {
     // infrequent transactions to complete, even though they take longer than the typical interval between restart
     // checkpoints to complete, thus causing an endless cycle of interrupted transactions.
     void disableCheckpointInterruptForNextTransaction() { _enableCheckpointInterrupt = false; }
+
+    // public read-only accessor for _dbCountAtStart.
+    uint64_t getDBCountAtStart() const;
 
   private:
 
@@ -291,7 +294,7 @@ class SQLite {
         //
         // This is a map of all currently "in flight" transactions. These are transactions for which a `prepare()` has been
         // called to generate a journal row, but have not yet been sent to peers.
-        map<uint64_t, pair<string, string>> _inFlightTransactions;
+        map<uint64_t, tuple<string, string, uint64_t>> _inFlightTransactions;
 
         // This mutex prevents any thread starting a new transaction when locked. The checkpoint thread will lock it
         // when required to make sure it can get exclusive use of the DB.
@@ -337,6 +340,11 @@ class SQLite {
     bool _insideTransaction;
     string _uncommittedQuery;
     string _uncommittedHash;
+
+    // The latest transaction ID at the start of the current transaction (note: it is allowed for this to be *higher*
+    // than the state inside the transaction, if another thread committed to the DB while we were in
+    // `beginTransaction`).
+    uint64_t _dbCountAtStart;
 
     // The name of the journal table
     string _journalName;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -88,20 +88,21 @@ BedrockTester::BedrockTester(int threadID, const map<string, string>& args,
     }
 
     map <string, string> defaultArgs = {
-        {"-db",               _dbName},
-        {"-serverHost",       _serverAddr},
-        {"-nodeName",         "bedrock_test"},
-        {"-nodeHost",         "localhost:" + to_string(_nodePort)},
-        {"-controlPort",      "localhost:" + to_string(_controlPort)},
-        {"-priority",         "200"},
-        {"-plugins",          "db"},
-        {"-workerThreads",    "8"},
-        {"-mmapSizeGB",       "1"},
-        {"-maxJournalSize",   "25000"},
-        {"-v",                ""},
+        {"-db", _dbName},
+        {"-serverHost", _serverAddr},
+        {"-nodeName", "bedrock_test"},
+        {"-nodeHost", "localhost:" + to_string(_nodePort)},
+        {"-controlPort", "localhost:" + to_string(_controlPort)},
+        {"-priority", "200"},
+        {"-plugins", "db"},
+        {"-workerThreads", "8"},
+        {"-mmapSizeGB", "1"},
+        {"-maxJournalSize", "25000"},
+        {"-v", ""},
         {"-quorumCheckpoint", "50"},
         {"-enableMultiWrite", "true"},
-        {"-cacheSize",        "1000"},
+        {"-cacheSize", "1000"},
+        {"-parallelReplication", "true"},
     };
 
     // Set defaults.


### PR DESCRIPTION
This adds the required parameter to replication messages to indicate where the DB was when LEADER started on a given transaction, and causes FOLLOWERs to wait to start the transaction at the same point, with the intention of drastically reducing conflicts.

It also changes the default behavior of the tests to use parallel replication, thus testing the command-line switch we added in a previous PR.

## Tests
Existing tests.