### PR TITLE
Don't double-wrap dates with quotes.

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -708,7 +708,9 @@ bool SQVerifyTable(sqlite3* db, const string& tableName, const string& sql);
 bool SQVerifyTableExists(sqlite3* db, const string& tableName);
 
 // --------------------------------------------------------------------------
-inline string STIMESTAMP(uint64_t when) { return SQ(SComposeTime("%Y-%m-%d %H:%M:%S", when)); }
+inline string SUNQUOTED_TIMESTAMP(uint64_t when) { return SComposeTime("%Y-%m-%d %H:%M:%S", when); }
+inline string STIMESTAMP(uint64_t when) { return SQ(SUNQUOTED_TIMESTAMP(when)); }
+inline string SUNQUOTED_CURRENT_TIMESTAMP() { return SUNQUOTED_TIMESTAMP(STimeNow()); }
 inline string SCURRENT_TIMESTAMP() { return STIMESTAMP(STimeNow()); }
 
 // --------------------------------------------------------------------------

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -865,13 +865,13 @@ void BedrockJobsCommand::process(SQLite& db) {
         if (!retriableJobs.empty()) {
             SINFO("Updating jobs with retryAfter");
             for (auto job : retriableJobs) {
-                string currentTime = SCURRENT_TIMESTAMP();
-                string retryAfterDateTime = "DATETIME(" + currentTime + ", " + SQ(job["retryAfter"]) + ")";
+                string currentTime = SUNQUOTED_CURRENT_TIMESTAMP();
+                string retryAfterDateTime = "DATETIME(" + SQ(currentTime) + ", " + SQ(job["retryAfter"]) + ")";
                 string repeatDateTime = _constructNextRunDATETIME(job["nextRun"], currentTime, job["repeat"]);
                 string nextRunDateTime = repeatDateTime != "" ? "MIN(" + retryAfterDateTime + ", " + repeatDateTime + ")" : retryAfterDateTime;
                 string updateQuery = "UPDATE jobs "
                                      "SET state='RUNQUEUED', "
-                                         "lastRun=" + currentTime + ", "
+                                         "lastRun=" + SQ(currentTime) + ", "
                                          "nextRun=" + nextRunDateTime + " "
                                      "WHERE jobID = " + SQ(job["jobID"]) + ";";
 


### PR DESCRIPTION
Fixes bug introduced here: https://github.com/Expensify/Bedrock/pull/904

We broke bedrock updating jobs because it was triple-quoting dates, which doesn't work:
```
 'read/write transaction', query failed with error #19 (NOT NULL constraint failed: jobs.nextRun): UPDATE jobs SET state='RUNQUEUED', lastRun='2020-10-08 01:00:59', nextRun=MIN(DATETIME('2020-10-08 01:00:59', '+30 MINUTES'), DATETIME( '''2020-10-08 01:00:59''', '+3 MONTH' )) WHERE jobID = '1232653360966088619';
```

`SCURRENT_TIMESTAMP` returns a quoted string.
Passing that string to `_constructNextRunDATETIME` adds another layer of quotes around the string, causing failures parsing dates.

This adds a non-quoted timestamp function and uses that instead.

# Tests: 
Existing tests, but extra tested by logging the the quoted and unquoted string locally, to verify it's using the unquoted one.