### PR TITLE
Add more logging

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -225,9 +225,7 @@ void BedrockServer::sync(const SData& args,
     bool committingCommand = false;
 
     // Timer for S_poll performance logging. Created outside the loop because it's cumulative.
-    chrono::steady_clock::time_point start = chrono::steady_clock::now();
-    chrono::steady_clock::duration pollTime(0);
-    size_t pollCount = 0;
+    AutoTimer pollTimer("sync thread poll");
 
     // We hold a lock here around all operations on `syncNode`, because `SQLiteNode` isn't thread-safe, but we need
     // `BedrockServer` to be able to introspect it in `Status` requests. We hold this lock at all times until exiting
@@ -342,26 +340,9 @@ void BedrockServer::sync(const SData& args,
 
         // Unlock our mutex, poll, and re-lock when finished.
         server._syncMutex.unlock();
-        auto timeBeforePoll = chrono::steady_clock::now();
-        S_poll(fdm, max(nextActivity, now) - now);
-        auto timeAfterPoll = chrono::steady_clock::now();
-        pollTime += timeAfterPoll - timeBeforePoll;
-        pollCount++;
-
-        // Every 10s, log and reset.
-        if (timeAfterPoll > (start + 10s)) {
-            auto totalTime = timeAfterPoll - start;
-
-            char buffer[10] = {0};
-            snprintf(buffer, 10, "%.2f", (static_cast<double>(pollTime.count()) / static_cast<double>(totalTime.count()) * 100.0));
-
-            SINFO("[performance] sync poll loop timing: "
-                  << chrono::duration_cast<chrono::milliseconds>(totalTime).count() << " ms elapsed. "
-                  << chrono::duration_cast<chrono::milliseconds>(pollTime).count() << " ms in poll. "
-                  << buffer << "% in poll, called " << pollCount << " times.");
-            pollTime = chrono::microseconds::zero();
-            start = timeAfterPoll;
-            pollCount = 0;
+        {
+            AutoTimerTime pollTime(pollTimer);
+            S_poll(fdm, max(nextActivity, now) - now);
         }
         server._syncMutex.lock();
 


### PR DESCRIPTION
More logging for diagnosing replication/synchronization slowdowns:
```
2020-08-18T23:24:39.065306+00:00 expensidev bedrock10013: xxxxxx (SQLiteNode.h:22) stop [sync] [info] [performance] AutoTimer (multi-replication): 1138/10002 ms timed, 11.38%
2020-08-18T23:24:39.065320+00:00 expensidev bedrock10013: xxxxxx (SQLiteNode.h:22) stop [sync] [info] [performance] AutoTimer (_onMESSAGE): 1640/10002 ms timed, 16.40%
2020-08-18T23:24:39.066795+00:00 expensidev bedrock10013: xxxxxx (SQLiteNode.h:22) stop [sync] [info] [performance] AutoTimer (sync thread poll): 6815/10000 ms timed, 68.15%

2020-08-18T23:24:49.069009+00:00 expensidev bedrock10013: xxxxxx (SQLiteNode.h:22) stop [sync] [info] [performance] AutoTimer (multi-replication): 2207/10000 ms timed, 22.07%
2020-08-18T23:24:49.069043+00:00 expensidev bedrock10013: xxxxxx (SQLiteNode.h:22) stop [sync] [info] [performance] AutoTimer (_onMESSAGE): 3080/10000 ms timed, 30.80%
2020-08-18T23:24:49.222219+00:00 expensidev bedrock10013: xxxxxx (SQLiteNode.h:22) stop [sync] [info] [performance] AutoTimer (sync thread poll): 4812/10155 ms timed, 47.39%

2020-08-18T23:24:59.334316+00:00 expensidev bedrock10013: xxxxxx (SQLiteNode.h:22) stop [sync] [info] [performance] AutoTimer (multi-replication): 3844/10179 ms timed, 37.76%
2020-08-18T23:24:59.334679+00:00 expensidev bedrock10013: xxxxxx (SQLiteNode.h:22) stop [sync] [info] [performance] AutoTimer (_onMESSAGE): 4575/10180 ms timed, 44.94%
2020-08-18T23:24:59.518513+00:00 expensidev bedrock10013: xxxxxx (SQLiteNode.h:22) stop [sync] [info] [performance] AutoTimer (sync thread poll): 3755/10291 ms timed, 36.49%

```