### PR TITLE
Add thread init func option

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -82,14 +82,16 @@ tpunit::TestFixture::~TestFixture() {
     delete _tests;
 }
 
-int tpunit::TestFixture::tpunit_detail_do_run(int threads) {
+int tpunit::TestFixture::tpunit_detail_do_run(int threads, std::function<void()> threadInitFunction) {
     const std::set<std::string> include, exclude;
     const std::list<std::string> before, after;
-    return tpunit_detail_do_run(include, exclude, before, after, threads);
+    return tpunit_detail_do_run(include, exclude, before, after, threads, threadInitFunction);
 }
 
 int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const set<string>& exclude,
-                                              const list<string>& before, const list<string>& after, int threads) {
+                                              const list<string>& before, const list<string>& after, int threads,
+                                              std::function<void()> threadInitFunction) {
+   threadInitFunction();
     /*
     * Run specific tests by name. If 'include' is empty, then every test is
     * run unless it's in 'exclude'. If 'include' has at least one entry,
@@ -145,6 +147,7 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
         // Capture everything by reference except threadID, because we don't want it to be incremented for the
         // next thread in the loop.
         thread t = thread([&, threadID]{
+           threadInitFunction();
             try {
                 // Do test.
                 while (1) {
@@ -406,11 +409,11 @@ list<tpunit::TestFixture*>* tpunit::TestFixture::tpunit_detail_fixture_list() {
     return _fixtureList;
 }
 
-int tpunit::Tests::run(int threads) {
-    return TestFixture::tpunit_detail_do_run(threads);
+int tpunit::Tests::run(int threads, std::function<void()> threadInitFunction) {
+    return TestFixture::tpunit_detail_do_run(threads, threadInitFunction);
 }
 
 int tpunit::Tests::run(const set<string>& include, const set<string>& exclude,
-                       const list<string>& before, const list<string>& after, int threads) {
-    return TestFixture::tpunit_detail_do_run(include, exclude, before, after, threads);
+                       const list<string>& before, const list<string>& after, int threads, std::function<void()> threadInitFunction) {
+    return TestFixture::tpunit_detail_do_run(include, exclude, before, after, threads, threadInitFunction);
 }

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -28,6 +28,7 @@
 #include <thread>
 #include <mutex>
 #include <algorithm>
+#include <functional>
 using namespace std;
 
 /**
@@ -297,10 +298,11 @@ namespace tpunit {
             return new method(this, static_cast<void (TestFixture::*)()>(_method), _name, _type);
          }
 
-         static int tpunit_detail_do_run(int threads = 1);
+         static int tpunit_detail_do_run(int threads = 1, std::function<void()> threadInitFunction = [](){});
 
          static int tpunit_detail_do_run(const std::set<std::string>& include, const std::set<std::string>& exclude,
-                                         const std::list<std::string>& before, const std::list<std::string>& after, int threads);
+                                         const std::list<std::string>& before, const std::list<std::string>& after, int threads,
+                                         std::function<void()> threadInitFunction);
 
       protected:
 
@@ -359,7 +361,7 @@ namespace tpunit {
        *
        * @return Number of failed assertions or zero if all tests pass.
        */
-      static int run(int threads = 1);
+      static int run(int threads = 1, std::function<void()> threadInitFunction = [](){});
 
       /**
        * Run specific tests by name. If 'include' is empty, then every test is
@@ -369,6 +371,7 @@ namespace tpunit {
        * @return Number of failed assertions or zero if all tests pass.
        */
       static int run(const std::set<std::string>& include, const std::set<std::string>& exclude,
-                     const std::list<std::string>& before, const std::list<std::string>& after, int threads = 1);
+                     const std::list<std::string>& before, const std::list<std::string>& after, int threads = 1,
+                     std::function<void()> threadInitFunction = [](){});
    };
 }


### PR DESCRIPTION
This adds the option to run a custom function inside test threads. We use that here: https://github.com/Expensify/Auth/pull/5037

To set the log level correctly so that logging from tests works as expected.