### PR TITLE
Allow signals to interrupt S_poll for faster shutdown.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1141,7 +1141,7 @@ void BedrockServer::worker(SQLitePool& dbPool,
 
         // If we hit the timeout, doesn't matter if we've got work to do. Exit.
         if (server._gracefulShutdownTimeout.ringing()) {
-            SINFO("_shutdownState is DONE and we've timed out, exiting worker.");
+            SINFO("_shutdownState is " <<  server._shutdownState.load() << " and we've timed out, exiting worker.");
             return;
         }
     }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -192,7 +192,7 @@ class BedrockServer : public SQLiteServer {
 
     // Accept connections and dispatch requests
     // STCPNode API.
-    void postPoll(fd_map& fdm, uint64_t& nextActivity);
+    void postPoll(fd_map& fdm);
 
     // Returns true when everything's ready to shutdown.
     bool shutdownComplete();

--- a/libstuff/SSignal.cpp
+++ b/libstuff/SSignal.cpp
@@ -74,6 +74,8 @@ void SPrePollSignals(fd_map& fdm, SSynchronizedQueue<int>& queue) {
 }
 
 void SPostPollSignals(fd_map& fdm, SSynchronizedQueue<int>& queue) {
+    // clear the pipe buffer.
+    queue.postPoll(fdm);
     try {
         while (true) {
             queue.pop();

--- a/libstuff/SSignal.cpp
+++ b/libstuff/SSignal.cpp
@@ -27,6 +27,11 @@ thread _SSignal_signalThread;
 // `abort()`, this records the original signal number until the signal handler for abort has a chance to log it.
 thread_local int _SSignal_threadCaughtSignalNumber = 0;
 
+// Required to allow signals to interrupt calls to `poll`, keeps track of any `poll` loop that wants to listen for
+// signals.
+mutex _SSignal_waitQueueMutex;
+list<SSynchronizedQueue<int>*> _SSignal_waitQueueList;
+
 bool SCheckSignal(int signum) {
     uint64_t signals = _SSignal_pendingSignalBitMask.load();
     signals >>= signum;
@@ -57,6 +62,25 @@ string SGetSignalDescription() {
 
 void SClearSignals() {
     _SSignal_pendingSignalBitMask.store(0);
+}
+
+void SPrePollSignals(fd_map& fdm, SSynchronizedQueue<int>& queue) {
+    lock_guard<mutex> lock(_SSignal_waitQueueMutex);
+    queue.prePoll(fdm);
+    if (SGetSignals()) {
+        queue.push(SGetSignals());
+    }
+    _SSignal_waitQueueList.push_back(&queue);
+}
+
+void SPostPollSignals(fd_map& fdm, SSynchronizedQueue<int>& queue) {
+    try {
+        while (true) {
+            queue.pop();
+        }
+    } catch (const out_of_range& e) {
+        // done.
+    }
 }
 
 void SInitializeSignals() {
@@ -129,7 +153,13 @@ void _SSignal_signalHandlerThreadFunc() {
             } else {
                 // Handle every other signal just by setting the mask. Anyone that cares can look them up.
                 SINFO("Got Signal: " << strsignal(signum) << "(" << signum << ").");
+                lock_guard<mutex> lock(_SSignal_waitQueueMutex);
                 _SSignal_pendingSignalBitMask.fetch_or(1 << signum);
+                for (auto q : _SSignal_waitQueueList) {
+                    int s = signum;
+                    q->push(move(s));
+                }
+                _SSignal_waitQueueList.clear();
             }
         }
     }

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -625,6 +625,17 @@ inline SFastBuffer S_recv(int s) {
 bool S_sendconsume(int s, SFastBuffer& sendBuffer);
 int S_poll(fd_map& fdm, uint64_t timeout);
 
+// There's currently no `SSignal.h`, everything is contained here in libstuff.h, so we need to include
+// SSynchronizedQueue here.
+#include "SSynchronizedQueue.h"
+
+// Gets ready for a poll loop top be interrupted if a signal occurs. If that happens, the signal number will be added
+// to `queue` and poll will return early.
+void SPrePollSignals(fd_map& fdm, SSynchronizedQueue<int>& queue);
+
+// This just clears `queue`, and is provided mostly to keep the API consistent with SPrePollSignals.
+void SPostPollSignals(fd_map& fdm, SSynchronizedQueue<int>& queue);
+
 // Network helpers
 string SGetHostName();
 string SGetPeerName(int s);

--- a/main.cpp
+++ b/main.cpp
@@ -362,7 +362,7 @@ int main(int argc, char* argv[]) {
             const uint64_t now = STimeNow();
             auto timeBeforePoll = chrono::steady_clock::now();
             S_poll(fdm, max(nextActivity, now) - now);
-            nextActivity = STimeNow() + STIME_US_PER_S; // 1s max period
+            nextActivity = STimeNow() + 20'000; // 20ms
             auto timeAfterPoll = chrono::steady_clock::now();
             server.postPoll(fdm, nextActivity);
             auto timeAfterPostPoll = chrono::steady_clock::now();


### PR DESCRIPTION
This is first pass at making shutdown faster to help with deploy speed. This doesn't actually do a ton in terms of the length of time it takes to shut down a production server, or any non-idle server, but it makes a huge difference in the time it takes to shut down an idle server, which makes a gigantic impact on the time it takes tests to run, as they start and stop servers hundreds of times.

What this change actually does is allow our `poll` loops to be interrupted when a signal is caught. There are three separate places that we wait for up to one second in `poll`, one in `main` waiting on network activity from clients, one in the `sync` thread waiting on network activity from peers, and one in `worker` threads waiting for new commands to become available.

This change adds the ability for `poll` to be interrupted by signals that we use to shut down, and uses this new functionality for the two `poll` loops, so that they return immediately once a signal is caught.

This does not fundamentally change the way the worker threads wait for commands, but does shorten the timeout from 1s to 50ms, which makes them return much more quickly. This results in slightly higher idle CPU usage for these threads, which will affect VMs a bit, but I don't think enough to worry about. The correct fix for this that's in-line with #bedrock3 is to switch to one thread per command, in which case, there will be no idle threads when there are no commands.

Here's performance numbers for this:

Without this change, running a throwaway `FastShutdownTest`:
```
 clustertest:$  ./clustertest -only FastShutdown -repeatCount 10
[--------------]
[ RUN          ] FastShutdownTest::test
Stopped 1 follower in 4003ms, remaining servers in: 8009ms.
Stopped 1 follower in 4001ms, remaining servers in: 7010ms.
Stopped 1 follower in 4017ms, remaining servers in: 7004ms.
Stopped 1 follower in 4006ms, remaining servers in: 6011ms.
Stopped 1 follower in 4002ms, remaining servers in: 7002ms.
Stopped 1 follower in 4009ms, remaining servers in: 6000ms.
Stopped 1 follower in 2000ms, remaining servers in: 6003ms.
Stopped 1 follower in 4003ms, remaining servers in: 7009ms.
Stopped 1 follower in 4004ms, remaining servers in: 7001ms.
Stopped 1 follower in 3002ms, remaining servers in: 4000ms.
[ TEST RESULTS ] Passed: 10, Failed: 0
```

And with this change (at ef0dbd7dda149e5a0e0cf1b91242f6d68d0b2c4f):
```
 clustertest:$  ./clustertest -only FastShutdown -repeatCount 10
[--------------]
[ RUN          ] FastShutdownTest::test
Stopped 1 follower in 39ms, remaining servers in: 98ms.
Stopped 1 follower in 63ms, remaining servers in: 83ms.
Stopped 1 follower in 46ms, remaining servers in: 82ms.
Stopped 1 follower in 15ms, remaining servers in: 100ms.
Stopped 1 follower in 44ms, remaining servers in: 103ms.
Stopped 1 follower in 46ms, remaining servers in: 101ms.
Stopped 1 follower in 52ms, remaining servers in: 98ms.
Stopped 1 follower in 17ms, remaining servers in: 101ms.
Stopped 1 follower in 59ms, remaining servers in: 100ms.
Stopped 1 follower in 53ms, remaining servers in: 102ms.
[ TEST RESULTS ] Passed: 10, Failed: 0
```

And auth tests before the change:
```
test:$  time ./authtest -threads 16 -repeatCount 1
[ TEST RESULTS ] Passed: 1364, Failed: 0
real	4m53.046s
user	1m30.156s
sys	0m49.976s
```

And after the change:
```
test:$  time ./authtest -threads 16 -repeatCount 1
[ TEST RESULTS ] Passed: 1364, Failed: 0
real	2m37.044s
user	2m17.032s
sys	1m36.116s
```