### PR TITLE
Make Bedrock clang++ compatible

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2602,7 +2602,7 @@ string SGetCurrentExceptionName()
     int status = 0;
     size_t length = 1000;
     char buffer[length];
-    memset(buffer,0,length);
+    memset(buffer, 0, length);
 
     // Demangle the name of the current exception.
     // See: https://libcxxabi.llvm.org/spec.html for details on this ABI interface.

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2601,7 +2601,8 @@ string SGetCurrentExceptionName()
     // exception name.
     int status = 0;
     size_t length = 1000;
-    char buffer[length] = {0};
+    char buffer[length];
+    memset(buffer,0,length);
 
     // Demangle the name of the current exception.
     // See: https://libcxxabi.llvm.org/spec.html for details on this ABI interface.

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -283,7 +283,7 @@ extern atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc;
             const string s = __out.str();                                       \
             const string prefix = SWHEREAMI;                                    \
             for (size_t i = 0; i < s.size(); i += 7168) {                       \
-                SSyslogFunc(_PRI_, "%s", (prefix + s.substr(i, 7168)).c_str()); \
+                (*SSyslogFunc)(_PRI_, "%s", (prefix + s.substr(i, 7168)).c_str()); \
             }                                                                   \
         }                                                                       \
     } while (false)


### PR DESCRIPTION
Bedrock is only two small changes away from clang++ compatibility, which is fixed in this PR.

Many analysis tools, such as Infer used by Muse, lean on Clang to compile the code into clang IR for analysis. By making bedrock compatible we can also use Infer and similar tools on downstream projects that include bedrock.

@flodnv This is the PR we previously discussed.

