### PR TITLE
Unlock mutex when re-queuing commands because of interrupted checkpoint in sync thread

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -686,6 +686,8 @@ void BedrockServer::sync(const SData& args,
                             server._reply(command);
                         }
                     } else if (result == BedrockCore::RESULT::ABANDONED_FOR_CHECKPOINT) {
+                        // Finished with this.
+                        server._syncThreadCommitMutex.unlock();
                         SINFO("[checkpoint] Re-queuing abandoned command (from process) in sync thread");
                         server._commandQueue.push(move(command));
                         break;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -637,6 +637,8 @@ void BedrockServer::sync(const SData& args,
                             // This is sort of the "default" case after checking if this command was complete above. If so,
                             // we'll fall through to calling processCommand below.
                         } else if (result == BedrockCore::RESULT::ABANDONED_FOR_CHECKPOINT) {
+                            // Finished with this.
+                            server._syncThreadCommitMutex.unlock();
                             SINFO("[checkpoint] Re-queuing abandoned command (from peek) in sync thread");
                             server._commandQueue.push(move(command));
                             break;


### PR DESCRIPTION
If we need to re-queue a command because it was interrupted by a checkpoint during peek or process, and this happened in the *sync* thread, then we need to unlock `_syncThreadCommitMutex`.

