### PR TITLE
Printing the body of an SException to help debug issues

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -295,7 +295,10 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
 }
 
 void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e) {
-    const string& msg = "Error processing command '" + command->request.methodLine + "' (" + e.what() + "), ignoring.";
+    string msg = "Error processing command '" + command->request.methodLine + "' (" + e.what() + "), ignoring.";
+    if (!e.body.empty()) {
+        msg = msg + " Request body: " + e.body;
+    }
     if (SContains(e.what(), "_ALERT_")) {
         SALERT(msg);
     } else if (SContains(e.what(), "_WARN_")) {


### PR DESCRIPTION
## Fixed Issue

When using `STHROW` with 3 parameters, the third one being `body`, we don't print said `body` in the logs and some useful debugging information is lost. In the case of a recent issue we had, we have 5 occurrences of `STHROW("507 Stripe Error, {}, jsonResponse.serialize())`, none of which we can get information from and isn't helping investigations on "Stripe Error" issues. 

## Tests

In order to test this change, I've modified some code in our Auth repository to do this for every Authenticate command : 
```cpp
STHROW("418 I'm a teapot", {}, request["partnerName"]);
```

The resulting log is the following : 
```
2021-01-07T10:56:14.651872+00:00 expensidev bedrock: bUoCMK clem@expensify.com (BedrockCore.cpp:311) _handleCommandException [worker1] [info] Error processing command 'Authenticate' (418 I'm a teapot), ignoring. Request body: expensify.com
```