### PR TITLE
Revert "Revert "Kill `stateMutex` and `syncMutex`, decouple node state from worker transactions, make peer objects thread-safe.""

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -227,12 +227,6 @@ void BedrockServer::sync(const SData& args,
     AutoTimer postPollTimer("sync thread PostPoll");
     AutoTimer escalateLoopTimer("sync thread escalate loop");
 
-    // We hold a lock here around all operations on `syncNode`, because `SQLiteNode` isn't thread-safe, but we need
-    // `BedrockServer` to be able to introspect it in `Status` requests. We hold this lock at all times until exiting
-    // our main loop, aside from when we're waiting on `poll`. Strictly, we could hold this lock less often, but there
-    // are not that many status commands coming in, and they can wait for a fraction of a second, which lets us keep
-    // the logic of this loop simpler.
-    server._syncMutex.lock();
     do {
         // Make sure the existing command prefix is still valid since they're reset when SAUTOPREFIX goes out of scope.
         if (command) {
@@ -337,14 +331,10 @@ void BedrockServer::sync(const SData& args,
 
         // Wait for activity on any of those FDs, up to a timeout.
         const uint64_t now = STimeNow();
-
-        // Unlock our mutex, poll, and re-lock when finished.
-        server._syncMutex.unlock();
         {
             AutoTimerTime pollTime(pollTimer);
             S_poll(fdm, max(nextActivity, now) - now);
         }
-        server._syncMutex.lock();
 
         // And set our next timeout for 1 second from now.
         nextActivity = STimeNow() + STIME_US_PER_S;
@@ -694,9 +684,6 @@ void BedrockServer::sync(const SData& args,
         db.rollback();
     }
 
-    // Done with the global lock.
-    server._syncMutex.unlock();
-
     // We've finished shutting down the sync node, tell the workers that it's finished.
     server._shutdownState.store(DONE);
     SINFO("Sync thread finished with commands.");
@@ -830,7 +817,7 @@ void BedrockServer::worker(SQLitePool& dbPool,
 
             // If this was a command initiated by a peer as part of a cluster operation, then we process it separately
             // and respond immediately. This allows SQLiteNode to offload read-only operations to worker threads.
-            if (SQLiteNode::peekPeerCommand(server._syncNode.get(), db, *command)) {
+            if (SQLiteNode::peekPeerCommand(server._syncNode, db, *command)) {
                 // Move on to the next command.
                 continue;
             }
@@ -1058,12 +1045,16 @@ void BedrockServer::worker(SQLitePool& dbPool,
                         // to the minimum time required.
                         bool commitSuccess = false;
                         {
-                            // This is the first place we get really particular with the state of the node from a
-                            // worker thread. We only want to do this commit if we're *SURE* we're leading, and
-                            // not allow the state of the node to change while we're committing. If it turns out
-                            // we've changed states, we'll roll this command back, so we lock the node's state
-                            // until we complete.
-                            shared_lock<decltype(server._syncNode->stateMutex)> stateLock(server._syncNode->stateMutex);
+                            // There used to be a mutex protecting this state change, with the idea that if we
+                            // prevented state changes, we couldn't fall out of leading in the middle of processing a
+                            // command. However, for "normal" graceful state changes, these changes are prevented by
+                            // checking canStandDown(), and we can't fall out of STANDINGDOWN until there are no
+                            // commands left. In the case of non-graceful state changes, i.e., we are spontaneously
+                            // disconnected from the cluster, all this really does is prevent the sync thread from
+                            // telling us about that until after we've already committed this transaction, which
+                            // doesn't really help. In those cases, it's possible that we fork the DB here, but that's
+                            // possible with or without a mutex for this, so we've removed it for the sake of
+                            // simplicity.
                             if (replicationState.load() != SQLiteNode::LEADING &&
                                 replicationState.load() != SQLiteNode::STANDINGDOWN) {
                                 SALERT("Node State changed from LEADING to "
@@ -1833,30 +1824,14 @@ bool BedrockServer::_isStatusCommand(const unique_ptr<BedrockCommand>& command) 
     return false;
 }
 
-bool BedrockServer::getPeerInfo(list<STable>& peerData) {
-    if (_syncMutex.try_lock_for(chrono::milliseconds(10))) {
-        lock_guard<decltype(_syncMutex)> lock(_syncMutex, adopt_lock_t());
-        auto _syncNodeCopy = _syncNode;
-        if (_syncNodeCopy) {
-            for (SQLiteNode::Peer* peer : _syncNodeCopy->peerList) {
-                peerData.emplace_back(peer->nameValueMap);
-                for (auto it : peer->params) {
-                    peerData.back()[it.first] = it.second;
-                }
-                peerData.back()["host"] = peer->host;
-                peerData.back()["name"] = peer->name;
-                peerData.back()["State"] = SQLiteNode::stateName(peer->state);
-            }
-        }
-    } else {
-        return false;
-    }
-    return true;
-}
-
 list<STable> BedrockServer::getPeerInfo() {
     list<STable> peerData;
-    getPeerInfo(peerData);
+    auto _syncNodeCopy = _syncNode;
+    if (_syncNodeCopy) {
+        for (SQLiteNode::Peer* peer : _syncNodeCopy->peerList) {
+            peerData.emplace_back(peer->getData());
+        }
+    }
     return peerData;
 }
 
@@ -1947,40 +1922,26 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         // We read from syncNode internal state here, so we lock to make sure that this doesn't conflict with the sync
         // thread.
         list<string> escalated;
-        {
-            if (_syncMutex.try_lock_for(chrono::milliseconds(10))) {
-                lock_guard<decltype(_syncMutex)> lock(_syncMutex, adopt_lock_t());
+        auto _syncNodeCopy = _syncNode;
+        if (_syncNodeCopy) {
+            content["syncNodeAvailable"] = "true";
+            // Set some information about this node.
+            content["CommitCount"] = to_string(_syncNodeCopy->getCommitCount());
+            content["priority"] = to_string(_syncNodeCopy->getPriority());
 
-                // There's no syncNode when the server is detached, so we can't get this data.
-                auto _syncNodeCopy = _syncNode;
-                if (_syncNodeCopy) {
-                    content["syncNodeAvailable"] = "true";
-                    // Set some information about this node.
-                    content["CommitCount"] = to_string(_syncNodeCopy->getCommitCount());
-                    content["priority"] = to_string(_syncNodeCopy->getPriority());
-
-                    // Get any escalated commands that are waiting to be processed.
-                    escalated = _syncNodeCopy->getEscalatedCommandRequestMethodLines();
-                } else {
-                    content["syncNodeAvailable"] = "false";
-                }
-            } else {
-                content["syncNodeBlocked"] = "true";
-            }
+            // Get any escalated commands that are waiting to be processed.
+            escalated = _syncNodeCopy->getEscalatedCommandRequestMethodLines();
+            _syncNodeCopy = nullptr;
+        } else {
+            content["syncNodeAvailable"] = "false";
         }
 
         // Coalesce all of the peer data into one value to return or return
         // an error message if we timed out getting the peerList data.
         list<string> peerList;
-        list<STable> peerData;
-        if (getPeerInfo(peerData)) {
-            for (const STable& peerTable : peerData) {
-                peerList.push_back(SComposeJSONObject(peerTable));
-            }
-        } else {
-            STable peerListResponse;
-            peerListResponse["peerListBlocked"] = "true";
-            peerList.push_back(SComposeJSONObject(peerListResponse));
+        list<STable> peerData = getPeerInfo();
+        for (const STable& peerTable : peerData) {
+            peerList.push_back(SComposeJSONObject(peerTable));
         }
 
         // We can use the `each` functionality to pass a lambda that will grab each method line in
@@ -2209,7 +2170,6 @@ SData BedrockServer::_generateCrashMessage(const unique_ptr<BedrockCommand>& com
 void BedrockServer::broadcastCommand(const SData& cmd) {
     SData message("BROADCAST_COMMAND");
     message.content = cmd.serialize();
-    lock_guard<decltype(_syncMutex)> lock(_syncMutex);
     auto _syncNodeCopy = _syncNode;
     if (_syncNodeCopy) {
         _syncNodeCopy->broadcast(message);

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -216,9 +216,8 @@ class BedrockServer : public SQLiteServer {
     // Returns whether or not this server was configured to backup.
     bool shouldBackup();
 
-    // Returns a copy of the internal state of the sync node's peers. This can be empty if there are no peers, or no
-    // sync node.
-    bool getPeerInfo(list<STable>& peerData);
+    // Returns a representation of the internal state of the sync node's peers. This can be empty if there are no
+    // peers, or no sync node.
     list<STable> getPeerInfo();
 
     // Send a command to all of our peers. It will be wrapped appropriately.
@@ -355,9 +354,6 @@ class BedrockServer : public SQLiteServer {
     // destroyed, we are also guaranteed that all peers are accessible as long as we hold a shared pointer to this
     // object.
     shared_ptr<SQLiteNode> _syncNode;
-
-    // Because status will access internal sync node data, we lock in both places that will access the pointer above.
-    recursive_timed_mutex _syncMutex;
 
     // Functions for checking for and responding to status and control commands.
     bool _isStatusCommand(const unique_ptr<BedrockCommand>& command);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -43,7 +43,6 @@
 //                   the leader to confirm that these responses were in fact sent in response to the correct message,
 //                   and not some old out-of-date message from the past.
 // Response:         Sent in STANDUP_RESPONSE, either "approve" or "deny".
-// Reason:           The reason for a failure case (typically, a "deny" Response). Explanatory string.
 // NumCommits:       With a "SYNCHRONIZE_RESPONSE" message, indicates the number of commits returned.
 // leaderSendTime:   Timestamp in microseconds that leader sent a message, for performance analysis.
 // dbCountAtStart:   The highest committed transaction in the DB at the start of this transaction on leader, for
@@ -63,10 +62,35 @@ const string SQLiteNode::consistencyLevelNames[] = {"ASYNC",
 
 atomic<int64_t> SQLiteNode::_currentCommandThreadID(0);
 
+const vector<STCPNode::Peer*> SQLiteNode::initPeers(const string& peerListString) {
+    vector<Peer*> peerList;
+    list<string> parsedPeerList = SParseList(peerListString);
+    for (const string& peerString : parsedPeerList) {
+        // Get the params from this peer, if any
+        string host;
+        STable params;
+        SASSERT(SParseURIPath(peerString, host, params));
+        string name = SGetDomain(host);
+        if (params.find("nodeName") != params.end()) {
+            name = params["nodeName"];
+        }
+
+        // Create a new peer and ready it for connection
+        SASSERT(SHostIsValid(host));
+        SINFO("Adding peer #" << peerList.size() << ": " << name << " (" << host << "), " << SComposeJSONObject(params));
+        Peer* peer = new Peer(name, host, params, peerList.size() + 1);
+
+        // Wait up to 2s before trying the first time
+        peer->nextReconnect = STimeNow() + SRandom::rand64() % (STIME_US_PER_S * 2);
+        peerList.push_back(peer);
+    }
+    return peerList;
+}
+
 SQLiteNode::SQLiteNode(SQLiteServer& server, SQLitePool& dbPool, const string& name,
                        const string& host, const string& peerList, int priority, uint64_t firstTimeout,
                        const string& version, const bool useParallelReplication)
-    : STCPNode(name, host, max(SQL_NODE_DEFAULT_RECV_TIMEOUT, SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT)),
+    : STCPNode(name, host, initPeers(peerList), max(SQL_NODE_DEFAULT_RECV_TIMEOUT, SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT)),
       _dbPool(dbPool),
       _db(_dbPool.getBase()),
       _commitState(CommitState::UNINITIALIZED),
@@ -101,20 +125,6 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, SQLitePool& dbPool, const string& n
     // Make sure we get notified when the DB needs to checkpoint.
     _dbPool.getBase().addCheckpointListener(_localCommitNotifier);
     _dbPool.getBase().addCheckpointListener(_leaderCommitNotifier);
-
-    // Add any peers.
-    list<string> parsedPeerList = SParseList(peerList);
-    for (const string& peer : parsedPeerList) {
-        // Get the params from this peer, if any
-        string host;
-        STable params;
-        SASSERT(SParseURIPath(peer, host, params));
-        string name = SGetDomain(host);
-        if (params.find("nodeName") != params.end()) {
-            name = params["nodeName"];
-        }
-        addPeer(name, host, params);
-    }
 }
 
 SQLiteNode::~SQLiteNode() {
@@ -356,7 +366,7 @@ bool SQLiteNode::shutdownComplete() {
 
     // If we have unsent data, not done
     for (auto peer : peerList) {
-        if (peer->s && !peer->s->sendBufferEmpty()) {
+        if (peer->socket && !peer->socket->sendBufferEmpty()) {
             // Still sending data
             SINFO("Can't graceful shutdown yet because unsent data to peer '" << peer->name << "'");
             return false;
@@ -407,7 +417,7 @@ void SQLiteNode::_sendOutstandingTransactions(const set<uint64_t>& commitOnlyIDs
             transaction.content = query;
             for (auto peer : peerList) {
                 // Clear the response flag from the last transaction
-                (*peer)["TransactionResponse"].clear();
+                peer->transactionResponse = Peer::Response::NONE;
             }
             _sendToAllPeers(transaction, true); // subscribed only
         } else {
@@ -513,9 +523,9 @@ bool SQLiteNode::update() {
                         to_string(chrono::duration_cast<chrono::milliseconds>(elapsed).count()) +
                         " ms elapsed. ";
         for (auto& p : peerList) {
-            if (p->s) {
-                logMsg += p->name + " sent " + to_string(p->s->getSentBytes()) + " bytes, recv " + to_string(p->s->getRecvBytes()) + " bytes. ";
-                p->s->resetCounters();
+            if (p->socket) {
+                logMsg += p->name + " sent " + to_string(p->socket->getSentBytes()) + " bytes, recv " + to_string(p->socket->getRecvBytes()) + " bytes. ";
+                p->socket->resetCounters();
             } else {
                 logMsg += p->name + " has no socket. ";
             }
@@ -559,8 +569,8 @@ bool SQLiteNode::update() {
         Peer* freshestPeer = nullptr;
         for (auto peer : peerList) {
             // Wait until all connected (or failed) and logged in
-            bool permaFollower = peer->params["Permafollower"] == "true";
-            bool loggedIn = peer->test("LoggedIn");
+            bool permaFollower = peer->permaFollower;
+            bool loggedIn = peer->loggedIn;
 
             // Count how many full peers (non-permafollowers) we have
             numFullPeers += !permaFollower;
@@ -571,7 +581,7 @@ bool SQLiteNode::update() {
             // Find the freshest peer
             if (loggedIn) {
                 // The freshest peer is the one that has the most commits.
-                if (!freshestPeer || peer->calcU64("CommitCount") > freshestPeer->calcU64("CommitCount")) {
+                if (!freshestPeer || peer->commitCount > freshestPeer->commitCount) {
                     freshestPeer = peer;
                 }
             }
@@ -598,7 +608,7 @@ bool SQLiteNode::update() {
 
         // How does our state compare with the freshest peer?
         SASSERT(freshestPeer);
-        uint64_t freshestPeerCommitCount = freshestPeer->calcU64("CommitCount");
+        uint64_t freshestPeerCommitCount = freshestPeer->commitCount;
         if (freshestPeerCommitCount == _db.getCommitCount()) {
             // We're up to date
             SINFO("Synchronized with the freshest peer '" << freshestPeer->name << "', WAITING.");
@@ -704,17 +714,17 @@ bool SQLiteNode::update() {
         Peer* currentLeader = nullptr;
         for (auto peer : peerList) {
             // Make sure we're a full peer
-            if (peer->params["Permafollower"] != "true") {
+            if (!peer->permaFollower) {
                 // Verify we're logged in
                 ++numFullPeers;
-                if (SIEquals((*peer)["LoggedIn"], "true")) {
+                if (peer->loggedIn) {
                     // Verify we're still fresh
                     ++numLoggedInFullPeers;
-                    if (!freshestPeer || peer->calcU64("CommitCount") > freshestPeer->calcU64("CommitCount"))
+                    if (!freshestPeer || peer->commitCount > freshestPeer->commitCount)
                         freshestPeer = peer;
 
                     // See if it's the highest priority
-                    if (!highestPriorityPeer || peer->calc("Priority") > highestPriorityPeer->calc("Priority"))
+                    if (!highestPriorityPeer || peer->priority > highestPriorityPeer->priority)
                         highestPriorityPeer = peer;
 
                     // See if it is currently the leader (or standing up/down)
@@ -744,12 +754,12 @@ bool SQLiteNode::update() {
         // If there is already a leader that is higher priority than us,
         // subscribe -- even if we're not in sync with it.  (It'll bring
         // us back up to speed while subscribing.)
-        if (currentLeader && _priority < highestPriorityPeer->calc("Priority") && currentLeader->state == LEADING) {
+        if (currentLeader && _priority < highestPriorityPeer->priority && currentLeader->state == LEADING) {
             // Subscribe to the leader
             SINFO("Subscribing to leader '" << currentLeader->name << "'");
             lock_guard<mutex> leadPeerLock(_leadPeerMutex);
             _leadPeer = currentLeader;
-            _leaderVersion = (*_leadPeer)["Version"];
+            _leaderVersion = _leadPeer.load()->version;
             _sendToPeer(currentLeader, SData("SUBSCRIBE"));
             _changeState(SUBSCRIBING);
             return true; // Re-update
@@ -758,7 +768,7 @@ bool SQLiteNode::update() {
         // No leader to subscribe to, let's see if there's anybody else
         // out there with commits we don't have.  Might as well synchronize
         // while waiting.
-        if (freshestPeer->calcU64("CommitCount") > _db.getCommitCount()) {
+        if (freshestPeer->commitCount > _db.getCommitCount()) {
             // Out of sync with a peer -- resynchronize
             SHMMM("Lost synchronization while waiting; re-SEARCHING.");
             _changeState(SEARCHING);
@@ -770,12 +780,12 @@ bool SQLiteNode::update() {
         // a real priority and are not a permafollower, and are connected to 
         // enough full peers to achieve quorum, we should be leader.
         if (!currentLeader && numLoggedInFullPeers * 2 >= numFullPeers &&
-            _priority > 0 && _priority > highestPriorityPeer->calc("Priority")) {
+            _priority > 0 && _priority > highestPriorityPeer->priority) {
             // Yep -- time for us to stand up -- clear everyone's
             // last approval status as they're about to send them.
             SINFO("No leader and we're highest priority (over " << highestPriorityPeer->name << "), STANDINGUP");
             for (auto peer : peerList) {
-                peer->erase("StandupResponse");
+                peer->standupResponse = Peer::Response::NONE;
             }
             _changeState(STANDINGUP);
             return true; // Re-update
@@ -812,19 +822,19 @@ bool SQLiteNode::update() {
         }
         for (auto peer : peerList) {
             // Check this peer; if not logged in, tacit approval
-            if (peer->params["Permafollower"] != "true") {
+            if (!peer->permaFollower) {
                 ++numFullPeers;
-                if (SIEquals((*peer)["LoggedIn"], "true")) {
+                if (peer->loggedIn) {
                     // Connected and logged in.
                     numLoggedInFullPeers++;
 
                     // Has it responded yet?
-                    if (!peer->isSet("StandupResponse")) {
+                    if (peer->standupResponse == Peer::Response::NONE) {
                         // At least one logged in full peer hasn't responded
                         allResponded = false;
-                    } else if (!SIEquals((*peer)["StandupResponse"], "approve")) {
+                    } else if (peer->standupResponse != Peer::Response::APPROVE) {
                         // It responeded, but didn't approve -- abort
-                        PHMMM("Refused our STANDUP (" << (*peer)["Reason"] << "), cancel and RESEARCH");
+                        PHMMM("Refused our STANDUP, cancel and RESEARCH");
                         _changeState(SEARCHING);
                         return true; // Re-update
                     }
@@ -871,7 +881,7 @@ bool SQLiteNode::update() {
     ///             if( there is a higher priority peer ) goto STANDINGDOWN
     ///             if( a command is queued )
     ///                 if( processing the command affects the database )
-    ///                    clear the TransactionResponse of all peers
+    ///                    clear the transactionResponse of all peers
     ///                    broadcast BEGIN_TRANSACTION to subscribed followers
     ///         if( we're standing down and all followers have unsubscribed )
     ///             goto SEARCHING
@@ -903,23 +913,22 @@ bool SQLiteNode::update() {
             int numFullDenied = 0;    // Num full peers that have denied
             for (auto peer : peerList) {
                 // Check this peer to see if it's full or a permafollower
-                if (peer->params["Permafollower"] != "true") {
+                if (!peer->permaFollower) {
                     // It's a full peer -- is it subscribed, and if so, how did it respond?
                     ++numFullPeers;
-                    if ((*peer)["Subscribed"] == "true") {
+                    if (peer->subscribed) {
                         // Subscribed, did it respond?
                         numFullFollowers++;
-                        const string& response = (*peer)["TransactionResponse"];
-                        if (response.empty()) {
+                        if (peer->transactionResponse == Peer::Response::NONE) {
                             continue;
                         }
                         numFullResponded++;
-                        numFullApproved += SIEquals(response, "approve");
-                        if (!SIEquals(response, "approve")) {
+                        if (peer->transactionResponse == Peer::Response::APPROVE) {
+                            SDEBUG("Peer '" << peer->name << "' has approved transaction.");
+                            ++numFullApproved;
+                        } else {
                             SWARN("Peer '" << peer->name << "' denied transaction.");
                             ++numFullDenied;
-                        } else {
-                            SDEBUG("Peer '" << peer->name << "' has approved transaction.");
                         }
                     }
                 }
@@ -1073,7 +1082,7 @@ bool SQLiteNode::update() {
 
             for (auto peer : peerList) {
                 // Clear the response flag from the last transaction
-                (*peer)["TransactionResponse"].clear();
+                peer->transactionResponse = Peer::Response::NONE;
             }
 
             // And send it to everyone who's subscribed.
@@ -1104,16 +1113,16 @@ bool SQLiteNode::update() {
                         standDownReason = "Found another LEADER (" + peer->name + "), STANDINGDOWN to clean it up.";
                     } else if (peer->state == WAITING) {
                         // We have a WAITING peer; is it waiting to STANDUP?
-                        if (peer->calc("Priority") > _priority) {
+                        if (peer->priority > _priority) {
                             // We've got a higher priority peer in the works; stand down so it can stand up.
                             standDownReason = "Found higher priority WAITING peer (" + peer->name
                                               + ") while LEADING, STANDINGDOWN";
-                        } else if (peer->calcU64("CommitCount") > _db.getCommitCount()) {
+                        } else if (peer->commitCount > _db.getCommitCount()) {
                             // It's got data that we don't, stand down so we can get it.
                             standDownReason = "Found WAITING peer (" + peer->name +
                                               ") with more data than us (we have " + SToStr(_db.getCommitCount()) +
-                                              "/" + _db.getCommittedHash() + ", it has " + (*peer)["CommitCount"] +
-                                              "/" + (*peer)["Hash"] + ") while LEADING, STANDINGDOWN";
+                                              "/" + _db.getCommittedHash() + ", it has " + to_string(peer->commitCount) +
+                                              "/" + peer->hash.load() + ") while LEADING, STANDINGDOWN";
                         }
                     }
                 }
@@ -1238,15 +1247,15 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
     if (!message.isSet("Hash")) {
         STHROW("missing Hash");
     }
-    (*peer)["CommitCount"] = message["CommitCount"];
-    (*peer)["Hash"] = message["Hash"];
+
+    peer->setCommit(message.calcU64("CommitCount"), message["Hash"]);
 
     // Classify and process the message
     if (SIEquals(message.methodLine, "LOGIN")) {
         // LOGIN: This is the first message sent to and received from a new peer. It communicates the current state of
         // the peer (hash and commit count), as well as the peer's priority. Peers can connect in any state, so this
         // message can be sent and received in any state.
-        if ((*peer)["LoggedIn"] == "true") {
+        if (peer->loggedIn) {
             STHROW("already logged in");
         }
         if (!message.isSet("Priority")) {
@@ -1258,10 +1267,10 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         if (!message.isSet("Version")) {
             STHROW("missing Version");
         }
-        if (peer->params["Permafollower"] == "true" && (message["Permafollower"] != "true" || message.calc("Priority") > 0)) {
+        if (peer->permaFollower && (message["Permafollower"] != "true" || message.calc("Priority") > 0)) {
             STHROW("you're supposed to be a 0-priority permafollower");
         }
-        if (peer->params["Permafollower"] != "true" && (message["Permafollower"] == "true" || message.calc("Priority") == 0)) {
+        if (!peer->permaFollower && (message["Permafollower"] == "true" || message.calc("Priority") == 0)) {
             STHROW("you're *not* supposed to be a 0-priority permafollower");
         }
 
@@ -1269,14 +1278,14 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         SASSERT(_priority == -1 || _priority == 0 || message.calc("Priority") != _priority);
         PINFO("Peer logged in at '" << message["State"] << "', priority #" << message["Priority"] << " commit #"
               << message["CommitCount"] << " (" << message["Hash"] << ")");
-        peer->set("Priority", message["Priority"]);
-        peer->set("LoggedIn", "true");
-        peer->set("Version",  message["Version"]);
+        peer->priority = message.calc("Priority");
+        peer->loggedIn = true;
+        peer->version = message["Version"];
         peer->state = stateFromName(message["State"]);
 
         // Let the server know that a peer has logged in.
         _server.onNodeLogin(peer);
-    } else if (!SIEquals((*peer)["LoggedIn"], "true")) {
+    } else if (!peer->loggedIn) {
         STHROW("not logged in");
     }
     else if (SIEquals(message.methodLine, "STATE")) {
@@ -1289,7 +1298,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             STHROW("missing Priority");
         }
         const State from = peer->state;
-        peer->set("Priority", message["Priority"]);
+        peer->priority = message.calc("Priority");
         peer->state = stateFromName(message["State"]);
         const State to = peer->state;
         if (from == to) {
@@ -1346,8 +1355,8 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 // SEARCHING: If anything ever goes wrong, a node reverts to the SEARCHING state. Thus if we see a peer
                 // go SEARCHING, we reset its accumulated state.  Specifically, we mark it is no longer being
                 // "subscribed", and we clear its last transaction response.
-                peer->erase("TransactionResponse");
-                peer->erase("Subscribed");
+                peer->transactionResponse = Peer::Response::NONE;
+                peer->subscribed = false;
             } else if (to == STANDINGUP) {
                 // STANDINGUP: When a peer announces it intends to stand up, we immediately respond with approval or
                 // denial. We determine this by checking to see if there is any  other peer who is already leader or
@@ -1357,17 +1366,20 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 SData response("STANDUP_RESPONSE");
                 // Parrot back the node's attempt count so that it can differentiate stale responses.
                 response["StateChangeCount"] = message["StateChangeCount"];
-                if (peer->params["Permafollower"] == "true") {
+
+                // Reason we would deny, if we do.
+                string reason;
+                if (peer->permaFollower) {
                     // We think it's a permafollower, deny
                     PHMMM("Permafollower trying to stand up, denying.");
                     response["Response"] = "deny";
-                    response["Reason"] = "You're a permafollower";
+                    reason = "You're a permafollower";
                 }
 
                 // What's our state
                 if (SWITHIN(STANDINGUP, _state, STANDINGDOWN)) {
                     // Oh crap, it's trying to stand up while we're leading. Who is higher priority?
-                    if (peer->calc("Priority") > _priority) {
+                    if (peer->priority > _priority) {
                         // The other peer is a higher priority than us, so we should stand down (maybe it crashed, we
                         // came up as leader, and now it's been brought back up). We'll want to stand down here, but we
                         // do it gracefully so that we won't lose any transactions in progress.
@@ -1383,7 +1395,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                     } else {
                         // Deny because we're currently in the process of leading and we're higher priority.
                         response["Response"] = "deny";
-                        response["Reason"] = "I am leading";
+                        reason = "I am leading";
 
                         // Hmm, why is a lower priority peer trying to stand up? Is it possible we're no longer in
                         // control of the cluster? Let's see how many nodes are subscribed.
@@ -1415,7 +1427,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                             if (otherPeer->state == STANDINGUP || otherPeer->state == LEADING || otherPeer->state == STANDINGDOWN) {
                                 // We need to contest this standup
                                 response["Response"] = "deny";
-                                response["Reason"] = "peer '" + otherPeer->name + "' is '" + stateName(otherPeer->state) + "'";
+                                reason = "peer '" + otherPeer->name + "' is '" + stateName(otherPeer->state) + "'";
                                 break;
                             }
                         }
@@ -1426,7 +1438,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                 if (SIEquals(response["Response"], "approve")) {
                     PINFO("Approving standup request");
                 } else {
-                    PHMMM("Denying standup request because " << response["Reason"]);
+                    PHMMM("Denying standup request because " << reason);
                 }
                 _sendToPeer(peer, response);
             } else if (from == STANDINGDOWN) {
@@ -1460,16 +1472,17 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             if (!message.isSet("Response")) {
                 STHROW("missing Response");
             }
-            if (peer->isSet("StandupResponse")) {
-                PWARN("Already received standup response '" << (*peer)["StandupResponse"] << "', now receiving '"
+            if (peer->standupResponse != Peer::Response::NONE) {
+                PWARN("Already received standup response '" << peer->standupResponse << "', now receiving '"
                       << message["Response"] << "', odd -- multiple leaders competing?");
             }
             if (SIEquals(message["Response"], "approve")) {
                 PINFO("Received standup approval");
+                peer->standupResponse = Peer::Response::APPROVE;
             } else {
                 PHMMM("Received standup denial: reason='" << message["Reason"] << "'");
+                peer->standupResponse = Peer::Response::DENY;
             }
-            (*peer)["StandupResponse"] = message["Response"];
         } else {
             SINFO("Got STANDUP_RESPONSE but not STANDINGUP. Probably a late message, ignoring.");
         }
@@ -1482,8 +1495,11 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             // processed asynchronously, but that is fine, the final `SUBSCRIBE` message and its response will be
             // processed synchronously.
             SData request = message;
-            request["peerCommitCount"] = (*peer)["CommitCount"];
-            request["peerHash"] = (*peer)["Hash"];
+            uint64_t count = 0;
+            string hash;
+            peer->getCommit(count, hash);
+            request["peerCommitCount"] = to_string(count);
+            request["peerHash"] = hash;
             request["peerID"] = to_string(getIDByPeer(peer));
 
             // The following properties are only used to expand out our log macros.
@@ -1517,7 +1533,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         try {
             // Received this synchronization response; are we done?
             _recvSynchronize(peer, message);
-            uint64_t peerCommitCount = _syncPeer->calcU64("CommitCount");
+            uint64_t peerCommitCount = _syncPeer->commitCount;
             if (_db.getCommitCount() == peerCommitCount) {
                 // All done
                 SINFO("Synchronization complete, at commitCount #" << _db.getCommitCount() << " ("
@@ -1568,8 +1584,8 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         SData response("SUBSCRIPTION_APPROVED");
         _queueSynchronize(peer, response, true); // Send everything it's missing
         _sendToPeer(peer, response);
-        SASSERTWARN(!SIEquals((*peer)["Subscribed"], "true"));
-        (*peer)["Subscribed"] = "true";
+        SASSERTWARN(!peer->subscribed);
+        peer->subscribed = true;
 
         // New follower; are we in the midst of a transaction?
         if (_commitState == CommitState::COMMITTING) {
@@ -1649,7 +1665,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         if (_state != LEADING && _state != STANDINGDOWN) {
             STHROW("not leading");
         }
-        string response = SIEquals(message.methodLine, "APPROVE_TRANSACTION") ? "approve" : "deny";
+        Peer::Response response = SIEquals(message.methodLine, "APPROVE_TRANSACTION") ? Peer::Response::APPROVE : Peer::Response::DENY;
         try {
             // We ignore late approvals of commits that have already been finalized. They could have been committed
             // already, in which case `_lastSentTransactionID` will have incremented, or they could have been rolled
@@ -1661,11 +1677,11 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
                     STHROW("commit count mismatch. Expected: " + message["NewCount"] + ", but would actually be: "
                           + to_string(_db.getCommitCount() + 1));
                 }
-                if (peer->params["Permafollower"] == "true") {
+                if (peer->permaFollower) {
                     STHROW("permafollowers shouldn't approve/deny");
                 }
                 PINFO("Peer " << response << " transaction #" << message["NewCount"] << " (" << message["NewHash"] << ")");
-                (*peer)["TransactionResponse"] = response;
+                peer->transactionResponse = response;
             } else {
                 // Old command.  Nothing to do.  We already sent a commit or rollback.
                 PINFO("Peer '" << message.methodLine << "' transaction #" << message["NewCount"]
@@ -1705,7 +1721,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             if (!request.deserialize(message.content)) {
                 STHROW("malformed request");
             }
-            if ((*peer)["Subscribed"] != "true") {
+            if (!peer->subscribed) {
                 STHROW("not subscribed");
             }
             if (!message.isSet("ID")) {
@@ -1736,7 +1752,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             if (!request.deserialize(message.content)) {
                 STHROW("malformed request");
             }
-            if ((*peer)["Subscribed"] != "true") {
+            if (!peer->subscribed) {
                 STHROW("not subscribed");
             }
             if (!message.isSet("ID")) {
@@ -1814,7 +1830,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
 
 void SQLiteNode::_onConnect(Peer* peer) {
     SASSERT(peer);
-    SASSERTWARN(!SIEquals((*peer)["LoggedIn"], "true"));
+    SASSERTWARN(!peer->loggedIn);
     // Send the LOGIN
     PINFO("Sending LOGIN");
     SData login("LOGIN");
@@ -1842,8 +1858,8 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
     ///   is out of touch with reality: we processed a command and reality doesn't
     ///   know it.  Not cool!
     ///
-    if (peer->s && peer->s->sendBufferCopy().find("ESCALATE_RESPONSE") != string::npos)
-        PWARN("Initiating follower died before receiving response to escalation: " << peer->s->sendBufferCopy());
+    if (peer->socket && peer->socket->sendBufferCopy().find("ESCALATE_RESPONSE") != string::npos)
+        PWARN("Initiating follower died before receiving response to escalation: " << peer->socket->sendBufferCopy());
 
     /// - Verify we didn't just lose contact with our leader.  This should
     ///   only be possible if we're SUBSCRIBING or FOLLOWING.  If we did lose our
@@ -1900,10 +1916,10 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
                 continue;
             }
             // Make sure we're a full peer
-            if (otherPeer->params["Permafollower"] != "true") {
+            if (!otherPeer->permaFollower) {
                 // Verify we're logged in
                 ++numFullPeers;
-                if (SIEquals((*otherPeer)["LoggedIn"], "true")) {
+                if (otherPeer->loggedIn) {
                     // Verify we're still fresh
                     ++numLoggedInFullPeers;
                 }
@@ -1929,7 +1945,7 @@ void SQLiteNode::_sendToPeer(Peer* peer, const SData& message) {
     SASSERT(!message.empty());
 
     // If a peer is currently disconnected, we can't send it a message.
-    if (!peer->s) {
+    if (!peer->socket) {
         PWARN("Can't send message to peer, no socket. Message '" << message.methodLine << "' will be discarded.");
         return;
     }
@@ -1937,7 +1953,7 @@ void SQLiteNode::_sendToPeer(Peer* peer, const SData& message) {
     SData messageCopy = message;
     messageCopy["CommitCount"] = to_string(_db.getCommitCount());
     messageCopy["Hash"] = _db.getCommittedHash();
-    peer->s->send(messageCopy.serialize());
+    peer->socket->send(messageCopy.serialize());
 }
 
 void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly) {
@@ -1954,9 +1970,9 @@ void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly) {
     // Loop across all connected peers and send the message
     for (auto peer : peerList) {
         // Send either to everybody, or just subscribed peers.
-        if (peer->s && (!subscribedOnly || SIEquals((*peer)["Subscribed"], "true"))) {
+        if (peer->socket && (!subscribedOnly || peer->subscribed)) {
             // Send it now, without waiting for the outer event loop
-            peer->s->send(serializedMessage);
+            peer->socket->send(serializedMessage);
         }
     }
 }
@@ -1972,9 +1988,6 @@ void SQLiteNode::broadcast(const SData& message, Peer* peer) {
 }
 
 void SQLiteNode::_changeState(SQLiteNode::State newState) {
-    // Exclusively lock the stateMutex, nobody else will be able to get a shared lock until this is released.
-    unique_lock<decltype(stateMutex)> lock(stateMutex);
-
     // Did we actually change _state?
     State oldState = _state;
 
@@ -2094,35 +2107,23 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
 }
 
 void SQLiteNode::_queueSynchronize(Peer* peer, SData& response, bool sendAll) {
-    _queueSynchronizeStateless(peer->nameValueMap, name, peer->name, _state, _db, response, sendAll);
-}
+    // Peer is requesting synchronization. First, does it have any data?
 
-void SQLiteNode::_queueSynchronizeStateless(const STable& params, const string& name, const string& peerName, State _state, SQLite& db, SData& response, bool sendAll) {
-    // This is a hack to make the PXXXX macros works, since they expect `peer->name` to be defined.
-    struct {string name;} peerBase;
-    auto peer = &peerBase;
-    peerBase.name = peerName;
-
-    // Peer is requesting synchronization.  First, does it have any data?
     uint64_t peerCommitCount = 0;
-    if(params.find("CommitCount") != params.end()) {
-        peerCommitCount = SToUInt64(params.at("CommitCount"));
-    }
-    if (peerCommitCount > db.getCommitCount())
+    string peerHash;
+    peer->getCommit(peerCommitCount, peerHash);
+
+    if (peerCommitCount > _db.getCommitCount())
         STHROW("you have more data than me");
     if (peerCommitCount) {
         // It has some data -- do we agree on what we share?
         string myHash, ignore;
-        if (!db.getCommit(peerCommitCount, ignore, myHash)) {
-            PWARN("Error getting commit for peer's commit: " << peerCommitCount << ", my commit count is: " << db.getCommitCount());
+        if (!_db.getCommit(peerCommitCount, ignore, myHash)) {
+            PWARN("Error getting commit for peer's commit: " << peerCommitCount << ", my commit count is: " << _db.getCommitCount());
             STHROW("error getting hash");
         }
-        string compareHash;
-        if (params.find("Hash") != params.end()) {
-            compareHash = params.at("Hash");
-        }
-        if (myHash != compareHash) {
-            SWARN("Hash mismatch. Peer at commit:" << peerCommitCount << " with hash " << compareHash
+        if (myHash != peerHash) {
+            SWARN("Hash mismatch. Peer at commit:" << peerCommitCount << " with hash " << peerHash
                   << ", but we have hash: " << myHash << " for that commit.");
             STHROW("hash mismatch");
         }
@@ -2138,7 +2139,7 @@ void SQLiteNode::_queueSynchronizeStateless(const STable& params, const string& 
     // The commitCount can change at any time, and on LEADER, we need to make sure we don't send the same transaction
     // twice, where _lastSentTransactionID only changes in the sync thread. From followers serving SYNCHRONIZE
     // requests, they can always serve their entire DB, there's no point at which they risk double-sending data.
-    uint64_t targetCommit = (_state == LEADING) ? _lastSentTransactionID : db.getCommitCount();
+    uint64_t targetCommit = (_state == LEADING) ? _lastSentTransactionID : _db.getCommitCount();
     if (peerCommitCount == targetCommit) {
         // Already synchronized; nothing to send
         PINFO("Peer is already synchronized");
@@ -2149,7 +2150,7 @@ void SQLiteNode::_queueSynchronizeStateless(const STable& params, const string& 
         uint64_t toIndex = targetCommit;
         if (!sendAll)
             toIndex = min(toIndex, fromIndex + 100); // 100 transactions at a time
-        if (!db.getCommits(fromIndex, toIndex, result))
+        if (!_db.getCommits(fromIndex, toIndex, result))
             STHROW("error getting commits");
         if ((uint64_t)result.size() != toIndex - fromIndex + 1)
             STHROW("mismatched commit count");
@@ -2254,7 +2255,7 @@ void SQLiteNode::_updateSyncPeer()
     uint64_t commitCount = _db.getCommitCount();
     for (auto peer : peerList) {
         // If either of these conditions are true, then we can't use this peer.
-        if (!peer->test("LoggedIn") || peer->calcU64("CommitCount") <= commitCount) {
+        if (!peer->loggedIn || peer->commitCount <= commitCount) {
             continue;
         }
 
@@ -2265,7 +2266,7 @@ void SQLiteNode::_updateSyncPeer()
         // If the previous best peer and this one have the same latency (meaning they're probably both 0), the best one
         // is the one with the highest commit count.
         else if (newSyncPeer->latency == peer->latency) {
-            if (peer->calc64("CommitCount") > newSyncPeer->calc64("CommitCount")) {
+            if (peer->commitCount > newSyncPeer->commitCount) {
                 newSyncPeer = peer;
             }
         }
@@ -2284,13 +2285,13 @@ void SQLiteNode::_updateSyncPeer()
     if (_syncPeer != newSyncPeer) {
         string from, to;
         if (_syncPeer) {
-            from = _syncPeer->name + " (commit count=" + (*_syncPeer)["CommitCount"] + "), latency="
+            from = _syncPeer->name + " (commit count=" + to_string(_syncPeer->commitCount) + "), latency="
                                    + to_string(_syncPeer->latency/1000) + "ms";
         } else {
             from = "(NONE)";
         }
         if (newSyncPeer) {
-            to = newSyncPeer->name + " (commit count=" + (*newSyncPeer)["CommitCount"] + "), latency="
+            to = newSyncPeer->name + " (commit count=" + to_string(newSyncPeer->commitCount) + "), latency="
                                    + to_string(newSyncPeer->latency/1000) + "ms";
         } else {
             to = "(NONE)";
@@ -2302,10 +2303,10 @@ void SQLiteNode::_updateSyncPeer()
         for (auto peer : peerList) {
             if (peer == newSyncPeer || peer == _syncPeer) {
                 continue; // These ones we're already logging.
-            } else if (!peer->test("LoggedIn")) {
+            } else if (!peer->loggedIn) {
                 nonChosenPeers.push_back(peer->name + ":!loggedIn");
-            } else if (peer->calcU64("CommitCount") <= commitCount) {
-                nonChosenPeers.push_back(peer->name + ":commit=" + (*peer)["CommitCount"]);
+            } else if (peer->commitCount <= commitCount) {
+                nonChosenPeers.push_back(peer->name + ":commit=" + to_string(peer->commitCount));
             } else {
                 nonChosenPeers.push_back(peer->name + ":" + to_string(peer->latency/1000) + "ms");
             }
@@ -2319,11 +2320,11 @@ void SQLiteNode::_updateSyncPeer()
 
 void SQLiteNode::_reconnectPeer(Peer* peer) {
     // If we're connected, just kill the connection
-    if (peer->s) {
+    if (peer->socket) {
         // Reset
         SHMMM("Reconnecting to '" << peer->name << "'");
-        shutdownSocket(peer->s);
-        (*peer)["LoggedIn"] = "false";
+        shutdownSocket(peer->socket);
+        peer->loggedIn = false;
     }
 }
 
@@ -2339,9 +2340,9 @@ bool SQLiteNode::_majoritySubscribed() {
     int numFullPeers = 0;
     int numFullFollowers = 0;
     for (auto peer : peerList) {
-        if (peer->params["Permafollower"] != "true") {
+        if (!peer->permaFollower) {
             ++numFullPeers;
-            if (peer->test("Subscribed")) {
+            if (peer->subscribed) {
                 ++numFullFollowers;
             }
         }
@@ -2351,8 +2352,13 @@ bool SQLiteNode::_majoritySubscribed() {
     return (numFullFollowers * 2 >= numFullPeers);
 }
 
-bool SQLiteNode::peekPeerCommand(SQLiteNode* node, SQLite& db, SQLiteCommand& command)
+bool SQLiteNode::peekPeerCommand(shared_ptr<SQLiteNode> node, SQLite& db, SQLiteCommand& command)
 {
+    if (!node) {
+        // Node deleted while trying to peek peer command, just pretend it worked.
+        return true;
+    }
+
     Peer* peer = nullptr;
     try {
         if (SIEquals(command.request.methodLine, "SYNCHRONIZE")) {
@@ -2362,13 +2368,10 @@ bool SQLiteNode::peekPeerCommand(SQLiteNode* node, SQLite& db, SQLiteCommand& co
                 return true;
             }
             command.response.methodLine = "SYNCHRONIZE_RESPONSE";
-            _queueSynchronizeStateless(command.request.nameValueMap,
-                                       command.request["name"],
-                                       command.request["peerName"],
-                                       node->_state,
-                                       db,
-                                       command.response,
-                                       false);
+
+            // Because we hold a sharedPtr to the node, it can't delete any peers (because it only does at
+            // destruction), and since our peers our thread-safe, we can run this just fine.
+            node->_queueSynchronize(peer, command.response, false);
 
             // The following two lines are copied from `_sendToPeer`.
             command.response["CommitCount"] = to_string(db.getCommitCount());
@@ -2785,9 +2788,9 @@ bool SQLiteNode::hasQuorum() {
     int numFullPeers = 0;
     int numFullFollowers = 0;
     for (auto peer : peerList) {
-        if (peer->params["Permafollower"] != "true") {
+        if (!peer->permaFollower) {
             ++numFullPeers;
-            if ((*peer)["Subscribed"] == "true") {
+            if (peer->subscribed) {
                 numFullFollowers++;
             }
         }

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -41,6 +41,8 @@ class SQLiteNode : public STCPNode {
                const string& peerList, int priority, uint64_t firstTimeout, const string& version, const bool useParallelReplication = false);
     ~SQLiteNode();
 
+    const vector<Peer*> initPeers(const string& peerList);
+
     // Simple Getters. See property definitions for details.
     State         getState()         { return _state; }
     int           getPriority()      { return _priority; }
@@ -93,16 +95,10 @@ class SQLiteNode : public STCPNode {
     // This is a static function that can 'peek' a command initiated by a peer, but can be called by any thread.
     // Importantly for thread safety, this cannot depend on the current state of the cluster or a specific node.
     // Returns false if the node can't peek the command.
-    static bool peekPeerCommand(SQLiteNode* node, SQLite& db, SQLiteCommand& command);
+    static bool peekPeerCommand(shared_ptr<SQLiteNode>, SQLite& db, SQLiteCommand& command);
 
     // This exists so that the _server can inspect internal state for diagnostic purposes.
     list<string> getEscalatedCommandRequestMethodLines();
-
-    // This mutex is exposed publicly so that others (particularly, the _server) can atomically act on the current
-    // state of the node. When working with this and SQLite::g_commitLock, the correct order of acquisition is always:
-    // 1. stateMutex
-    // 2. SQLite::g_commitLock
-    shared_timed_mutex stateMutex;
 
     // This will broadcast a message to all peers, or a specific peer.
     void broadcast(const SData& message, Peer* peer = nullptr);
@@ -184,11 +180,8 @@ class SQLiteNode : public STCPNode {
     void _sendToAllPeers(const SData& message, bool subscribedOnly = false);
     void _changeState(State newState);
 
-    // Queue a SYNCHRONIZE message based on the current state of the node.
+    // Queue a SYNCHRONIZE message based on the current state of the node, thread-safe.
     void _queueSynchronize(Peer* peer, SData& response, bool sendAll);
-
-    // Queue a SYNCHRONIZE message based on pre-computed state of the node. This version is thread-safe.
-    static void _queueSynchronizeStateless(const STable& params, const string& name, const string& peerName, State _state, SQLite& db, SData& response, bool sendAll);
     void _recvSynchronize(Peer* peer, const SData& message);
     void _reconnectPeer(Peer* peer);
     void _reconnectAll();

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -145,7 +145,7 @@ struct GracefulFailoverTest : tpunit::TestFixture {
             list<string> peers = SParseJSONArray(peerList);
             for (auto& peer : peers) {
                 STable peerInfo = SParseJSONObject(peer);
-                if (peerInfo["name"] == "cluster_node_2" && (peerInfo["State"] == "" || peerInfo["State"] == "SEARCHING")) {
+                if (peerInfo["name"] == "cluster_node_2" && (peerInfo["State"] == "" || SStartsWith(peerInfo["State"], "SEARCHING"))) {
                     success = true;
                     break;
                 }

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -44,20 +44,15 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         close(fd);
         SQLitePool dbPool(10, filename, 1000000, 5000, 0);
         TestServer server("");
-        SQLiteNode testNode(server, dbPool, "test", "localhost:19998", "", 1, 1000000000, "1.0");
-
-        STable dummyParams;
-        testNode.addPeer("peer1", "host1.fake:15555", dummyParams);
-        testNode.addPeer("peer2", "host2.fake:16666", dummyParams);
-        testNode.addPeer("peer3", "host3.fake:17777", dummyParams);
-        testNode.addPeer("peer4", "host4.fake:18888", dummyParams);
+        string peerList = "host1.fake:15555?nodeName=peer1,host2.fake:16666?nodeName=peer2,host3.fake:17777?nodeName=peer3,host4.fake:18888?nodeName=peer4";
+        SQLiteNode testNode(server, dbPool, "test", "localhost:19998", peerList, 1, 1000000000, "1.0");
 
         // Do a base test, with one peer with no latency.
         SQLiteNode::Peer* fastest = nullptr;
         for (auto peer : testNode.peerList) {
             int peerNum = peer->name[4] - 48;
-            (*peer)["LoggedIn"] = "true";
-            (*peer)["CommitCount"] = to_string(10000000 + peerNum);
+            peer->loggedIn = true;
+            peer->setCommit(10000000 + peerNum, "");
 
             // 0, 100, 200, 300.
             peer->latency = (peerNum - 1) * 100;
@@ -84,7 +79,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         // And see what happens if our fastest peer logs out.
         for (auto peer : testNode.peerList) {
             if (peer->name == "peer3") {
-                (*peer)["LoggedIn"] = "false";
+                peer->loggedIn = false;
                 peer->latency = 50;
             }
 


### PR DESCRIPTION
Reverts Expensify/Bedrock#889