### PR TITLE
Add requestIDs in more places where they're relevant (including attaching to HTTPS transactions)

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2224,6 +2224,8 @@ void BedrockServer::waitForHTTPS(unique_ptr<BedrockCommand>&& command) {
 
     for (auto request : commandPtr->httpsRequests) {
         if (!request->response) {
+            SAUTOPREFIX(commandPtr->request);
+            SINFO("Pushing HTTPS request to _outstandingHTTPSRequests to complete.");
             _outstandingHTTPSRequests.emplace(make_pair(request, commandPtr));
         }
     }
@@ -2248,6 +2250,8 @@ int BedrockServer::finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& comp
         if (commandPtrIt != _outstandingHTTPSCommands.end()) {
             // I guess it's still here! Is it done?
             if (commandPtr->areHttpsRequestsComplete()) {
+                SAUTOPREFIX(commandPtr->request);
+                SINFO("All HTTPS requests complete, returning to main queue.");
                 // If so, add it back to the main queue, erase its entry in _outstandingHTTPSCommands, and delete it.
                 _commandQueue.push(unique_ptr<BedrockCommand>(commandPtr));
                 _outstandingHTTPSCommands.erase(commandPtrIt);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -52,6 +52,7 @@ void BedrockServer::acceptCommand(unique_ptr<SQLiteCommand>&& command, bool isNe
             } else {
                 newCommand = getCommandFromPlugins(move(command));
             }
+            SAUTOPREFIX(newCommand->request);
             SINFO("Accepted command " << newCommand->request.methodLine << " from plugin " << newCommand->getName());
         }
 

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -117,6 +117,7 @@ void SStandaloneHTTPSManager::postPoll(fd_map& fdm, uint64_t& nextActivity, list
         // Did we get any responses?
         list<Transaction*>::iterator activeIt = nextIt++;
         Transaction* active = *activeIt;
+        SAUTOPREFIX(active->requestID);
         if (active->isDelayedSend && !active->sentTime) {
             // This transaction was created, queued, and then meant to be sent later.
             // As such we'll use STimeNow() as it's "created" time for time.

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -179,7 +179,8 @@ SStandaloneHTTPSManager::Transaction::Transaction(SStandaloneHTTPSManager& manag
     response(0),
     manager(manager_),
     isDelayedSend(0),
-    sentTime(0)
+    sentTime(0),
+    requestID(SThreadLogPrefix)
 {
     manager.validate();
 }

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -21,6 +21,7 @@ class SStandaloneHTTPSManager : public STCPManager {
         SStandaloneHTTPSManager& manager;
         bool isDelayedSend;
         uint64_t sentTime;
+        const string requestID;
     };
 
     // Constructor/Destructor

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -313,6 +313,11 @@ struct SAutoThreadPrefix {
         const string requestID = request.isSet("requestID") ? request["requestID"] : "xxxxxx";
         SLogSetThreadPrefix(requestID + (request.isSet("logParam") ? " " + request["logParam"] : "") + " ");
     }
+    SAutoThreadPrefix(const string& rID) {
+        oldPrefix = SThreadLogPrefix;
+        const string requestID = rID.empty() ? "xxxxxx" : rID;
+        SLogSetThreadPrefix(requestID + " ");
+    }
     ~SAutoThreadPrefix() { SLogSetThreadPrefix(oldPrefix); }
 
   private:

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1742,6 +1742,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
             if (!message.isSet("ID")) {
                 STHROW("missing ID");
             }
+            SAUTOPREFIX(request);
             PINFO("Received ESCALATE command for '" << message["ID"] << "' (" << request.methodLine << ")");
 
             // Create a new Command and send to the server.


### PR DESCRIPTION
This adds and improves logging to attempt to diagnose https://github.com/Expensify/Expensify/issues/147377

Mostly, it attempts to give more loglines the correct request ID. This is the purpose of adding requestID to SHTTPSManager::Transaction - because these are looked at in the main poll loop, they're not easily associated back to the request owning them at that point, so we can use the request ID from the Transaction object to still log them with the correct request ID.

There will be a followup Auth PR that does more of the same, but requires the SHTTPSMananager::Transaction changes here.