### PR TITLE
Add more precision to commit timing

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -829,7 +829,9 @@ int SQLite::commit() {
     } else {
         result = SQuery(_db, "committing db transaction", "COMMIT");
     }
-    SINFO("SQuery 'COMMIT' took " << ((STimeNow() - beforeCommit)/1000) << "ms.");
+    char time[16];
+    snprintf(time, 16, "%.2fms", (double)(STimeNow() - beforeCommit) / 1000.0);
+    SINFO("SQuery 'COMMIT' took " << time << ".");
 
     // And record pages after the commit.
     int endPages;


### PR DESCRIPTION
Just change whole ms to fractional ms in logs.

Tests:
existing

Example logs from dev:
```
2020-09-03T20:23:46.708430+00:00 expensidev bedrock10037: guJD4K (SQLite.cpp:834) commit [worker3] [info] SQuery 'COMMIT' took 0.95ms.
```