### PR TITLE
Preserve mockRequest when updating a job

### DIFF
--- a/test/tests/jobs/UpdateJobTest.cpp
+++ b/test/tests/jobs/UpdateJobTest.cpp
@@ -34,7 +34,7 @@ struct UpdateJobTest : tpunit::TestFixture {
         command.clear();
         command.methodLine = "UpdateJob";
         command["jobID"] = jobID;
-        command["data"] = "{key:\"value\"}";
+        command["data"] = "{\"key\":\"value\"}";
         command["repeat"] = "HOURLY";
         command["jobPriority"] = "1000";
         command["nextRun"] = "2020-01-01 00:00:00";
@@ -44,7 +44,7 @@ struct UpdateJobTest : tpunit::TestFixture {
         SQResult currentJob;
         tester->readDB("SELECT repeat, data, priority, nextRun FROM jobs WHERE jobID = " + jobID + ";", currentJob);
         ASSERT_EQUAL(currentJob[0][0], "HOURLY");
-        ASSERT_EQUAL(currentJob[0][1], "{key:\"value\"}");
+        ASSERT_EQUAL(currentJob[0][1], "{\"key\":\"value\"}");
         ASSERT_EQUAL(currentJob[0][2], "1000");
         ASSERT_NOT_EQUAL(currentJob[0][2], oldPriority);
         ASSERT_EQUAL(currentJob[0][3], "2020-01-01 00:00:00");
@@ -75,7 +75,7 @@ struct UpdateJobTest : tpunit::TestFixture {
         SQResult currentJob;
         tester->readDB("SELECT repeat, data, priority, nextRun FROM jobs WHERE jobID = " + jobID + ";", currentJob);
         ASSERT_EQUAL(currentJob[0][0], "HOURLY");
-        ASSERT_EQUAL(currentJob[0][1], "{\"key\":\"value\",\"mockRequest\":1}");
+        ASSERT_EQUAL(currentJob[0][1], "{\"key\":\"value\",\"mockRequest\":true}");
         ASSERT_EQUAL(currentJob[0][2], "1000");
         ASSERT_NOT_EQUAL(currentJob[0][2], oldPriority);
         ASSERT_EQUAL(currentJob[0][3], "2020-01-01 00:00:00");


### PR DESCRIPTION
# Fixed Issue
$ https://github.com/Expensify/Expensify/issues/151702

# Tests
New automatic test

Manually tested by
1. Enabling LOAD_TEST on dev
2. Requested a call from the inbox
3. Completed calls in expensiworks
4. _Verified_ I only got 1 call, not multiple that were mocked.