### PR TITLE
Fix mysql handshake auth packet for clients that strictly follow the handshake specs

### DIFF
--- a/plugins/MySQL.cpp
+++ b/plugins/MySQL.cpp
@@ -83,11 +83,11 @@ string MySQLPacket::serializeHandshake() {
     // Just hard code the values for now
     MySQLPacket handshake;
     handshake.payload += lenEncInt(10);      // protocol version
-    handshake.payload += (string) "5.0.0"; // server version
+    handshake.payload += "5.0.0"s; // server version
     handshake.payload += lenEncInt(0);       // NULL
     uint32_t connectionID = 1;
     SAppend(handshake.payload, &connectionID, 4); // connection_id
-    handshake.payload += (string) "xxxxxxxx";     // auth_plugin_data_part_1
+    handshake.payload += "xxxxxxxx"s;     // auth_plugin_data_part_1
     handshake.payload += lenEncInt(0);            // filler
 
     uint32_t CLIENT_LONG_PASSWORD = 0x00000001;
@@ -107,20 +107,18 @@ string MySQLPacket::serializeHandshake() {
 
     SAppend(handshake.payload, &capability_flags_2, 2); // capability_flags_2 (high 2 bytes)
 
-    // Random challenge bytes client expects for mysql_native_password authentication.
-    // Hardcoded for now as proper authentication is not yet supported by Bedrock.
-    // Specific bytes are taken from example handshake packed provided by Oracle:
+    // The first byte is the length of the auth_plugin_name string. Followed by 10 NULL
+    // characters for the "reserved" field. Since we don't support CLIENT_SECURE_CONNECTION 
+    // in our capabilities we can skip auth-plugin-data-part-2
     // https://dev.mysql.com/doc/internals/en/client-wants-native-server-wants-old.html
     // (Initial Handshake Packet)
     uint8_t auth_plugin_data[] = {
         0x15, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x40, 0x42, 0x68, 0x66, 0x48,
-        0x74, 0x2f, 0x2d, 0x34, 0x5e, 0x5a, 0x2c, 0x00 };
+        0x00, 0x00, 0x00 };
 
     SAppend(handshake.payload, auth_plugin_data, sizeof(auth_plugin_data));
 
-    handshake.payload += (string) "mysql_native_password"; // auth_plugin_name
-    handshake.payload += lenEncInt(0);                     // filler
+    handshake.payload += "mysql_native_password"s; // auth_plugin_name
 
     return handshake.serialize();
 }


### PR DESCRIPTION
@tylerkaraszewski Please review.

This resolves https://github.com/Expensify/Bedrock/issues/818.

The Rust MySQL implementation strictly follows the spec for handshake packet data, specifically this portion:
```
  if capabilities & CLIENT_SECURE_CONNECTION {
string[$len]   auth-plugin-data-part-2 ($len=MAX(13, length of auth-plugin-data - 8))
```

from https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::Handshake. 

We do not set `CLIENT_SECURE_CONNECTION` in our capabilities flags, so therefore we do not need to send auth-plugin-data-part-2; however we were sending it anyways. The MySQL implementation of reading the handshake packets allows for you to send extra data, it will still parse the packets correctly; and since most clients we have tested with the MySQL plugin use the MySQL implementation, we have not seen this error before. 

## Tests
Tested that the `mysql` binary will still connect:
```bash
user@host$ mysql -h 127.0.0.1
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 1
Server version: 5.0.0 9c8f2d9

Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> select @@max_allowed_packet;
+--------------------+
| max_allowed_packet |
+--------------------+
| 5242880            |
+--------------------+
1 row in set (0.00 sec)
```

Tested that the python client, which uses MySQL's implementation also connects:
```python
user@host$ python
Python 2.7.12 (default, Jul 21 2020, 15:19:50)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import mysql.connector
>>> mydb = mysql.connector.connect(user='root', password='root', host='127.0.0.1')
>>> cursor = mydb.cursor()
>>> results = cursor.execute("SELECT @@SOCKET;"
>>> for result in cursor:
...     print(result)
...
(u'/tmp/mysql.sock',)
>>>
```

Finally, I checked out prisma's e2e-tests branch that was having the auth plugin error, as it seemed to be the easiest way to test the error and rust library they are using. I then ran the e2e tests, it now fails inside of their test code and not inside of Bedrock.
```bash
user@host$ sh run.sh
+ export DEBUG=*
+ export RUST_BACKTRACE=full
+ yarn install
yarn install v1.22.4
warning ../../package.json: No license field
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.08s.
+ yarn prisma generate
yarn run v1.22.4
warning ../../package.json: No license field
$ /home/vagrant/e2e-tests/databases/bedrock/node_modules/.bin/prisma generate
Environment variables loaded from prisma/.env

✔ Generated Prisma Client to ./node_modules/@prisma/client in 34ms

You can now start using Prisma Client in your code:

\```
import { PrismaClient } from '@prisma/client'
// or const { PrismaClient } = require('@prisma/client')

const prisma = new PrismaClient()
\```

Explore the full API: http://pris.ly/d/client
Done in 1.43s.
+ yarn prisma migrate save --create-db --experimental
yarn run v1.22.4
warning ../../package.json: No license field
$ /home/vagrant/e2e-tests/databases/bedrock/node_modules/.bin/prisma migrate save --create-db --experimental
Environment variables loaded from prisma/.env
Error: Error: P1001: Can't reach database server at `127.0.0.1`:`3306`

Please make sure your database server is running at `127.0.0.1`:`3306`.
    at Object.ensureDatabaseExists (/home/vagrant/e2e-tests/databases/bedrock/node_modules/@prisma/cli/build/index.js:2:2818789)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async MigrateSave.parse (/home/vagrant/e2e-tests/databases/bedrock/node_modules/@prisma/cli/build/index.js:2:2089873)
    at async main (/home/vagrant/e2e-tests/databases/bedrock/node_modules/@prisma/cli/build/index.js:2:1561778)
error Command failed with exit code 1.
```