### PR TITLE
Fix jobs that have a retryAfter and a repeat 'scheduled'

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1050,10 +1050,7 @@ void BedrockJobsCommand::process(SQLite& db) {
             // 'retryAfter' from 'nextRun' to get back the originally scheduled time which was 'nextRun' when the job ran.
             if (!retryAfter.empty() && SToUpper(repeat).find("SCHEDULED") != string::npos) {
                 SQResult scheduledJobResult;
-                if (!db.read("SELECT DATETIME(nextRun, REPLACE(retryAfter, '+', '-')) "
-                             "FROM jobs "
-                             "WHERE jobID = " + SQ(jobID) + ";",
-                             scheduledJobResult)) {
+                if (!db.read("SELECT DATETIME(" + SQ(nextRun) + ", REPLACE(" + SQ(retryAfter) + ", '+', '-'));", scheduledJobResult)) {
                     STHROW("502 Select failed");
                 }
                 lastScheduled = scheduledJobResult[0][0];

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -304,7 +304,7 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(response["jobID"], jobID);
         ASSERT_EQUAL(response["name"], jobName);
 
-        // Query the db and confirm that state, nextRun and lastRun are 1 second apart because of retryAfter
+        // Query the db and confirm the state, and that nextRun and lastRun are 5 seconds apart because of retryAfter
         SQResult jobData;
         tester->readDB("SELECT state, nextRun, lastRun FROM jobs WHERE jobID = " + jobID + ";", jobData);
         ASSERT_EQUAL(jobData[0][0], "RUNQUEUED");
@@ -360,7 +360,7 @@ struct CreateJobTest : tpunit::TestFixture {
         nextRunTime = JobTestHelper::getTimestampForDateTimeString(jobData[0][1]);
         lastRunTime = JobTestHelper::getTimestampForDateTimeString(jobData[0][2]);
         ASSERT_EQUAL(jobData[0][0], "QUEUED");
-        ASSERT_EQUAL(difftime(nextRunTime, lastRunTime), 15);
+        ASSERT_EQUAL(difftime(nextRunTime, lastRunTime), 10);
     }
 
     void retryWithMalformedValue() {

--- a/test/tests/jobs/GetJobsTest.cpp
+++ b/test/tests/jobs/GetJobsTest.cpp
@@ -108,8 +108,8 @@ struct GetJobsTest : tpunit::TestFixture {
 
             // Let's see if it's scheduled at the right time.
             if (stoull(row[0]) == jobIDs[0]) {
-
-                ASSERT_LESS_THAN(absoluteDiff(stringToUnixTimestamp(row[3]), stringToUnixTimestamp(row[2]) + 1 * 60 * 60), 3);
+                // Assert that the difference between "lastRun + 1hour" and "nextRun" is less than 3 seconds.
+                ASSERT_LESS_THAN(absoluteDiff(stringToUnixTimestamp(row[2]) + 1 * 60 * 60, stringToUnixTimestamp(row[3])), 3);
             } else if (stoull(row[0]) == jobIDs[1]) {
                 // Assert that the difference between "lastRun + 1day" and "nextRun" is less than 3 seconds.
                 ASSERT_LESS_THAN(absoluteDiff(stringToUnixTimestamp(row[2]) + 1 * 60 * 60 * 24, stringToUnixTimestamp(row[3])), 3);

--- a/test/tests/jobs/GetJobsTest.cpp
+++ b/test/tests/jobs/GetJobsTest.cpp
@@ -108,14 +108,8 @@ struct GetJobsTest : tpunit::TestFixture {
 
             // Let's see if it's scheduled at the right time.
             if (stoull(row[0]) == jobIDs[0]) {
-                // This uses a `SCHEDULED` modified, but it also uses `retryAfter`, which is just a broken combination.
-                // What happens with `scheduled`, is that when we finish a job we take `nextRun` and add our time
-                // interval to it. This assumes that `nextRun` is whatever it was set to last time we got the job. But
-                // with `retryAfter`, we updated that to some failure check interval, like 5 minutes, rather than
-                // running this from when it was last scheduled, it runs it from when it was last scheduled to be
-                // retried.
-                //
-                // We assert nothing here because this case is broken.
+
+                ASSERT_LESS_THAN(absoluteDiff(stringToUnixTimestamp(row[3]), stringToUnixTimestamp(row[2]) + 1 * 60 * 60), 3);
             } else if (stoull(row[0]) == jobIDs[1]) {
                 // Assert that the difference between "lastRun + 1day" and "nextRun" is less than 3 seconds.
                 ASSERT_LESS_THAN(absoluteDiff(stringToUnixTimestamp(row[2]) + 1 * 60 * 60 * 24, stringToUnixTimestamp(row[3])), 3);


### PR DESCRIPTION
cc @coleaeason @nkuoch 

Fixes https://github.com/Expensify/Expensify/issues/143712

The problem in a nutshell:
> In the case of retryAfter, we update nextRun on GetJob (eg +12 HOUR) and we update nextRun on FinishJob (eg +1 DAY) which results in nextRun getting updated to +36 HOUR instead of the intended +1 DAY. 

I believe this works in all scenarios, please try to think where this could break. With an example job where retryAfter=+5 MINUTES and repeat=+1 HOUR, the following will happen:
1. Job runs at 00:00, nextRun is updated to 00:05
2. Job finishes, nextRun is updated to 00:05 - 5 MINUTES + 1 HOUR = 01:00

The only scenario where this is still broken is when the job actually gets retried, eg:
1. Job runs at 00:00, nextRun is updated to 00:05
2. Job still hasn't finished so it runs again at 00:05, nextRun is updated to 00:10
3. Job finishes, nextRun is updated to 00:10 - 5 MINUTES + 1 HOUR = 00:05

Given retried jobs are more of a rarity than the main case this is fixing, I think it is acceptable in the context of this PR. If we want to fix this, I am pretty sure we need to store another piece of data (eg "how many times have we retried this job?"). I'm of the opinion of crossing this line when this becomes an apparent problem.


