### PR TITLE
Kill `stateMutex` and `syncMutex`, decouple node state from worker transactions, make peer objects thread-safe.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1842,14 +1842,8 @@ bool BedrockServer::getPeerInfo(list<STable>& peerData) {
         lock_guard<decltype(_syncMutex)> lock(_syncMutex, adopt_lock_t());
         auto _syncNodeCopy = _syncNode;
         if (_syncNodeCopy) {
-            for (SQLiteNode::Peer* peer : _syncNodeCopy->peerList.atomic()) {
-                peerData.emplace_back(peer->nameValueMap);
-                for (auto it : peer->params) {
-                    peerData.back()[it.first] = it.second;
-                }
-                peerData.back()["host"] = peer->host;
-                peerData.back()["name"] = peer->name;
-                peerData.back()["State"] = SQLiteNode::stateName(peer->state);
+            for (SQLiteNode::Peer* peer : _syncNodeCopy->peerList) {
+                peerData.emplace_back(peer->getData());
             }
         }
     } else {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -331,8 +331,10 @@ void BedrockServer::sync(const SData& args,
 
         // Wait for activity on any of those FDs, up to a timeout.
         const uint64_t now = STimeNow();
-        AutoTimerTime pollTime(pollTimer);
-        S_poll(fdm, max(nextActivity, now) - now);
+        {
+            AutoTimerTime pollTime(pollTimer);
+            S_poll(fdm, max(nextActivity, now) - now);
+        }
 
         // And set our next timeout for 1 second from now.
         nextActivity = STimeNow() + STIME_US_PER_S;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -830,7 +830,7 @@ void BedrockServer::worker(SQLitePool& dbPool,
 
             // If this was a command initiated by a peer as part of a cluster operation, then we process it separately
             // and respond immediately. This allows SQLiteNode to offload read-only operations to worker threads.
-            if (SQLiteNode::peekPeerCommand(server._syncNode.get(), db, *command)) {
+            if (SQLiteNode::peekPeerCommand(server._syncNode, db, *command)) {
                 // Move on to the next command.
                 continue;
             }
@@ -1842,7 +1842,7 @@ bool BedrockServer::getPeerInfo(list<STable>& peerData) {
         lock_guard<decltype(_syncMutex)> lock(_syncMutex, adopt_lock_t());
         auto _syncNodeCopy = _syncNode;
         if (_syncNodeCopy) {
-            for (SQLiteNode::Peer* peer : _syncNodeCopy->peerList) {
+            for (SQLiteNode::Peer* peer : _syncNodeCopy->peerList.atomic()) {
                 peerData.emplace_back(peer->nameValueMap);
                 for (auto it : peer->params) {
                     peerData.back()[it.first] = it.second;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -355,9 +355,6 @@ class BedrockServer : public SQLiteServer {
     // object.
     shared_ptr<SQLiteNode> _syncNode;
 
-    // Because status will access internal sync node data, we lock in both places that will access the pointer above.
-    recursive_timed_mutex _syncMutex;
-
     // Functions for checking for and responding to status and control commands.
     bool _isStatusCommand(const unique_ptr<BedrockCommand>& command);
     void _status(unique_ptr<BedrockCommand>& command);

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -216,9 +216,8 @@ class BedrockServer : public SQLiteServer {
     // Returns whether or not this server was configured to backup.
     bool shouldBackup();
 
-    // Returns a copy of the internal state of the sync node's peers. This can be empty if there are no peers, or no
-    // sync node.
-    bool getPeerInfo(list<STable>& peerData);
+    // Returns a representation of the internal state of the sync node's peers. This can be empty if there are no
+    // peers, or no sync node.
     list<STable> getPeerInfo();
 
     // Send a command to all of our peers. It will be wrapped appropriately.

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -435,6 +435,3 @@ ostream& operator<<(ostream& os, const atomic<STCPNode::Peer::Response>& respons
     os << STCPNode::Peer::responseName(response.load());
     return os;
 }
-
-
-

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -314,7 +314,7 @@ void STCPNode::_sendPING(Peer* peer) {
     peer->s->send(ping.serialize());
 }
 
-Peer::Peer(const string& name_, const string& host_, const STable& params_, uint64_t id_)
+STCPNode::Peer::Peer(const string& name_, const string& host_, const STable& params_, uint64_t id_)
   : name(name_), host(host_), id(id_), params(params_), permaFollower(isPermafollower(params)),
     commitCount(0),
     failedConnections(0),
@@ -368,20 +368,20 @@ void STCPNode::Peer::closeSocket(STCPManager* manager) {
     }
 }
 
-        string STCPNode::Peer::responseName(Response response) {
-            switch (response) {
-                case STCPNode::Peer::Response::NONE:
-                return "NONE";
-                break;
-                case STCPNode::Peer::Response::APPROVE:
-                return "APPROVE";
-                break;
-                case STCPNode::Peer::Response::DENY:
-                return "DENY";
-                break;
-            }
-            return "";
-        }
+string STCPNode::Peer::responseName(Response response) {
+    switch (response) {
+        case STCPNode::Peer::Response::NONE:
+        return "NONE";
+        break;
+        case STCPNode::Peer::Response::APPROVE:
+        return "APPROVE";
+        break;
+        case STCPNode::Peer::Response::DENY:
+        return "DENY";
+        break;
+    }
+    return "";
+}
 
 void STCPNode::Peer::setCommit(uint64_t count, const string& hashString) {
     lock_guard<decltype(_stateMutex)> l(_stateMutex);
@@ -422,16 +422,13 @@ STable STCPNode::Peer::getData() const {
     return result;
 }
 
-        // For initializing the permafollower value from the params list.
-        static bool STCPNode::Peer::isPermafollower(const STable params) {
-            auto it = params.find("Permafollower");
-            if (it != params.end() && it->second == "true") {
-                return true;
-            }
-            return false;
-        }
-
-    };
+bool STCPNode::Peer::isPermafollower(const STable params) {
+    auto it = params.find("Permafollower");
+    if (it != params.end() && it->second == "true") {
+        return true;
+    }
+    return false;
+}
 
 ostream& operator<<(ostream& os, const atomic<STCPNode::Peer::Response>& response)
 {

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -422,7 +422,7 @@ STable STCPNode::Peer::getData() const {
     return result;
 }
 
-bool STCPNode::Peer::isPermafollower(const STable params) {
+bool STCPNode::Peer::isPermafollower(const STable& params) {
     auto it = params.find("Permafollower");
     if (it != params.end() && it->second == "true") {
         return true;

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -331,12 +331,12 @@ STCPNode::Peer::Peer(const string& name_, const string& host_, const STable& par
 { }
 
 bool STCPNode::Peer::connected() const {
-    lock_guard<decltype(_stateMutex)> l(_stateMutex);
+    lock_guard<decltype(_stateMutex)> lock(_stateMutex);
     return (s && s->state.load() == STCPManager::Socket::CONNECTED);
 }
 
 void STCPNode::Peer::reset() {
-    lock_guard<decltype(_stateMutex)> l(_stateMutex);
+    lock_guard<decltype(_stateMutex)> lock(_stateMutex);
     latency = 0;
     loggedIn = false;
     priority = 0;
@@ -371,26 +371,27 @@ void STCPNode::Peer::closeSocket(STCPManager* manager) {
 string STCPNode::Peer::responseName(Response response) {
     switch (response) {
         case STCPNode::Peer::Response::NONE:
-        return "NONE";
-        break;
+            return "NONE";
+            break;
         case STCPNode::Peer::Response::APPROVE:
-        return "APPROVE";
-        break;
+            return "APPROVE";
+            break;
         case STCPNode::Peer::Response::DENY:
-        return "DENY";
-        break;
+            return "DENY";
+            break;
+        default:
+            return "";
     }
-    return "";
 }
 
 void STCPNode::Peer::setCommit(uint64_t count, const string& hashString) {
-    lock_guard<decltype(_stateMutex)> l(_stateMutex);
+    lock_guard<decltype(_stateMutex)> lock(_stateMutex);
     const_cast<atomic<uint64_t>&>(commitCount) = count;
     hash = hashString;
 }
 
 void STCPNode::Peer::getCommit(uint64_t& count, string& hashString) {
-    lock_guard<decltype(_stateMutex)> l(_stateMutex);
+    lock_guard<decltype(_stateMutex)> lock(_stateMutex);
     count = commitCount.load();
     hashString = hash.load();
 }

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -121,7 +121,7 @@ struct STCPNode : public STCPServer {
         friend class SQLiteNode;
         Socket* s;
 
-        // These are not meant to be accessible from STCPNode (but have to be)
+        // This is not meant to be accessible from STCPNode (but has to be with the way `friend` works).
         mutable recursive_mutex _stateMutex;
     };
 

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -135,7 +135,7 @@ struct STCPNode : public STCPServer {
         // but for the time being, the amount of refactoring required to fix that is too high.
         friend class STCPNode;
         friend class SQLiteNode;
-        Socket* s = nullptr;
+        Socket* socket = nullptr;
 
         // Mutex for locking around non-atomic member access (for set/getCommit, accessing socket, etc).
         mutable recursive_mutex _stateMutex;

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -141,7 +141,7 @@ struct STCPNode : public STCPServer {
         mutable recursive_mutex _stateMutex;
 
         // For initializing the permafollower value from the params list.
-        static bool isPermafollower(const STable params);
+        static bool isPermafollower(const STable& params);
     };
 
     // Begins listening for connections on a given port

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2555,13 +2555,3 @@ bool SIsValidSQLiteDateModifier(const string& modifier) {
     // Matched all parts, valid syntax
     return true;
 }
-
-// Extra operator overloads for atomic strings.
-string operator+(const string& lhs, const atomic<string>& rhs) {
-    return lhs + rhs.load();
-}
-ostream& operator<<(ostream& os, const atomic<string>& as)
-{
-    os << as.load();
-    return os;
-}

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2555,3 +2555,13 @@ bool SIsValidSQLiteDateModifier(const string& modifier) {
     // Matched all parts, valid syntax
     return true;
 }
+
+// Extra operator overloads for atomic strings.
+string operator+(const string& lhs, const atomic<string>& rhs) {
+    return lhs + rhs.load();
+}
+ostream& operator<<(ostream& os, const atomic<string>& as)
+{
+    os << as.load();
+    return os;
+}

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -101,6 +101,10 @@ class STableComp : binary_function<string, string, bool> {
 // types.
 class SString : public string {
   public:
+    SString() {
+    }
+    SString(const string& s) : string(s) {
+    }
     // Templated assignment operator for arithmetic types.
     template <typename T>
     typename enable_if<is_arithmetic<T>::value, SString&>::type operator=(const T& from) {

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -328,8 +328,32 @@ struct SAutoThreadPrefix {
 namespace std {
     template<>
     struct atomic<string> {
+        atomic<string>() {
+        }
+        atomic<string>(const string& s) : _string(s) {
+        }
+        string operator+(const char* rhs) {
+            lock_guard<decltype(m)> l(m);
+            return _string + rhs;
+        }
+        string operator+(const string& rhs) {
+            lock_guard<decltype(m)> l(m);
+            return _string + rhs;
+        }
+        bool operator==(const char* rhs) {
+            lock_guard<decltype(m)> l(m);
+            return _string == rhs;
+        }
+        bool operator==(const string& rhs) {
+            lock_guard<decltype(m)> l(m);
+            return _string == rhs;
+        }
+        char operator[](size_t i) {
+            lock_guard<decltype(m)> l(m);
+            return _string[i];
+        }
         string operator=(string desired) {
-            SAUTOLOCK(m);
+            lock_guard<decltype(m)> l(m);
             _string = desired;
             return _string;
         }
@@ -337,16 +361,19 @@ namespace std {
             return false;
         }
         void store(string desired, std::memory_order order = std::memory_order_seq_cst) {
-            SAUTOLOCK(m);
+            lock_guard<decltype(m)> l(m);
             _string = desired;
         };
         string load(std::memory_order order = std::memory_order_seq_cst) const {
-            SAUTOLOCK(m);
+            lock_guard<decltype(m)> l(m);
             return _string;
         }
-        operator string() const;
+        operator string() const {
+            lock_guard<decltype(m)> l(m);
+            return _string;
+        }
         string exchange(string desired, std::memory_order order = std::memory_order_seq_cst) {
-            SAUTOLOCK(m);
+            lock_guard<decltype(m)> l(m);
             string existing = _string;
             _string = desired;
             return existing;
@@ -357,6 +384,8 @@ namespace std {
         mutable recursive_mutex m;
     };
 };
+string operator+(const string& lhs, const atomic<string>& rhs);
+ostream& operator<<(ostream& os, const atomic<string>& as);
 
 // --------------------------------------------------------------------------
 // Math stuff

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1972,9 +1972,6 @@ void SQLiteNode::broadcast(const SData& message, Peer* peer) {
 }
 
 void SQLiteNode::_changeState(SQLiteNode::State newState) {
-    // Exclusively lock the stateMutex, nobody else will be able to get a shared lock until this is released.
-    unique_lock<decltype(stateMutex)> lock(stateMutex);
-
     // Did we actually change _state?
     State oldState = _state;
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1920,7 +1920,7 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
             if (!otherPeer->isPermafollower()) {
                 // Verify we're logged in
                 ++numFullPeers;
-                if (peer->loggedIn) {
+                if (otherPeer->loggedIn) {
                     // Verify we're still fresh
                     ++numLoggedInFullPeers;
                 }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -63,8 +63,7 @@ const string SQLiteNode::consistencyLevelNames[] = {"ASYNC",
 atomic<int64_t> SQLiteNode::_currentCommandThreadID(0);
 
 const vector<STCPNode::Peer*> SQLiteNode::initPeers(const string& peerListString) {
-     vector<Peer*> peerList;
-    // Add any peers.
+    vector<Peer*> peerList;
     list<string> parsedPeerList = SParseList(peerListString);
     for (const string& peerString : parsedPeerList) {
         // Get the params from this peer, if any
@@ -2110,7 +2109,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
 void SQLiteNode::_queueSynchronize(Peer* peer, SData& response, bool sendAll) {
     // Peer is requesting synchronization. First, does it have any data?
 
-    uint64_t peerCommitCount;
+    uint64_t peerCommitCount = 0;
     string peerHash;
     peer->getCommit(peerCommitCount, peerHash);
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -43,7 +43,6 @@
 //                   the leader to confirm that these responses were in fact sent in response to the correct message,
 //                   and not some old out-of-date message from the past.
 // Response:         Sent in STANDUP_RESPONSE, either "approve" or "deny".
-// Reason:           The reason for a failure case (typically, a "deny" Response). Explanatory string.
 // NumCommits:       With a "SYNCHRONIZE_RESPONSE" message, indicates the number of commits returned.
 // leaderSendTime:   Timestamp in microseconds that leader sent a message, for performance analysis.
 // dbCountAtStart:   The highest committed transaction in the DB at the start of this transaction on leader, for
@@ -63,10 +62,36 @@ const string SQLiteNode::consistencyLevelNames[] = {"ASYNC",
 
 atomic<int64_t> SQLiteNode::_currentCommandThreadID(0);
 
+const vector<STCPNode::Peer*> SQLiteNode::initPeers(const string& peerListString) {
+     vector<Peer*> peerList;
+    // Add any peers.
+    list<string> parsedPeerList = SParseList(peerListString);
+    for (const string& peerString : parsedPeerList) {
+        // Get the params from this peer, if any
+        string host;
+        STable params;
+        SASSERT(SParseURIPath(peerString, host, params));
+        string name = SGetDomain(host);
+        if (params.find("nodeName") != params.end()) {
+            name = params["nodeName"];
+        }
+
+        // Create a new peer and ready it for connection
+        SASSERT(SHostIsValid(host));
+        SINFO("Adding peer #" << peerList.size() << ": " << name << " (" << host << "), " << SComposeJSONObject(params));
+        Peer* peer = new Peer(name, host, params, peerList.size() + 1);
+
+        // Wait up to 2s before trying the first time
+        peer->nextReconnect = STimeNow() + SRandom::rand64() % (STIME_US_PER_S * 2);
+        peerList.push_back(peer);
+    }
+    return peerList;
+}
+
 SQLiteNode::SQLiteNode(SQLiteServer& server, SQLitePool& dbPool, const string& name,
                        const string& host, const string& peerList, int priority, uint64_t firstTimeout,
                        const string& version, const bool useParallelReplication)
-    : STCPNode(name, host, max(SQL_NODE_DEFAULT_RECV_TIMEOUT, SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT)),
+    : STCPNode(name, host, initPeers(peerList), max(SQL_NODE_DEFAULT_RECV_TIMEOUT, SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT)),
       _dbPool(dbPool),
       _db(_dbPool.getBase()),
       _commitState(CommitState::UNINITIALIZED),
@@ -102,19 +127,7 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, SQLitePool& dbPool, const string& n
     _dbPool.getBase().addCheckpointListener(_localCommitNotifier);
     _dbPool.getBase().addCheckpointListener(_leaderCommitNotifier);
 
-    // Add any peers.
-    list<string> parsedPeerList = SParseList(peerList);
-    for (const string& peer : parsedPeerList) {
-        // Get the params from this peer, if any
-        string host;
-        STable params;
-        SASSERT(SParseURIPath(peer, host, params));
-        string name = SGetDomain(host);
-        if (params.find("nodeName") != params.end()) {
-            name = params["nodeName"];
-        }
-        addPeer(name, host, params);
-    }
+
 }
 
 SQLiteNode::~SQLiteNode() {
@@ -355,7 +368,7 @@ bool SQLiteNode::shutdownComplete() {
     }
 
     // If we have unsent data, not done
-    for (auto peer : peerList.atomic()) {
+    for (auto peer : peerList) {
         if (peer->s && !peer->s->sendBufferEmpty()) {
             // Still sending data
             SINFO("Can't graceful shutdown yet because unsent data to peer '" << peer->name << "'");
@@ -405,9 +418,9 @@ void SQLiteNode::_sendOutstandingTransactions(const set<uint64_t>& commitOnlyIDs
             transaction["dbCountAtStart"] = to_string(dbCountAtStart);
             transaction["ID"] = idHeader;
             transaction.content = query;
-            for (auto peer : peerList.atomic()) {
+            for (auto peer : peerList) {
                 // Clear the response flag from the last transaction
-                (*peer)["TransactionResponse"].clear();
+                peer->transactionResponse = Peer::Response::NONE;
             }
             _sendToAllPeers(transaction, true); // subscribed only
         } else {
@@ -512,7 +525,7 @@ bool SQLiteNode::update() {
         string logMsg = "[performance] Network stats: " +
                         to_string(chrono::duration_cast<chrono::milliseconds>(elapsed).count()) +
                         " ms elapsed. ";
-        for (auto& p : peerList.atomic()) {
+        for (auto& p : peerList) {
             if (p->s) {
                 logMsg += p->name + " sent " + to_string(p->s->getSentBytes()) + " bytes, recv " + to_string(p->s->getRecvBytes()) + " bytes. ";
                 p->s->resetCounters();
@@ -557,10 +570,10 @@ bool SQLiteNode::update() {
         int numFullPeers = 0;
         int numLoggedInFullPeers = 0;
         Peer* freshestPeer = nullptr;
-        for (auto peer : peerList.atomic()) {
+        for (auto peer : peerList) {
             // Wait until all connected (or failed) and logged in
             bool permaFollower = peer->isPermafollower();
-            bool loggedIn = peer->test("LoggedIn");
+            bool loggedIn = peer->loggedIn;
 
             // Count how many full peers (non-permafollowers) we have
             numFullPeers += !permaFollower;
@@ -571,7 +584,7 @@ bool SQLiteNode::update() {
             // Find the freshest peer
             if (loggedIn) {
                 // The freshest peer is the one that has the most commits.
-                if (!freshestPeer || peer->calcU64("CommitCount") > freshestPeer->calcU64("CommitCount")) {
+                if (!freshestPeer || peer->commitCount > freshestPeer->commitCount) {
                     freshestPeer = peer;
                 }
             }
@@ -598,7 +611,7 @@ bool SQLiteNode::update() {
 
         // How does our state compare with the freshest peer?
         SASSERT(freshestPeer);
-        uint64_t freshestPeerCommitCount = freshestPeer->calcU64("CommitCount");
+        uint64_t freshestPeerCommitCount = freshestPeer->commitCount;
         if (freshestPeerCommitCount == _db.getCommitCount()) {
             // We're up to date
             SINFO("Synchronized with the freshest peer '" << freshestPeer->name << "', WAITING.");
@@ -702,19 +715,19 @@ bool SQLiteNode::update() {
         Peer* highestPriorityPeer = nullptr;
         Peer* freshestPeer = nullptr;
         Peer* currentLeader = nullptr;
-        for (auto peer : peerList.atomic()) {
+        for (auto peer : peerList) {
             // Make sure we're a full peer
             if (!peer->isPermafollower()) {
                 // Verify we're logged in
                 ++numFullPeers;
-                if (SIEquals((*peer)["LoggedIn"], "true")) {
+                if (peer->loggedIn) {
                     // Verify we're still fresh
                     ++numLoggedInFullPeers;
-                    if (!freshestPeer || peer->calcU64("CommitCount") > freshestPeer->calcU64("CommitCount"))
+                    if (!freshestPeer || peer->commitCount > freshestPeer->commitCount)
                         freshestPeer = peer;
 
                     // See if it's the highest priority
-                    if (!highestPriorityPeer || peer->calc("Priority") > highestPriorityPeer->calc("Priority"))
+                    if (!highestPriorityPeer || peer->priority > highestPriorityPeer->priority)
                         highestPriorityPeer = peer;
 
                     // See if it is currently the leader (or standing up/down)
@@ -744,12 +757,12 @@ bool SQLiteNode::update() {
         // If there is already a leader that is higher priority than us,
         // subscribe -- even if we're not in sync with it.  (It'll bring
         // us back up to speed while subscribing.)
-        if (currentLeader && _priority < highestPriorityPeer->calc("Priority") && currentLeader->state == LEADING) {
+        if (currentLeader && _priority < highestPriorityPeer->priority && currentLeader->state == LEADING) {
             // Subscribe to the leader
             SINFO("Subscribing to leader '" << currentLeader->name << "'");
             lock_guard<mutex> leadPeerLock(_leadPeerMutex);
             _leadPeer = currentLeader;
-            _leaderVersion = (*_leadPeer)["Version"];
+            _leaderVersion = _leadPeer.load()->version;
             _sendToPeer(currentLeader, SData("SUBSCRIBE"));
             _changeState(SUBSCRIBING);
             return true; // Re-update
@@ -758,7 +771,7 @@ bool SQLiteNode::update() {
         // No leader to subscribe to, let's see if there's anybody else
         // out there with commits we don't have.  Might as well synchronize
         // while waiting.
-        if (freshestPeer->calcU64("CommitCount") > _db.getCommitCount()) {
+        if (freshestPeer->commitCount > _db.getCommitCount()) {
             // Out of sync with a peer -- resynchronize
             SHMMM("Lost synchronization while waiting; re-SEARCHING.");
             _changeState(SEARCHING);
@@ -770,12 +783,12 @@ bool SQLiteNode::update() {
         // a real priority and are not a permafollower, and are connected to 
         // enough full peers to achieve quorum, we should be leader.
         if (!currentLeader && numLoggedInFullPeers * 2 >= numFullPeers &&
-            _priority > 0 && _priority > highestPriorityPeer->calc("Priority")) {
+            _priority > 0 && _priority > highestPriorityPeer->priority) {
             // Yep -- time for us to stand up -- clear everyone's
             // last approval status as they're about to send them.
             SINFO("No leader and we're highest priority (over " << highestPriorityPeer->name << "), STANDINGUP");
-            for (auto peer : peerList.atomic()) {
-                peer->erase("StandupResponse");
+            for (auto peer : peerList) {
+                peer->standupResponse = Peer::Response::NONE;
             }
             _changeState(STANDINGUP);
             return true; // Re-update
@@ -810,21 +823,21 @@ bool SQLiteNode::update() {
             _changeState(SEARCHING);
             return true; // Re-update
         }
-        for (auto peer : peerList.atomic()) {
+        for (auto peer : peerList) {
             // Check this peer; if not logged in, tacit approval
             if (!peer->isPermafollower()) {
                 ++numFullPeers;
-                if (SIEquals((*peer)["LoggedIn"], "true")) {
+                if (peer->loggedIn) {
                     // Connected and logged in.
                     numLoggedInFullPeers++;
 
                     // Has it responded yet?
-                    if (!peer->isSet("StandupResponse")) {
+                    if (peer->standupResponse == Peer::Response::NONE) {
                         // At least one logged in full peer hasn't responded
                         allResponded = false;
-                    } else if (!SIEquals((*peer)["StandupResponse"], "approve")) {
+                    } else if (peer->standupResponse != Peer::Response::APPROVE) {
                         // It responeded, but didn't approve -- abort
-                        PHMMM("Refused our STANDUP (" << (*peer)["Reason"] << "), cancel and RESEARCH");
+                        PHMMM("Refused our STANDUP, cancel and RESEARCH");
                         _changeState(SEARCHING);
                         return true; // Re-update
                     }
@@ -871,7 +884,7 @@ bool SQLiteNode::update() {
     ///             if( there is a higher priority peer ) goto STANDINGDOWN
     ///             if( a command is queued )
     ///                 if( processing the command affects the database )
-    ///                    clear the TransactionResponse of all peers
+    ///                    clear the transactionResponse of all peers
     ///                    broadcast BEGIN_TRANSACTION to subscribed followers
     ///         if( we're standing down and all followers have unsubscribed )
     ///             goto SEARCHING
@@ -901,25 +914,24 @@ bool SQLiteNode::update() {
             int numFullResponded = 0; // Num full peers that have responded approve/deny
             int numFullApproved = 0;  // Num full peers that have approved
             int numFullDenied = 0;    // Num full peers that have denied
-            for (auto peer : peerList.atomic()) {
+            for (auto peer : peerList) {
                 // Check this peer to see if it's full or a permafollower
                 if (!peer->isPermafollower()) {
                     // It's a full peer -- is it subscribed, and if so, how did it respond?
                     ++numFullPeers;
-                    if ((*peer)["Subscribed"] == "true") {
+                    if (peer->subscribed) {
                         // Subscribed, did it respond?
                         numFullFollowers++;
-                        const string& response = (*peer)["TransactionResponse"];
-                        if (response.empty()) {
+                        if (peer->transactionResponse == Peer::Response::NONE) {
                             continue;
                         }
                         numFullResponded++;
-                        numFullApproved += SIEquals(response, "approve");
-                        if (!SIEquals(response, "approve")) {
+                        if (peer->transactionResponse == Peer::Response::APPROVE) {
+                            SDEBUG("Peer '" << peer->name << "' has approved transaction.");
+                            ++numFullApproved;
+                        } else {
                             SWARN("Peer '" << peer->name << "' denied transaction.");
                             ++numFullDenied;
-                        } else {
-                            SDEBUG("Peer '" << peer->name << "' has approved transaction.");
                         }
                     }
                 }
@@ -1071,9 +1083,9 @@ bool SQLiteNode::update() {
             }
             transaction.content = _db.getUncommittedQuery();
 
-            for (auto peer : peerList.atomic()) {
+            for (auto peer : peerList) {
                 // Clear the response flag from the last transaction
-                (*peer)["TransactionResponse"].clear();
+                peer->transactionResponse = Peer::Response::NONE;
             }
 
             // And send it to everyone who's subscribed.
@@ -1096,7 +1108,7 @@ bool SQLiteNode::update() {
                 _priority = 1;
             } else {
                 // Loop across peers
-                for (auto peer : peerList.atomic()) {
+                for (auto peer : peerList) {
                     // Check this peer
                     if (peer->state == LEADING) {
                         // Hm... somehow we're in a multi-leader scenario -- not good.
@@ -1104,16 +1116,16 @@ bool SQLiteNode::update() {
                         standDownReason = "Found another LEADER (" + peer->name + "), STANDINGDOWN to clean it up.";
                     } else if (peer->state == WAITING) {
                         // We have a WAITING peer; is it waiting to STANDUP?
-                        if (peer->calc("Priority") > _priority) {
+                        if (peer->priority > _priority) {
                             // We've got a higher priority peer in the works; stand down so it can stand up.
                             standDownReason = "Found higher priority WAITING peer (" + peer->name
                                               + ") while LEADING, STANDINGDOWN";
-                        } else if (peer->calcU64("CommitCount") > _db.getCommitCount()) {
+                        } else if (peer->commitCount > _db.getCommitCount()) {
                             // It's got data that we don't, stand down so we can get it.
                             standDownReason = "Found WAITING peer (" + peer->name +
                                               ") with more data than us (we have " + SToStr(_db.getCommitCount()) +
-                                              "/" + _db.getCommittedHash() + ", it has " + (*peer)["CommitCount"] +
-                                              "/" + (*peer)["Hash"] + ") while LEADING, STANDINGDOWN";
+                                              "/" + _db.getCommittedHash() + ", it has " + to_string(peer->commitCount) +
+                                              "/" + peer->hash.load() + ") while LEADING, STANDINGDOWN";
                         }
                     }
                 }
@@ -1238,15 +1250,15 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
     if (!message.isSet("Hash")) {
         STHROW("missing Hash");
     }
-    (*peer)["CommitCount"] = message["CommitCount"];
-    (*peer)["Hash"] = message["Hash"];
+    peer->commitCount = message.calcU64("CommitCount");
+    peer->hash = message["Hash"];
 
     // Classify and process the message
     if (SIEquals(message.methodLine, "LOGIN")) {
         // LOGIN: This is the first message sent to and received from a new peer. It communicates the current state of
         // the peer (hash and commit count), as well as the peer's priority. Peers can connect in any state, so this
         // message can be sent and received in any state.
-        if ((*peer)["LoggedIn"] == "true") {
+        if (peer->loggedIn) {
             STHROW("already logged in");
         }
         if (!message.isSet("Priority")) {
@@ -1269,14 +1281,18 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         SASSERT(_priority == -1 || _priority == 0 || message.calc("Priority") != _priority);
         PINFO("Peer logged in at '" << message["State"] << "', priority #" << message["Priority"] << " commit #"
               << message["CommitCount"] << " (" << message["Hash"] << ")");
-        peer->set("Priority", message["Priority"]);
-        peer->set("LoggedIn", "true");
-        peer->set("Version",  message["Version"]);
+        //peer->set("Priority", message["Priority"]);
+        //peer->set("LoggedIn", "true");
+        //peer->set("Version",  message["Version"]);
+
+        peer->priority = message.calc("Priority");
+        peer->loggedIn = true;
+        peer->version = message["Version"];
         peer->state = stateFromName(message["State"]);
 
         // Let the server know that a peer has logged in.
         _server.onNodeLogin(peer);
-    } else if (!SIEquals((*peer)["LoggedIn"], "true")) {
+    } else if (!peer->loggedIn) {
         STHROW("not logged in");
     }
     else if (SIEquals(message.methodLine, "STATE")) {
@@ -1289,7 +1305,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             STHROW("missing Priority");
         }
         const State from = peer->state;
-        peer->set("Priority", message["Priority"]);
+        peer->priority = message.calc("Priority");
         peer->state = stateFromName(message["State"]);
         const State to = peer->state;
         if (from == to) {
@@ -1346,8 +1362,8 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 // SEARCHING: If anything ever goes wrong, a node reverts to the SEARCHING state. Thus if we see a peer
                 // go SEARCHING, we reset its accumulated state.  Specifically, we mark it is no longer being
                 // "subscribed", and we clear its last transaction response.
-                peer->erase("TransactionResponse");
-                peer->erase("Subscribed");
+                peer->transactionResponse = Peer::Response::NONE;
+                peer->subscribed = false;
             } else if (to == STANDINGUP) {
                 // STANDINGUP: When a peer announces it intends to stand up, we immediately respond with approval or
                 // denial. We determine this by checking to see if there is any  other peer who is already leader or
@@ -1357,17 +1373,20 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 SData response("STANDUP_RESPONSE");
                 // Parrot back the node's attempt count so that it can differentiate stale responses.
                 response["StateChangeCount"] = message["StateChangeCount"];
+
+                // Reason we would deny, if we do.
+                string reason;
                 if (peer->isPermafollower()) {
                     // We think it's a permafollower, deny
                     PHMMM("Permafollower trying to stand up, denying.");
                     response["Response"] = "deny";
-                    response["Reason"] = "You're a permafollower";
+                    reason = "You're a permafollower";
                 }
 
                 // What's our state
                 if (SWITHIN(STANDINGUP, _state, STANDINGDOWN)) {
                     // Oh crap, it's trying to stand up while we're leading. Who is higher priority?
-                    if (peer->calc("Priority") > _priority) {
+                    if (peer->priority > _priority) {
                         // The other peer is a higher priority than us, so we should stand down (maybe it crashed, we
                         // came up as leader, and now it's been brought back up). We'll want to stand down here, but we
                         // do it gracefully so that we won't lose any transactions in progress.
@@ -1383,7 +1402,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                     } else {
                         // Deny because we're currently in the process of leading and we're higher priority.
                         response["Response"] = "deny";
-                        response["Reason"] = "I am leading";
+                        reason = "I am leading";
 
                         // Hmm, why is a lower priority peer trying to stand up? Is it possible we're no longer in
                         // control of the cluster? Let's see how many nodes are subscribed.
@@ -1409,13 +1428,13 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 } else {
                     // Approve if nobody else is trying to stand up
                     response["Response"] = "approve"; // Optimistic; will override
-                    for (auto otherPeer : peerList.atomic()) {
+                    for (auto otherPeer : peerList) {
                         if (otherPeer != peer) {
                             // See if it's trying to be leader
                             if (otherPeer->state == STANDINGUP || otherPeer->state == LEADING || otherPeer->state == STANDINGDOWN) {
                                 // We need to contest this standup
                                 response["Response"] = "deny";
-                                response["Reason"] = "peer '" + otherPeer->name + "' is '" + stateName(otherPeer->state) + "'";
+                                reason = "peer '" + otherPeer->name + "' is '" + stateName(otherPeer->state) + "'";
                                 break;
                             }
                         }
@@ -1426,7 +1445,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 if (SIEquals(response["Response"], "approve")) {
                     PINFO("Approving standup request");
                 } else {
-                    PHMMM("Denying standup request because " << response["Reason"]);
+                    PHMMM("Denying standup request because " << reason);
                 }
                 _sendToPeer(peer, response);
             } else if (from == STANDINGDOWN) {
@@ -1460,16 +1479,17 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             if (!message.isSet("Response")) {
                 STHROW("missing Response");
             }
-            if (peer->isSet("StandupResponse")) {
-                PWARN("Already received standup response '" << (*peer)["StandupResponse"] << "', now receiving '"
+            if (peer->standupResponse != Peer::Response::NONE) {
+                PWARN("Already received standup response '" << peer->standupResponse << "', now receiving '"
                       << message["Response"] << "', odd -- multiple leaders competing?");
             }
             if (SIEquals(message["Response"], "approve")) {
                 PINFO("Received standup approval");
+                peer->standupResponse = Peer::Response::APPROVE;
             } else {
                 PHMMM("Received standup denial: reason='" << message["Reason"] << "'");
+                peer->standupResponse = Peer::Response::DENY;
             }
-            (*peer)["StandupResponse"] = message["Response"];
         } else {
             SINFO("Got STANDUP_RESPONSE but not STANDINGUP. Probably a late message, ignoring.");
         }
@@ -1482,8 +1502,8 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             // processed asynchronously, but that is fine, the final `SUBSCRIBE` message and its response will be
             // processed synchronously.
             SData request = message;
-            request["peerCommitCount"] = (*peer)["CommitCount"];
-            request["peerHash"] = (*peer)["Hash"];
+            request["peerCommitCount"] = to_string(peer->commitCount);
+            request["peerHash"] = peer->hash;
             request["peerID"] = to_string(getIDByPeer(peer));
 
             // The following properties are only used to expand out our log macros.
@@ -1517,7 +1537,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         try {
             // Received this synchronization response; are we done?
             _recvSynchronize(peer, message);
-            uint64_t peerCommitCount = _syncPeer->calcU64("CommitCount");
+            uint64_t peerCommitCount = _syncPeer->commitCount;
             if (_db.getCommitCount() == peerCommitCount) {
                 // All done
                 SINFO("Synchronization complete, at commitCount #" << _db.getCommitCount() << " ("
@@ -1568,8 +1588,8 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         SData response("SUBSCRIPTION_APPROVED");
         _queueSynchronize(peer, response, true); // Send everything it's missing
         _sendToPeer(peer, response);
-        SASSERTWARN(!SIEquals((*peer)["Subscribed"], "true"));
-        (*peer)["Subscribed"] = "true";
+        SASSERTWARN(!peer->subscribed);
+        peer->subscribed = true;
 
         // New follower; are we in the midst of a transaction?
         if (_commitState == CommitState::COMMITTING) {
@@ -1649,7 +1669,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         if (_state != LEADING && _state != STANDINGDOWN) {
             STHROW("not leading");
         }
-        string response = SIEquals(message.methodLine, "APPROVE_TRANSACTION") ? "approve" : "deny";
+        Peer::Response response = SIEquals(message.methodLine, "APPROVE_TRANSACTION") ? Peer::Response::APPROVE : Peer::Response::DENY;
         try {
             // We ignore late approvals of commits that have already been finalized. They could have been committed
             // already, in which case `_lastSentTransactionID` will have incremented, or they could have been rolled
@@ -1665,7 +1685,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                     STHROW("permafollowers shouldn't approve/deny");
                 }
                 PINFO("Peer " << response << " transaction #" << message["NewCount"] << " (" << message["NewHash"] << ")");
-                (*peer)["TransactionResponse"] = response;
+                peer->transactionResponse = response;
             } else {
                 // Old command.  Nothing to do.  We already sent a commit or rollback.
                 PINFO("Peer '" << message.methodLine << "' transaction #" << message["NewCount"]
@@ -1705,7 +1725,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             if (!request.deserialize(message.content)) {
                 STHROW("malformed request");
             }
-            if ((*peer)["Subscribed"] != "true") {
+            if (!peer->subscribed) {
                 STHROW("not subscribed");
             }
             if (!message.isSet("ID")) {
@@ -1736,7 +1756,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             if (!request.deserialize(message.content)) {
                 STHROW("malformed request");
             }
-            if ((*peer)["Subscribed"] != "true") {
+            if (!peer->subscribed) {
                 STHROW("not subscribed");
             }
             if (!message.isSet("ID")) {
@@ -1814,7 +1834,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
 
 void SQLiteNode::_onConnect(Peer* peer) {
     SASSERT(peer);
-    SASSERTWARN(!SIEquals((*peer)["LoggedIn"], "true"));
+    SASSERTWARN(!peer->loggedIn);
     // Send the LOGIN
     PINFO("Sending LOGIN");
     SData login("LOGIN");
@@ -1894,7 +1914,7 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
     if (_state == LEADING || _state == STANDINGUP || _state == STANDINGDOWN) {
         int numFullPeers = 0;
         int numLoggedInFullPeers = 0;
-        for (auto otherPeer : peerList.atomic()) {
+        for (auto otherPeer : peerList) {
             // Skip the current peer, it no longer counts.
             if (otherPeer == peer) {
                 continue;
@@ -1903,7 +1923,7 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
             if (!otherPeer->isPermafollower()) {
                 // Verify we're logged in
                 ++numFullPeers;
-                if (SIEquals((*otherPeer)["LoggedIn"], "true")) {
+                if (peer->loggedIn) {
                     // Verify we're still fresh
                     ++numLoggedInFullPeers;
                 }
@@ -1952,9 +1972,9 @@ void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly) {
     const string& serializedMessage = messageCopy.serialize();
 
     // Loop across all connected peers and send the message
-    for (auto peer : peerList.atomic()) {
+    for (auto peer : peerList) {
         // Send either to everybody, or just subscribed peers.
-        if (peer->s && (!subscribedOnly || SIEquals((*peer)["Subscribed"], "true"))) {
+        if (peer->s && (!subscribedOnly || peer->subscribed)) {
             // Send it now, without waiting for the outer event loop
             peer->s->send(serializedMessage);
         }
@@ -2091,35 +2111,23 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
 }
 
 void SQLiteNode::_queueSynchronize(Peer* peer, SData& response, bool sendAll) {
-    _queueSynchronizeStateless(peer->nameValueMap, name, peer->name, _state, _db, response, sendAll);
-}
+    // Peer is requesting synchronization. First, does it have any data?
 
-void SQLiteNode::_queueSynchronizeStateless(const STable& params, const string& name, const string& peerName, State _state, SQLite& db, SData& response, bool sendAll) {
-    // This is a hack to make the PXXXX macros works, since they expect `peer->name` to be defined.
-    struct {string name;} peerBase;
-    auto peer = &peerBase;
-    peerBase.name = peerName;
+    //TODO: These need to be retrieved (and thus updated) atomically.
+    uint64_t peerCommitCount = peer->commitCount;
+    string peerHash = peer->hash;
 
-    // Peer is requesting synchronization.  First, does it have any data?
-    uint64_t peerCommitCount = 0;
-    if(params.find("CommitCount") != params.end()) {
-        peerCommitCount = SToUInt64(params.at("CommitCount"));
-    }
-    if (peerCommitCount > db.getCommitCount())
+    if (peerCommitCount > _db.getCommitCount())
         STHROW("you have more data than me");
     if (peerCommitCount) {
         // It has some data -- do we agree on what we share?
         string myHash, ignore;
-        if (!db.getCommit(peerCommitCount, ignore, myHash)) {
-            PWARN("Error getting commit for peer's commit: " << peerCommitCount << ", my commit count is: " << db.getCommitCount());
+        if (!_db.getCommit(peerCommitCount, ignore, myHash)) {
+            PWARN("Error getting commit for peer's commit: " << peerCommitCount << ", my commit count is: " << _db.getCommitCount());
             STHROW("error getting hash");
         }
-        string compareHash;
-        if (params.find("Hash") != params.end()) {
-            compareHash = params.at("Hash");
-        }
-        if (myHash != compareHash) {
-            SWARN("Hash mismatch. Peer at commit:" << peerCommitCount << " with hash " << compareHash
+        if (myHash != peerHash) {
+            SWARN("Hash mismatch. Peer at commit:" << peerCommitCount << " with hash " << peerHash
                   << ", but we have hash: " << myHash << " for that commit.");
             STHROW("hash mismatch");
         }
@@ -2135,7 +2143,7 @@ void SQLiteNode::_queueSynchronizeStateless(const STable& params, const string& 
     // The commitCount can change at any time, and on LEADER, we need to make sure we don't send the same transaction
     // twice, where _lastSentTransactionID only changes in the sync thread. From followers serving SYNCHRONIZE
     // requests, they can always serve their entire DB, there's no point at which they risk double-sending data.
-    uint64_t targetCommit = (_state == LEADING) ? _lastSentTransactionID : db.getCommitCount();
+    uint64_t targetCommit = (_state == LEADING) ? _lastSentTransactionID : _db.getCommitCount();
     if (peerCommitCount == targetCommit) {
         // Already synchronized; nothing to send
         PINFO("Peer is already synchronized");
@@ -2146,7 +2154,7 @@ void SQLiteNode::_queueSynchronizeStateless(const STable& params, const string& 
         uint64_t toIndex = targetCommit;
         if (!sendAll)
             toIndex = min(toIndex, fromIndex + 100); // 100 transactions at a time
-        if (!db.getCommits(fromIndex, toIndex, result))
+        if (!_db.getCommits(fromIndex, toIndex, result))
             STHROW("error getting commits");
         if ((uint64_t)result.size() != toIndex - fromIndex + 1)
             STHROW("mismatched commit count");
@@ -2249,9 +2257,9 @@ void SQLiteNode::_updateSyncPeer()
 {
     Peer* newSyncPeer = nullptr;
     uint64_t commitCount = _db.getCommitCount();
-    for (auto peer : peerList.atomic()) {
+    for (auto peer : peerList) {
         // If either of these conditions are true, then we can't use this peer.
-        if (!peer->test("LoggedIn") || peer->calcU64("CommitCount") <= commitCount) {
+        if (!peer->loggedIn || peer->commitCount <= commitCount) {
             continue;
         }
 
@@ -2262,7 +2270,7 @@ void SQLiteNode::_updateSyncPeer()
         // If the previous best peer and this one have the same latency (meaning they're probably both 0), the best one
         // is the one with the highest commit count.
         else if (newSyncPeer->latency == peer->latency) {
-            if (peer->calc64("CommitCount") > newSyncPeer->calc64("CommitCount")) {
+            if (peer->commitCount > newSyncPeer->commitCount) {
                 newSyncPeer = peer;
             }
         }
@@ -2281,13 +2289,13 @@ void SQLiteNode::_updateSyncPeer()
     if (_syncPeer != newSyncPeer) {
         string from, to;
         if (_syncPeer) {
-            from = _syncPeer->name + " (commit count=" + (*_syncPeer)["CommitCount"] + "), latency="
+            from = _syncPeer->name + " (commit count=" + to_string(_syncPeer->commitCount) + "), latency="
                                    + to_string(_syncPeer->latency/1000) + "ms";
         } else {
             from = "(NONE)";
         }
         if (newSyncPeer) {
-            to = newSyncPeer->name + " (commit count=" + (*newSyncPeer)["CommitCount"] + "), latency="
+            to = newSyncPeer->name + " (commit count=" + to_string(newSyncPeer->commitCount) + "), latency="
                                    + to_string(newSyncPeer->latency/1000) + "ms";
         } else {
             to = "(NONE)";
@@ -2296,13 +2304,13 @@ void SQLiteNode::_updateSyncPeer()
         // We see strange behavior when choosing peers. Peers are being chosen from distant data centers rather than
         // peers on the same LAN. This is extra diagnostic info to try and see why we don't choose closer ones.
         list<string> nonChosenPeers;
-        for (auto peer : peerList.atomic()) {
+        for (auto peer : peerList) {
             if (peer == newSyncPeer || peer == _syncPeer) {
                 continue; // These ones we're already logging.
-            } else if (!peer->test("LoggedIn")) {
+            } else if (!peer->loggedIn) {
                 nonChosenPeers.push_back(peer->name + ":!loggedIn");
-            } else if (peer->calcU64("CommitCount") <= commitCount) {
-                nonChosenPeers.push_back(peer->name + ":commit=" + (*peer)["CommitCount"]);
+            } else if (peer->commitCount <= commitCount) {
+                nonChosenPeers.push_back(peer->name + ":commit=" + to_string(peer->commitCount));
             } else {
                 nonChosenPeers.push_back(peer->name + ":" + to_string(peer->latency/1000) + "ms");
             }
@@ -2320,13 +2328,13 @@ void SQLiteNode::_reconnectPeer(Peer* peer) {
         // Reset
         SHMMM("Reconnecting to '" << peer->name << "'");
         shutdownSocket(peer->s);
-        (*peer)["LoggedIn"] = "false";
+        peer->loggedIn = false;
     }
 }
 
 void SQLiteNode::_reconnectAll() {
     // Loop across and reconnect
-    for (auto peer : peerList.atomic()) {
+    for (auto peer : peerList) {
         _reconnectPeer(peer);
     }
 }
@@ -2335,10 +2343,10 @@ bool SQLiteNode::_majoritySubscribed() {
     // Count up how may full and subscribed peers we have (A "full" peer is one that *isn't* a permafollower).
     int numFullPeers = 0;
     int numFullFollowers = 0;
-    for (auto peer : peerList.atomic()) {
+    for (auto peer : peerList) {
         if (!peer->isPermafollower()) {
             ++numFullPeers;
-            if (peer->test("Subscribed")) {
+            if (peer->subscribed) {
                 ++numFullFollowers;
             }
         }
@@ -2364,13 +2372,10 @@ bool SQLiteNode::peekPeerCommand(shared_ptr<SQLiteNode> node, SQLite& db, SQLite
                 return true;
             }
             command.response.methodLine = "SYNCHRONIZE_RESPONSE";
-            _queueSynchronizeStateless(command.request.nameValueMap,
-                                       command.request["name"],
-                                       command.request["peerName"],
-                                       node->_state,
-                                       db,
-                                       command.response,
-                                       false);
+
+            // Because we hold a sharedPtr to the node, it can't delete any peers (because it only does at
+            // destruction), and since our peers our thread-safe, we can run this just fine.
+            node->_queueSynchronize(peer, command.response, false);
 
             // The following two lines are copied from `_sendToPeer`.
             command.response["CommitCount"] = to_string(db.getCommitCount());
@@ -2786,10 +2791,10 @@ bool SQLiteNode::hasQuorum() {
     }
     int numFullPeers = 0;
     int numFullFollowers = 0;
-    for (auto peer : peerList.atomic()) {
+    for (auto peer : peerList) {
         if (!peer->isPermafollower()) {
             ++numFullPeers;
-            if ((*peer)["Subscribed"] == "true") {
+            if (peer->subscribed) {
                 numFullFollowers++;
             }
         }

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -93,7 +93,7 @@ class SQLiteNode : public STCPNode {
     // This is a static function that can 'peek' a command initiated by a peer, but can be called by any thread.
     // Importantly for thread safety, this cannot depend on the current state of the cluster or a specific node.
     // Returns false if the node can't peek the command.
-    static bool peekPeerCommand(SQLiteNode* node, SQLite& db, SQLiteCommand& command);
+    static bool peekPeerCommand(shared_ptr<SQLiteNode>, SQLite& db, SQLiteCommand& command);
 
     // This exists so that the _server can inspect internal state for diagnostic purposes.
     list<string> getEscalatedCommandRequestMethodLines();

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -41,6 +41,8 @@ class SQLiteNode : public STCPNode {
                const string& peerList, int priority, uint64_t firstTimeout, const string& version, const bool useParallelReplication = false);
     ~SQLiteNode();
 
+    const vector<Peer*> initPeers(const string& peerList);
+
     // Simple Getters. See property definitions for details.
     State         getState()         { return _state; }
     int           getPriority()      { return _priority; }
@@ -178,11 +180,8 @@ class SQLiteNode : public STCPNode {
     void _sendToAllPeers(const SData& message, bool subscribedOnly = false);
     void _changeState(State newState);
 
-    // Queue a SYNCHRONIZE message based on the current state of the node.
+    // Queue a SYNCHRONIZE message based on the current state of the node, thread-safe.
     void _queueSynchronize(Peer* peer, SData& response, bool sendAll);
-
-    // Queue a SYNCHRONIZE message based on pre-computed state of the node. This version is thread-safe.
-    static void _queueSynchronizeStateless(const STable& params, const string& name, const string& peerName, State _state, SQLite& db, SData& response, bool sendAll);
     void _recvSynchronize(Peer* peer, const SData& message);
     void _reconnectPeer(Peer* peer);
     void _reconnectAll();

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -98,12 +98,6 @@ class SQLiteNode : public STCPNode {
     // This exists so that the _server can inspect internal state for diagnostic purposes.
     list<string> getEscalatedCommandRequestMethodLines();
 
-    // This mutex is exposed publicly so that others (particularly, the _server) can atomically act on the current
-    // state of the node. When working with this and SQLite::g_commitLock, the correct order of acquisition is always:
-    // 1. stateMutex
-    // 2. SQLite::g_commitLock
-    shared_timed_mutex stateMutex;
-
     // This will broadcast a message to all peers, or a specific peer.
     void broadcast(const SData& message, Peer* peer = nullptr);
 

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -145,7 +145,7 @@ struct GracefulFailoverTest : tpunit::TestFixture {
             list<string> peers = SParseJSONArray(peerList);
             for (auto& peer : peers) {
                 STable peerInfo = SParseJSONObject(peer);
-                if (peerInfo["name"] == "cluster_node_2" && (peerInfo["State"] == "" || peerInfo["State"] == "SEARCHING")) {
+                if (peerInfo["name"] == "cluster_node_2" && (peerInfo["State"] == "" || SStartsWith(peerInfo["State"], "SEARCHING"))) {
                     success = true;
                     break;
                 }

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -54,7 +54,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
 
         // Do a base test, with one peer with no latency.
         SQLiteNode::Peer* fastest = nullptr;
-        for (auto peer : testNode.peerList) {
+        for (auto peer : testNode.peerList.atomic()) {
             int peerNum = peer->name[4] - 48;
             (*peer)["LoggedIn"] = "true";
             (*peer)["CommitCount"] = to_string(10000000 + peerNum);
@@ -71,7 +71,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         ASSERT_EQUAL(SQLiteNodeTester::getSyncPeer(testNode), fastest);
 
         // See what happens when another peer becomes faster.
-        for (auto peer : testNode.peerList) {
+        for (auto peer : testNode.peerList.atomic()) {
             // New fastest is peer 3.
             if (peer->name == "peer3") {
                 peer->latency = 50;
@@ -82,7 +82,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         ASSERT_EQUAL(SQLiteNodeTester::getSyncPeer(testNode), fastest);
 
         // And see what happens if our fastest peer logs out.
-        for (auto peer : testNode.peerList) {
+        for (auto peer : testNode.peerList.atomic()) {
             if (peer->name == "peer3") {
                 (*peer)["LoggedIn"] = "false";
                 peer->latency = 50;
@@ -97,7 +97,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         ASSERT_EQUAL(SQLiteNodeTester::getSyncPeer(testNode), fastest);
 
         // And then if our previously 0 latency peer gets (fast) latency data.
-        for (auto peer : testNode.peerList) {
+        for (auto peer : testNode.peerList.atomic()) {
             // New fastest is peer 3.
             if (peer->name == "peer1") {
                 peer->latency = 75;
@@ -108,7 +108,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         ASSERT_EQUAL(SQLiteNodeTester::getSyncPeer(testNode), fastest);
 
         // Now none of our peers have latency data, but one has more commits.
-        for (auto peer : testNode.peerList) {
+        for (auto peer : testNode.peerList.atomic()) {
             peer->latency = 0;
 
             // 4 had highest commit count.

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -52,7 +52,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         for (auto peer : testNode.peerList) {
             int peerNum = peer->name[4] - 48;
             peer->loggedIn = true;
-            peer->commitCount = 10000000 + peerNum;
+            peer->setCommit(10000000 + peerNum, "");
 
             // 0, 100, 200, 300.
             peer->latency = (peerNum - 1) * 100;


### PR DESCRIPTION
This removes two different mutexes, one protecting changes to `SQLiteNode::State` and one protecting accesses to peer objects.

We've made peer objects thread-safe (except for their sockets, which are private and only accessible by the sync thread) by making all of their properties either const, or atomic, or protecting access to them with a mutex. We've made the entire `peerList` for a node thread-safe by making it const, and it survives unchanged for the life of a `SQLiteNode`. So long as the node isn't destroyed, the `peerList` wont change, and multiple threads can read it simultaneously. Because `BedrockServer` keeps a `sharedPtr` to the node, we make a copy of that pointer any time we need the node object to stay in scope for some other operation. This isn't required inside `BedrockServer::sync` or `BedrockServer::worker`.

Since we no longer have to lock around access to peer objects, we no longer have to block `Status` commands until the sync thread is in `poll`, nor explicitly manage any locks around them from outside of a `Peer` object itself.

## Tests
All existing Bedrock tests pass.

Auth tests:
```
[==============]
[ TEST RESULTS ] Passed: 1335, Failed: 0
[==============]
```

FuzzyBot tests:
```
[==============]
[ TEST RESULTS ] Passed: 14, Failed: 0
[==============]
```

ExpensifyBackupManager tests: *With this PR:* https://github.com/Expensify/ExpensifyBackupManager/pull/21
```
[==============]
[ TEST RESULTS ] Passed: 6, Failed: 0
[==============]
```

ExpensifyTableManager: no tests, but builds fine.