### PR TITLE
Add optional overwrite parameter to `CreateJob` and `CreateJobs`

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -505,10 +505,7 @@ void BedrockJobsCommand::process(SQLite& db) {
                 // If we found a job, but the data was different, we'll need to update it.
                 if (!result.empty()) {
                     updateJobID = SToInt64(result[0][0]);
-                    continue;
                 }
-
-                SINFO("ALEX NO DUPE FOUND");
             }
 
             // Record whether or not this job is scheduling itself in the future. If so, it's not suitable for
@@ -584,7 +581,6 @@ void BedrockJobsCommand::process(SQLite& db) {
                         STHROW("502 update query failed");
                     }
                 }
-
 
                 // If we are calling CreateJob, return early, there are no more jobs to create.
                 if (SIEquals(requestVerb, "CreateJob")) {

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -402,7 +402,7 @@ void BedrockJobsCommand::process(SQLite& db) {
         //     - jobPriority - High priorities go first (optional, default 500)
         //     - unique - if true, it will check that no other job with this name already exists, if it does it will
         //                return that jobID
-        //     - overwrite - Only applicable when submit is is true. When set to true it will overwrite the existing job
+        //     - overwrite - Only applicable when unique is is true. When set to true it will overwrite the existing job
         //                   with the new jobs data
         //     - parentJobID - The ID of the parent job (optional)
         //     - retryAfter - Amount of auto-retries before marking job as failed (optional)
@@ -423,7 +423,7 @@ void BedrockJobsCommand::process(SQLite& db) {
         //          - jobPriority - High priorities go first (optional, default 500)
         //          - unique - if true, it will check that no other job with this name already exists, if it does it will
         //                     return that jobID
-        //          - overwrite - Only applicable when submit is is true. When set to true it will overwrite the existing job
+        //          - overwrite - Only applicable when unique is is true. When set to true it will overwrite the existing job
         //                        with the new jobs data
         //          - parentJobID - The ID of the parent job (optional)
         //          - retryAfter - Amount of auto-retries before marking job as failed (optional)

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -402,8 +402,8 @@ void BedrockJobsCommand::process(SQLite& db) {
         //     - jobPriority - High priorities go first (optional, default 500)
         //     - unique - if true, it will check that no other job with this name already exists, if it does it will
         //                return that jobID
-        //     - overwrite - if true, and unique is true, it will overwrite the existing job with the new jobs data
-        //                   (optional, default: true)
+        //     - overwrite - Only applicable when submit is is true. When set to true it will overwrite the existing job
+        //                   with the new jobs data
         //     - parentJobID - The ID of the parent job (optional)
         //     - retryAfter - Amount of auto-retries before marking job as failed (optional)
         //
@@ -423,8 +423,8 @@ void BedrockJobsCommand::process(SQLite& db) {
         //          - jobPriority - High priorities go first (optional, default 500)
         //          - unique - if true, it will check that no other job with this name already exists, if it does it will
         //                     return that jobID
-        //          - overwrite - if true, and unique is true, it will overwrite the existing job with the new jobs data
-        //                        (optional, default: true)
+        //          - overwrite - Only applicable when submit is is true. When set to true it will overwrite the existing job
+        //                        with the new jobs data
         //          - parentJobID - The ID of the parent job (optional)
         //          - retryAfter - Amount of auto-retries before marking job as failed (optional)
         //

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -570,7 +570,7 @@ void BedrockJobsCommand::process(SQLite& db) {
 
             // Are we creating a new job, or updating an existing job?
             if (updateJobID) {
-                if (!SContains(job, "overwrite") || job["overwrite"] == "true") {
+                if (!SContains(job, "overwrite") || job["overwrite"] == "true" || job["overwrite"] == "") {
                     // Update the existing job.
                     if(!db.writeIdempotent("UPDATE jobs SET "
                                              "repeat   = " + SQ(SToUpper(job["repeat"])) + ", " +

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -199,6 +199,29 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(updatedJob[0][7], data);
         ASSERT_EQUAL(updatedJob[0][8], originalJob[0][8]);
         ASSERT_EQUAL(updatedJob[0][9], originalJob[0][9]);
+
+
+        // Try to recreate the job with new data, without overwriting the existing data
+        string data2 = "{\"blabla2\":\"test2\"}";
+        command["data"] = data2;
+        command["overwrite"] = "false";
+        response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_EQUAL(stol(response["jobID"]), jobID);
+
+        SQResult nonoverwritenJob;
+        tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID FROM jobs WHERE jobID = " + response["jobID"] + ";", nonoverwritenJob);
+        ASSERT_EQUAL(updatedJob.size(), 1);
+        // Assert that we have not overwritten the job data
+        ASSERT_EQUAL(nonoverwritenJob[0][0], updatedJob[0][0]);
+        ASSERT_EQUAL(nonoverwritenJob[0][1], updatedJob[0][1]);
+        ASSERT_EQUAL(nonoverwritenJob[0][2], updatedJob[0][2]);
+        ASSERT_EQUAL(nonoverwritenJob[0][3], updatedJob[0][3]);
+        ASSERT_EQUAL(nonoverwritenJob[0][4], updatedJob[0][4]);
+        ASSERT_EQUAL(nonoverwritenJob[0][5], updatedJob[0][5]);
+        ASSERT_EQUAL(nonoverwritenJob[0][6], updatedJob[0][6]);
+        ASSERT_EQUAL(nonoverwritenJob[0][7], data2);
+        ASSERT_EQUAL(nonoverwritenJob[0][8], updatedJob[0][8]);
+        ASSERT_EQUAL(nonoverwritenJob[0][9], updatedJob[0][9]);
     }
 
     void createWithBadData() {

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -200,7 +200,6 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(updatedJob[0][8], originalJob[0][8]);
         ASSERT_EQUAL(updatedJob[0][9], originalJob[0][9]);
 
-
         // Try to recreate the job with new data, without overwriting the existing data
         string data2 = "{\"blabla2\":\"test2\"}";
         command["data"] = data2;
@@ -219,7 +218,7 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(nonoverwritenJob[0][4], updatedJob[0][4]);
         ASSERT_EQUAL(nonoverwritenJob[0][5], updatedJob[0][5]);
         ASSERT_EQUAL(nonoverwritenJob[0][6], updatedJob[0][6]);
-        ASSERT_EQUAL(nonoverwritenJob[0][7], data2);
+        ASSERT_EQUAL(nonoverwritenJob[0][7], updatedJob[0][7]);
         ASSERT_EQUAL(nonoverwritenJob[0][8], updatedJob[0][8]);
         ASSERT_EQUAL(nonoverwritenJob[0][9], updatedJob[0][9]);
     }


### PR DESCRIPTION
@iwiznia can you review please?

Part of https://github.com/Expensify/Expensify/issues/143805

This adds an optional parameter to `CreateJob` and `CreateJobs` where we will not overwrite any data when when attempting to create a unique job that already exists. This optional parameter is assumed to be `true` when not included to not break any existing behavior

## Tests

Added a new automated test, will be further tested in followup prs