### PR TITLE
Use correct date for LastRun

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -867,7 +867,7 @@ void BedrockJobsCommand::process(SQLite& db) {
             for (auto job : retriableJobs) {
                 string currentTime = SCURRENT_TIMESTAMP();
                 string retryAfterDateTime = "DATETIME(" + currentTime + ", " + SQ(job["retryAfter"]) + ")";
-                string repeatDateTime = _constructNextRunDATETIME(job["nextRun"], job["lastRun"] != "" ? job["lastRun"] : job["nextRun"], job["repeat"]);
+                string repeatDateTime = _constructNextRunDATETIME(job["nextRun"], currentTime, job["repeat"]);
                 string nextRunDateTime = repeatDateTime != "" ? "MIN(" + retryAfterDateTime + ", " + repeatDateTime + ")" : retryAfterDateTime;
                 string updateQuery = "UPDATE jobs "
                                      "SET state='RUNQUEUED', "


### PR DESCRIPTION
This should resolve:

$ https://github.com/Expensify/Expensify/issues/142735

What you'll see here is that we're updating `lastRun` and `nextRun`:
```
                string updateQuery = "UPDATE jobs "
                                     "SET state='RUNQUEUED', "
                                         "lastRun=" + currentTime + ", "
                                         "nextRun=" + nextRunDateTime + " "
                                     "WHERE jobID = " + SQ(job["jobID"]) + ";";
```

We're updating `lastRun` to *right now*.
The problem is that we're calling `_constructNextRunDATETIME` and passing in not *right now*, but rather the *previous* `lastRun`. For weekly jobs, this is typically about a week ago, but critically, just slightly *over* a week ago, because this job is being run slightly (maybe seconds or minutes) after it was scheduled to run.

For jobs with a `STARTED` base, this happens:
```
    } else if (base == "STARTED") {
        safeParts.push_back(SQ(lastRun));
```

This computes a time that's one week after just a little bit over a week ago, which is a few seconds or minutes in the past. However the actual last started time of the job is *right now*. The bug causes the job to run twice, because the first iteration sets `lastRun` to just a few seconds ago, re-runs the job immediately, and then sets the new nextRun based on a week from a few seconds ago.

This fix causes us to calculate lastRun based on *right now* when we're starting the job.

## Tests
Existing tests pass.

## Followup:
Once this is deployed and verified working, we can revert:
https://github.com/Expensify/Bedrock/pull/902

cc @nkuoch who wanted to know the resolution here.