### PR TITLE
Fix tests that fail on ubuntu 2004

### DIFF
--- a/test/clustertest/tests/FinishJobTest.cpp
+++ b/test/clustertest/tests/FinishJobTest.cpp
@@ -436,13 +436,8 @@ struct FinishJobTest : tpunit::TestFixture {
         // Confirm nextRun is in 1 hour, not in the 5 second delay
         SQResult result;
         clusterTester->getTester(0).readDB("SELECT lastRun, nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
-        struct tm tm1;
-        struct tm tm2;
-        strptime(result[0][0].c_str(), "%Y-%m-%d %H:%M:%S", &tm1);
-        time_t createdTime = mktime(&tm1);
-        strptime(result[0][1].c_str(), "%Y-%m-%d %H:%M:%S", &tm2);
-        time_t nextRunTime = mktime(&tm2);
-        ASSERT_EQUAL(difftime(nextRunTime, createdTime), 3600);
+        ASSERT_EQUAL(result.size(), 1);
+        ASSERT_EQUAL(difftime(JobTestHelper::getTimestampForDateTimeString(result[0][1]), JobTestHelper::getTimestampForDateTimeString(result[0][0])), 3600);
     }
 
     // FinishJob should ignore the 'delay' parameter
@@ -497,13 +492,8 @@ struct FinishJobTest : tpunit::TestFixture {
         // Confirm nextRun is in 1 hour, not in the given nextRun time
         SQResult result;
         clusterTester->getTester(0).readDB("SELECT lastRun, nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
-        struct tm tm1;
-        struct tm tm2;
-        strptime(result[0][0].c_str(), "%Y-%m-%d %H:%M:%S", &tm1);
-        time_t createdTime = mktime(&tm1);
-        strptime(result[0][1].c_str(), "%Y-%m-%d %H:%M:%S", &tm2);
-        time_t nextRunTime = mktime(&tm2);
-        ASSERT_EQUAL(difftime(nextRunTime, createdTime), 3600);
+        ASSERT_EQUAL(result.size(), 1);
+        ASSERT_EQUAL(difftime(JobTestHelper::getTimestampForDateTimeString(result[0][1]), JobTestHelper::getTimestampForDateTimeString(result[0][0])), 3600);
     }
 
     // FinishJob should delete any job with data.delete = true

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -31,7 +31,8 @@ struct SQLiteNodeTest : tpunit::TestFixture {
                                            TEST(SQLiteNodeTest::testFindSyncPeer)) { }
 
     // Filename for temp DB.
-    char filename[17] = "br_sync_dbXXXXXX";
+    char filenameTemplate[17] = "br_sync_dbXXXXXX";
+    char filename[17];
 
     void teardown() {
         unlink(filename);
@@ -40,6 +41,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
     void testFindSyncPeer() {
 
         // This exposes just enough to test the peer selection logic.
+        strcpy(filename, filenameTemplate);
         int fd = mkstemp(filename);
         close(fd);
         SQLitePool dbPool(10, filename, 1000000, 5000, 0);

--- a/test/tests/jobs/GetJobsTest.cpp
+++ b/test/tests/jobs/GetJobsTest.cpp
@@ -1,12 +1,6 @@
 #include <test/lib/BedrockTester.h>
+#include <test/tests/jobs/JobTestHelper.h>
 #include <time.h>
-
-// Get a unix timestamp from one of our sqlite date strings.
-time_t stringToUnixTimestamp(const string& timestamp) {
-    struct tm time;
-    strptime(timestamp.c_str(), "%Y-%m-%d %H:%M:%S", &time);
-    return mktime(&time);
-}
 
 // Get the difference in seconds between a and b
 uint64_t absoluteDiff(time_t a, time_t b) {
@@ -83,7 +77,7 @@ struct GetJobsTest : tpunit::TestFixture {
         SQResult jobData = getAllJobData(tester);
         for (auto& row : jobData.rows) {
             // Assert that the difference between "lastRun + 5min" and "nextRun" is less than 3 seconds.
-            ASSERT_LESS_THAN(absoluteDiff(stringToUnixTimestamp(row[2]) + 5 * 60, stringToUnixTimestamp(row[3])), 3);
+            ASSERT_LESS_THAN(absoluteDiff(JobTestHelper::getTimestampForDateTimeString(row[2]) + 5 * 60, JobTestHelper::getTimestampForDateTimeString(row[3])), 3);
             ASSERT_EQUAL(row[1], "RUNQUEUED");
         }
 
@@ -110,13 +104,13 @@ struct GetJobsTest : tpunit::TestFixture {
             if (stoull(row[0]) == jobIDs[0]) {
                 // Assert that the difference between "lastRun + 1hour - 5 seconds" and "nextRun" is less than 3 seconds.
                 // We remove 5 seconds here because the job is rescheduled for when it was _scheduled_, not when it started/finished
-                ASSERT_LESS_THAN(absoluteDiff(stringToUnixTimestamp(row[2]) + 1 * 60 * 60 - 5, stringToUnixTimestamp(row[3])), 3);
+                ASSERT_LESS_THAN(absoluteDiff(JobTestHelper::getTimestampForDateTimeString(row[2]) + 1 * 60 * 60 - 5, JobTestHelper::getTimestampForDateTimeString(row[3])), 3);
             } else if (stoull(row[0]) == jobIDs[1]) {
                 // Assert that the difference between "lastRun + 1day" and "nextRun" is less than 3 seconds.
-                ASSERT_LESS_THAN(absoluteDiff(stringToUnixTimestamp(row[2]) + 1 * 60 * 60 * 24, stringToUnixTimestamp(row[3])), 3);
+                ASSERT_LESS_THAN(absoluteDiff(JobTestHelper::getTimestampForDateTimeString(row[2]) + 1 * 60 * 60 * 24, JobTestHelper::getTimestampForDateTimeString(row[3])), 3);
             } else if (stoull(row[0]) == jobIDs[2]) {
                 // Assert that the difference between "finishedTime + 7days" and "nextRun" is less than 3 seconds.
-                ASSERT_LESS_THAN(absoluteDiff(stringToUnixTimestamp(finishedTime) + 7 * 60 * 60 * 24, stringToUnixTimestamp(row[3])), 3);
+                ASSERT_LESS_THAN(absoluteDiff(JobTestHelper::getTimestampForDateTimeString(finishedTime) + 7 * 60 * 60 * 24, JobTestHelper::getTimestampForDateTimeString(row[3])), 3);
             } else {
                 // It should be one of the above three.
                 ASSERT_TRUE(false);

--- a/test/tests/jobs/JobTestHelper.cpp
+++ b/test/tests/jobs/JobTestHelper.cpp
@@ -1,8 +1,8 @@
 #include <libstuff/libstuff.h>
 #include "JobTestHelper.h"
 
-time_t JobTestHelper::getTimestampForDateTimeString(string datetime) {
-    struct tm tm;
+time_t JobTestHelper::getTimestampForDateTimeString(const string& datetime) {
+    struct tm tm = {0};
     strptime(datetime.c_str(), "%Y-%m-%d %H:%M:%S", &tm);
     return mktime(&tm);
 }

--- a/test/tests/jobs/JobTestHelper.h
+++ b/test/tests/jobs/JobTestHelper.h
@@ -4,5 +4,5 @@
 
 class JobTestHelper {
 public:
-    static time_t getTimestampForDateTimeString(string datetime);
+    static time_t getTimestampForDateTimeString(const string& datetime);
 };

--- a/test/tests/jobs/RetryJobTest.cpp
+++ b/test/tests/jobs/RetryJobTest.cpp
@@ -504,13 +504,8 @@ struct RetryJobTest : tpunit::TestFixture {
         // Confirm nextRun is in 1 hour, not in the given nextRun time
         SQResult result;
         tester->readDB("SELECT lastRun, nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
-        struct tm tm1;
-        struct tm tm2;
-        strptime(result[0][0].c_str(), "%Y-%m-%d %H:%M:%S", &tm1);
-        time_t createdTime = mktime(&tm1);
-        strptime(result[0][1].c_str(), "%Y-%m-%d %H:%M:%S", &tm2);
-        time_t nextRunTime = mktime(&tm2);
-        ASSERT_EQUAL(difftime(nextRunTime, createdTime), 3600);
+        ASSERT_EQUAL(result.size(), 1);
+        ASSERT_FLOAT_EQUAL(difftime(JobTestHelper::getTimestampForDateTimeString(result[0][1]), JobTestHelper::getTimestampForDateTimeString(result[0][0])), 3600);
     }
 
     // Repeat should take precedence over delay
@@ -538,13 +533,8 @@ struct RetryJobTest : tpunit::TestFixture {
         // Confirm nextRun is in 1 hour, not in the 5 second delay
         SQResult result;
         tester->readDB("SELECT lastRun, nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
-        struct tm tm1;
-        struct tm tm2;
-        strptime(result[0][0].c_str(), "%Y-%m-%d %H:%M:%S", &tm1);
-        time_t createdTime = mktime(&tm1);
-        strptime(result[0][1].c_str(), "%Y-%m-%d %H:%M:%S", &tm2);
-        time_t nextRunTime = mktime(&tm2);
-        ASSERT_EQUAL(difftime(nextRunTime, createdTime), 3600);
+        ASSERT_EQUAL(result.size(), 1);
+        ASSERT_FLOAT_EQUAL(difftime(JobTestHelper::getTimestampForDateTimeString(result[0][1]), JobTestHelper::getTimestampForDateTimeString(result[0][0])), 3600);
     }
 
     // nextRun should take precedence over delay


### PR DESCRIPTION
This is some minor fixes to the tests that make them work on the upcoming changeover to Ubuntu 20.04.

cc @fukawi2 

### Tests:
Is tests. You can't test it in dev without setting up an Ubuntu 20.04 VM, but that shouldn't matter so long as it isn't broken on the current servers/VM, which Travis will test.