### PR TITLE
Turn multi-rep back on for tests.

### DIFF
--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -102,7 +102,7 @@ BedrockTester::BedrockTester(int threadID, const map<string, string>& args,
         {"-quorumCheckpoint", "50"},
         {"-enableMultiWrite", "true"},
         {"-cacheSize", "1000"},
-        //{"-parallelReplication", "true"}, // Disabled to test single rep.
+        {"-parallelReplication", "true"},
     };
 
     // Set defaults.


### PR DESCRIPTION
Since we're using it in production again, it's a good idea to test against it as well.