### PR TITLE
Fix "Status" segfault

### DIFF
--- a/SynchronizedMap.h
+++ b/SynchronizedMap.h
@@ -1,5 +1,6 @@
 // This is a class that's just a std::map that's thread-safe. It does not implement every std::map function, please add
 // them as needed.
+#pragma once
 template <typename T, typename U>
 class SynchronizedMap {
   public:

--- a/SynchronizedMap.h
+++ b/SynchronizedMap.h
@@ -1,0 +1,68 @@
+// This is a class that's just a std::map that's thread-safe. It does not implement every std::map function, please add
+// them as needed.
+template <typename T, typename U>
+class SynchronizedMap {
+  public:
+
+    // A LockGuard is like a std::lock_guard, but for the entire object. It allows the whole thing to be locked so
+    // that the caller can perform multiple operations atomically. A LockGuard can easily be created for a
+    // SynchronizedMap by calling `scopedLock()` on the map.
+    friend class LockGuard;
+    class LockGuard {
+      public:
+        LockGuard(SynchronizedMap& map) : _map(map) {
+            _map._m.lock();
+        }
+        ~LockGuard() {
+            _map._m.unlock();
+        }
+      private:
+        SynchronizedMap& _map;
+    };
+
+    // These are just passed through to the underlying object, but with the lock locked first.
+    auto begin() {
+        lock_guard <decltype(_m)> lock(_m);
+        return _data.begin();
+    }
+    auto clear() {
+        lock_guard <decltype(_m)> lock(_m);
+        return _data.clear();
+    }
+
+    // Note: Key is copied, value is moved.
+    template <typename V, typename W>
+    auto emplace(V& first, W&& second) {
+        lock_guard <decltype(_m)> lock(_m);
+        return _data.emplace(first, move(second));
+    }
+    auto empty() {
+        lock_guard <decltype(_m)> lock(_m);
+        return _data.empty();
+    }
+    auto end() {
+        lock_guard <decltype(_m)> lock(_m);
+        return _data.end();
+    }
+    template <typename V>
+    auto erase(V item) {
+        lock_guard <decltype(_m)> lock(_m);
+        return _data.erase(item);
+    }
+    template <typename V>
+    auto find(V item) {
+        lock_guard <decltype(_m)> lock(_m);
+        return _data.find(item);
+    }
+    auto size() {
+        lock_guard <decltype(_m)> lock(_m);
+        return _data.size();
+    }
+    LockGuard scopedLock() {
+        return LockGuard(*this);
+    }
+    
+  private :
+    map<T, U> _data;
+    recursive_mutex _m;
+};

--- a/SynchronizedMap.h
+++ b/SynchronizedMap.h
@@ -32,9 +32,9 @@ class SynchronizedMap {
 
     // Note: Key is copied, value is moved.
     template <typename V, typename W>
-    auto emplace(V& first, W&& second) {
+    auto emplace(V& key, W&& value) {
         lock_guard <decltype(_m)> lock(_m);
-        return _data.emplace(first, move(second));
+        return _data.emplace(key, move(value));
     }
     auto empty() {
         lock_guard <decltype(_m)> lock(_m);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -472,8 +472,6 @@ void SQLiteNode::escalateCommand(unique_ptr<SQLiteCommand>&& command, bool forge
 }
 
 list<string> SQLiteNode::getEscalatedCommandRequestMethodLines() {
-// Needs to lock around access to _escalatedCommandMap (and possibly "request.methodLine"? No, they're unique pointers,
-// if they're in this list, nobody else has access)
     list<string> returnList;
     auto lock = _escalatedCommandMap.scopedLock();
     for (auto& commandPair : _escalatedCommandMap) {

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -3,6 +3,7 @@
 #include "SQLitePool.h"
 #include "SQLiteSequentialNotifier.h"
 #include "WallClockTimer.h"
+#include "../SynchronizedMap.h"
 class SQLiteCommand;
 class SQLiteServer;
 
@@ -193,7 +194,7 @@ class SQLiteNode : public STCPNode {
 
     // When we're a follower, we can escalate a command to the leader. When we do so, we store that command in the
     // following map of commandID to Command until the follower responds.
-    map<string, unique_ptr<SQLiteCommand>> _escalatedCommandMap;
+    SynchronizedMap<string, unique_ptr<SQLiteCommand>> _escalatedCommandMap;
 
     // Replicates any transactions that have been made on our database by other threads to peers.
     void _sendOutstandingTransactions(const set<uint64_t>& commitOnlyIDs = {});


### PR DESCRIPTION
This was caused by multiple threads accessing `_escalatedCommandMap` simultaneously. The fix is to make this object thread safe. We do this by adding a new class.

## Tests
Existing tests.