### PR TITLE
Continue committing received transactions on leader standdown

### DIFF
--- a/sqlitecluster/SQLiteSequentialNotifier.cpp
+++ b/sqlitecluster/SQLiteSequentialNotifier.cpp
@@ -14,13 +14,26 @@ SQLiteSequentialNotifier::RESULT SQLiteSequentialNotifier::waitFor(uint64_t valu
     }
     while (true) {
         unique_lock<mutex> lock(state->waitingThreadMutex);
-        if (_globalResult != RESULT::UNKNOWN) {
+        if (_globalResult == RESULT::CANCELED) {
+            if (_cancelAfter != 0 && value <= _cancelAfter) {
+                // We can just keep going here, it's canceled after what we're waiting for.
+                SINFO("Canceled after " << _cancelAfter << " but we're only waiting for " << value << " so continuing.");
+            } else {
+                // Canceled and we're not before the cancellation cutoff.
+                return _globalResult;
+            }
+        } else if (_globalResult != RESULT::UNKNOWN) {
             return _globalResult;
         } else if (state->result != RESULT::UNKNOWN) {
             return state->result;
         }
         state->waitingThreadConditionVariable.wait(lock);
     }
+}
+
+uint64_t SQLiteSequentialNotifier::getValue() {
+    lock_guard<mutex> lock(_internalStateMutex);
+    return _value;
 }
 
 void SQLiteSequentialNotifier::notifyThrough(uint64_t value) {
@@ -46,7 +59,7 @@ void SQLiteSequentialNotifier::notifyThrough(uint64_t value) {
 
     // Now we've finished with all of our updates and notifications and can remove everything from our map.
     // Note that erasing an empty range (i.e., from() begin to begin()) is tested to be a no-op. The documentation I've
-    // fond for multimap is unclear on this, though the docuemtnation for `std::list` specifies:
+    // fond for multimap is unclear on this, though the documentation for `std::list` specifies:
     // "The iterator first does not need to be dereferenceable if first==last: erasing an empty range is a no-op."
     //
     // I think it's reasonable to assume this is the intention for multimap as well, and in my testing, that was the
@@ -54,16 +67,29 @@ void SQLiteSequentialNotifier::notifyThrough(uint64_t value) {
     _valueToPendingThreadMap.erase(_valueToPendingThreadMap.begin(), lastToDelete);
 }
 
-void SQLiteSequentialNotifier::cancel() {
+void SQLiteSequentialNotifier::cancel(uint64_t cancelAfter) {
     lock_guard<mutex> lock(_internalStateMutex);
     _globalResult = RESULT::CANCELED;
-    for (auto& p : _valueToPendingThreadMap) {
-        lock_guard<mutex> lock(p.second->waitingThreadMutex);
-        p.second->result = RESULT::CANCELED;
-        p.second->waitingThreadConditionVariable.notify_all();
+
+    // If cancelAfter is specified, start from that value. Otherwise, we start from the beginning.
+    auto start = cancelAfter ? _valueToPendingThreadMap.upper_bound(cancelAfter) : _valueToPendingThreadMap.begin();
+    if (start == _valueToPendingThreadMap.end()) {
+        // There's nothing to remove.
+        return;
     }
-    _valueToPendingThreadMap.clear();
-    _value = 0;
+
+    // Now iterate across whatever's remaining and mark it canceled.
+    auto current = start;
+    while(current != _valueToPendingThreadMap.end()) {
+        lock_guard<mutex> lock(current->second->waitingThreadMutex);
+        SINFO("Canceling: " << current->first);
+        current->second->result = RESULT::CANCELED;
+        current->second->waitingThreadConditionVariable.notify_all();
+        current++;
+    }
+
+    // And remove these items entirely.
+    _valueToPendingThreadMap.erase(start, _valueToPendingThreadMap.end());
 }
 
 void SQLiteSequentialNotifier::checkpointRequired(SQLite& db) {
@@ -86,4 +112,5 @@ void SQLiteSequentialNotifier::reset() {
     lock_guard<mutex> lock(_internalStateMutex);
     _globalResult = RESULT::UNKNOWN;
     _value = 0;
+    _cancelAfter = 0;
 }

--- a/sqlitecluster/SQLiteSequentialNotifier.cpp
+++ b/sqlitecluster/SQLiteSequentialNotifier.cpp
@@ -64,7 +64,7 @@ void SQLiteSequentialNotifier::notifyThrough(uint64_t value) {
 
     // Now we've finished with all of our updates and notifications and can remove everything from our map.
     // Note that erasing an empty range (i.e., from() begin to begin()) is tested to be a no-op. The documentation I've
-    // fond for multimap is unclear on this, though the documentation for `std::list` specifies:
+    // found for multimap is unclear on this, though the documentation for `std::list` specifies:
     // "The iterator first does not need to be dereferenceable if first==last: erasing an empty range is a no-op."
     //
     // I think it's reasonable to assume this is the intention for multimap as well, and in my testing, that was the
@@ -91,7 +91,6 @@ void SQLiteSequentialNotifier::cancel(uint64_t cancelAfter) {
     auto current = start;
     while(current != _valueToPendingThreadMap.end()) {
         lock_guard<mutex> lock(current->second->waitingThreadMutex);
-        SINFO("Canceling: " << current->first);
         current->second->result = RESULT::CANCELED;
         current->second->waitingThreadConditionVariable.notify_all();
         current++;

--- a/sqlitecluster/SQLiteSequentialNotifier.h
+++ b/sqlitecluster/SQLiteSequentialNotifier.h
@@ -28,7 +28,7 @@ class SQLiteSequentialNotifier : public SQLite::CheckpointRequiredListener {
     };
 
     // Constructor
-    SQLiteSequentialNotifier() : _value(0), _globalResult(RESULT::UNKNOWN) {}
+    SQLiteSequentialNotifier() : _value(0), _globalResult(RESULT::UNKNOWN), _cancelAfter(0) {}
 
     // Blocks until `_value` meets or exceeds `value`, unless an exceptional case (CANCELED, CHEKPOINT_REQUIRED) is
     // hit, and returns the corresponding RESULT.
@@ -38,8 +38,13 @@ class SQLiteSequentialNotifier : public SQLite::CheckpointRequiredListener {
     void notifyThrough(uint64_t value);
 
     // Causes any thread waiting for any value to return `false`. Also, any future calls to `waitFor` will return
-    // `false` until `reset` is called.
-    void cancel();
+    // `RESULT::CANCELED` until `reset` is called.
+    // If `cancelAfter` is specified, then only threads waiting for a value *greater than* cacelAfter are interrupted,
+    // and only calls to `waitFor` with values higher than the current _value return `RESULT::CANCELED`.
+    void cancel(uint64_t cancelAfter = 0);
+
+    // Returns the current value of this notifier.
+    uint64_t getValue();
 
     // Implement the base class to notify for checkpoints
     void checkpointRequired(SQLite& db) override;
@@ -68,4 +73,7 @@ class SQLiteSequentialNotifier : public SQLite::CheckpointRequiredListener {
     // If there is a global result for all pending operations (i.e., they've been canceled or a checkpoint needs to
     // happen), that is stored here.
     RESULT _globalResult;
+
+    // If we're canceling values after a certain number, we still allow threads up to that value to start.
+    atomic<uint64_t> _cancelAfter;
 };

--- a/sqlitecluster/SQLiteSequentialNotifier.h
+++ b/sqlitecluster/SQLiteSequentialNotifier.h
@@ -39,7 +39,7 @@ class SQLiteSequentialNotifier : public SQLite::CheckpointRequiredListener {
 
     // Causes any thread waiting for any value to return `false`. Also, any future calls to `waitFor` will return
     // `RESULT::CANCELED` until `reset` is called.
-    // If `cancelAfter` is specified, then only threads waiting for a value *greater than* cacelAfter are interrupted,
+    // If `cancelAfter` is specified, then only threads waiting for a value *greater than* cancelAfter are interrupted,
     // and only calls to `waitFor` with values higher than the current _value return `RESULT::CANCELED`.
     void cancel(uint64_t cancelAfter = 0);
 
@@ -74,6 +74,6 @@ class SQLiteSequentialNotifier : public SQLite::CheckpointRequiredListener {
     // happen), that is stored here.
     RESULT _globalResult;
 
-    // If we're canceling values after a certain number, we still allow threads up to that value to start.
+    // For saving the value after which new or existing waiters will be returned a CANCELED result.
     atomic<uint64_t> _cancelAfter;
 };


### PR DESCRIPTION
## Fixes:
$ https://github.com/Expensify/Expensify/issues/143561

When leader stands down, followers go SEARCHING. This means they stop committing replicated transactions until a new leader stands up.

However, with multi-rep and asynchronous replication, it's entirely possible that the following happens:

1. Leader broadcasts transaction.
2. Follower begins transaction.
3. Leader stands down.
4. Follower abandons transactions in progress.

It actually happens often enough that the final transaction sent be leader isn't committed *anywhere* else because every other node gets the `stand down` message and abandons all in-progress transactions before that last transaction is committed. The slower that transaction happens to be, the less likely it is to get committed. If no other nodes commit it, then leader has forked as it shut down one transaction ahead of the rest of the cluster.

This change adds a parameter to `cancel` on a sequential notifier to only cancel transactions *after* whatever leader has told us its most recent commit is. This means that before falling out of FOLLOWING, we'll catch up to wherever we think leader was when it shut down. Note that this only applies to messages we've already deserialized from leader, so if we're *really* far behind, we'll just finish whatever we've already started, but we do not start any new replication transactions.

## Tests
This has run through `clustertest` 20x in a row with no failures.
