### PR TITLE
Escalate commands on version mismatch

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1426,23 +1426,6 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
 
     // Open the port the first time we enter a command-processing state
     SQLiteNode::State state = _replicationState.load();
-
-    // If we're a follower, and the leader's on a different version than us, we don't open the command port.
-    // If we do, we'll escalate all of our commands to the leader, which causes undue load on leader during upgrades.
-    // Instead, we'll simply not respond and let this request get re-directed to another follower.
-    string leaderVersion = _leaderVersion.load();
-    if (!_suppressCommandPort && state == SQLiteNode::FOLLOWING && (leaderVersion != _version)) {
-        SINFO("Node " << args["-nodeName"] << " following on version " << _version << ", leader is version: "
-              << leaderVersion << ", not opening command port.");
-        suppressCommandPort("leader version mismatch", true);
-    } else if (_suppressCommandPort && (state == SQLiteNode::LEADING || (leaderVersion == _version))) {
-        // If we become leader, or if leader's version resumes matching ours, open the command port again.
-        if (!_suppressCommandPortManualOverride) {
-            // Only generate this logline if we haven't manually blocked this.
-            SINFO("Node " << args["-nodeName"] << " disabling previously suppressed command port after version check.");
-        }
-        suppressCommandPort("leader version match", false);
-    }
     if (!_suppressCommandPort && (state == SQLiteNode::LEADING || state == SQLiteNode::FOLLOWING) &&
         _shutdownState.load() == RUNNING) {
         // Open the port

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2025,6 +2025,9 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
             // Guaranteed to be done right now.
             _localCommitNotifier.reset();
             _leaderCommitNotifier.reset();
+
+            // We have no leader anymore.
+            _leaderVersion = "";
         }
 
         // Depending on the state, set a timeout

--- a/test/clustertest/tests/VersionMismatchTest.cpp
+++ b/test/clustertest/tests/VersionMismatchTest.cpp
@@ -1,0 +1,36 @@
+#include "../BedrockClusterTester.h"
+
+struct VersionMismatchTest : tpunit::TestFixture {
+    VersionMismatchTest()
+        : tpunit::TestFixture("VersionMismatch", TEST(VersionMismatchTest::test)) { }
+
+    void test()
+    {
+        // Create a cluster.
+        BedrockClusterTester tester;
+
+        // Restart one of the followers on a new version.
+        tester.getTester(2).stopServer();
+        tester.getTester(2).updateArgs({{"-versionOverride", "ABCDE"}});
+        tester.getTester(2).startServer();
+
+        // Send a query to all three and make sure the version-mismatched one escalates.
+        // Can do them all in parallel so might as well.
+        list<thread> threads;
+        for (size_t i = 0; i < 3; i++) {
+            threads.emplace_back([this, i, &tester](){
+                SData command("Query");
+                command["Query"] = "SELECT 1;";
+                auto result = tester.getTester(i).executeWaitMultipleData({command})[0];
+
+                // For read commands sent directly to leader, or to a follower on the same version as leader, there
+                // should be no upstream times. However, on a follower on a different version to leader, it should
+                // escalates even read commands.
+                ASSERT_EQUAL(result.isSet("upstreamPeekTime"), i == 2);
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+} __VersionMismatchTest;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -164,6 +164,12 @@ BedrockTester::~BedrockTester() {
     }
 }
 
+void BedrockTester::updateArgs(const map<string, string> args) {
+    for (auto& row : args) {
+        _args[row.first] = row.second;
+    }
+}
+
 string BedrockTester::startServer(bool dontWait) {
     string serverName = getServerName();
     int childPID = fork();

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -60,6 +60,9 @@ class BedrockTester {
     string startServer(bool dontWait = false);
     void stopServer(int signal = SIGINT);
 
+    // Change the args on a stopped server.
+    void updateArgs(const map<string, string> args);
+
     // Takes a list of requests, and returns a corresponding list of responses.
     // Uses `connections` parallel connections to the server to send the requests.
     // If `control` is set, sends the message to the control port.


### PR DESCRIPTION
This escalates all commands to leader when our version does not match. If this causes performance issues during deploys, we'll want to be able to escalate to random peers, but that's a lot more work.

## Fixes:
$ https://github.com/Expensify/Expensify/issues/104706

## Tests:
New test added.