### PR TITLE
Use bounds checking in row access

### DIFF
--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -76,3 +76,32 @@ bool SQResult::deserialize(const string& json) {
     clear();
     return false;
 }
+
+bool SQResult::empty() const {
+    return rows.empty();
+}
+
+size_t SQResult::size() const {
+    return rows.size();
+}
+
+void SQResult::clear() {
+    headers.clear();
+    rows.clear();
+}
+
+vector<string>& SQResult::operator[](size_t rowNum) {
+    try {
+        return rows.at(rowNum);
+    } catch (const out_of_range& e) {
+        STHROW("Out of range");
+    }
+}
+
+const vector<string>& SQResult::operator[](size_t rowNum) const {
+    try {
+        return rows.at(rowNum);
+    } catch (const out_of_range& e) {
+        STHROW("Out of range");
+    }
+}

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -11,18 +11,15 @@ class SQResult {
     vector<vector<string>> rows;
 
     // Accessors
-    inline bool empty() const { return rows.empty(); }
-    inline size_t size() const { return rows.size(); }
+    bool empty() const;
+    size_t size() const;
 
     // Mutators
-    inline void clear() {
-        headers.clear();
-        rows.clear();
-    }
+    void clear();
 
     // Operators
-    inline vector<string>& operator[](size_t rowNum) { return rows[rowNum]; }
-    inline const vector<string>& operator[](size_t rowNum) const { return rows[rowNum]; }
+    vector<string>& operator[](size_t rowNum);
+    const vector<string>& operator[](size_t rowNum) const;
 
     // Serializers
     string serializeToJSON() const;


### PR DESCRIPTION
This would prevent future bugs like the one that required us to move a deploy to Friday here:
https://expensify.slack.com/archives/C03TQ48KC/p1613784290022100

## Tests:
Automated tests pass and were tested in auth as well.
