### PR TITLE
Allowing multiple https calls to be made on a single socket

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -279,11 +279,17 @@ list<SStandaloneHTTPSManager::Transaction*> SStandaloneHTTPSManager::_httpsSendM
 
     // Send all of the requests over the socket.
     for (auto& request : requests) {
-        // Send that transaction on the socket.
+        // Create a request transaction
         Transaction* transaction = _httpsSend(url, request, s);
 
-        // Add the transaction to our transactions list.
+        // Send the transaction on the socket and add it to our transactions list.
         transactions.push_back(transaction);
+
+        // There is no guarantee that multiple responses on the same socket will come back in the order they were sent.
+        // Wait until we have the response from the current request before sending the next one.
+        while (transaction->fullResponse.empty()) {
+            continue;
+        }
     }
 
     return transactions;

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -52,10 +52,13 @@ void SStandaloneHTTPSManager::closeTransaction(Transaction* transaction) {
     // Clean up the socket and done
     _activeTransactionList.remove(transaction);
     _completedTransactionList.remove(transaction);
-    if (transaction->s && !SContains(_closedSocketsList, transaction->s)) {
+
+    // If the socket has not been closed and removed from the socketList, close it.
+    if (transaction->s && find(socketList.begin(), socketList.end(), transaction->s) != socketList.end()) {
         closeSocket(transaction->s);
-        _closedSocketsList.push_back(transaction->s);
     }
+
+    // Since the socket has been closed, update the transaction's socket to the null pointer.
     transaction->s = nullptr;
     delete transaction;
 }

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -62,12 +62,11 @@ class SStandaloneHTTPSManager : public STCPManager {
     Transaction* _httpsSend(const string& url, const SData& request);
     Transaction* _createErrorTransaction();
     virtual bool _onRecv(Transaction* transaction);
-
     list<Transaction*> _httpsSendMultiple(const string& url, vector<SData>& sendRequests);
 
     list<Transaction*> _activeTransactionList;
     list<Transaction*> _completedTransactionList;
-    list<STCPManager::Socket*> _closedSockets;
+    list<Socket*> _closedSocketsList;
 
     // SStandaloneHTTPSManager operations are thread-safe, we lock around any accesses to our transaction lists, so that
     // multiple threads can add/remove from them.

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -66,7 +66,6 @@ class SStandaloneHTTPSManager : public STCPManager {
 
     list<Transaction*> _activeTransactionList;
     list<Transaction*> _completedTransactionList;
-    list<Socket*> _closedSocketsList;
 
     // SStandaloneHTTPSManager operations are thread-safe, we lock around any accesses to our transaction lists, so that
     // multiple threads can add/remove from them.

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -63,8 +63,11 @@ class SStandaloneHTTPSManager : public STCPManager {
     Transaction* _createErrorTransaction();
     virtual bool _onRecv(Transaction* transaction);
 
+    list<Transaction*> _httpsSendMultiple(const string& url, vector<SData>& sendRequests);
+
     list<Transaction*> _activeTransactionList;
     list<Transaction*> _completedTransactionList;
+    list<STCPManager::Socket*> _closedSockets;
 
     // SStandaloneHTTPSManager operations are thread-safe, we lock around any accesses to our transaction lists, so that
     // multiple threads can add/remove from them.

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -59,10 +59,10 @@ class SStandaloneHTTPSManager : public STCPManager {
     const string _caCrt;
 
     // Methods
-    Transaction* _httpsSend(const string& url, const SData& request);
+    Transaction* _httpsSend(const string& url, const SData& request, Socket* s = nullptr);
     Transaction* _createErrorTransaction();
     virtual bool _onRecv(Transaction* transaction);
-    list<Transaction*> _httpsSendMultiple(const string& url, vector<SData>& sendRequests);
+    list<Transaction*> _httpsSendMultiple(const string& url, list<SData>& requests);
 
     list<Transaction*> _activeTransactionList;
     list<Transaction*> _completedTransactionList;


### PR DESCRIPTION
@coleaeason will you please review this?
cc: @tylerkaraszewski

This PR allows us to create a socket over which multiple requests can be made. The `_httpsSend` method creates a new socket for every single request that is being made. If many requests are being made to the same server/ip, opening and closing new sockets every time ends up being significantly more time consuming. By handling many of those requests on the same socket, it makes things significantly faster.

### Test
I tested this with calls to the GIACT API. It demonstrated that doing multiple calls per socket significantly increased the speed of making and handling the calls with the `RunGiactFraudCheck` Auth command. Here are a few of the results. You can see that as the number of API calls increases, the more significant the time savings are to have multiple calls on a socket.

```
API Calls  |  Sockets  |  peekTime  |  processTime  |  totalTime
---------     -------     --------     -----------     ---------
500           500         458501       54399           7003151
500           50          300273       59814           3643981
1000          1000        2172908      111881          17559371
1000          50          635162       106510          6214122
```