### PR TITLE
Fix race condition

### DIFF
--- a/sqlitecluster/SQLiteSequentialNotifier.cpp
+++ b/sqlitecluster/SQLiteSequentialNotifier.cpp
@@ -59,6 +59,7 @@ void SQLiteSequentialNotifier::cancel() {
     _globalResult = RESULT::CANCELED;
     for (auto& p : _valueToPendingThreadMap) {
         lock_guard<mutex> lock(p.second->waitingThreadMutex);
+        p.second->result = RESULT::CANCELED;
         p.second->waitingThreadConditionVariable.notify_all();
     }
     _valueToPendingThreadMap.clear();
@@ -70,6 +71,7 @@ void SQLiteSequentialNotifier::checkpointRequired(SQLite& db) {
     _globalResult = RESULT::CHECKPOINT_REQUIRED;
     for (auto& p : _valueToPendingThreadMap) {
         lock_guard<mutex> lock(p.second->waitingThreadMutex);
+        p.second->result = RESULT::CHECKPOINT_REQUIRED;
         p.second->waitingThreadConditionVariable.notify_all();
     }
     _valueToPendingThreadMap.clear();


### PR DESCRIPTION
This fixes a race condition where the following could happen:

1. `checkpointRequired` is called and sets `_globalResult`.
2. All pending threads are noified, but for at least one of them, the code in `waitFor` that checks the result state has *not yet run*
3. `checkpointComplete` is called and resets `_globalResult` to `UNKNOWN`.
4. For one of the pending threads, it finally checks `if (_globalResult != RESULT::UNKNOWN)` and finds that it does, and it goes back to waiting for whatever condition it was waiting for originally.
5. Because `_valueToPendingThreadMap.clear()`, this thread is no longer in the list of threads to notify, and it is never notified again, and just sits waiting forever.

This fix sets `result` as well as `_globalResult` in these cases, so that even if `_globalResult` gets set, `waitFor` still returns in this cases.

Tests:
Run the existing tests 100 times.