### PR TITLE
Fix segfault from using wrong DB object in synchronize

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -227,12 +227,6 @@ void BedrockServer::sync(const SData& args,
     AutoTimer postPollTimer("sync thread PostPoll");
     AutoTimer escalateLoopTimer("sync thread escalate loop");
 
-    // We hold a lock here around all operations on `syncNode`, because `SQLiteNode` isn't thread-safe, but we need
-    // `BedrockServer` to be able to introspect it in `Status` requests. We hold this lock at all times until exiting
-    // our main loop, aside from when we're waiting on `poll`. Strictly, we could hold this lock less often, but there
-    // are not that many status commands coming in, and they can wait for a fraction of a second, which lets us keep
-    // the logic of this loop simpler.
-    server._syncMutex.lock();
     do {
         // Make sure the existing command prefix is still valid since they're reset when SAUTOPREFIX goes out of scope.
         if (command) {
@@ -337,14 +331,10 @@ void BedrockServer::sync(const SData& args,
 
         // Wait for activity on any of those FDs, up to a timeout.
         const uint64_t now = STimeNow();
-
-        // Unlock our mutex, poll, and re-lock when finished.
-        server._syncMutex.unlock();
         {
             AutoTimerTime pollTime(pollTimer);
             S_poll(fdm, max(nextActivity, now) - now);
         }
-        server._syncMutex.lock();
 
         // And set our next timeout for 1 second from now.
         nextActivity = STimeNow() + STIME_US_PER_S;
@@ -694,9 +684,6 @@ void BedrockServer::sync(const SData& args,
         db.rollback();
     }
 
-    // Done with the global lock.
-    server._syncMutex.unlock();
-
     // We've finished shutting down the sync node, tell the workers that it's finished.
     server._shutdownState.store(DONE);
     SINFO("Sync thread finished with commands.");
@@ -830,7 +817,7 @@ void BedrockServer::worker(SQLitePool& dbPool,
 
             // If this was a command initiated by a peer as part of a cluster operation, then we process it separately
             // and respond immediately. This allows SQLiteNode to offload read-only operations to worker threads.
-            if (SQLiteNode::peekPeerCommand(server._syncNode.get(), db, *command)) {
+            if (SQLiteNode::peekPeerCommand(server._syncNode, db, *command)) {
                 // Move on to the next command.
                 continue;
             }
@@ -1058,12 +1045,16 @@ void BedrockServer::worker(SQLitePool& dbPool,
                         // to the minimum time required.
                         bool commitSuccess = false;
                         {
-                            // This is the first place we get really particular with the state of the node from a
-                            // worker thread. We only want to do this commit if we're *SURE* we're leading, and
-                            // not allow the state of the node to change while we're committing. If it turns out
-                            // we've changed states, we'll roll this command back, so we lock the node's state
-                            // until we complete.
-                            shared_lock<decltype(server._syncNode->stateMutex)> stateLock(server._syncNode->stateMutex);
+                            // There used to be a mutex protecting this state change, with the idea that if we
+                            // prevented state changes, we couldn't fall out of leading in the middle of processing a
+                            // command. However, for "normal" graceful state changes, these changes are prevented by
+                            // checking canStandDown(), and we can't fall out of STANDINGDOWN until there are no
+                            // commands left. In the case of non-graceful state changes, i.e., we are spontaneously
+                            // disconnected from the cluster, all this really does is prevent the sync thread from
+                            // telling us about that until after we've already committed this transaction, which
+                            // doesn't really help. In those cases, it's possible that we fork the DB here, but that's
+                            // possible with or without a mutex for this, so we've removed it for the sake of
+                            // simplicity.
                             if (replicationState.load() != SQLiteNode::LEADING &&
                                 replicationState.load() != SQLiteNode::STANDINGDOWN) {
                                 SALERT("Node State changed from LEADING to "
@@ -1833,30 +1824,14 @@ bool BedrockServer::_isStatusCommand(const unique_ptr<BedrockCommand>& command) 
     return false;
 }
 
-bool BedrockServer::getPeerInfo(list<STable>& peerData) {
-    if (_syncMutex.try_lock_for(chrono::milliseconds(10))) {
-        lock_guard<decltype(_syncMutex)> lock(_syncMutex, adopt_lock_t());
-        auto _syncNodeCopy = _syncNode;
-        if (_syncNodeCopy) {
-            for (SQLiteNode::Peer* peer : _syncNodeCopy->peerList) {
-                peerData.emplace_back(peer->nameValueMap);
-                for (auto it : peer->params) {
-                    peerData.back()[it.first] = it.second;
-                }
-                peerData.back()["host"] = peer->host;
-                peerData.back()["name"] = peer->name;
-                peerData.back()["State"] = SQLiteNode::stateName(peer->state);
-            }
-        }
-    } else {
-        return false;
-    }
-    return true;
-}
-
 list<STable> BedrockServer::getPeerInfo() {
     list<STable> peerData;
-    getPeerInfo(peerData);
+    auto _syncNodeCopy = _syncNode;
+    if (_syncNodeCopy) {
+        for (SQLiteNode::Peer* peer : _syncNodeCopy->peerList) {
+            peerData.emplace_back(peer->getData());
+        }
+    }
     return peerData;
 }
 
@@ -1947,40 +1922,26 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         // We read from syncNode internal state here, so we lock to make sure that this doesn't conflict with the sync
         // thread.
         list<string> escalated;
-        {
-            if (_syncMutex.try_lock_for(chrono::milliseconds(10))) {
-                lock_guard<decltype(_syncMutex)> lock(_syncMutex, adopt_lock_t());
+        auto _syncNodeCopy = _syncNode;
+        if (_syncNodeCopy) {
+            content["syncNodeAvailable"] = "true";
+            // Set some information about this node.
+            content["CommitCount"] = to_string(_syncNodeCopy->getCommitCount());
+            content["priority"] = to_string(_syncNodeCopy->getPriority());
 
-                // There's no syncNode when the server is detached, so we can't get this data.
-                auto _syncNodeCopy = _syncNode;
-                if (_syncNodeCopy) {
-                    content["syncNodeAvailable"] = "true";
-                    // Set some information about this node.
-                    content["CommitCount"] = to_string(_syncNodeCopy->getCommitCount());
-                    content["priority"] = to_string(_syncNodeCopy->getPriority());
-
-                    // Get any escalated commands that are waiting to be processed.
-                    escalated = _syncNodeCopy->getEscalatedCommandRequestMethodLines();
-                } else {
-                    content["syncNodeAvailable"] = "false";
-                }
-            } else {
-                content["syncNodeBlocked"] = "true";
-            }
+            // Get any escalated commands that are waiting to be processed.
+            escalated = _syncNodeCopy->getEscalatedCommandRequestMethodLines();
+            _syncNodeCopy = nullptr;
+        } else {
+            content["syncNodeAvailable"] = "false";
         }
 
         // Coalesce all of the peer data into one value to return or return
         // an error message if we timed out getting the peerList data.
         list<string> peerList;
-        list<STable> peerData;
-        if (getPeerInfo(peerData)) {
-            for (const STable& peerTable : peerData) {
-                peerList.push_back(SComposeJSONObject(peerTable));
-            }
-        } else {
-            STable peerListResponse;
-            peerListResponse["peerListBlocked"] = "true";
-            peerList.push_back(SComposeJSONObject(peerListResponse));
+        list<STable> peerData = getPeerInfo();
+        for (const STable& peerTable : peerData) {
+            peerList.push_back(SComposeJSONObject(peerTable));
         }
 
         // We can use the `each` functionality to pass a lambda that will grab each method line in
@@ -2209,7 +2170,6 @@ SData BedrockServer::_generateCrashMessage(const unique_ptr<BedrockCommand>& com
 void BedrockServer::broadcastCommand(const SData& cmd) {
     SData message("BROADCAST_COMMAND");
     message.content = cmd.serialize();
-    lock_guard<decltype(_syncMutex)> lock(_syncMutex);
     auto _syncNodeCopy = _syncNode;
     if (_syncNodeCopy) {
         _syncNodeCopy->broadcast(message);

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -216,9 +216,8 @@ class BedrockServer : public SQLiteServer {
     // Returns whether or not this server was configured to backup.
     bool shouldBackup();
 
-    // Returns a copy of the internal state of the sync node's peers. This can be empty if there are no peers, or no
-    // sync node.
-    bool getPeerInfo(list<STable>& peerData);
+    // Returns a representation of the internal state of the sync node's peers. This can be empty if there are no
+    // peers, or no sync node.
     list<STable> getPeerInfo();
 
     // Send a command to all of our peers. It will be wrapped appropriately.
@@ -355,9 +354,6 @@ class BedrockServer : public SQLiteServer {
     // destroyed, we are also guaranteed that all peers are accessible as long as we hold a shared pointer to this
     // object.
     shared_ptr<SQLiteNode> _syncNode;
-
-    // Because status will access internal sync node data, we lock in both places that will access the pointer above.
-    recursive_timed_mutex _syncMutex;
 
     // Functions for checking for and responding to status and control commands.
     bool _isStatusCommand(const unique_ptr<BedrockCommand>& command);

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -145,7 +145,7 @@ struct GracefulFailoverTest : tpunit::TestFixture {
             list<string> peers = SParseJSONArray(peerList);
             for (auto& peer : peers) {
                 STable peerInfo = SParseJSONObject(peer);
-                if (peerInfo["name"] == "cluster_node_2" && (peerInfo["State"] == "" || peerInfo["State"] == "SEARCHING")) {
+                if (peerInfo["name"] == "cluster_node_2" && (peerInfo["State"] == "" || SStartsWith(peerInfo["State"], "SEARCHING"))) {
                     success = true;
                     break;
                 }

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -44,20 +44,15 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         close(fd);
         SQLitePool dbPool(10, filename, 1000000, 5000, 0);
         TestServer server("");
-        SQLiteNode testNode(server, dbPool, "test", "localhost:19998", "", 1, 1000000000, "1.0");
-
-        STable dummyParams;
-        testNode.addPeer("peer1", "host1.fake:15555", dummyParams);
-        testNode.addPeer("peer2", "host2.fake:16666", dummyParams);
-        testNode.addPeer("peer3", "host3.fake:17777", dummyParams);
-        testNode.addPeer("peer4", "host4.fake:18888", dummyParams);
+        string peerList = "host1.fake:15555?nodeName=peer1,host2.fake:16666?nodeName=peer2,host3.fake:17777?nodeName=peer3,host4.fake:18888?nodeName=peer4";
+        SQLiteNode testNode(server, dbPool, "test", "localhost:19998", peerList, 1, 1000000000, "1.0");
 
         // Do a base test, with one peer with no latency.
         SQLiteNode::Peer* fastest = nullptr;
         for (auto peer : testNode.peerList) {
             int peerNum = peer->name[4] - 48;
-            (*peer)["LoggedIn"] = "true";
-            (*peer)["CommitCount"] = to_string(10000000 + peerNum);
+            peer->loggedIn = true;
+            peer->setCommit(10000000 + peerNum, "");
 
             // 0, 100, 200, 300.
             peer->latency = (peerNum - 1) * 100;
@@ -84,7 +79,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         // And see what happens if our fastest peer logs out.
         for (auto peer : testNode.peerList) {
             if (peer->name == "peer3") {
-                (*peer)["LoggedIn"] = "false";
+                peer->loggedIn = false;
                 peer->latency = 50;
             }
 


### PR DESCRIPTION
This undoes the revert here:
https://github.com/Expensify/Bedrock/pull/889

After merging this PR, also un-revert the EBM change here:
https://github.com/Expensify/ExpensifyBackupManager/pull/24

And add the fix for the segfault from using the SQLiteNode's DB handle from workers.

In order to review *just* the difference between the original PR that was reverted, and this PR, to see the segfault fix, use this link to compare this branch to the last commit in the original branch:
https://github.com/Expensify/Bedrock/compare/412e9fe0ae30058214a20553b4469f7b476586a2...tyler-fix-refactor-handle-segfault-2