### PR TITLE
Aviod spin, use better mutex type

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -383,7 +383,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
             uint64_t start = STimeNow();
 
             // Lock the mutex that keeps anyone from starting a new transaction.
-            lock_guard<decltype(object->_sharedData->blockNewTransactionsMutex)> transactionLock(object->_sharedData->blockNewTransactionsMutex);
+            unique_lock<decltype(object->_sharedData->blockNewTransactionsMutex)> transactionLock(object->_sharedData->blockNewTransactionsMutex);
 
             while (1) {
                 // Lock first, this prevents anyone from updating the count while we're operating here.
@@ -489,7 +489,7 @@ SQLite::~SQLite() {
 }
 
 void SQLite::waitForCheckpoint() {
-    lock_guard<mutex> lock(_sharedData->blockNewTransactionsMutex);
+    shared_lock<decltype(_sharedData->blockNewTransactionsMutex)> lock(_sharedData->blockNewTransactionsMutex);
 }
 
 bool SQLite::beginTransaction(bool useCache, const string& transactionName) {

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -298,7 +298,7 @@ class SQLite {
 
         // This mutex prevents any thread starting a new transaction when locked. The checkpoint thread will lock it
         // when required to make sure it can get exclusive use of the DB.
-        mutex blockNewTransactionsMutex;
+        shared_timed_mutex blockNewTransactionsMutex;
 
         // These three variables let us notify the checkpoint thread when a transaction ends (or starts, but it will
         // have blocked any new ones from starting by locking blockNewTransactionsMutex).

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -138,7 +138,8 @@ void SQLiteNode::replicate(SQLiteNode& node, Peer* peer, SData command, SQLite& 
                     SINFO("_localCommitNotifier.waitFor canceled early, returning.");
                     return;
                 } else if (result == SQLiteSequentialNotifier::RESULT::CHECKPOINT_REQUIRED) {
-                    SINFO("Checkpoint required while waiting for DB to come up-to-date. Just waiting again.");
+                    SINFO("Checkpoint required while waiting for DB to come up-to-date. Waiting for checkpoint.");
+                    db.waitForCheckpoint();
                     continue;
                 } else {
                     SERROR("Got unhandled SQLiteSequentialNotifier::RESULT value, did someone update the enum without updating this block?");
@@ -173,7 +174,8 @@ void SQLiteNode::replicate(SQLiteNode& node, Peer* peer, SData command, SQLite& 
                             db.rollback();
                             break;
                         } else if (waitResult == SQLiteSequentialNotifier::RESULT::CHECKPOINT_REQUIRED) {
-                            SINFO("Checkpoint required in replication, restarting transaction.");
+                            SINFO("Checkpoint required in replication, waiting for checkpoint and restarting transaction.");
+                            db.waitForCheckpoint();
                             db.rollback();
                             continue;
                         }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -194,7 +194,8 @@ void SQLiteNode::replicate(SQLiteNode& node, Peer* peer, SData command, SQLite& 
                         db.rollback();
                         break;
                     } else if (waitResult == SQLiteSequentialNotifier::RESULT::CHECKPOINT_REQUIRED) {
-                        SINFO("Checkpoint required in replication, restarting transaction.");
+                        SINFO("Checkpoint required in replication, waiting for checkpoint and restarting transaction.");
+                        db.waitForCheckpoint();
                         db.rollback();
                         continue;
                     }


### PR DESCRIPTION
This fix does two things:

1. If we get a `CHECKPOINT_REQUIRED` result back from waiting for a commit, we wait until the checkpoint completes before checking again, rather than spinning in endless loop. This will hopefully fix performance issues we've seen where threads gets stuck in this loop and eat CPU cycles.

2. It changes the type of `blockNewTransactionsMutex` to `shared_timed_mutex` so that mutliple threads (except for the checkpoint thread) can lock this simultaneously and not serialize checking for a pending checkpoint, which should be more efficient.

Tests:
Existing tests