### PR TITLE
[HOLD] Run travis on focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
-jobs:
-    include:
-        - dist: xenial
-        - dist: focal
-
 sudo: false
+dist: focal
 env:
     - GXX=g++-9 CC=gcc-9
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+jobs:
+    include:
+        - dist: xenial
+        - dist: focal
+
 sudo: false
 env:
     - GXX=g++-9 CC=gcc-9
@@ -13,7 +18,6 @@ notifications:
         on_success: never
 before_install:
 script: ./travis.sh
-dist: xenial
 deploy:
     provider: releases
     # `api_key` is an encrypted oauth token for rafecolton. See https://docs.travis-ci.com/user/deployment/releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: false
-dist: focal
 env:
     - GXX=g++-9 CC=gcc-9
 addons:
@@ -14,6 +13,7 @@ notifications:
         on_success: never
 before_install:
 script: ./travis.sh
+dist: focal
 deploy:
     provider: releases
     # `api_key` is an encrypted oauth token for rafecolton. See https://docs.travis-ci.com/user/deployment/releases


### PR DESCRIPTION
Run travis tests on focal in preparation for upcoming Ubuntu 20.04 upgrade.

## Fixed Issues

Part of Expensify/Expensify#137410

## Tests

It looks like some legitimate test failures under 20.04

![image](https://user-images.githubusercontent.com/139959/98333809-a6f03080-2055-11eb-82a6-68ac2bca6fc4.png)

![image](https://user-images.githubusercontent.com/139959/98333821-afe10200-2055-11eb-8882-57bc0f97a4a6.png)
