### PR TITLE
Add hack to time munmap

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -335,7 +335,8 @@ int main(int argc, char* argv[]) {
     // Create our BedrockServer object so we can keep it for the life of the
     // program.
     SINFO("Starting bedrock server");
-    BedrockServer server(args);
+    BedrockServer* _server = new BedrockServer(args);
+    BedrockServer& server = *_server;
 
     // Keep going until someone kills it (either via TERM or Control^C)
     while (!(SGetSignal(SIGTERM) || SGetSignal(SIGINT))) {
@@ -386,6 +387,10 @@ int main(int argc, char* argv[]) {
             break;
         }
     }
+
+    SINFO("Deleting BedrockServer");
+    delete _server;
+    SINFO("BedrockServer deleted");
 
     // All done
     SINFO("Graceful process shutdown complete");


### PR DESCRIPTION
This adds a hack to time `munmap` when we destroy our DB handles.

It also explicitly destroys our bedrock server *before* exiting main, because otherwise we could see strange behavior with a sync thread that was still joining (slowly, as it ran through destroying all it's DB handles) when `main` returned and the `BedrockServer` destructor was called.

This is throwaway code (at least, the change to `sqlite3.c`, the change to `main.cpp` might be worth keeping).