### PR TITLE
Fix Fork Situation

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -811,8 +811,8 @@ int SQLite::commit() {
     return result;
 }
 
-map<uint64_t, tuple<string, string, uint64_t>> SQLite::popCommittedTransactions(uint64_t maxCommitID) {
-    return _sharedData.popCommittedTransactions(maxCommitID);
+map<uint64_t, tuple<string, string, uint64_t>> SQLite::popCommittedTransactions() {
+    return _sharedData.popCommittedTransactions();
 }
 
 void SQLite::rollback() {
@@ -1158,18 +1158,10 @@ void SQLite::SharedData::commitTransactionInfo(uint64_t commitID) {
     _committedTransactions.insert(_preparedTransactions.extract(commitID));
 }
 
-map<uint64_t, tuple<string, string, uint64_t>> SQLite::SharedData::popCommittedTransactions(uint64_t maxCommitID) {
+map<uint64_t, tuple<string, string, uint64_t>> SQLite::SharedData::popCommittedTransactions() {
     lock_guard<decltype(_internalStateMutex)> lock(_internalStateMutex);
     decltype(_committedTransactions) result;
-    if (maxCommitID == 0) {
-        // If no maximum is specified, remove and return them all.
-        result = move(_committedTransactions);
-        _committedTransactions.clear();
-    } else {
-        // Otherwise, extract the relevant transactions from the front of the commit list.
-        while (_committedTransactions.size() && _committedTransactions.begin()->first <= maxCommitID) {
-            result.insert(_committedTransactions.extract(_committedTransactions.begin()));
-        }
-    }
+    result = move(_committedTransactions);
+    _committedTransactions.clear();
     return result;
 }

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -194,8 +194,8 @@ class SQLite {
     void removeCheckpointListener(CheckpointRequiredListener& listener);
 
     // This atomically removes and returns committed transactions from our internal list. SQLiteNode can call this, and
-    // it will return a map of transaction IDs to pairs of (query, hash), so that those transactions can be replicated
-    // out to peers. You can limit the number of transactions to a certain commit ID.
+    // it will return a map of transaction IDs to tuples of (query, hash, dbCountAtTransactionStart), so that those
+    // transactions can be replicated out to peers.
     map<uint64_t, tuple<string,string, uint64_t>> popCommittedTransactions();
 
     // The whitelist is either nullptr, in which case the feature is disabled, or it's a map of table names to sets of
@@ -243,8 +243,7 @@ class SQLite {
         // after completing a commit and before releasing the commit lock.
         void incrementCommit(const string& commitHash);
 
-        // This removes and returns any committed transactions up through the given commit ID, or all of them if
-        // maxCommitID is 0.
+        // This removes and returns all committed transactions.
         map<uint64_t, tuple<string, string, uint64_t>> popCommittedTransactions();
 
         // This is the last committed hash by *any* thread for this file.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -196,7 +196,7 @@ class SQLite {
     // This atomically removes and returns committed transactions from our internal list. SQLiteNode can call this, and
     // it will return a map of transaction IDs to pairs of (query, hash), so that those transactions can be replicated
     // out to peers. You can limit the number of transactions to a certain commit ID.
-    map<uint64_t, tuple<string,string, uint64_t>> popCommittedTransactions(uint64_t maxCommitID = 0);
+    map<uint64_t, tuple<string,string, uint64_t>> popCommittedTransactions();
 
     // The whitelist is either nullptr, in which case the feature is disabled, or it's a map of table names to sets of
     // column names that are allowed for reading. Using whitelist at all put the database handle into a more
@@ -245,7 +245,7 @@ class SQLite {
 
         // This removes and returns any committed transactions up through the given commit ID, or all of them if
         // maxCommitID is 0.
-        map<uint64_t, tuple<string, string, uint64_t>> popCommittedTransactions(uint64_t maxCommitID = 0);
+        map<uint64_t, tuple<string, string, uint64_t>> popCommittedTransactions();
 
         // This is the last committed hash by *any* thread for this file.
         atomic<string> lastCommittedHash;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -415,7 +415,7 @@ void SQLiteNode::_sendOutstandingTransactions(const set<uint64_t>& commitOnlyIDs
         }
         SData commit("COMMIT_TRANSACTION");
         commit["ID"] = idHeader;
-        transaction["NewCount"] = to_string(id);
+        commit["NewCount"] = to_string(id);
         commit["NewHash"] = hash;
         _sendToAllPeers(commit, true); // subscribed only
         _lastSentTransactionID = id;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -201,7 +201,7 @@ class SQLiteNode : public STCPNode {
     map<string, unique_ptr<SQLiteCommand>> _escalatedCommandMap;
 
     // Replicates any transactions that have been made on our database by other threads to peers.
-    void _sendOutstandingTransactions();
+    void _sendOutstandingTransactions(const set<uint64_t>& commitOnlyIDs = {});
 
     // The server object to which we'll pass incoming escalated commands.
     SQLiteServer& _server;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -102,7 +102,7 @@ BedrockTester::BedrockTester(int threadID, const map<string, string>& args,
         {"-quorumCheckpoint", "50"},
         {"-enableMultiWrite", "true"},
         {"-cacheSize", "1000"},
-        {"-parallelReplication", "true"},
+        //{"-parallelReplication", "true"}, // Disabled to test single rep.
     };
 
     // Set defaults.


### PR DESCRIPTION
Here's the very detailed account of how this happened. When we committed a QUORUM transaction, we'd get to here:

https://github.com/Expensify/Bedrock/blob/650f020b44d70a90b5c4757ec71b1a420377390c/sqlitecluster/SQLiteNode.cpp#L981-L985

We send a `COMMIT_TRANSACTION` message to all peers. We carefully set "ID", to `_lastSentTransactionID + 1` and thids is important: We know we have not *sent* any transactions to peers since we committed this transaction a few lines up, but we may have *committed* transactions since then, as we are no longer holding the commit mutex.

In older versions of the code, we would have still been holding the commit mutex here, and so we'd know that we had neither committed nor sent any transactions since committing above. Here's why this is important:

You see that the *only* field we add to this `COMMIT_TRANSACTION` message is "ID", however, this is how we validate that message:
https://github.com/Expensify/Bedrock/blob/650f020b44d70a90b5c4757ec71b1a420377390c/sqlitecluster/SQLiteNode.cpp#L2679-L2685

We don't look at "ID" at all. We look at "CommitCount" and "Hash". We didn't even attach those to the message, where did they even come from?

`SendToAllPeers` attaches them if they're missing:
https://github.com/Expensify/Bedrock/blob/650f020b44d70a90b5c4757ec71b1a420377390c/sqlitecluster/SQLiteNode.cpp#L1908-L1916

But, importantly, it attaches the *current highest values in the DB*, which might not match the COMMIT message we're trying to send, if another transaction is committed between the time our QUORUM finishes and the time that we send the message to peers.

If this happened, FOLLOWERs would receive the message for the wrong commit, refuse to commit it, and disconnect. At this point, leader is already forked, as it *already* has a commit ahead of the one that everyone refused to commit (it's the one who's id and hash were incorrectly sent), and it's finished.

Interestingly, this only happens in legacy replication mode. Parallel replication mode correctly uses the newer `newHash` and `newCount` values that apply specifically to this transaction.

The fix does a few things:

1. Removes `maxCommitID` from `popCommittedTransactions` as it's no longer required (we'll see why in a moment).
2. Adds an explanation of the differnce between `ID`, `CommitCount`, `NewCount` and all the other message fields we send.
3. Updates `_sendOutstandingTransactions` to take a set of transaction IDs for which it should only send `COMMIT` and not `BEGIN` messages. This lets us use thew same function to send QUORUM commits as we use everywhere else, and allows us to remove `maxCommitID` as above, because the only thing we needed it for was to make sure we only popped a single transaction (the quorum one) off the list, which is no longer necessary. 
4. Removes some logging of `message["Command"]` because as I went through the list of message fields, it turns out we never set this, it's always blank.
5. Changes the check in `handleSerialCommitTransaction` to look at `NewCount` if available or "ID" if not (and parse the number following `ASYNC_` out "ID" if required). It also updates this to check for "NewHash" instead of "Hash"
6. Disables multi-rep in the tests to test the fixed code.

## Tests
Existing tests, but in addition the code as-is, I tested it without sending "NewCount" to followers and verified that we parsed "ID" correctly in those cases, and also tested it with multi-rep turned back on.
