### PR TITLE
Fix for lost billing commands

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2086,6 +2086,7 @@ void BedrockServer::_postPollPlugins(fd_map& fdm, uint64_t nextActivity) {
         auto timeoutIt = _outstandingHTTPSCommands.begin();
         while (timeoutIt != _outstandingHTTPSCommands.end() && (*timeoutIt)->timeout() < now) {
             // Add all the transactions for this command, even if some are already complete, they'll just get ignored.
+            SAUTOPREFIX((*timeoutIt)->request);
             for (auto transaction : (*timeoutIt)->httpsRequests) {
                 transactionTimeouts[transaction] = (*timeoutIt)->timeout();
             }
@@ -2219,21 +2220,36 @@ void BedrockServer::_acceptSockets() {
 }
 
 void BedrockServer::waitForHTTPS(unique_ptr<BedrockCommand>&& command) {
+    SAUTOPREFIX(command->request);
     lock_guard<mutex> lock(_httpsCommandMutex);
 
-    // Un-uniquify the unique_ptr. I don't love this, but it works better with the code we've already got.
-    BedrockCommand* commandPtr = command.get();
-    command.release();
-
-    // And we keep it in a set of all commands with outstanding HTTPS requests.
-    _outstandingHTTPSCommands.insert(commandPtr);
-
+    // If the command has outstanding HTTPS requests, we'll need to save a plain pointer to it.
+    BedrockCommand* commandPtr = 0;
     for (auto request : commandPtr->httpsRequests) {
         if (!request->response) {
-            SAUTOPREFIX(commandPtr->request);
-            SINFO("Pushing HTTPS request to _outstandingHTTPSRequests to complete.");
+            // This request is outstanding, save it.
             _outstandingHTTPSRequests.emplace(make_pair(request, commandPtr));
+
+            // And if we haven't saved the pointer to the command, do so now.
+            if (!commandPtr) {
+                // Un-uniquify the unique_ptr. I don't love this, but it works better with the code we've already got.
+                commandPtr = command.get();
+                command.release();
+            }
         }
+    }
+
+    // If we had any outstanding requests, we save the command pointer.
+    if (commandPtr) {
+        auto result = _outstandingHTTPSCommands.insert(commandPtr);
+        if (!result.second) {
+            SWARN("Failed to insert command with pending request, likely leaked!");
+        }
+    } else {
+        // This is a warn even though it should work, because it's an unexpected case, and likely would have failed in
+        // the previous version of this code, so we're curious if it ever happens.
+        SWARN("Tried to wait for HTTPS for command, but no pending requests. Returning to main queue.");
+        _commandQueue.push(move(command));
     }
 }
 
@@ -2241,6 +2257,7 @@ int BedrockServer::finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& comp
     lock_guard<mutex> lock(_httpsCommandMutex);
     int commandsCompleted = 0;
     for (auto transaction : completedHTTPSRequests) {
+        SAUTOPREFIX(transaction->requestID);
         auto transactionIt = _outstandingHTTPSRequests.find(transaction);
         if (transactionIt == _outstandingHTTPSRequests.end()) {
             // We should never be looking for a transaction in this list that isn't there.
@@ -2256,13 +2273,14 @@ int BedrockServer::finishWaitingForHTTPS(list<SHTTPSManager::Transaction*>& comp
         if (commandPtrIt != _outstandingHTTPSCommands.end()) {
             // I guess it's still here! Is it done?
             if (commandPtr->areHttpsRequestsComplete()) {
-                SAUTOPREFIX(commandPtr->request);
-                SINFO("All HTTPS requests complete, returning to main queue.");
                 // If so, add it back to the main queue, erase its entry in _outstandingHTTPSCommands, and delete it.
+                SINFO("All HTTPS requests complete, returning to main queue.");
                 _commandQueue.push(unique_ptr<BedrockCommand>(commandPtr));
                 _outstandingHTTPSCommands.erase(commandPtrIt);
                 commandsCompleted++;
             }
+        } else {
+            SINFO("Command not found, possibly completed on previous request.");
         }
 
         // Now we can erase the transaction, as it's no longer outstanding.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2225,17 +2225,15 @@ void BedrockServer::waitForHTTPS(unique_ptr<BedrockCommand>&& command) {
 
     // If the command has outstanding HTTPS requests, we'll need to save a plain pointer to it.
     BedrockCommand* commandPtr = 0;
-    for (auto request : commandPtr->httpsRequests) {
+    for (auto request : command->httpsRequests) {
         if (!request->response) {
-            // This request is outstanding, save it.
-            _outstandingHTTPSRequests.emplace(make_pair(request, commandPtr));
-
-            // And if we haven't saved the pointer to the command, do so now.
+            // This request is outstanding, save it, and if we haven't saved the pointer to the command, do so now.
             if (!commandPtr) {
                 // Un-uniquify the unique_ptr. I don't love this, but it works better with the code we've already got.
                 commandPtr = command.get();
                 command.release();
             }
+            _outstandingHTTPSRequests.emplace(make_pair(request, commandPtr));
         }
     }
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -416,6 +416,10 @@ class BedrockServer : public SQLiteServer {
     // commands ordered such that the first ones to time out are at the front.
     struct compareCommandByTimeout {
         bool operator() (BedrockCommand* a, BedrockCommand* b) const {
+            if (a->timeout() == b->timeout()) {
+                // Tiebreaker so that two commands with the same timeout don't appear equivalent.
+                return a < b;
+            }
             return a->timeout() < b->timeout();
         }
     };


### PR DESCRIPTION
This fixes billing commands mysteriously disappearing after `peek` but before `process`. The discussion and explanation for why this works is here: https://expensify.slack.com/archives/C01JUCY61NV/p1612466794150100

Fixes:
$ https://github.com/Expensify/Expensify/issues/147377

I also re-wrote `waitForHTTPS` a bit to prevent another potential problem that could happen if a request completed while we were running `waitForHTTPS`, though I have no evidence that has ever actually occurred, it seemed possible.

### Tests
Now new tests were added, but the problem could be induced by forcing timeout collisions, i.e., by changing the end of `BedrockCommand::_getTimeout` to:
```
    int64_t retVal = timeout + start;
    retVal -= retVal % 10'000; // Make these only have 10ms resolution to induce collisions.
    return retVal;
```

This causes timeouts to happen only on 10ms increments, and causes these collisions to be easily reproducible. This was used to replicate the issue and then verify it was fixed.

Also, auth test was run with the following results:
```
[==============]
[ TEST RESULTS ] Passed: 1434, Failed: 0
[==============]
```