### PR TITLE
Add '(DISCONNECTED)' to status messages

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1846,6 +1846,7 @@ bool BedrockServer::getPeerInfo(list<STable>& peerData) {
                 peerData.back()["host"] = peer->host;
                 peerData.back()["name"] = peer->name;
                 peerData.back()["State"] = SQLiteNode::stateName(peer->state);
+                peerData.back()["Connected"] = peer->connected() ? "true" : "false";
             }
         }
     } else {
@@ -1974,7 +1975,11 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         list<string> peerList;
         list<STable> peerData;
         if (getPeerInfo(peerData)) {
-            for (const STable& peerTable : peerData) {
+            for (STable& peerTable : peerData) {
+                if (peerTable["Connected"] == "false") {
+                    peerTable["State"] += " (DISCONNECTED)";
+                }
+                peerTable.erase("Connected");
                 peerList.push_back(SComposeJSONObject(peerTable));
             }
         } else {

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -145,7 +145,7 @@ struct GracefulFailoverTest : tpunit::TestFixture {
             list<string> peers = SParseJSONArray(peerList);
             for (auto& peer : peers) {
                 STable peerInfo = SParseJSONObject(peer);
-                if (peerInfo["name"] == "cluster_node_2" && (peerInfo["State"] == "" || peerInfo["State"] == "SEARCHING")) {
+                if (peerInfo["name"] == "cluster_node_2" && (peerInfo["State"] == "" || SStartsWith(peerInfo["State"], "SEARCHING"))) {
                     success = true;
                     break;
                 }


### PR DESCRIPTION
This adds `(DISCONNECTED)` to the `State` field in status message for peers that aren't currently connected.

Tests:
Adding logging of `Status` commands in tests produces:
```
{
   "CommitCount":1,
   "crashCommands":0,
   "escalatedCommandList":[
      
   ],
   "host":"127.0.0.1:10007",
   "isLeader":false,
   "peerList":[
      {
         "CommitCount":1,
         "Hash":"504FCC4A93186D6411730C1E18F33597FC4BFFD3",
         "host":"127.0.0.1:10001",
         "LoggedIn":true,
         "name":"cluster_node_0",
         "nodeName":"cluster_node_0",
         "Permafollower":"",
         "Priority":100,
         "State":"LEADING",
         "Version":"1c7c6b1"
      },
      {
         "host":"127.0.0.1:10004",
         "LoggedIn":"",
         "name":"cluster_node_1",
         "nodeName":"cluster_node_1",
         "Permafollower":"",
         "State":"SEARCHING (DISCONNECTED)"
      }
   ],
   "plugins":[
      {
         "name":"Cache"
      },
      {
         "name":"DB"
      },
      {
         "name":"Jobs"
      },
      {
         "name":"TestPlugin"
      }
   ],
   "priority":80,
   "queuedCommandList":[
      
   ],
   "state":"FOLLOWING",
   "syncNodeAvailable":true,
   "syncThreadQueuedCommandList":[
      
   ],
   "version":"1c7c6b1"
}
```