### PR TITLE
Move initilization before DB creation

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -68,7 +68,6 @@ sqlite3* SQLite::initializeDB(const string& filename, int64_t mmapSizeGB) {
 
     // If we're the first to initialize *any* DB, we'll set the global values for sqlite3.
     if(!initializer.fetch_add(1)) {
-        SINFO("TYLER initializing globals");
         // Set the logging callback for sqlite errors.
         SASSERT(sqlite3_config(SQLITE_CONFIG_LOG, _sqliteLogCallback, 0) == SQLITE_OK);
 
@@ -88,8 +87,6 @@ sqlite3* SQLite::initializeDB(const string& filename, int64_t mmapSizeGB) {
         // Disabled by default, but lets really beat it in. This way checkpointing does not need to wait on locks
         // created in this thread.
         SASSERT(sqlite3_enable_shared_cache(0) == SQLITE_OK);
-    } else {
-        SINFO("TYLER globals already initialized");
     }
 
     // Open the DB in read-write mode.

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -29,34 +29,10 @@ string SQLite::initializeFilename(const string& filename) {
     }
 }
 
-SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, int64_t mmapSizeGB, const string& filename, const vector<string>& journalNames) {
+SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames) {
     static map<string, SharedData*> sharedDataLookupMap;
     static mutex instantiationMutex;
     lock_guard<mutex> lock(instantiationMutex);
-
-    // If we're the first to initialize *any* DB, we'll set the global values for sqlite3.
-    if(sharedDataLookupMap.empty()) {
-        // Set the logging callback for sqlite errors.
-        sqlite3_config(SQLITE_CONFIG_LOG, _sqliteLogCallback, 0);
-
-        // Enable memory-mapped files.
-        if (mmapSizeGB) {
-            SINFO("Enabling Memory-Mapped I/O with " << mmapSizeGB << " GB.");
-            const int64_t GB = 1024 * 1024 * 1024;
-            sqlite3_config(SQLITE_CONFIG_MMAP_SIZE, mmapSizeGB * GB, 16 * 1024 * GB); // Max is 16TB
-        }
-
-        // Disable a mutex around `malloc`, which is *EXTREMELY IMPORTANT* for multi-threaded performance. Without this
-        // setting, all reads are essentially single-threaded as they'll all fight with each other for this mutex.
-        sqlite3_config(SQLITE_CONFIG_MEMSTATUS, 0);
-        sqlite3_initialize();
-        SASSERT(sqlite3_threadsafe());
-
-        // Disabled by default, but lets really beat it in. This way checkpointing does not need to wait on locks
-        // created in this thread.
-        SASSERT(sqlite3_enable_shared_cache(0) == SQLITE_OK);
-    }
-
     auto sharedDataIterator = sharedDataLookupMap.find(filename);
     if (sharedDataIterator == sharedDataLookupMap.end()) {
         SharedData* sharedData = new SharedData();
@@ -87,7 +63,35 @@ SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, int64_t mmapSizeGB
     }
 }
 
-sqlite3* SQLite::initializeDB(const string& filename) {
+sqlite3* SQLite::initializeDB(const string& filename, int64_t mmapSizeGB) {
+    static atomic<uint64_t> initializer(0);
+
+    // If we're the first to initialize *any* DB, we'll set the global values for sqlite3.
+    if(!initializer.fetch_add(1)) {
+        SINFO("TYLER initializing globals");
+        // Set the logging callback for sqlite errors.
+        SASSERT(sqlite3_config(SQLITE_CONFIG_LOG, _sqliteLogCallback, 0) == SQLITE_OK);
+
+        // Enable memory-mapped files.
+        if (mmapSizeGB) {
+            SINFO("Enabling Memory-Mapped I/O with " << mmapSizeGB << " GB.");
+            const int64_t GB = 1024 * 1024 * 1024;
+            SASSERT(sqlite3_config(SQLITE_CONFIG_MMAP_SIZE, mmapSizeGB * GB, 16 * 1024 * GB) == SQLITE_OK); // Max is 16TB
+        }
+
+        // Disable a mutex around `malloc`, which is *EXTREMELY IMPORTANT* for multi-threaded performance. Without this
+        // setting, all reads are essentially single-threaded as they'll all fight with each other for this mutex.
+        SASSERT(sqlite3_config(SQLITE_CONFIG_MEMSTATUS, 0) == SQLITE_OK);
+        sqlite3_initialize();
+        SASSERT(sqlite3_threadsafe());
+
+        // Disabled by default, but lets really beat it in. This way checkpointing does not need to wait on locks
+        // created in this thread.
+        SASSERT(sqlite3_enable_shared_cache(0) == SQLITE_OK);
+    } else {
+        SINFO("TYLER globals already initialized");
+    }
+
     // Open the DB in read-write mode.
     SINFO((SFileExists(filename) ? "Opening" : "Creating") << " database '" << filename << "'.");
     sqlite3* db;
@@ -210,9 +214,9 @@ SQLite::SQLite(const string& filename, int cacheSize, int maxJournalSize,
                int minJournalTables, const string& synchronous, int64_t mmapSizeGB, bool pageLoggingEnabled) :
     _filename(initializeFilename(filename)),
     _maxJournalSize(maxJournalSize),
-    _db(initializeDB(_filename)),
+    _db(initializeDB(_filename, mmapSizeGB)),
     _journalNames(initializeJournal(_db, minJournalTables)),
-    _sharedData(initializeSharedData(_db, mmapSizeGB, _filename, _journalNames)),
+    _sharedData(initializeSharedData(_db, _filename, _journalNames)),
     _journalName(_journalNames[0]),
     _journalSize(initializeJournalSize(_db, _journalNames)),
     _pageLoggingEnabled(pageLoggingEnabled),
@@ -226,7 +230,7 @@ SQLite::SQLite(const string& filename, int cacheSize, int maxJournalSize,
 SQLite::SQLite(const SQLite& from) :
     _filename(from._filename),
     _maxJournalSize(from._maxJournalSize),
-    _db(initializeDB(_filename)), // Create a *new* DB handle from the same filename, don't copy the existing handle.
+    _db(initializeDB(_filename, from._mmapSizeGB)), // Create a *new* DB handle from the same filename, don't copy the existing handle.
     _journalNames(from._journalNames),
     _sharedData(from._sharedData),
     _journalName(_journalNames[(_sharedData.nextJournalCount++ % _journalNames.size() - 1) + 1]),

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -305,8 +305,8 @@ class SQLite {
 
     // Initializers to support RAII-style allocation in constructors.
     static string initializeFilename(const string& filename);
-    static SharedData& initializeSharedData(sqlite3* db, int64_t mmapSizeGB, const string& filename, const vector<string>& journalNames);
-    static sqlite3* initializeDB(const string& filename);
+    static SharedData& initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames);
+    static sqlite3* initializeDB(const string& filename, int64_t mmapSizeGB);
     static vector<string> initializeJournal(sqlite3* db, int minJournalTables);
     static uint64_t initializeJournalSize(sqlite3* db, const vector<string>& journalNames);
     void commonConstructorInitialization();


### PR DESCRIPTION
Fixes:
$ https://github.com/Expensify/Expensify/issues/141928

So, in the refactor, we moved calls to `sqlite3_config` to inside `initializeSharedData`. However, `initializeSharedData` is called *after* `initializeDB`, because we need to look at the DB to set up our shared data.

The problem is that `sqlite3_config` can only be called either *before* `sqlite3_initialize` or after `sqlite3_shutdown`, and when you look at the code, this looks fine, because we call `sqlite3_config` a couple of times, and then call `sqlite3_initialize`, just like the docs say.

The problem is that creating a DB handle is an implicit `sqlite3_initialize` so none of the `sqlite3_config` calls do anything.

This means that our three calls to `sqlite3_config` for `SQLITE_CONFIG_LOG`, `SQLITE_CONFIG_MMAP_SIZE` and `SQLITE_CONFIG_MEMSTATUS` were having no effect.

The change is to move these configuration options to happen *before* any DB is created. We use an `atomic<int>` to make sure only the first DB created makes these calls.


## Tests
The test for this, and want to catch it in the future, is to add asserts for all three of these calls, which will fail if these are called after `sqlite3_initialize`.