### PR TITLE
Time Commits, do passive checkpoints outside commit lock, clean up unused vars

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -85,7 +85,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
             if (request.test("disableCheckpointInterrupt")) {
                 _db.disableCheckpointInterruptForNextTransaction();
             }
-            if (!_db.beginTransaction(exclusive ? SQLite::TRANSACTION_TYPE::EXCLUSIVE : SQLite::TRANSACTION_TYPE::SHARED, true)) {
+            if (!_db.beginTransaction(exclusive ? SQLite::TRANSACTION_TYPE::EXCLUSIVE : SQLite::TRANSACTION_TYPE::SHARED)) {
                 STHROW("501 Failed to begin " + (exclusive ? "exclusive"s : "shared"s) + " transaction");
             }
 
@@ -195,7 +195,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
             // If a transaction was already begun in `peek`, then this won't run. We call it here to support the case where
             // peek created a httpsRequest and closed it's first transaction until the httpsRequest was complete, in which
             // case we need to open a new transaction.
-            if (!_db.beginTransaction(exclusive ? SQLite::TRANSACTION_TYPE::EXCLUSIVE : SQLite::TRANSACTION_TYPE::SHARED, true)) {
+            if (!_db.beginTransaction(exclusive ? SQLite::TRANSACTION_TYPE::EXCLUSIVE : SQLite::TRANSACTION_TYPE::SHARED)) {
                 STHROW("501 Failed to begin " + (exclusive ? "exclusive"s : "shared"s) + " transaction");
             }
         }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -85,7 +85,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
             if (request.test("disableCheckpointInterrupt")) {
                 _db.disableCheckpointInterruptForNextTransaction();
             }
-            if (!_db.beginTransaction(exclusive ? SQLite::TRANSACTION_TYPE::EXCLUSIVE : SQLite::TRANSACTION_TYPE::SHARED, true, command->request.methodLine)) {
+            if (!_db.beginTransaction(exclusive ? SQLite::TRANSACTION_TYPE::EXCLUSIVE : SQLite::TRANSACTION_TYPE::SHARED, true)) {
                 STHROW("501 Failed to begin " + (exclusive ? "exclusive"s : "shared"s) + " transaction");
             }
 
@@ -195,7 +195,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
             // If a transaction was already begun in `peek`, then this won't run. We call it here to support the case where
             // peek created a httpsRequest and closed it's first transaction until the httpsRequest was complete, in which
             // case we need to open a new transaction.
-            if (!_db.beginTransaction(exclusive ? SQLite::TRANSACTION_TYPE::EXCLUSIVE : SQLite::TRANSACTION_TYPE::SHARED, true, command->request.methodLine)) {
+            if (!_db.beginTransaction(exclusive ? SQLite::TRANSACTION_TYPE::EXCLUSIVE : SQLite::TRANSACTION_TYPE::SHARED, true)) {
                 STHROW("501 Failed to begin " + (exclusive ? "exclusive"s : "shared"s) + " transaction");
             }
         }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -181,7 +181,7 @@ void BedrockServer::sync(const SData& args,
     // We use fewer FDs on test machines that have other resource restrictions in place.
     int fdLimit = args.isSet("-live") ? 25'000 : 250;
     SINFO("Setting dbPool size to: " << fdLimit);
-    SQLitePool dbPool(fdLimit, args["-db"], args.calc("-cacheSize"), true, args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.test("-pageLogging"));
+    SQLitePool dbPool(fdLimit, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.test("-pageLogging"));
     SQLite& db = dbPool.getBase();
 
     // Initialize the command processor.

--- a/Makefile
+++ b/Makefile
@@ -123,12 +123,12 @@ test/clustertest/clustertest: $(CLUSTERTESTOBJ) $(BINPREREQS)
 # where for the object file rule, the reverse is true.
 $(INTERMEDIATEDIR)/%.d: %.cpp $(PRECOMPILE_D)
 	@mkdir -p $(dir $@)
-	$(GXX) $(CXXFLAGS) -MMD -MF $@ $(PRECOMPILE_INCLUDE) -o $(INTERMEDIATEDIR)/$*.o -c $<
+	$(GXX) $(CXXFLAGS) -MD -MF $@ $(PRECOMPILE_INCLUDE) -o $(INTERMEDIATEDIR)/$*.o -c $<
 
 # .o files depend on .d files to prevent simultaneous jobs from trying to create both.
 $(INTERMEDIATEDIR)/%.o: %.cpp $(INTERMEDIATEDIR)/%.d
 	@mkdir -p $(dir $@)
-	$(GXX) $(CXXFLAGS) -MMD -MF $(INTERMEDIATEDIR)/$*.d $(PRECOMPILE_INCLUDE) -o $@ -c $<
+	$(GXX) $(CXXFLAGS) -MD -MF $(INTERMEDIATEDIR)/$*.d $(PRECOMPILE_INCLUDE) -o $@ -c $<
 
 # Build c files. This is basically just for sqlite, so we don't bother with dependencies for it.
 # SQLITE_MAX_MMAP_SIZE is set to 16TB.

--- a/Makefile
+++ b/Makefile
@@ -84,16 +84,6 @@ CLUSTERTESTCPP += test/tests/jobs/JobTestHelper.cpp
 CLUSTERTESTOBJ = $(CLUSTERTESTCPP:%.cpp=$(INTERMEDIATEDIR)/%.o)
 CLUSTERTESTDEP = $(CLUSTERTESTCPP:%.cpp=$(INTERMEDIATEDIR)/%.d)
 
-# Bring in the dependency files. This will cause them to be created if necessary. This is skipped if we're cleaning, as
-# they'll just get deleted anyway.
-ifneq ($(MAKECMDGOALS),clean)
--include $(STUFFDEP)
--include $(LIBBEDROCKDEP)
--include $(BEDROCKDEP)
-#-include $(TESTDEP)
-#-include $(CLUSTERTESTDEP)
-endif
-
 # Our static libraries just depend on their object files.
 libstuff.a: $(STUFFOBJ)
 	ar crv $@ $(STUFFOBJ)
@@ -135,3 +125,13 @@ $(INTERMEDIATEDIR)/%.o: %.cpp $(INTERMEDIATEDIR)/%.d
 $(INTERMEDIATEDIR)/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) -O2 $(BEDROCK_OPTIM_COMPILE_FLAG) -Wno-unused-but-set-variable -DSQLITE_ENABLE_STAT4 -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_SESSION -DSQLITE_ENABLE_PREUPDATE_HOOK -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT -DSQLITE_ENABLE_NOOP_UPDATE -DSQLITE_MUTEX_ALERT_MILLISECONDS=20 -DHAVE_USLEEP=1 -DSQLITE_MAX_MMAP_SIZE=17592186044416ull -DSQLITE_SHARED_MAPPING -DSQLITE_ENABLE_NORMALIZE -o $@ -c $<
+
+# Bring in the dependency files. This will cause them to be created if necessary. This is skipped if we're cleaning, as
+# they'll just get deleted anyway.
+ifneq ($(MAKECMDGOALS),clean)
+-include $(STUFFDEP)
+-include $(LIBBEDROCKDEP)
+-include $(BEDROCKDEP)
+#-include $(TESTDEP)
+#-include $(CLUSTERTESTDEP)
+endif

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ testplugin:
 PRECOMPILE_D =libstuff/libstuff.d
 PRECOMPILE_INCLUDE =-include libstuff/libstuff.h
 libstuff/libstuff.h.gch libstuff/libstuff.d: libstuff/libstuff.h mbedtls/library/libmbedcrypto.a
-	$(GXX) $(CXXFLAGS) -MMD -MF libstuff/libstuff.d -MT libstuff/libstuff.h.gch -c libstuff/libstuff.h
+	$(GXX) $(CXXFLAGS) -MD -MF libstuff/libstuff.d -MT libstuff/libstuff.h.gch -c libstuff/libstuff.h
 ifneq ($(MAKECMDGOALS),clean)
 -include  libstuff/libstuff.d
 endif

--- a/libstuff/SPerformanceTimer.cpp
+++ b/libstuff/SPerformanceTimer.cpp
@@ -1,9 +1,11 @@
 #include <libstuff/libstuff.h>
 #include "SPerformanceTimer.h"
 
-SPerformanceTimer::SPerformanceTimer(string description)
+SPerformanceTimer::SPerformanceTimer(string description, map<string, chrono::steady_clock::duration> defaults)
   : _description(description),
-  _lastLogStart(chrono::steady_clock::now())
+  _lastLogStart(chrono::steady_clock::now()),
+  _defaults(defaults),
+  _totals(_defaults)
 {}
 
 void SPerformanceTimer::start(const string& type) {
@@ -30,7 +32,7 @@ void SPerformanceTimer::stop() {
 
         // Reset.
         _lastLogStart = now;
-        _totals.clear();
+        _totals = _defaults;
     }
 }
 

--- a/libstuff/SPerformanceTimer.h
+++ b/libstuff/SPerformanceTimer.h
@@ -1,19 +1,17 @@
 #pragma once
+#include <libstuff/libstuff.h>
 
 class SPerformanceTimer {
   public:
-    SPerformanceTimer(string description, bool reverse = false, uint64_t logIntervalSeconds = 10);
-    void start();
+    SPerformanceTimer(string description);
+    void start(const string& type);
     void stop();
-    virtual void log();
+    void log(chrono::steady_clock::duration elapsed);
 
   protected:
-    bool _reverse;
-    uint64_t _logPeriod;
-    uint64_t _lastStart;
-    uint64_t _lastStop;
-    uint64_t _lastLogStart;
-    uint64_t _timeLogged;
-    uint64_t _timeNotLogged;
     string _description;
+    chrono::steady_clock::time_point _lastStart;
+    chrono::steady_clock::time_point _lastLogStart;
+    string _lastType;
+    map <string, chrono::steady_clock::duration> _totals;
 };

--- a/libstuff/SPerformanceTimer.h
+++ b/libstuff/SPerformanceTimer.h
@@ -3,7 +3,7 @@
 
 class SPerformanceTimer {
   public:
-    SPerformanceTimer(string description);
+    SPerformanceTimer(string description, map<string, chrono::steady_clock::duration> defaults = {});
     void start(const string& type);
     void stop();
     void log(chrono::steady_clock::duration elapsed);
@@ -13,5 +13,6 @@ class SPerformanceTimer {
     chrono::steady_clock::time_point _lastStart;
     chrono::steady_clock::time_point _lastLogStart;
     string _lastType;
+    map <string, chrono::steady_clock::duration> _defaults;
     map <string, chrono::steady_clock::duration> _totals;
 };

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1124,7 +1124,11 @@ nextJournalCount(0),
 currentTransactionCount(0),
 _currentPageCount(0),
 _checkpointThreadBusy(0),
-_commitLockTimer("commit lock timer")
+_commitLockTimer("commit lock timer", {
+    {"EXCLUSIVE", chrono::steady_clock::duration::zero()},
+    {"SHARED", chrono::steady_clock::duration::zero()},
+    //{"BLOCKED", chrono::steady_clock::duration::zero()}, // For when we can't do anything cause of a checkpoint.
+})
 { }
 
 void SQLite::SharedData::addCheckpointListener(SQLite::CheckpointRequiredListener& listener) {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -206,7 +206,7 @@ void SQLite::commonConstructorInitialization() {
     }
 }
 
-SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints, int maxJournalSize,
+SQLite::SQLite(const string& filename, int cacheSize, int maxJournalSize,
                int minJournalTables, const string& synchronous, int64_t mmapSizeGB, bool pageLoggingEnabled) :
     _filename(initializeFilename(filename)),
     _maxJournalSize(maxJournalSize),
@@ -215,7 +215,6 @@ SQLite::SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints
     _sharedData(initializeSharedData(_db, mmapSizeGB, _filename, _journalNames)),
     _journalName(_journalNames[0]),
     _journalSize(initializeJournalSize(_db, _journalNames)),
-    _enableFullCheckpoints(enableFullCheckpoints),
     _pageLoggingEnabled(pageLoggingEnabled),
     _cacheSize(cacheSize),
     _synchronous(synchronous),
@@ -232,7 +231,6 @@ SQLite::SQLite(const SQLite& from) :
     _sharedData(from._sharedData),
     _journalName(_journalNames[(_sharedData.nextJournalCount++ % _journalNames.size() - 1) + 1]),
     _journalSize(from._journalSize),
-    _enableFullCheckpoints(from._enableFullCheckpoints),
     _pageLoggingEnabled(from._pageLoggingEnabled),
     _cacheSize(from._cacheSize),
     _synchronous(from._synchronous),
@@ -279,7 +277,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
     object->_sharedData._currentPageCount.store(pageCount);
     // Try a passive checkpoint if full checkpoints aren't enabled, *or* if the page count is less than the required
     // size for a full checkpoint.
-    if (object->_enableFullCheckpoints && pageCount >= fullCheckpointPageMin.load()) {
+    if (pageCount >= fullCheckpointPageMin.load()) {
         // If we get here, then full checkpoints are enabled, and we have enough pages in the WAL file to perform one.
         SINFO("[checkpoint] " << pageCount << " pages behind, beginning complete checkpoint.");
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1114,7 +1114,6 @@ _checkpointThreadBusy(0),
 _commitLockTimer("commit lock timer", {
     {"EXCLUSIVE", chrono::steady_clock::duration::zero()},
     {"SHARED", chrono::steady_clock::duration::zero()},
-    //{"BLOCKED", chrono::steady_clock::duration::zero()}, // For when we can't do anything cause of a checkpoint.
 })
 { }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -432,7 +432,7 @@ bool SQLite::beginTransaction(bool useCache, const string& transactionName) {
 bool SQLite::beginTransaction(TRANSACTION_TYPE type, bool useCache, const string& transactionName) {
     if (type == TRANSACTION_TYPE::EXCLUSIVE) {
         _sharedData.commitLock.lock();
-        _sharedData._commitLockTimer.start();
+        _sharedData._commitLockTimer.start("EXCLUSIVE");
         _mutexLocked = true;
     }
     return beginTransaction(useCache, transactionName);
@@ -659,7 +659,7 @@ bool SQLite::prepare() {
     // We lock this here, so that we can guarantee the order in which commits show up in the database.
     if (!_mutexLocked) {
         _sharedData.commitLock.lock();
-        _sharedData._commitLockTimer.start();
+        _sharedData._commitLockTimer.start("SHARED");
         _mutexLocked = true;
     }
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -64,17 +64,15 @@ class SQLite {
     // Performs a read-only query (eg, SELECT) that returns a single value.
     string read(const string& query);
 
-    // Begins a new transaction. Returns true on success. Can optionally be instructed to use the query cache, if so
-    // the transaction can be named so that log lines about cache success can be associated to the transaction.
-    bool beginTransaction(bool useCache = false);
-
+    // Types of transactions that we can begin.
     enum class TRANSACTION_TYPE {
         SHARED,
         EXCLUSIVE
     };
 
-    // Same as above, but locks the commit mutex to guarantee that this transaction cannot conflict with any others.
-    bool beginTransaction(TRANSACTION_TYPE type, bool useCache = false);
+    // Begins a new transaction. Returns true on success. If type is EXCLUSIVE, locks the commit mutex to guarantee
+    // that this transaction cannot conflict with any others.
+    bool beginTransaction(TRANSACTION_TYPE type = TRANSACTION_TYPE::SHARED);
 
     // Verifies a table exists and has a particular definition. If the database is left with the right schema, it
     // returns true. If it had to create a new table (ie, the table was missing), it also sets created to true. If the
@@ -450,9 +448,6 @@ class SQLite {
 
     // Number of queries found in cache in this transaction (for metrics only).
     int64_t _cacheHits = 0;
-
-    // Set to true if the cache is in use for this transaction.
-    bool _useCache = false;
 
     // A string indicating the name of the transaction (typically a command name) for metric purposes.
     string _transactionName;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -66,7 +66,7 @@ class SQLite {
 
     // Begins a new transaction. Returns true on success. Can optionally be instructed to use the query cache, if so
     // the transaction can be named so that log lines about cache success can be associated to the transaction.
-    bool beginTransaction(bool useCache = false, const string& transactionName = "");
+    bool beginTransaction(bool useCache = false);
 
     enum class TRANSACTION_TYPE {
         SHARED,
@@ -74,7 +74,7 @@ class SQLite {
     };
 
     // Same as above, but locks the commit mutex to guarantee that this transaction cannot conflict with any others.
-    bool beginTransaction(TRANSACTION_TYPE type, bool useCache = false, const string& transactionName = "");
+    bool beginTransaction(TRANSACTION_TYPE type, bool useCache = false);
 
     // Verifies a table exists and has a particular definition. If the database is left with the right schema, it
     // returns true. If it had to create a new table (ie, the table was missing), it also sets created to true. If the

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -41,12 +41,12 @@ class SQLite {
     //                   passed, no tables are created.
     //
     // mmapSizeGB: address space to use for memory-mapped IO, in GB.
-    SQLite(const string& filename, int cacheSize, bool enableFullCheckpoints, int maxJournalSize,
-           int minJournalTables, const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false);
+    SQLite(const string& filename, int cacheSize, int maxJournalSize, int minJournalTables,
+           const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false);
 
     // Compatibility constructor. Remove when AuthTester::getStripeSQLiteDB no longer uses this outdated version.
-    SQLite(const string& filename, int cacheSize, int enableFullCheckpoints, int maxJournalSize, int minJournalTables, int synchronous) :
-        SQLite(filename, cacheSize, (bool)enableFullCheckpoints, maxJournalSize, minJournalTables, "") {}
+    SQLite(const string& filename, int cacheSize, int maxJournalSize, int minJournalTables, int synchronous) :
+        SQLite(filename, cacheSize, maxJournalSize, minJournalTables, "") {}
     
     // This constructor is not exactly a copy constructor. It creates an other SQLite object based on the first except
     // with a *different* journal table. This avoids a lot of locking around creating structures that we know already
@@ -440,10 +440,6 @@ class SQLite {
     bool _autoRolledBack = false;
 
     bool _noopUpdateMode = false;
-
-    // Flag for enabling full checkpoints, though it's effectively impossible to turn this off, so it should be removed
-    // and replaced with `true`.
-    bool _enableFullCheckpoints;
 
     // A map of queries to their cached results. This is populated only with deterministic queries, and is reset on any
     // write, rollback, or commit.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <libstuff/sqlite3.h>
+#include <libstuff/SPerformanceTimer.h>
 
 class SQLite {
   public:
@@ -288,6 +289,7 @@ class SQLite {
         // Used as a flag to prevent starting multiple checkpoint threads simultaneously.
         atomic<int> _checkpointThreadBusy;
 
+        SPerformanceTimer _commitLockTimer;
       private:
 
         // The data required to replicate transactions, in two lists, depending on whether this has only been prepared

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -215,7 +215,7 @@ class SQLiteNode : public STCPNode {
     chrono::steady_clock::time_point _lastNetStatTime;
 
     // Handler for transaction messages.
-    void handleBeginTransaction(SQLite& db, Peer* peer, const SData& message);
+    void handleBeginTransaction(SQLite& db, Peer* peer, const SData& message, bool wasConflict);
     void handlePrepareTransaction(SQLite& db, Peer* peer, const SData& message);
     int handleCommitTransaction(SQLite& db, Peer* peer, const uint64_t commandCommitCount, const string& commandCommitHash);
     void handleRollbackTransaction(SQLite& db, Peer* peer, const SData& message);

--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -4,14 +4,13 @@
 SQLitePool::SQLitePool(size_t maxDBs,
                        const string& filename,
                        int cacheSize,
-                       bool enableFullCheckpoints,
                        int maxJournalSize,
                        int minJournalTables,
                        const string& synchronous,
                        int64_t mmapSizeGB,
                        bool pageLoggingEnabled)
 : _maxDBs(max(maxDBs, 1ul)),
-  _baseDB(filename, cacheSize, enableFullCheckpoints, maxJournalSize, minJournalTables, synchronous, mmapSizeGB, pageLoggingEnabled),
+  _baseDB(filename, cacheSize, maxJournalSize, minJournalTables, synchronous, mmapSizeGB, pageLoggingEnabled),
   _objects(_maxDBs, nullptr)
 {
 }

--- a/sqlitecluster/SQLitePool.h
+++ b/sqlitecluster/SQLitePool.h
@@ -5,8 +5,8 @@ class SQLite;
 class SQLitePool {
   public:
     // Create a pool of DB handles.
-    SQLitePool(size_t maxDBs, const string& filename, int cacheSize, bool enableFullCheckpoints, int maxJournalSize,
-               int minJournalTables, const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false);
+    SQLitePool(size_t maxDBs, const string& filename, int cacheSize, int maxJournalSize, int minJournalTables,
+               const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false);
     ~SQLitePool();
 
     // Get the base object (the first one created, which uses the `journal` table). Note that if called by multiple

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -514,21 +514,18 @@ SQLite& BedrockTester::getSQLiteDB()
     if (!_db) {
         _db = new SQLite(_dbName, 1000000, 3000000, -1);
     }
+    _db->rollback();
     return *_db;
 }
 
 string BedrockTester::readDB(const string& query)
 {
-    string result = getSQLiteDB().read(query);
-    getSQLiteDB().rollback();
-    return result;
+    return getSQLiteDB().read(query);
 }
 
 bool BedrockTester::readDB(const string& query, SQResult& result)
 {
-    bool success = getSQLiteDB().read(query, result);
-    getSQLiteDB().rollback();
-    return success;
+    return getSQLiteDB().read(query, result);
 }
 
 int BedrockTester::getServerPort() {

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -514,7 +514,9 @@ SQLite& BedrockTester::getSQLiteDB()
     if (!_db) {
         _db = new SQLite(_dbName, 1000000, 3000000, -1);
     }
-    _db->rollback();
+    if (autoRollbackEveryDBCall) {
+        _db->rollback();
+    }
     return *_db;
 }
 

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -512,7 +512,7 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
 SQLite& BedrockTester::getSQLiteDB()
 {
     if (!_db) {
-        _db = new SQLite(_dbName, 1000000, false, 3000000, -1);
+        _db = new SQLite(_dbName, 1000000, 3000000, -1);
     }
     return *_db;
 }

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -519,12 +519,16 @@ SQLite& BedrockTester::getSQLiteDB()
 
 string BedrockTester::readDB(const string& query)
 {
-    return getSQLiteDB().read(query);
+    string result = getSQLiteDB().read(query);
+    getSQLiteDB().rollback();
+    return result;
 }
 
 bool BedrockTester::readDB(const string& query, SQResult& result)
 {
-    return getSQLiteDB().read(query, result);
+    bool success = getSQLiteDB().read(query, result);
+    getSQLiteDB().rollback();
+    return success;
 }
 
 int BedrockTester::getServerPort() {

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -77,6 +77,22 @@ class BedrockTester {
     string readDB(const string& query);
     bool readDB(const string& query, SQResult& result);
     SQLite& getSQLiteDB();
+    bool autoRollbackEveryDBCall = true;
+
+    // This allows callers to run an entire transaction easily.
+    class ScopedTransaction {
+      public:
+        ScopedTransaction(BedrockTester* tester) : _tester(tester) {
+            _tester->autoRollbackEveryDBCall = false;
+            _tester->getSQLiteDB().beginTransaction();
+        }
+        ~ScopedTransaction() {
+            _tester->getSQLiteDB().rollback();
+            _tester->autoRollbackEveryDBCall = true;
+        }
+      private:
+        BedrockTester* _tester;
+    };
 
     int getServerPID() { return _serverPID; }
 

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -42,7 +42,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         // This exposes just enough to test the peer selection logic.
         int fd = mkstemp(filename);
         close(fd);
-        SQLitePool dbPool(10, filename, 1000000, 100, 5000, 0);
+        SQLitePool dbPool(10, filename, 1000000, 5000, 0);
         TestServer server("");
         SQLiteNode testNode(server, dbPool, "test", "localhost:19998", "", 1, 1000000000, "1.0");
 


### PR DESCRIPTION
This removes a few unused vars:

`_useCache`: We'll always use the cache.
`_enableFullCheckpoints`: This is always on.
`_transactionName`: this was not very useful.

This changes the makefile to better detect dependencies when a header file changes.

This adds timing for the commit mutex to see how often it's locked. This re-writes `SPerformanceTimer` which wasn't being used anywhere else, anyway.

The biggest change here is that *passive commits are done after the commit lock is released on every commit*

Note: there are companion S-E and FuzzyBot changes for this.

Tests:
Existing tests.