### PR TITLE
Revert "Kill `stateMutex` and `syncMutex`, decouple node state from worker transactions, make peer objects thread-safe."

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -216,8 +216,9 @@ class BedrockServer : public SQLiteServer {
     // Returns whether or not this server was configured to backup.
     bool shouldBackup();
 
-    // Returns a representation of the internal state of the sync node's peers. This can be empty if there are no
-    // peers, or no sync node.
+    // Returns a copy of the internal state of the sync node's peers. This can be empty if there are no peers, or no
+    // sync node.
+    bool getPeerInfo(list<STable>& peerData);
     list<STable> getPeerInfo();
 
     // Send a command to all of our peers. It will be wrapped appropriately.
@@ -354,6 +355,9 @@ class BedrockServer : public SQLiteServer {
     // destroyed, we are also guaranteed that all peers are accessible as long as we hold a shared pointer to this
     // object.
     shared_ptr<SQLiteNode> _syncNode;
+
+    // Because status will access internal sync node data, we lock in both places that will access the pointer above.
+    recursive_timed_mutex _syncMutex;
 
     // Functions for checking for and responding to status and control commands.
     bool _isStatusCommand(const unique_ptr<BedrockCommand>& command);

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -3,8 +3,8 @@
 #undef SLOGPREFIX
 #define SLOGPREFIX "{" << name << "} "
 
-STCPNode::STCPNode(const string& name_, const string& host, const vector<Peer*> _peerList, const uint64_t recvTimeout_)
-    : STCPServer(host), name(name_), recvTimeout(recvTimeout_), peerList(_peerList), _deserializeTimer("STCPNode::deserialize"),
+STCPNode::STCPNode(const string& name_, const string& host, const uint64_t recvTimeout_)
+    : STCPServer(host), name(name_), recvTimeout(recvTimeout_), _deserializeTimer("STCPNode::deserialize"),
       _sConsumeFrontTimer("STCPNode::SConsumeFront"), _sAppendTimer("STCPNode::append") {
 }
 
@@ -19,6 +19,7 @@ STCPNode::~STCPNode() {
         peer->closeSocket(this);
         delete peer;
     }
+    peerList.clear();
 }
 
 const string& STCPNode::stateName(STCPNode::State state) {
@@ -67,15 +68,22 @@ STCPNode::State STCPNode::stateFromName(const string& name) {
     }
 }
 
+void STCPNode::addPeer(const string& peerName, const string& host, const STable& params) {
+    // Create a new peer and ready it for connection
+    SASSERT(SHostIsValid(host));
+    SINFO("Adding peer #" << peerList.size() << ": " << peerName << " (" << host << "), " << SComposeJSONObject(params));
+    Peer* peer = new Peer(peerName, host, params, peerList.size() + 1);
+
+    // Wait up to 2s before trying the first time
+    peer->nextReconnect = STimeNow() + SRandom::rand64() % (STIME_US_PER_S * 2);
+    peerList.push_back(peer);
+}
+
 STCPNode::Peer* STCPNode::getPeerByID(uint64_t id) {
-    if (id <= 0) {
-        return nullptr;
-    }
-    try {
+    if (id && id <= peerList.size()) {
         return peerList[id - 1];
-    } catch (const out_of_range& e) {
-        return nullptr;
     }
+    return nullptr;
 }
 
 uint64_t STCPNode::getIDByPeer(STCPNode::Peer* peer) {
@@ -132,10 +140,10 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                         // **FIXME: Authenticate and match by public key
                         if (peer->name == message["Name"]) {
                             // Found it!  Are we already connected?
-                            if (!peer->socket) {
+                            if (!peer->s) {
                                 // Attach to this peer and LOGIN
                                 PINFO("Attaching incoming socket");
-                                peer->socket = socket;
+                                peer->s = socket;
                                 peer->failedConnections = 0;
                                 acceptedSocketList.erase(socketIt);
                                 foundIt = true;
@@ -176,24 +184,24 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     // Try to establish connections with peers and process messages
     for (Peer* peer : peerList) {
         // See if we're connected
-        if (peer->socket) {
+        if (peer->s) {
             // We have a socket; process based on its state
-            switch (peer->socket->state.load()) {
+            switch (peer->s->state.load()) {
             case Socket::CONNECTED: {
                 // See if there is anything new.
                 peer->failedConnections = 0; // Success; reset failures
                 SData message;
                 int messageSize = 0;
                 try {
-                    // peer->socket->lastRecvTime is always set, it's initialized to STimeNow() at creation.
-                    if (peer->socket->lastRecvTime + recvTimeout < STimeNow()) {
+                    // peer->s->lastRecvTime is always set, it's initialized to STimeNow() at creation.
+                    if (peer->s->lastRecvTime + recvTimeout < STimeNow()) {
                         // Reset and reconnect.
                         SHMMM("Connection with peer '" << peer->name << "' timed out.");
                         STHROW("Timed Out!");
                     }
 
                     // Send PINGs 5s before the socket times out
-                    if (STimeNow() - peer->socket->lastSendTime > recvTimeout - 5 * STIME_US_PER_S) {
+                    if (STimeNow() - peer->s->lastSendTime > recvTimeout - 5 * STIME_US_PER_S) {
                         // Let's not delay on flushing the PING PONG exchanges
                         // in case we get blocked before we get to flush later.
                         SINFO("Sending PING to peer '" << peer->name << "'");
@@ -201,16 +209,16 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                     }
 
                     // Process all messages
-                    while (AutoTimerTime(_deserializeTimer), (messageSize = message.deserialize(peer->socket->recvBuffer))) {
+                    while (AutoTimerTime(_deserializeTimer), (messageSize = message.deserialize(peer->s->recvBuffer))) {
                         // Which message?
                         {
                             AutoTimerTime consumeTime(_sConsumeFrontTimer);
-                            peer->socket->recvBuffer.consumeFront(messageSize);
+                            peer->s->recvBuffer.consumeFront(messageSize);
                         }
-                        if (peer->socket->recvBuffer.size() > 10'000) {
+                        if (peer->s->recvBuffer.size() > 10'000) {
                             // Make in known if this buffer ever gets big.
                             PINFO("Received '" << message.methodLine << "'(size: " << messageSize << ") with " 
-                                  << (peer->socket->recvBuffer.size()) << " bytes remaining in message buffer.");
+                                  << (peer->s->recvBuffer.size()) << " bytes remaining in message buffer.");
                         } else {
                             PDEBUG("Received '" << message.methodLine << "'.");
                         }
@@ -223,7 +231,7 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                             SINFO("Received PING from peer '" << peer->name << "'. Sending PONG.");
                             SData pong("PONG");
                             pong["Timestamp"] = message["Timestamp"];
-                            peer->socket->send(pong.serialize());
+                            peer->s->send(pong.serialize());
                         } else if (SIEquals(message.methodLine, "PONG")) {
                             // Recevied the PONG; update our latency estimate for this peer.
                             // We set a lower bound on this at 1, because even though it should be pretty impossible
@@ -245,8 +253,8 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                     }
                     SData reconnect("RECONNECT");
                     reconnect["Reason"] = e.what();
-                    peer->socket->send(reconnect.serialize());
-                    shutdownSocket(peer->socket);
+                    peer->s->send(reconnect.serialize());
+                    shutdownSocket(peer->s);
                     break;
                 }
                 break;
@@ -255,20 +263,20 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
             case Socket::CLOSED: {
                 // Done; clean up and try to reconnect
                 uint64_t delay = SRandom::rand64() % (STIME_US_PER_S * 5);
-                if (peer->socket->connectFailure) {
-                    PINFO("Peer connection failed after " << (STimeNow() - peer->socket->openTime) / 1000
+                if (peer->s->connectFailure) {
+                    PINFO("Peer connection failed after " << (STimeNow() - peer->s->openTime) / 1000
                                                           << "ms, reconnecting in " << delay / 1000 << "ms");
                 } else {
-                    PHMMM("Lost peer connection after " << (STimeNow() - peer->socket->openTime) / 1000
+                    PHMMM("Lost peer connection after " << (STimeNow() - peer->s->openTime) / 1000
                                                         << "ms, reconnecting in " << delay / 1000 << "ms");
                 }
                 _onDisconnect(peer);
-                if (peer->socket->connectFailure)
+                if (peer->s->connectFailure)
                     peer->failedConnections++;
                 peer->closeSocket(this);
                 peer->reset();
                 peer->nextReconnect = STimeNow() + delay;
-                nextActivity = min(nextActivity, peer->nextReconnect.load());
+                nextActivity = min(nextActivity, peer->nextReconnect);
                 break;
             }
 
@@ -283,13 +291,13 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 // Try again
                 PINFO("Retrying the connection");
                 peer->reset();
-                peer->socket = openSocket(peer->host);
-                if (peer->socket) {
+                peer->s = openSocket(peer->host);
+                if (peer->s) {
                     // Try to log in now.  Send a PING immediately after so we
                     // can get a fast estimate of latency.
                     SData login("NODE_LOGIN");
                     login["Name"] = name;
-                    peer->socket->send(login.serialize());
+                    peer->s->send(login.serialize());
                     _sendPING(peer);
                     _onConnect(peer);
                 } else {
@@ -300,7 +308,7 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 }
             } else {
                 // Waiting to reconnect -- notify the caller
-                nextActivity = min(nextActivity, peer->nextReconnect.load());
+                nextActivity = min(nextActivity, peer->nextReconnect);
             }
         }
     }
@@ -311,128 +319,24 @@ void STCPNode::_sendPING(Peer* peer) {
     SASSERT(peer);
     SData ping("PING");
     ping["Timestamp"] = SToStr(STimeNow());
-    peer->socket->send(ping.serialize());
-}
-
-STCPNode::Peer::Peer(const string& name_, const string& host_, const STable& params_, uint64_t id_)
-  : name(name_), host(host_), id(id_), params(params_), permaFollower(isPermafollower(params)),
-    commitCount(0),
-    failedConnections(0),
-    latency(0),
-    loggedIn(false),
-    nextReconnect(0),
-    priority(0),
-    state(SEARCHING),
-    standupResponse(Response::NONE),
-    subscribed(false),
-    transactionResponse(Response::NONE),
-    version(),
-    hash()
-{ }
-
-bool STCPNode::Peer::connected() const {
-    lock_guard<decltype(_stateMutex)> lock(_stateMutex);
-    return (socket && socket->state.load() == STCPManager::Socket::CONNECTED);
-}
-
-void STCPNode::Peer::reset() {
-    lock_guard<decltype(_stateMutex)> lock(_stateMutex);
-    latency = 0;
-    loggedIn = false;
-    priority = 0;
-    socket = nullptr;
-    state = SEARCHING;
-    standupResponse = Response::NONE;
-    subscribed = false;
-    transactionResponse = Response::NONE;
-    version = "";
-    setCommit(0, "");
+    peer->s->send(ping.serialize());
 }
 
 void STCPNode::Peer::sendMessage(const SData& message) {
-    lock_guard<decltype(_stateMutex)> lock(_stateMutex);
-    if (socket) {
-        socket->send(message.serialize());
+    lock_guard<decltype(socketMutex)> lock(socketMutex);
+    if (s) {
+        s->send(message.serialize());
     } else {
         SWARN("Tried to send " << message.methodLine << " to peer, but not available.");
     }
 }
 
 void STCPNode::Peer::closeSocket(STCPManager* manager) {
-    lock_guard<decltype(_stateMutex)> lock(_stateMutex);
-    if (socket) {
-        manager->closeSocket(socket);
-        socket = nullptr;
+    lock_guard<decltype(socketMutex)> lock(socketMutex);
+    if (s) {
+        manager->closeSocket(s);
+        s = nullptr;
     } else {
         SWARN("Peer " << name << " has no socket.");
     }
-}
-
-string STCPNode::Peer::responseName(Response response) {
-    switch (response) {
-        case STCPNode::Peer::Response::NONE:
-            return "NONE";
-            break;
-        case STCPNode::Peer::Response::APPROVE:
-            return "APPROVE";
-            break;
-        case STCPNode::Peer::Response::DENY:
-            return "DENY";
-            break;
-        default:
-            return "";
-    }
-}
-
-void STCPNode::Peer::setCommit(uint64_t count, const string& hashString) {
-    lock_guard<decltype(_stateMutex)> lock(_stateMutex);
-    const_cast<atomic<uint64_t>&>(commitCount) = count;
-    hash = hashString;
-}
-
-void STCPNode::Peer::getCommit(uint64_t& count, string& hashString) {
-    lock_guard<decltype(_stateMutex)> lock(_stateMutex);
-    count = commitCount.load();
-    hashString = hash.load();
-}
-
-STable STCPNode::Peer::getData() const {
-    // Add all of our standard stuff.
-    STable result({
-        {"name", name},
-        {"host", host},
-        {"state", (stateName(state) + (connected() ? "" : " (DISCONNECTED)"))},
-        {"latency", to_string(latency)},
-        {"nextReconnect", to_string(nextReconnect)},
-        {"id", to_string(id)},
-        {"failedConnections", to_string(failedConnections)},
-        {"loggedIn", (loggedIn ? "true" : "false")},
-        {"priority", to_string(priority)},
-        {"version", version},
-        {"hash", hash},
-        {"commitCount", to_string(commitCount)},
-        {"standupResponse", responseName(standupResponse)},
-        {"transactionResponse", responseName(transactionResponse)},
-        {"subscribed", (subscribed ? "true" : "false")},
-    });
-
-    // And anything from the params (note: doesn't overwrite our standard stuff).
-    for (auto& p : params) {
-        result.emplace(p);
-    }
-    return result;
-}
-
-bool STCPNode::Peer::isPermafollower(const STable& params) {
-    auto it = params.find("Permafollower");
-    if (it != params.end() && it->second == "true") {
-        return true;
-    }
-    return false;
-}
-
-ostream& operator<<(ostream& os, const atomic<STCPNode::Peer::Response>& response)
-{
-    os << STCPNode::Peer::responseName(response.load());
-    return os;
 }

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <libstuff/libstuff.h>
 
 // Convenience class for maintaining connections with a mesh of peers
 #define PDEBUG(_MSG_) SDEBUG("->{" << peer->name << "} " << _MSG_)
@@ -43,6 +42,10 @@ class AutoTimerTime {
 };
 
 struct STCPNode : public STCPServer {
+    // Begins listening for connections on a given port
+    STCPNode(const string& name, const string& host, const uint64_t recvTimeout_ = STIME_US_PER_M);
+    virtual ~STCPNode();
+
     // Possible states of a node in a DB cluster
     enum State {
         UNKNOWN,
@@ -63,95 +66,52 @@ struct STCPNode : public STCPServer {
     void postPoll(fd_map& fdm, uint64_t& nextActivity);
 
     // Represents a single peer in the database cluster
-    class Peer {
-      public:
-
-        // Possible responses from a peer.
-        enum class Response {
-            NONE,
-            APPROVE,
-            DENY
-        };
-
-        // Const (and thus implicitly thread-safe) attributes of this Peer.
-        const string name;
-        const string host;
-        const uint64_t id;
-        const STable params;
-        const bool permaFollower;
-
-        // This is const because it's public, and we don't want it to be changed outside of this class, as it needs to
-        // be synchronized with `hash`. However, it's often useful just as it is, so we expose it like this and update
-        // it with `const_cast`. `hash` is only used in few places, so is private, and can only be accessed with
-        // `getCommit`, thus reducing the risk of anyone getting out-of-sync commitCount and hash.
-        const atomic<uint64_t> commitCount;
-
-        // The rest of these are atomic so they can be read by multiple threads, but there's no special synchronization
-        // required between them.
-        atomic<int> failedConnections;
-        atomic<uint64_t> latency;
-        atomic<bool> loggedIn;
-        atomic<uint64_t> nextReconnect;
-        atomic<int> priority;
-        atomic<State> state;
-        atomic<Response> standupResponse;
-        atomic<bool> subscribed;
-        atomic<Response> transactionResponse;
-        atomic<string> version;
-
-        // Constructor.
-        Peer(const string& name_, const string& host_, const STable& params_, uint64_t id_);
-
-        // Atomically set commit and hash.
-        void setCommit(uint64_t count, const string& hashString);
-
-        // Atomically get commit and hash.
-        void getCommit(uint64_t& count, string& hashString);
-
-        // Gets an STable representation of this peer's current state in order to display status info.
-        STable getData() const;
-
-        // Returns true if there's an active connection to this Peer.
-        bool connected() const;
-
-        // Reset a peer, as if disconnected and starting the connection over.
-        void reset();
-
-        // Close the peer's socket. Thread-safe.
-        void closeSocket(STCPManager* manager);
-
-        // Send a message to this peer. Thread-safe.
-        void sendMessage(const SData& message);
-
-        // Get a string name for a Response object.
-        static string responseName(Response response);
-
-      private:
-        // The hash corresponding to commitCount.
-        atomic<string> hash;
-
-        // This allows direct access to the socket from the node object that should actually be managing peer
-        // connections, which should always be handled by a single thread, and thus safe. Ideally, this isn't required,
-        // but for the time being, the amount of refactoring required to fix that is too high.
+    struct Peer : public SData {
         friend class STCPNode;
         friend class SQLiteNode;
-        Socket* socket = nullptr;
 
-        // Mutex for locking around non-atomic member access (for set/getCommit, accessing socket, etc).
-        mutable recursive_mutex _stateMutex;
+        // Attributes
+        string name;
+        string host;
+        STable params;
+        State state;
+        uint64_t latency;
+        uint64_t nextReconnect;
+        uint64_t id;
+        int failedConnections;
 
-        // For initializing the permafollower value from the params list.
-        static bool isPermafollower(const STable& params);
+        // Helper methods
+        Peer(const string& name_, const string& host_, const STable& params_, uint64_t id_)
+          : name(name_), host(host_), params(params_), state(SEARCHING), latency(0), nextReconnect(0), id(id_),
+            failedConnections(0), s(nullptr)
+        { }
+        bool connected() { return (s && s->state.load() == STCPManager::Socket::CONNECTED); }
+        void reset() {
+            clear();
+            state = SEARCHING;
+            s = nullptr;
+            latency = 0;
+        }
+
+        // Close the peer's socket. This is synchronized so that you can safely call closeSocket and sendMessage on
+        // different threads.
+        void closeSocket(STCPManager* manager);
+
+        // Send a message to this peer.
+        void sendMessage(const SData& message);
+
+      private:
+        Socket* s;
+        recursive_mutex socketMutex;
     };
 
-    // Begins listening for connections on a given port
-    STCPNode(const string& name, const string& host, const vector<Peer*> _peerList, const uint64_t recvTimeout_ = STIME_US_PER_M);
-    virtual ~STCPNode();
+    // Connects to a peer in the database cluster
+    void addPeer(const string& name, const string& host, const STable& params);
 
     // Attributes
     string name;
     uint64_t recvTimeout;
-    const vector<Peer*> peerList;
+    vector<Peer*> peerList;
     list<Socket*> acceptedSocketList;
 
     // Called when we first establish a connection with a new peer
@@ -181,6 +141,3 @@ struct STCPNode : public STCPServer {
     AutoTimer _sConsumeFrontTimer;
     AutoTimer _sAppendTimer;
 };
-
-// serialization for Responses.
-ostream& operator<<(ostream& os, const atomic<STCPNode::Peer::Response>& response);

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -108,10 +108,6 @@ class SString : public string {
         return *this;
     }
 
-    template <typename T>
-    SString(const T& from) : string(from) {}
-    SString() {}
-
     // Templated assignment operator for non-arithmetic types.
     template <typename T>
     typename enable_if<!is_arithmetic<T>::value, SString&>::type operator=(const T& from) {
@@ -333,7 +329,7 @@ namespace std {
     template<>
     struct atomic<string> {
         string operator=(string desired) {
-            lock_guard<decltype(m)> l(m);
+            SAUTOLOCK(m);
             _string = desired;
             return _string;
         }
@@ -341,19 +337,16 @@ namespace std {
             return false;
         }
         void store(string desired, std::memory_order order = std::memory_order_seq_cst) {
-            lock_guard<decltype(m)> l(m);
+            SAUTOLOCK(m);
             _string = desired;
         };
         string load(std::memory_order order = std::memory_order_seq_cst) const {
-            lock_guard<decltype(m)> l(m);
+            SAUTOLOCK(m);
             return _string;
         }
-        operator string() const {
-            lock_guard<decltype(m)> l(m);
-            return _string;
-        }
+        operator string() const;
         string exchange(string desired, std::memory_order order = std::memory_order_seq_cst) {
-            lock_guard<decltype(m)> l(m);
+            SAUTOLOCK(m);
             string existing = _string;
             _string = desired;
             return existing;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -41,8 +41,6 @@ class SQLiteNode : public STCPNode {
                const string& peerList, int priority, uint64_t firstTimeout, const string& version, const bool useParallelReplication = false);
     ~SQLiteNode();
 
-    const vector<Peer*> initPeers(const string& peerList);
-
     // Simple Getters. See property definitions for details.
     State         getState()         { return _state; }
     int           getPriority()      { return _priority; }
@@ -95,10 +93,16 @@ class SQLiteNode : public STCPNode {
     // This is a static function that can 'peek' a command initiated by a peer, but can be called by any thread.
     // Importantly for thread safety, this cannot depend on the current state of the cluster or a specific node.
     // Returns false if the node can't peek the command.
-    static bool peekPeerCommand(shared_ptr<SQLiteNode>, SQLite& db, SQLiteCommand& command);
+    static bool peekPeerCommand(SQLiteNode* node, SQLite& db, SQLiteCommand& command);
 
     // This exists so that the _server can inspect internal state for diagnostic purposes.
     list<string> getEscalatedCommandRequestMethodLines();
+
+    // This mutex is exposed publicly so that others (particularly, the _server) can atomically act on the current
+    // state of the node. When working with this and SQLite::g_commitLock, the correct order of acquisition is always:
+    // 1. stateMutex
+    // 2. SQLite::g_commitLock
+    shared_timed_mutex stateMutex;
 
     // This will broadcast a message to all peers, or a specific peer.
     void broadcast(const SData& message, Peer* peer = nullptr);
@@ -180,8 +184,11 @@ class SQLiteNode : public STCPNode {
     void _sendToAllPeers(const SData& message, bool subscribedOnly = false);
     void _changeState(State newState);
 
-    // Queue a SYNCHRONIZE message based on the current state of the node, thread-safe.
+    // Queue a SYNCHRONIZE message based on the current state of the node.
     void _queueSynchronize(Peer* peer, SData& response, bool sendAll);
+
+    // Queue a SYNCHRONIZE message based on pre-computed state of the node. This version is thread-safe.
+    static void _queueSynchronizeStateless(const STable& params, const string& name, const string& peerName, State _state, SQLite& db, SData& response, bool sendAll);
     void _recvSynchronize(Peer* peer, const SData& message);
     void _reconnectPeer(Peer* peer);
     void _reconnectAll();

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -145,7 +145,7 @@ struct GracefulFailoverTest : tpunit::TestFixture {
             list<string> peers = SParseJSONArray(peerList);
             for (auto& peer : peers) {
                 STable peerInfo = SParseJSONObject(peer);
-                if (peerInfo["name"] == "cluster_node_2" && (peerInfo["State"] == "" || SStartsWith(peerInfo["State"], "SEARCHING"))) {
+                if (peerInfo["name"] == "cluster_node_2" && (peerInfo["State"] == "" || peerInfo["State"] == "SEARCHING")) {
                     success = true;
                     break;
                 }


### PR DESCRIPTION
Reverts Expensify/Bedrock#887

there is a segfault hiding in this new code