### PR TITLE
Remove authTokens from slow queries

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2454,6 +2454,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
     // Warn if it took longer than the specified threshold
     string sqlToLog = sql;
     if ((int64_t)elapsed > warnThreshold) {
+        // This code removing authTokens is a quick fix and should be removed once https://github.com/Expensify/Expensify/issues/144185 is done.
         string match;
         const bool hasAuthToken = SREMatch(".*(\"authToken\"\\:\"[0-9A-F]{400,1024}\").*", sql, match);
         if (hasAuthToken) {


### PR DESCRIPTION
cc @coleaeason 

Part of https://github.com/Expensify/Expensify/issues/135439

I _assume_ this regex matching shouldn't slow down bedrock significantly.. 

## Tests

1. Change `warnThreshold` to `1`
2. Trigger an offending query
3. Observe logs: 
```
2020-10-19T17:38:00.279399+00:00 expensidev bedrock: 6AwE2T blob@asdfasdfasdf.com (libstuff.cpp:2463) SQuery [worker3] [warn] Slow query (6ms) : INSERT INTO notifications (json, priority, created) VALUES ( JSON('{"accountID":122,<REDACTED_AUTHTOKEN>,"template":"CreateAccount2","to":"blob@asdfasdfasdf.com"}'), 200, '2020-10-19 17:38:00');
```
4. Ensure other queries don't seem to be affected 