### PR TITLE
Tyler fix stand down race condition

### DIFF
--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -22,6 +22,10 @@ bool SQLiteCore::commit() {
         SINFO("Commit conflict, rolling back.");
         _db.rollback();
         return false;
+    } else if (errorCode == SQLite::COMMIT_DISABLED) {
+        SINFO("Commits currently disabled, rolling back.");
+        _db.rollback();
+        return false;
     }
 
     return true;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2077,7 +2077,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
         }
 
         // Re-enable commits if they were disabled during a previous stand-down.
-        if (newState == LEADING || newState == FOLLOWING) {
+        if (newState != SEARCHING) {
             _db.setCommitEnabled(true);
         }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2060,6 +2060,10 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
                 _db.rollback();
             }
 
+            // Turn off commits. This prevents late commits coming in right after we call `_sendOutstandingTransactions`
+            // below, which otherwise could get committed on leader and not replicated to followers.
+            _db.setCommitEnabled(false);
+
             // We send any unsent transactions here before we finish switching states, we need to make sure these are
             // all sent to the new leader before we complete the transition.
             _sendOutstandingTransactions();
@@ -2070,6 +2074,11 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
             // We're no longer SUBSCRIBING or FOLLOWING, so we have no leader
             lock_guard<mutex> leadPeerLock(_leadPeerMutex);
             _leadPeer = nullptr;
+        }
+
+        // Re-enable commits if they were disabled during a previous stand-down.
+        if (newState == LEADING || newState == FOLLOWING) {
+            _db.setCommitEnabled(true);
         }
 
         // Additional logic for some new states


### PR DESCRIPTION
Fixes:
$ https://github.com/Expensify/Expensify/issues/143561

The problem we're fixing is here:
https://github.com/Expensify/Bedrock/blob/024fe68aee06b84eca9b399d8ef8c18cf9a3e448/sqlitecluster/SQLiteNode.cpp#L2050-L2066

When we switch states away from `STANDINGDOWN` we should no longer be able to commit to the DB. And the last thing we do there is `_sendOutstandingTransactions()` which should boradcast all committed transactions to the rest of the cluster.

The problem is that we removed the mutex around state changes, and so it's possible that the code here:
https://github.com/Expensify/Bedrock/blob/024fe68aee06b84eca9b399d8ef8c18cf9a3e448/BedrockServer.cpp#L1058-L1068
Can check that we're standing down, and start a commit, which doesn't complete until the sync thread has already run `_sendOutstandingTransactions()` as it's shutting down. This leaves a committed transaction in the former leader's DB that nobody else will get.

What we need, is to make sure that nobody can commit once we've decided that  no more commits are allowed. There's no way to do this when we have multi-threaded commits without using a mutex, and so we use the existing commit mutex to set a flag that juts plain turns off commits. Calling `setCommitEnabled(false)` will wait for anyone who's currently committing, and then when it has the commit mutex, will disable commits, and then, even if someone else attempts to commit after that, they'll receive an error that is treated the same way as a conflict, and need to re-run the command.

This change may still have a conceptual problem if `setCommitEnabled` disables commits and then re-enables them fast enough that some thread and is still running this code:
https://github.com/Expensify/Bedrock/blob/024fe68aee06b84eca9b399d8ef8c18cf9a3e448/sqlitecluster/SQLiteCore.cpp#L11-L19

Imagine a node that switched *very quickly* from `LEADING` to `FOLLOWING` while one of its worker threads was in the process of attempting to start a commit. This is probably worth fixing, but I think we should deploy the existing fix that catches something that's 1000x more likely to happen even if we continue to fix that edge case.

## Tests
Existing tests run many times in a row.