### PR TITLE
Turn off socket logging in tests

### DIFF
--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -103,7 +103,8 @@ BedrockTester::BedrockTester(int threadID, const map<string, string>& args,
         {"-enableMultiWrite", "true"},
         {"-cacheSize", "1000"},
         {"-parallelReplication", "true"},
-        {"-logDirectlyToSyslogSocket", ""},
+        // Currently breaks only in Travis and needs debugging, which has been removed, maybe?
+        //{"-logDirectlyToSyslogSocket", ""},
     };
 
     // Set defaults.


### PR DESCRIPTION
This breaks in travis and debugging in travis is currently disabled so we're turning this off for the moment.