### PR TITLE
Move new DB allocation outside of lock and to child threads

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -789,8 +789,8 @@ void BedrockServer::worker(SQLitePool& dbPool,
     SInitialize(threadId ? "worker" + to_string(threadId) : "blockingCommit");
 
     // Get a DB handle to work on. This will automatically be returned when dbScope goes out of scope.
-    SQLite& db = dbPool.get();
-    SQLiteScopedHandle dbScope(dbPool, db);
+    SQLiteScopedHandle dbScope(dbPool, dbPool.getIndex());
+    SQLite& db = dbScope.db();
     BedrockCore core(db, server);
 
     // Command to work on. This default command is replaced when we find work to do.

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -133,7 +133,7 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 // What is it?
                 socket->recvBuffer.consumeFront(messageSize);
                 if (SIEquals(message.methodLine, "NODE_LOGIN")) {
-                    // Got it -- can we asssociate with a peer?
+                    // Got it -- can we associate with a peer?
                     bool foundIt = false;
                     for (Peer* peer : peerList) {
                         // Just match any unconnected peer

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -252,7 +252,7 @@ class SQLiteNode : public STCPNode {
     //
     // This thread exits on completion of handling the command or when node._replicationThreadsShouldExit is set,
     // which happens when a node stops FOLLOWING.
-    static void replicate(SQLiteNode& node, Peer* peer, SData command, SQLite& db);
+    static void replicate(SQLiteNode& node, Peer* peer, SData command, size_t sqlitePoolIndex);
 
     // Counter of the total number of currently active replication threads. This is used to let us know when all
     // threads have finished.

--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -11,8 +11,10 @@ SQLitePool::SQLitePool(size_t maxDBs,
                        int64_t mmapSizeGB,
                        bool pageLoggingEnabled)
 : _maxDBs(max(maxDBs, 1ul)),
-  _baseDB(filename, cacheSize, enableFullCheckpoints, maxJournalSize, minJournalTables, synchronous, mmapSizeGB, pageLoggingEnabled)
-{ }
+  _baseDB(filename, cacheSize, enableFullCheckpoints, maxJournalSize, minJournalTables, synchronous, mmapSizeGB, pageLoggingEnabled),
+  _objects(_maxDBs, nullptr)
+{
+}
 
 SQLitePool::~SQLitePool() {
     lock_guard<mutex> lock(_sync);
@@ -20,10 +22,12 @@ SQLitePool::~SQLitePool() {
         SWARN("Destroying SQLitePool with DBs in use.");
     }
     for (auto dbHandle : _availableHandles) {
-        delete dbHandle;
+        delete _objects[dbHandle];
+        _objects[dbHandle] = nullptr;
     }
     for (auto dbHandle : _inUseHandles) {
-        delete dbHandle;
+        delete _objects[dbHandle];
+        _objects[dbHandle] = nullptr;
     }
 }
 
@@ -31,23 +35,29 @@ SQLite& SQLitePool::getBase() {
     return _baseDB;
 }
 
-SQLite& SQLitePool::get() {
+size_t SQLitePool::getIndex(bool createHandle) {
     while (true) {
         unique_lock<mutex> lock(_sync);
         if (_availableHandles.size()) {
             // Return an existing handle.
             auto frontIt = _availableHandles.begin();
-            SQLite* db = *frontIt;
-            _inUseHandles.insert(db);
+            size_t index = *frontIt;
+            _inUseHandles.insert(index);
             _availableHandles.erase(frontIt);
             SINFO("Returning existing DB handle");
-            return *db;
+            return index;
         } else if (_availableHandles.size() + _inUseHandles.size() < (_maxDBs - 1)) {
-            // Create a new handle.
-            SQLite* db = new SQLite(_baseDB);
-            _inUseHandles.insert(db);
-            SINFO("Returning new DB handle: " << (_availableHandles.size() + _inUseHandles.size()));
-            return *db;
+            size_t index = _availableHandles.size() + _inUseHandles.size();
+            _inUseHandles.insert(index);
+
+            // Create a new handle unless we're not supposed to. We unlock here as we're no longer in a position to
+            // change which indices are in use.
+            lock.unlock();
+            if (createHandle) {
+                initializeIndex(index);
+            }
+            SINFO("Returning new DB handle: " << index);
+            return index;
         } else {
             // Wait for a handle.
             SINFO("Waiting for DB handle");
@@ -56,23 +66,34 @@ SQLite& SQLitePool::get() {
     }
 }
 
-void SQLitePool::returnToPool(SQLite& object) {
+SQLite& SQLitePool::initializeIndex(size_t index) {
+    // We don't lock here on purpose. Because these indexes are handed out individually, no two threads should have the
+    // same one, and thus they should independently be able to update the addresses in this vector, as neither will
+    // change the allocation of the vector itself.
+    // It's an error to run `initializeIndex` in two threads on the same index at the same time.
+    if (_objects[index] == nullptr) {
+        _objects[index] = new SQLite(_baseDB);
+    }
+    return *_objects[index];
+}
+
+void SQLitePool::returnToPool(size_t index) {
     {
         lock_guard<mutex> lock(_sync);
-        _availableHandles.insert(&object);
-        _inUseHandles.erase(&object);
+        _availableHandles.insert(index);
+        _inUseHandles.erase(index);
         SINFO("DB handle returned to pool.");
     }
     _wait.notify_one();
 }
 
-SQLiteScopedHandle::SQLiteScopedHandle(SQLitePool& pool, SQLite& db) : _pool(pool), _db(db)
+SQLiteScopedHandle::SQLiteScopedHandle(SQLitePool& pool, size_t index) : _pool(pool), _index(index)
 {} 
 
 SQLiteScopedHandle::~SQLiteScopedHandle() {
-    _pool.returnToPool(_db);
+    _pool.returnToPool(_index);
 }
 
 SQLite& SQLiteScopedHandle::db() {
-    return _db;
+    return _pool.initializeIndex(_index);
 }


### PR DESCRIPTION
This changes how SQLitePool works to allocate slots in a static vector of `SQLite*`s, rather than to allocate `SQLite` objects directly. This allows passing the instantiation of those objects to worker threads.

In the case that the SQLite objects *are* created directly in the pool, it unlocks the mutex for getting other DB handles while the creation happens as well.

Tests:
Existing Tests