### PR TITLE
Add state logging

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1063,7 +1063,7 @@ void BedrockServer::worker(SQLitePool& dbPool,
                                 core.rollback();
                             } else {
                                 BedrockCore::AutoTimer(command, BedrockCommand::COMMIT_WORKER);
-                                commitSuccess = core.commit();
+                                commitSuccess = core.commit(SQLiteNode::stateName(server._replicationState));
                             }
                         }
                         if (commitSuccess) {

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -167,7 +167,7 @@ class SQLite {
     void setRewriteHandler(bool (*handler)(int, const char*, string&));
 
     // Commits the current transaction to disk. Returns an sqlite3 result code.
-    int commit();
+    int commit(const string& description = "UNSPECIFIED");
 
     // Cancels the current transaction and rolls it back.
     void rollback();

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -6,7 +6,7 @@
 SQLiteCore::SQLiteCore(SQLite& db) : _db(db)
 { }
 
-bool SQLiteCore::commit() {
+bool SQLiteCore::commit(const string& description) {
     // This should always succeed.
     SASSERT(_db.prepare());
 
@@ -17,7 +17,7 @@ bool SQLiteCore::commit() {
     }
 
     // Perform the actual commit, rollback if it fails.
-    int errorCode = _db.commit();
+    int errorCode = _db.commit(description);
     if (errorCode == SQLITE_BUSY_SNAPSHOT) {
         SINFO("Commit conflict, rolling back.");
         _db.rollback();

--- a/sqlitecluster/SQLiteCore.h
+++ b/sqlitecluster/SQLiteCore.h
@@ -8,7 +8,7 @@ class SQLiteCore {
 
     // Commit the outstanding transaction on the DB.
     // Returns true on successful commit, false on conflict.
-    bool commit();
+    bool commit(const string& description);
 
     // Roll back a transaction if we've decided not to commit it.
     void rollback();

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1009,7 +1009,7 @@ bool SQLiteNode::update() {
                 // Commit this distributed transaction. Either we have quorum, or we don't need it.
                 SDEBUG("Committing current transaction because consistentEnough: " << _db.getUncommittedQuery());
                 uint64_t beforeCommit = STimeNow();
-                int result = _db.commit();
+                int result = _db.commit(stateName(_state));
                 SINFO("SQLite::commit in SQLiteNode took " << ((STimeNow() - beforeCommit)/1000) << "ms.");
 
                 // If this is the case, there was a commit conflict.
@@ -2269,7 +2269,7 @@ void SQLiteNode::_recvSynchronize(Peer* peer, const SData& message) {
 
         // Transaction succeeded, commit and go to the next
         SDEBUG("Committing current transaction because _recvSynchronize: " << _db.getUncommittedQuery());
-        _db.commit();
+        _db.commit(stateName(_state));
 
         // Should work here.
         SINFO("[NOTIFY] setting commit count to: " << _db.getCommitCount());
@@ -2581,7 +2581,7 @@ int SQLiteNode::handleCommitTransaction(SQLite& db, Peer* peer, const uint64_t c
     }
 
     SDEBUG("Committing current transaction because COMMIT_TRANSACTION: " << db.getUncommittedQuery());
-    int result = db.commit();
+    int result = db.commit(stateName(_state));
     if (result == SQLITE_BUSY_SNAPSHOT) {
         // conflict, bail out early.
         return result;
@@ -2777,7 +2777,7 @@ void SQLiteNode::handleSerialCommitTransaction(Peer* peer, const SData& message)
     }
 
     SDEBUG("Committing current transaction because COMMIT_TRANSACTION: " << _db.getUncommittedQuery());
-    _db.commit();
+    _db.commit(stateName(_state));
 
     // Clear the list of committed transactions. We're following, so we don't need to send these.
     _db.popCommittedTransactions();


### PR DESCRIPTION
This adds the node state to the log line for complete commits. I also consolidated several loglines that happen at the same time into one.

fixes:
$ https://github.com/Expensify/Expensify/issues/147873

## Tests:

Run some of the bedrock tests and tail the logs for lines that look like:
```
2020-12-09T22:16:09.432134+00:00 expensidev bedrock10047: r2K71y (SQLite.cpp:773) commit [worker7] [info] LEADING COMMIT complete in 0.85ms. Wrote 3 pages. WAL file size is 49472 bytes. 5 queries attempted, 0 served from cache.
```