### PR TITLE
Add duplicate detection code

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -2,6 +2,62 @@
 #include "../BedrockServer.h"
 
 #undef SLOGPREFIX
+#define SLOGPREFIX "{DupeDiagnoser} "
+class DupeDiagnoser {
+  public:
+    DupeDiagnoser();
+    void check(uint64_t jobID, string requestID);
+
+  private:
+    mutex _m;
+    map<uint64_t, pair<string, chrono::steady_clock::time_point>> _jobIdToRequestIdAndInsertionTimeMap;
+    multimap<chrono::steady_clock::time_point, uint64_t> _insertionTimeToJobIdMap;
+};
+
+DupeDiagnoser::DupeDiagnoser() {
+}
+
+void DupeDiagnoser::check(uint64_t jobID, string requestID) {
+    lock_guard<decltype(_m)> lock(_m);
+
+    // Delete everything more than 3s old.
+    while (true) {
+        auto it = _insertionTimeToJobIdMap.begin();
+        if (it == _insertionTimeToJobIdMap.end()) {
+            // We're at the end.
+            break;
+        }
+        if (it->first <= (chrono::steady_clock::now() - 3s)) {
+            // This one should be deleted.
+            _jobIdToRequestIdAndInsertionTimeMap.erase(it->second);
+            _insertionTimeToJobIdMap.erase(it);
+        } else {
+            // Not more than 3s old.
+            break;
+        }
+    }
+
+    // Now check for duplicates.
+    auto it = _jobIdToRequestIdAndInsertionTimeMap.find(jobID);
+    if (it != _jobIdToRequestIdAndInsertionTimeMap.end()) {
+        // Duplicate!
+        SWARN("Duplicate jobIDs returned within 3s of one another! Requests: " << requestID << " and " << it->second.first << ", JobID: " << jobID);
+
+        // Now delete this one.
+        _insertionTimeToJobIdMap.erase(it->second.second);
+        _jobIdToRequestIdAndInsertionTimeMap.erase(it);
+    }
+
+    // Now we insert this value (we may have just removed it if this was a duplicate).
+    auto insertionTime = chrono::steady_clock::now();
+    _jobIdToRequestIdAndInsertionTimeMap.insert(make_pair(jobID, make_pair(requestID, insertionTime)));
+    _insertionTimeToJobIdMap.insert(make_pair(insertionTime, jobID));
+}
+
+// Instance.
+DupeDiagnoser diagnoser;
+
+#undef SLOGPREFIX
 #define SLOGPREFIX "{" << getName() << "} "
 
 const int64_t BedrockPlugin_Jobs::JOBS_DEFAULT_PRIORITY = 500;
@@ -54,6 +110,19 @@ class scopedDisableNoopMode {
 BedrockJobsCommand::BedrockJobsCommand(SQLiteCommand&& baseCommand, BedrockPlugin_Jobs* plugin) :
   BedrockCommand(move(baseCommand), plugin, canEscalateImmediately(baseCommand))
 {
+}
+
+BedrockJobsCommand::~BedrockJobsCommand() {
+    if (request.methodLine == "GetJobs" ) {
+        auto it = jsonContent.find("jobs");
+        if (it != jsonContent.end()) {
+            list<string> jobs = SParseJSONArray(it->second);
+            for (auto& jobString : jobs) {
+                STable job = SParseJSONObject(jobString);
+                diagnoser.check(SToUInt64(job["jobID"]), request["requestID"]);
+            }
+        }
+    }
 }
 
 BedrockPlugin_Jobs::BedrockPlugin_Jobs(BedrockServer& s) :
@@ -805,6 +874,8 @@ void BedrockJobsCommand::process(SQLite& db) {
                                          "lastRun=" + currentTime + ", "
                                          "nextRun=" + nextRunDateTime + " "
                                      "WHERE jobID = " + SQ(job["jobID"]) + ";";
+
+                SINFO("Updating last/nextRun: " << updateQuery);
                 if (!db.writeIdempotent(updateQuery)) {
                     STHROW("502 Update failed");
                 }
@@ -1364,5 +1435,8 @@ void BedrockJobsCommand::handleFailedReply() {
         auto cmd = make_unique<SQLiteCommand>(move(requeue));
         cmd->initiatingClientID = -1;
         _plugin->server.acceptCommand(move(cmd));
+
+        // Keep these from warning about duplicates on destruction.
+        jsonContent.clear();
     }
 }

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -27,6 +27,7 @@ class BedrockPlugin_Jobs : public BedrockPlugin {
 class BedrockJobsCommand : public BedrockCommand {
   public:
     BedrockJobsCommand(SQLiteCommand&& baseCommand, BedrockPlugin_Jobs* plugin);
+    ~BedrockJobsCommand();
     virtual bool peek(SQLite& db);
     virtual void process(SQLite& db);
     virtual void handleFailedReply();

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -102,7 +102,7 @@ BedrockTester::BedrockTester(int threadID, const map<string, string>& args,
         {"-quorumCheckpoint", "50"},
         {"-enableMultiWrite", "true"},
         {"-cacheSize", "1000"},
-        {"-parallelReplication", "true"},
+        //{"-parallelReplication", "true"}, // Disabled to test single rep.
     };
 
     // Set defaults.

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -102,7 +102,7 @@ BedrockTester::BedrockTester(int threadID, const map<string, string>& args,
         {"-quorumCheckpoint", "50"},
         {"-enableMultiWrite", "true"},
         {"-cacheSize", "1000"},
-        //{"-parallelReplication", "true"}, // Disabled to test single rep.
+        {"-parallelReplication", "true"},
     };
 
     // Set defaults.

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -296,13 +296,17 @@ struct CreateJobTest : tpunit::TestFixture {
 
         // Get the job
         command.clear();
-        command.methodLine = "GetJob";
+        command.methodLine = "GetJobs";
         command["name"] = jobName;
+        command["numResults"] = "10";
         response = tester->executeWaitVerifyContentTable(command);
+        list<string> jobs = SParseJSONArray(response["jobs"]);
+        ASSERT_EQUAL(jobs.size(), 1);
+        STable job = SParseJSONObject(jobs.front());
 
-        ASSERT_EQUAL(response["data"], "{}");
-        ASSERT_EQUAL(response["jobID"], jobID);
-        ASSERT_EQUAL(response["name"], jobName);
+        ASSERT_EQUAL(job["data"], "{}");
+        ASSERT_EQUAL(job["jobID"], jobID);
+        ASSERT_EQUAL(job["name"], jobName);
 
         // Query the db and confirm that state, nextRun and lastRun are 1 second apart because of retryAfter
         SQResult jobData;
@@ -327,9 +331,12 @@ struct CreateJobTest : tpunit::TestFixture {
             try {
                 // Let it repeat until it works or we run out of retries.
                 response = tester->executeWaitVerifyContentTable(command);
-                ASSERT_EQUAL(response["data"], "{}");
-                ASSERT_EQUAL(response["jobID"], jobID);
-                ASSERT_EQUAL(response["name"], jobName);
+                list<string> jobs = SParseJSONArray(response["jobs"]);
+                ASSERT_EQUAL(jobs.size(), 1);
+                STable job = SParseJSONObject(jobs.front());
+                ASSERT_EQUAL(job["data"], "{}");
+                ASSERT_EQUAL(job["jobID"], jobID);
+                ASSERT_EQUAL(job["name"], jobName);
             } catch (...) {
                 sleep(1);
                 continue;


### PR DESCRIPTION
This adds diagnostic code to help diagnose:
https://github.com/Expensify/Expensify/issues/142735

An example is here:
```
2020-10-05T19:05:16.308602+00:00 expensidev bedrock: ayPOhR (Jobs.cpp:802) process [worker3] [info] {Jobs} Returning jobID 5073505937275590182 from GetJobs
2020-10-05T19:05:16.308934+00:00 expensidev bedrock: ayPOhR (Jobs.cpp:878) process [worker3] [info] {Jobs} Updating last/nextRun: UPDATE jobs SET state='RUNQUEUED', lastRun='2020-10-05 19:05:16', nextRun=MIN(DATETIME('2020-10-05 19:05:16', '+5 SECOND'), DATETIME( '2020-10-05 19:05:16', '+10 SECONDS' )) WHERE jobID = '5073505937275590182';
2020-10-05T19:05:21.380678+00:00 expensidev bedrock: ivsevi (Jobs.cpp:802) process [worker1] [info] {Jobs} Returning jobID 5073505937275590182 from GetJobs
2020-10-05T19:05:21.381448+00:00 expensidev bedrock: ivsevi (Jobs.cpp:878) process [worker1] [info] {Jobs} Updating last/nextRun: UPDATE jobs SET state='RUNQUEUED', lastRun='2020-10-05 19:05:21', nextRun=MIN(DATETIME('2020-10-05 19:05:21', '+5 SECOND'), DATETIME( '2020-10-05 19:05:21', '+10 SECONDS' )) WHERE jobID = '5073505937275590182';
2020-10-05T19:05:21.389073+00:00 expensidev bedrock: xxxxxx (Jobs.cpp:44) check [worker1] [warn] {DupeDiagnoser} Duplicate jobIDs returned within 3s of one another! Requests: ivsevi and ayPOhR, JobID: 5073505937275590182
```

Note that to trigger the example, I set the time limit for duplicate jobs being returned to 30 seconds so that the existing tests would trigger it. The actual code is set to 3 seconds to reduce any chance of false positives, but 3 seconds is still plenty of time top catch cases we see in production.

This adds logging of what we set the next run time to, as well as giving us an easy-to-search-for logline to check how often this is happening.

It also refactors one test to use `GetJobs` instead of `GetJob`, which is more in line with how we run in production.