### PR TITLE
Replace syslog with a function that sends directly to the syslog socket

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1289,6 +1289,11 @@ BedrockServer::BedrockServer(const SData& args_)
         SQLite::enableTrace.store(true);
     }
 
+    // Bypass journald.
+    if (args.isSet("-logDirectlyToSyslogSocket")) {
+        SSyslogFunc = &SSyslogSocketDirect;
+    }
+
     // Check for commands that will be forced to use QUORUM write consistency.
     if (args.isSet("-synchronousCommands")) {
         list<string> syncCommands;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -68,7 +68,7 @@ thread_local int SSyslogSocketFD = 0;
 thread_local string SProcessName;
 
 // Set to `syslog` or `SSyslogSocketDirect`.
-void (*SSyslogFunc)(int priority, const char *format, ...) = &SSyslogSocketDirect;
+atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc = &syslog;
 
 void SInitialize(string threadName, const char* processName) {
     // If a specific process name has been supplied, initialize syslog with it.
@@ -189,6 +189,7 @@ void SSyslogSocketDirect(int priority, const char *format, ...) {
         va_start(argptr, format);
         int bytesWritten = vsnprintf(messageBuffer + messageHeader.size(), MAX_MESSAGE_SIZE - messageHeader.size(), format, argptr);
         va_end(argptr);
+
 
         // Assume we send the whole message. We don't do anything to handle message truncation.
         ssize_t bytesSent = sendto(SSyslogSocketFD, messageBuffer, bytesWritten + messageHeader.size(), 0, (struct sockaddr *)&SSyslogSocketAddr, sizeof(struct sockaddr_un));

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -274,17 +274,17 @@ extern void (*SSyslogFunc)(int priority, const char *format, ...);
 
 // **NOTE: rsyslog default max line size is 8k bytes. We split on 7k byte boundaries in order to fit the syslog line prefix and the expanded \r\n to #015#012
 #define SWHEREAMI SThreadLogPrefix + "(" + basename((char*)__FILE__) + ":" + SToStr(__LINE__) + ") " + __FUNCTION__ + " [" + SThreadLogName + "] "
-#define SSYSLOG(_PRI_, _MSG_)                                                               \
-    do {                                                                                    \
-        if (_g_SLogMask & (1 << (_PRI_))) {                                                 \
-            ostringstream __out;                                                            \
-            __out << _MSG_ << endl;                                                         \
-            const string s = __out.str();                                                   \
-            const string prefix = SWHEREAMI;                                                \
-            for (size_t i = 0; i < s.size(); i += 7168) {                                   \
-                SSyslogFunc(_PRI_, "%s", (prefix + s.substr(i, 7168)).c_str());             \
-            }                                                                               \
-        }                                                                                   \
+#define SSYSLOG(_PRI_, _MSG_)                                                   \
+    do {                                                                        \
+        if (_g_SLogMask & (1 << (_PRI_))) {                                     \
+            ostringstream __out;                                                \
+            __out << _MSG_ << endl;                                             \
+            const string s = __out.str();                                       \
+            const string prefix = SWHEREAMI;                                    \
+            for (size_t i = 0; i < s.size(); i += 7168) {                       \
+                SSyslogFunc(_PRI_, "%s", (prefix + s.substr(i, 7168)).c_str()); \
+            }                                                                   \
+        }                                                                       \
     } while (false)
 
 #define SLOGPREFIX ""

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -267,10 +267,10 @@ inline void SLogLevel(int level) {
 void SLogStackTrace();
 
 // This is a drop-in replacement for syslog that directly logs to `/run/systemd/journal/syslog` bypassing journald.
-void SSyslogSocketDirect(int priority, const char *format, ...);
+void SSyslogSocketDirect(int priority, const char* format, ...);
 
-// Pointer to the syslog function that we'll actually use. Easy to change to `syslog` or `SSyslogSocketDirect`.
-extern void (*SSyslogFunc)(int priority, const char *format, ...);
+// Atomic pointer to the syslog function that we'll actually use. Easy to change to `syslog` or `SSyslogSocketDirect`.
+extern atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc;
 
 // **NOTE: rsyslog default max line size is 8k bytes. We split on 7k byte boundaries in order to fit the syslog line prefix and the expanded \r\n to #015#012
 #define SWHEREAMI SThreadLogPrefix + "(" + basename((char*)__FILE__) + ":" + SToStr(__LINE__) + ") " + __FUNCTION__ + " [" + SThreadLogName + "] "

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -103,6 +103,7 @@ BedrockTester::BedrockTester(int threadID, const map<string, string>& args,
         {"-enableMultiWrite", "true"},
         {"-cacheSize", "1000"},
         {"-parallelReplication", "true"},
+        {"-logDirectlyToSyslogSocket", ""},
     };
 
     // Set defaults.


### PR DESCRIPTION
This adds a drop-in replacement for syslog that’s configurable via command-line, and makes that option the default for tests. 

Tested by hacking the new function to contain `SOCK` and verifying it’s logged in dev logs when enabled, but not when disabled. 

We will want to test on one production server after deploy before adding the command-line option globally. 

Additionally tested with the following command added to `testplugin` in `clustertest`:
```
} else if (request.methodLine == "sequentiallog") {
    list<thread> threads;
    atomic<uint64_t> logID(0);
    const string randomID = request["randomID"];
    for (int i = 0; i < 32; i++) {
        threads.emplace_back([i, &logID  , &randomID](){
            SInitialize("seqlog" + to_string(i));
            while (true) {
                uint64_t myLog = ++logID;
                if (myLog > 1'000'000) {
                    return;
                }
                SINFO("sequentiallog test (" << randomID << ") line: " << myLog);
            }
        });
    }
    for( auto& t : threads) {
        t.join();
    }
    return true;
}
```

And the test harness:
```
BedrockClusterTester tester;
const string randomID = SRandom::randStr(8);
cout << "Running sequential log test with ID: " << randomID << endl;
SData cmd("sequentiallog");
cmd["randomID"] = randomID;
string response = tester.getTester(0).executeWaitVerifyContent(cmd);
```

This output:
```
 clustertest:$  ./clustertest -only SequentialLog
[--------------]
[ RUN          ] SequentialLogTest::test
Running sequential log test with ID: 8IqG2FTD
[       PASSED ] SequentialLogTest::test
[--------------]
```

And had the result:
```
 Bedrock:$  tail -F /var/log/syslog | grep --line-buffered 'sequential' > seq.log
 Bedrock:$  grep '8IqG2FTD' seq.log | wc -l
1000000
```