### PR TITLE
Fix deadlock

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -176,8 +176,8 @@ void SQLiteNode::replicate(SQLiteNode& node, Peer* peer, SData command, size_t s
                             break;
                         } else if (waitResult == SQLiteSequentialNotifier::RESULT::CHECKPOINT_REQUIRED) {
                             SINFO("Checkpoint required in replication, waiting for checkpoint and restarting transaction.");
-                            db.waitForCheckpoint();
                             db.rollback();
+                            db.waitForCheckpoint();
                             continue;
                         }
                     }
@@ -196,8 +196,8 @@ void SQLiteNode::replicate(SQLiteNode& node, Peer* peer, SData command, size_t s
                         break;
                     } else if (waitResult == SQLiteSequentialNotifier::RESULT::CHECKPOINT_REQUIRED) {
                         SINFO("Checkpoint required in replication, waiting for checkpoint and restarting transaction.");
-                        db.waitForCheckpoint();
                         db.rollback();
+                        db.waitForCheckpoint();
                         continue;
                     }
 


### PR DESCRIPTION
Once the checkpoint starts, it waits for all outstanding transactions to finish.

So, if we are going to wait for a checkpoint, we need to rollback *first*, otherwise the checkpoint is waiting for our (not yet rolled back) transaction to finish, but we're waiting for the checkpoint to finish before we roll back.