### PR TITLE
dosc(README): add build-essential to ubuntu instructions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ You can build from scratch as follows:
     # Install some dependencies
     sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     sudo apt-get update
-    sudo apt-get install gcc-9 g++-9 libpcre++-dev zlib1g-dev
+    sudo apt-get install build-essential gcc-9 g++-9 libpcre++-dev zlib1g-dev
 
     # Build it
     cd Bedrock


### PR DESCRIPTION
closes #843