### PR TITLE
Use socket pool for logging to avoid running out of FDs

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -90,12 +90,15 @@ void SInitialize(string threadName, const char* processName) {
         }
     }
 
+    // We statically store whichever process name was passed most recently to reuse. This lets new threads start up
+    // with the same process name as existing threads, even when using socket logging, since "openlog" has no effect
+    // then.
+    static string initialProcessName = processName ? processName : "bedrock";
+    SProcessName = initialProcessName;
+
     // If a specific process name has been supplied, initialize syslog with it.
     if (processName) {
         openlog(processName, 0, 0);
-        SProcessName = processName;
-    } else {
-        SProcessName = "bedrock";
     }
 
     // Initialize signal handling

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -62,15 +62,34 @@
 thread_local string SThreadLogPrefix;
 thread_local string SThreadLogName;
 
-// Socket logging variables.
-thread_local struct sockaddr_un SSyslogSocketAddr;
-thread_local int SSyslogSocketFD = 0;
+// We store the process name passed in `SInitialize` to use in logging.
 thread_local string SProcessName;
+
+// This is a set of reusable sockets, each with an associated mutex, to allow for parallel logging directly to the
+// syslog socket, rather than going through the syslog() system call, which goes through journald.
+const size_t S_LOG_SOCKET_MAX = 500;
+int SLogSocketFD[S_LOG_SOCKET_MAX] = {};
+mutex SLogSocketMutex[S_LOG_SOCKET_MAX];
+atomic<size_t> SLogSocketCurrentOffset(0);
+struct sockaddr_un SLogSocketAddr;
+atomic_flag SLogSocketsInitialized = ATOMIC_FLAG_INIT;
 
 // Set to `syslog` or `SSyslogSocketDirect`.
 atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc = &syslog;
 
 void SInitialize(string threadName, const char* processName) {
+    // This is not really thread safe. It's guaranteed to run only once, because of the atomic flag, but it's not
+    // guaranteed that a second caller to `SInitialize` will wait until this block has completed before attempting to
+    // use the socket logging variables. This is handled by the fact that we call `SInitialize` in main() which waits
+    // for the completion of the call before any other threads can be initialized.
+    if (!SLogSocketsInitialized.test_and_set()) {
+        SLogSocketAddr.sun_family = AF_UNIX;
+        strcpy(SLogSocketAddr.sun_path, "/run/systemd/journal/syslog");
+        for (size_t i = 0; i < S_LOG_SOCKET_MAX; i++) {
+            SLogSocketFD[i] = -1;
+        }
+    }
+
     // If a specific process name has been supplied, initialize syslog with it.
     if (processName) {
         openlog(processName, 0, 0);
@@ -83,10 +102,6 @@ void SInitialize(string threadName, const char* processName) {
     SLogSetThreadName(threadName);
     SLogSetThreadPrefix("xxxxxx ");
     SInitializeSignals();
-
-    SSyslogSocketAddr.sun_family = AF_UNIX;
-    strcpy(SSyslogSocketAddr.sun_path, "/run/systemd/journal/syslog");
-    SSyslogSocketFD = -1;
 }
 
 // Thread-local log prefix
@@ -161,19 +176,17 @@ void SSyslogSocketDirect(int priority, const char *format, ...) {
     int socketError = 0;
     static const size_t MAX_MESSAGE_SIZE = 8 * 1024;
 
-    // This block shouldn't be required, but it kicks in if this is used from somewhere that fails to call
-    // `SInitialize`. I figured this is better than just losing the log.
-    if (SSyslogSocketFD == 0) {
-        SSyslogSocketAddr.sun_family = AF_UNIX;
-        strcpy(SSyslogSocketAddr.sun_path, "/run/systemd/journal/syslog");
-        SSyslogSocketFD = -1;
-    }
+    // Choose an FD from our array.
+    size_t socketIndex = (++SLogSocketCurrentOffset) % S_LOG_SOCKET_MAX;
 
-    if (SSyslogSocketFD == -1) {
+    // Lock for this particular socket. If more than one thread want to log using the same FD, some will wait.
+    lock_guard<mutex> lock(SLogSocketMutex[socketIndex]);
+
+    if (SLogSocketFD[socketIndex] == -1) {
         // Create a socket if there isn't one already.
-        SSyslogSocketFD = socket(AF_UNIX, SOCK_DGRAM, 0);
+        SLogSocketFD[socketIndex] = socket(AF_UNIX, SOCK_DGRAM, 0);
     }
-    if (SSyslogSocketFD == -1) {
+    if (SLogSocketFD[socketIndex] == -1) {
         // Error opening the socket. We'll fall back to regular syslog.
         socketError = errno;
     } else {
@@ -192,11 +205,11 @@ void SSyslogSocketDirect(int priority, const char *format, ...) {
 
 
         // Assume we send the whole message. We don't do anything to handle message truncation.
-        ssize_t bytesSent = sendto(SSyslogSocketFD, messageBuffer, bytesWritten + messageHeader.size(), 0, (struct sockaddr *)&SSyslogSocketAddr, sizeof(struct sockaddr_un));
+        ssize_t bytesSent = sendto(SLogSocketFD[socketIndex], messageBuffer, bytesWritten + messageHeader.size(), 0, (const struct sockaddr *)&SLogSocketAddr, sizeof(struct sockaddr_un));
         if (bytesSent == -1) {
             socketError = errno;
-            close(SSyslogSocketFD);
-            SSyslogSocketFD = -1;
+            close(SLogSocketFD[socketIndex]);
+            SLogSocketFD[socketIndex] = -1;
         }
     }
 


### PR DESCRIPTION
This updates the change we made previously (https://github.com/Expensify/Bedrock/pull/951) for logging directly to the syslog socket to use a pool of sockets rather than one socket per thread. The original version actually leaked sockets, as they were opened per thread, but never closed. With multi-rep, there's a new thread (and thus a new socket) for each replicated transaction, which causes us to eventually run out.

This change uses a pool of 500 sockets, which is similar to how we handle running out of threads in multi-rep.

This has run the same tests as the previous PR. This also resolves the failures we saw using the previous branch in Travis.

This really needs to get merged and deployed today (Jan 27, 2021) so that we can test and enable before billing on Feb 1.