### PR TITLE
Fix unique constraints error in multi-rep

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -270,7 +270,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
         command->complete = false;
         SINFO("[checkpoint] Command " << command->request.methodLine << " abandoned (process) for checkpoint");
         return RESULT::ABANDONED_FOR_CHECKPOINT;
-    } catch (const SQLite::unique_constraints_error& e) {
+    } catch (const SQLite::constraint_error& e) {
         SWARN("Unique Constraints Violation, command: " << request.methodLine);
         command->response.methodLine = "400 Unique Constraints Violation";
         _db.rollback();

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -270,6 +270,11 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
         command->complete = false;
         SINFO("[checkpoint] Command " << command->request.methodLine << " abandoned (process) for checkpoint");
         return RESULT::ABANDONED_FOR_CHECKPOINT;
+    } catch (const SQLite::unique_constraints_error& e) {
+        SWARN("Unique Constraints Violation, command: " << request.methodLine);
+        command->response.methodLine = "400 Unique Constraints Violation";
+        _db.rollback();
+        needsCommit = false;
     } catch(...) {
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
         command->response.methodLine = "500 Unhandled Exception";

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2479,8 +2479,9 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
         }
     }
 
+    // But we log for commit conflicts as well, to keep track of how often this happens with this experimental feature.
     if (extErr == SQLITE_BUSY_SNAPSHOT) {
-        SHMMM("[concurrent] commit conflict or unique constraint (" << sqlite3_errmsg(db) << ")");
+        SHMMM("[concurrent] commit conflict.");
         return extErr;
     }
     return error;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2472,14 +2472,14 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
         SASSERT(fwrite(csvRow.c_str(), 1, csvRow.size(), _g_sQueryLogFP) == csvRow.size());
     }
 
-    // Only OK, commit conflicts, and unique constraints errors are allowed without warning.
-    if (error != SQLITE_OK && extErr != SQLITE_BUSY_SNAPSHOT && extErr != SQLITE_CONSTRAINT_UNIQUE) {
+    // Only OK and commit conflicts are allowed without warning.
+    if (error != SQLITE_OK && extErr != SQLITE_BUSY_SNAPSHOT) {
         if (!skipWarn) {
             SWARN("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
         }
     }
 
-    if (extErr == SQLITE_BUSY_SNAPSHOT || extErr == SQLITE_CONSTRAINT_UNIQUE) {
+    if (extErr == SQLITE_BUSY_SNAPSHOT) {
         SHMMM("[concurrent] commit conflict or unique constraint (" << sqlite3_errmsg(db) << ")");
         return extErr;
     }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -604,7 +604,7 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
 
     // If we got a constraints error, throw that.
     if (resultCode == SQLITE_CONSTRAINT) {
-        throw unique_constraints_error();
+        throw constraint_error();
     }
 
     _checkInterruptErrors("SQLite::write"s);

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -481,6 +481,35 @@ class SQLite {
     const string _synchronous;
     int64_t _mmapSizeGB;
 
+    // If we get a SQLITE_CONSTRAINT_UNIQUE error in a write command, we treat it as a success until we attempt to commit the
+    // transaction, when we act as if it were a conflict. The reasoning for this is there are cases where two commands
+    // that would conflict on commit, and would otherwise be handled just fine like that, instead error out early in a
+    // write. For the example case for this, assume the following table:
+    // CREATE TABLE t (identifier PRIMARY KEY);
+    //
+    // With the following start state:
+    // INSERT INTO t VALUES(1);
+    //
+    // If you run these two commands in this order:
+    // DELETE FROM t WHERE identifier = 1;
+    // INSERT INTO t VALUES(1);
+    //
+    // They will work just fine. If you run them simultaneously, you might expect that they'd conflict, but they don't
+    // because the unique constraints error doesn't get thrown at commit, it gets thrown at the time the `INSERT`
+    // command tries to run but the `DELETE` hasn't completed yet. Re-running the `INSERT` after the `DELETE` will work
+    // as expected.
+    //
+    // You might ask why you'd run these two queries simultaneously in the first place, and the answer is that it's
+    // probably a bug to do so, which might be caused by simply not waiting for a `DELETE` to finish before running an
+    // `INSERT` with new data. Depending on the order the two commands finish, you could end up with data or no data.
+    //
+    // However, the actual case here isn't just to fix a caller sending two commands simultaneously, but to handle the
+    // case where these run successfully in DELETE, INSERT order on LEADER but then run simultaneously on a FOLLOWER.
+    // The follower must commit in the same order as leader, but because the error happens in write, not in commit, we
+    // can throw the error from replication if the follower starts the second transaction before the first finishes.
+    // This would be automatically handled in a commit conflict, so we mimic that behavior for this type of error.
+    bool _willConflictAtCommit = false;
+
     // This is a bit of a weird construct. We lock this in the destructor for an SQLite object because we spawn a
     // separate thread to do checkpoints, and that thread needs this object to exist until it finishes, so we lock
     // until that thread completes. This can go away when we no longer have dedicated checkpoint threads.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -24,8 +24,8 @@ class SQLite {
     };
 
     // We can get a SQLITE_CONSTRAINT error in a write command for two reasons. One is a legitimate error caused
-    // by a user trying to two rows with the same key. The other is in multi-threaded replication, when transactions
-    // start in a different order on a follower than they did on the leader. Consider this example case:
+    // by a user trying to insert two rows with the same key. The other is in multi-threaded replication, when
+    // transactions start in a different order on a follower than they did on the leader. Consider this example case:
     // CREATE TABLE t (identifier PRIMARY KEY);
     //
     // With the start state on all nodes:

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -23,7 +23,7 @@ class SQLite {
         const char* what() const noexcept { return "checkpoint_required"; }
     };
 
-    // We can get a SQLITE_CONSTRAINT_UNIQUE error in a write command for two reasons. One is a legitimate error caused
+    // We can get a SQLITE_CONSTRAINT error in a write command for two reasons. One is a legitimate error caused
     // by a user trying to two rows with the same key. The other is in multi-threaded replication, when transactions
     // start in a different order on a follower than they did on the leader. Consider this example case:
     // CREATE TABLE t (identifier PRIMARY KEY);
@@ -40,14 +40,14 @@ class SQLite {
     // command tries to run but the `DELETE` hasn't completed yet. Re-running the `INSERT` after the `DELETE` will work
     // as expected.
     //
-    // If we detect this error, we throw the following exception, which just returns an error when enocountered in a
+    // If we detect this error, we throw the following exception, which just returns an error when encountered in a
     // normal `process` phase of a command on leader, but is treated similarly to a commit conflict in replication, and
     // re-runs the command after the other command (the `DELETE`) has finished.
-    class unique_constraints_error : public exception {
+    class constraint_error : public exception {
       public :
-        unique_constraints_error() {};
-        virtual ~unique_constraints_error() {};
-        const char* what() const noexcept { return "unique_constraints_error"; }
+        constraint_error() {};
+        virtual ~constraint_error() {};
+        const char* what() const noexcept { return "constraint_error"; }
     };
 
     // Constant to use like a sqlite result code when commits are disabled (see: https://www.sqlite.org/rescode.html)

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -223,7 +223,7 @@ void SQLiteNode::replicate(SQLiteNode& node, Peer* peer, SData command, size_t s
 
                         // Ok, almost ready.
                         node.handlePrepareTransaction(db, peer, command);
-                    } catch (const SQLite::unique_constraints_error& e) {
+                    } catch (const SQLite::constraint_error& e) {
                         // We could `continue` immediately upon catching this exception, but instead, we wait for the
                         // leader commit notifier to be ready. This prevents us from spinning in an endless loop on the
                         // same error over and over until whatever thread we're waiting for finishes.

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -186,48 +186,59 @@ void SQLiteNode::replicate(SQLiteNode& node, Peer* peer, SData command, size_t s
 
             try {
                 int result = -1;
-                int attemptCount = 1;
+                int commitAttemptCount = 0;
                 while (result != SQLITE_OK) {
-                    if (attemptCount > 1) {
-                        SINFO("Commit attempt number " << attemptCount << " for concurrent replication.");
+                    if (commitAttemptCount > 1) {
+                        SINFO("Commit attempt number " << commitAttemptCount << " for concurrent replication.");
                     }
                     SINFO("BEGIN for commit " << newCount);
-                    node.handleBeginTransaction(db, peer, command, attemptCount > 1);
+                    bool uniqueContraintsError = false;
+                    try {
+                        node.handleBeginTransaction(db, peer, command, commitAttemptCount > 1);
 
-                    // Now we need to wait for the DB to be up-to-date (if the transaction is QUORUM, we can
-                    // skip this, we did it above) to enforce that commits are in the same order on followers as on
-                    // leader.
-                    if (!quorum) {
-                        // If we get here, we're *in* a transaction (begin ran) so the checkpoint thread is blocked
-                        // waiting for us to finish. But the thread that needs to commit to unblock us can be blocked
-                        // on the checkpoint if these are started out of order.
-                        //
-                        // Let's see if we can verify that happened.
-                        // Yes, we get this line logged 4 times from four threads as their last activity and then:
-                        // (SQLite.cpp:403) operator() [checkpoint] [info] [checkpoint] Waiting on 4 remaining transactions.
-                        SINFO("Waiting at commit " << db.getCommitCount() << " for commit " << currentCount);
-                        SQLiteSequentialNotifier::RESULT waitResult = node._localCommitNotifier.waitFor(currentCount);
-                        if (waitResult == SQLiteSequentialNotifier::RESULT::CANCELED) {
-                            SINFO("Replication canceled mid-transaction, stopping.");
-                            db.rollback();
-                            break;
-                        } else if (waitResult == SQLiteSequentialNotifier::RESULT::CHECKPOINT_REQUIRED) {
-                            SINFO("Checkpoint required in replication, waiting for checkpoint and restarting transaction.");
-                            db.rollback();
-                            db.waitForCheckpoint();
-                            continue;
+                        // Now we need to wait for the DB to be up-to-date (if the transaction is QUORUM, we can
+                        // skip this, we did it above) to enforce that commits are in the same order on followers as on
+                        // leader.
+                        if (!quorum) {
+                            // If we get here, we're *in* a transaction (begin ran) so the checkpoint thread is blocked
+                            // waiting for us to finish. But the thread that needs to commit to unblock us can be blocked
+                            // on the checkpoint if these are started out of order.
+                            //
+                            // Let's see if we can verify that happened.
+                            // Yes, we get this line logged 4 times from four threads as their last activity and then:
+                            // (SQLite.cpp:403) operator() [checkpoint] [info] [checkpoint] Waiting on 4 remaining transactions.
+                            SINFO("Waiting at commit " << db.getCommitCount() << " for commit " << currentCount);
+                            SQLiteSequentialNotifier::RESULT waitResult = node._localCommitNotifier.waitFor(currentCount);
+                            if (waitResult == SQLiteSequentialNotifier::RESULT::CANCELED) {
+                                SINFO("Replication canceled mid-transaction, stopping.");
+                                db.rollback();
+                                break;
+                            } else if (waitResult == SQLiteSequentialNotifier::RESULT::CHECKPOINT_REQUIRED) {
+                                SINFO("Checkpoint required in replication, waiting for checkpoint and restarting transaction.");
+                                db.rollback();
+                                db.waitForCheckpoint();
+                                continue;
+                            }
                         }
+
+                        // Ok, almost ready.
+                        node.handlePrepareTransaction(db, peer, command);
+                    } catch (const SQLite::unique_constraints_error& e) {
+                        // We could `continue` immediately upon catching this exception, but instead, we wait for the
+                        // leader commit notifier to be ready. This prevents us from spinning in an endless loop on the
+                        // same error over and over until whatever thread we're waiting for finishes.
+                        uniqueContraintsError = true;
                     }
-
-                    // Ok, almost ready.
-                    node.handlePrepareTransaction(db, peer, command);
-
                     // Now see if we can commit. We wait until *after* prepare because for QUORUM transactions, we
                     // don't send LEADER the approval for this until inside of `prepare`. This potentially makes us
                     // wait while holding the commit lock for non-concurrent transactions, but I guess nobody else with
                     // a commit after us will be able to commit, either.
                     SQLiteSequentialNotifier::RESULT waitResult = node._leaderCommitNotifier.waitFor(command.calcU64("NewCount"));
-                    if (waitResult == SQLiteSequentialNotifier::RESULT::CANCELED) {
+                    if (uniqueContraintsError) {
+                        SINFO("Got unique constraints error in replication, restarting.");
+                        db.rollback();
+                        continue;
+                    } else if (waitResult == SQLiteSequentialNotifier::RESULT::CANCELED) {
                         SINFO("Replication canceled mid-transaction, stopping.");
                         db.rollback();
                         break;
@@ -239,7 +250,7 @@ void SQLiteNode::replicate(SQLiteNode& node, Peer* peer, SData command, size_t s
                     }
 
                     // Leader says it has committed this transaction, so we can too.
-                    ++attemptCount;
+                    ++commitAttemptCount;
                     result = node.handleCommitTransaction(db, peer, command.calcU64("NewCount"), command["NewHash"]);
                     if (result != SQLITE_OK) {
                         db.rollback();
@@ -2441,10 +2452,8 @@ void SQLiteNode::handleBeginTransaction(SQLite& db, Peer* peer, const SData& mes
             SINFO("Waiting for checkpoint");
             db.waitForCheckpoint();
             SINFO("Done waiting for checkpoint");
-            // If we are running this after a conflict, we'll grab an exclusive lock here. This makes no practical
-            // difference in replication, as transactions must commit in order, thus if we've failed one commit, nobody
-            // else can attempt to commit anyway, but this logs our time spent in the commit mutex in EXCLUSIVE rather
-            // than SHARED mode.
+            // If we are running this after a conflict, we'll grab an exclusive lock here so this transaction must run
+            // entirely by itself.
             if (!db.beginTransaction(wasConflict ? SQLite::TRANSACTION_TYPE::EXCLUSIVE : SQLite::TRANSACTION_TYPE::SHARED)) {
                 STHROW("failed to begin transaction");
             }

--- a/test/clustertest/tests/UniqueConstraintsTest.cpp
+++ b/test/clustertest/tests/UniqueConstraintsTest.cpp
@@ -1,0 +1,17 @@
+#include "../BedrockClusterTester.h"
+
+struct UniqueConstraintsTest : tpunit::TestFixture {
+    UniqueConstraintsTest()
+        : tpunit::TestFixture("UniqueConstraints", TEST(UniqueConstraintsTest::test)) { }
+
+    void test()
+    {
+        BedrockClusterTester tester;
+        SData command("Query");
+        command["Query"] = "INSERT INTO test VALUES(" + SQ(1) + ", " + SQ("val") + ");";
+        auto result1 = tester.getTester(0).executeWaitMultipleData({command})[0];
+        auto result2 = tester.getTester(0).executeWaitMultipleData({command})[0];
+        ASSERT_TRUE(SStartsWith(result1.methodLine, "200"));
+        ASSERT_TRUE(SStartsWith(result2.methodLine, "400"));
+    }
+} __UniqueConstraintsTest;


### PR DESCRIPTION
This handles unique constraint errors in replication. Because why we need this is not at all straightforward by inspection, I've added the explanation as a comment for the new field in SQLite.h so that future readers will be able to understand what it's for.

### Fixes:
$ https://github.com/Expensify/Expensify/issues/145252

### Tests
This is essentially impossible to test in dev. We should enable multi-rep on two production servers for a few days with this change to confirm it's working.