### PR TITLE
Speed up checkpointing

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -300,7 +300,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
                     break;
                 } else {
                     SINFO("[checkpoint] Waiting on " << count << " remaining transactions.");
-                    object->_sharedData.checkpointRequired(*object);
+                    object->_sharedData.checkpointRequired();
                 }
 
                 if (count == 0) {
@@ -317,7 +317,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
                           << " in " << ((STimeNow() - checkpointStart) / 1000) << "ms.");
 
                     // We're done. Anyone can start a new transaction.
-                    object->_sharedData.checkpointComplete(*object);
+                    object->_sharedData.checkpointComplete();
                     break;
                 }
 
@@ -1119,17 +1119,17 @@ void SQLite::SharedData::removeCheckpointListener(SQLite::CheckpointRequiredList
     _checkpointListeners.erase(&listener);
 }
 
-void SQLite::SharedData::checkpointRequired(SQLite& db) {
+void SQLite::SharedData::checkpointRequired() {
     lock_guard<decltype(_internalStateMutex)> lock(_internalStateMutex);
     for (auto listener : _checkpointListeners) {
-        listener->checkpointRequired(db);
+        listener->checkpointRequired();
     }
 }
 
-void SQLite::SharedData::checkpointComplete(SQLite& db) {
+void SQLite::SharedData::checkpointComplete() {
     lock_guard<decltype(_internalStateMutex)> lock(_internalStateMutex);
     for (auto listener : _checkpointListeners) {
-        listener->checkpointComplete(db);
+        listener->checkpointComplete();
     }
 }
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -64,8 +64,8 @@ class SQLite {
     // transaction) to be notified that it needs to either finish or abandon the transaction.
     class CheckpointRequiredListener {
       public:
-        virtual void checkpointRequired(SQLite& db) = 0;
-        virtual void checkpointComplete(SQLite& db) = 0;
+        virtual void checkpointRequired() = 0;
+        virtual void checkpointComplete() = 0;
     };
 
     // minJournalTables: Creates journal tables through the specified number. If `-1` is passed, only `journal` is
@@ -276,8 +276,8 @@ class SQLite {
         // Add and remove and call checkpoint listeners in a thread-safe way.
         void addCheckpointListener(CheckpointRequiredListener& listener);
         void removeCheckpointListener(CheckpointRequiredListener& listener);
-        void checkpointRequired(SQLite& db);
-        void checkpointComplete(SQLite& db);
+        void checkpointRequired();
+        void checkpointComplete();
 
         // Enable or disable commits for the DB.
         void setCommitEnabled(bool enable);

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -328,6 +328,7 @@ class SQLite {
         // we need to store it across callbacks so we can check if the full check point thread still needs to run.
         atomic<int> _currentPageCount;
 
+
         // Used as a flag to prevent starting multiple checkpoint threads simultaneously.
         atomic<int> _checkpointThreadBusy;
 
@@ -335,6 +336,10 @@ class SQLite {
         atomic<bool> _commitEnabled;
 
         SPerformanceTimer _commitLockTimer;
+
+        // We keep track of the commitCount at each complete checkpoint, so that we can throttle the frequency of
+        // checkpoints to not more often than every N commits.
+        atomic<uint64_t> lastCompleteCheckpointCommitCount;
 
       private:
         // The data required to replicate transactions, in two lists, depending on whether this has only been prepared

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -430,9 +430,12 @@ void SQLiteNode::_sendOutstandingTransactions(const set<uint64_t>& commitOnlyIDs
                 // Clear the response flag from the last transaction
                 peer->transactionResponse = Peer::Response::NONE;
             }
+
+            // Allows us to easily figure out how far behind followers are by analyzing the logs.
+            SINFO("Sending COMMIT for ASYNC transaction " << id << " to followers");
             _sendToAllPeers(transaction, true); // subscribed only
         } else {
-            SINFO("Sending COMMIT for QUORUM transaction " << idHeader << " to followers");
+            SINFO("Sending COMMIT for QUORUM transaction " << id << " to followers");
         }
         SData commit("COMMIT_TRANSACTION");
         commit["ID"] = idHeader;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -165,7 +165,7 @@ void SQLiteNode::replicate(SQLiteNode& node, Peer* peer, SData command, size_t s
             uint64_t waitForCount = SStartsWith(command["ID"], "ASYNC") ? command.calcU64("dbCountAtStart") : currentCount;
             SINFO("Thread for commit " << newCount << " waiting on DB count " << waitForCount << " (" << (quorum ? "QUORUM" : "ASYNC") << ")");
             while (true) {
-                SQLiteSequentialNotifier::RESULT result = node._localCommitNotifier.waitFor(waitForCount);
+                SQLiteSequentialNotifier::RESULT result = node._localCommitNotifier.waitFor(waitForCount, false);
                 if (result == SQLiteSequentialNotifier::RESULT::UNKNOWN) {
                     // This should be impossible.
                     SERROR("Got UNKNOWN result from waitFor, which shouldn't happen");
@@ -208,7 +208,7 @@ void SQLiteNode::replicate(SQLiteNode& node, Peer* peer, SData command, size_t s
                             // Yes, we get this line logged 4 times from four threads as their last activity and then:
                             // (SQLite.cpp:403) operator() [checkpoint] [info] [checkpoint] Waiting on 4 remaining transactions.
                             SINFO("Waiting at commit " << db.getCommitCount() << " for commit " << currentCount);
-                            SQLiteSequentialNotifier::RESULT waitResult = node._localCommitNotifier.waitFor(currentCount);
+                            SQLiteSequentialNotifier::RESULT waitResult = node._localCommitNotifier.waitFor(currentCount, true);
                             if (waitResult == SQLiteSequentialNotifier::RESULT::CANCELED) {
                                 SINFO("Replication canceled mid-transaction, stopping.");
                                 db.rollback();
@@ -233,7 +233,7 @@ void SQLiteNode::replicate(SQLiteNode& node, Peer* peer, SData command, size_t s
                     // don't send LEADER the approval for this until inside of `prepare`. This potentially makes us
                     // wait while holding the commit lock for non-concurrent transactions, but I guess nobody else with
                     // a commit after us will be able to commit, either.
-                    SQLiteSequentialNotifier::RESULT waitResult = node._leaderCommitNotifier.waitFor(command.calcU64("NewCount"));
+                    SQLiteSequentialNotifier::RESULT waitResult = node._leaderCommitNotifier.waitFor(command.calcU64("NewCount"), true);
                     if (uniqueContraintsError) {
                         SINFO("Got unique constraints error in replication, restarting.");
                         db.rollback();

--- a/sqlitecluster/SQLiteSequentialNotifier.cpp
+++ b/sqlitecluster/SQLiteSequentialNotifier.cpp
@@ -122,7 +122,7 @@ void SQLiteSequentialNotifier::checkpointRequired() {
     }
     _valueToPendingThreadMap.clear();
     if (_valueToPendingThreadMapNoCurrentTransaction.size()) {
-        SINFO("[checkpoint] Not unblocking threads waiting with no transaction.");
+        SINFO("[checkpoint] Not unblocking " << _valueToPendingThreadMapNoCurrentTransaction.size() << " threads waiting with no transaction.");
     }
 }
 

--- a/sqlitecluster/SQLiteSequentialNotifier.cpp
+++ b/sqlitecluster/SQLiteSequentialNotifier.cpp
@@ -118,9 +118,12 @@ void SQLiteSequentialNotifier::checkpointRequired() {
         p.second->result = RESULT::CHECKPOINT_REQUIRED;
         auto start = STimeNow();
         p.second->waitingThreadConditionVariable.notify_all();
-        SINFO("Notified all threads waiting on a checkpoint in " << ((STimeNow() - start) / 1000) << "ms");
+        SINFO("[checkpoint] Notified all threads waiting on a checkpoint in " << ((STimeNow() - start) / 1000) << "ms");
     }
     _valueToPendingThreadMap.clear();
+    if (_valueToPendingThreadMapNoCurrentTransaction.size()) {
+        SINFO("[checkpoint] Not unblocking threads waiting with no transaction.");
+    }
 }
 
 void SQLiteSequentialNotifier::checkpointComplete() {

--- a/sqlitecluster/SQLiteSequentialNotifier.cpp
+++ b/sqlitecluster/SQLiteSequentialNotifier.cpp
@@ -1,6 +1,6 @@
 #include "SQLiteSequentialNotifier.h"
 
-SQLiteSequentialNotifier::RESULT SQLiteSequentialNotifier::waitFor(uint64_t value) {
+SQLiteSequentialNotifier::RESULT SQLiteSequentialNotifier::waitFor(uint64_t value,  bool insideTransaction) {
     shared_ptr<WaitState> state(nullptr);
     {
         lock_guard<mutex> lock(_internalStateMutex);
@@ -10,7 +10,11 @@ SQLiteSequentialNotifier::RESULT SQLiteSequentialNotifier::waitFor(uint64_t valu
 
         // Create a new WaitState object and save a shared_ptr to it in `state`.
         state = make_shared<WaitState>();
-        _valueToPendingThreadMap.emplace(value, state);
+        if (insideTransaction) {
+            _valueToPendingThreadMap.emplace(value, state);
+        } else {
+            _valueToPendingThreadMapNoCurrentTransaction.emplace(value, state);
+        }
     }
     while (true) {
         unique_lock<mutex> lock(state->waitingThreadMutex);
@@ -46,30 +50,33 @@ void SQLiteSequentialNotifier::notifyThrough(uint64_t value) {
     if (value > _value) {
         _value = value;
     }
-    auto lastToDelete = _valueToPendingThreadMap.begin();
-    for (auto it = _valueToPendingThreadMap.begin(); it != _valueToPendingThreadMap.end(); it++) {
-        if (it->first > value)  {
-            // If we've passed our value, there's nothing else to erase, so we can stop.
-            break;
+    for (auto valueThreadMapPtr : {&_valueToPendingThreadMap, &_valueToPendingThreadMapNoCurrentTransaction}) {
+        auto& valueThreadMap = *valueThreadMapPtr;
+        auto lastToDelete = valueThreadMap.begin();
+        for (auto it = valueThreadMap.begin(); it != valueThreadMap.end(); it++) {
+            if (it->first > value)  {
+                // If we've passed our value, there's nothing else to erase, so we can stop.
+                break;
+            }
+
+            // Note that we'll delete this item from the map.
+            lastToDelete++;
+
+            // Make the changes to the state object - mark it complete and notify anyone waiting.
+            lock_guard<mutex> lock(it->second->waitingThreadMutex);
+            it->second->result = RESULT::COMPLETED;
+            it->second->waitingThreadConditionVariable.notify_all();
         }
 
-        // Note that we'll delete this item from the map.
-        lastToDelete++;
-
-        // Make the changes to the state object - mark it complete and notify anyone waiting.
-        lock_guard<mutex> lock(it->second->waitingThreadMutex);
-        it->second->result = RESULT::COMPLETED;
-        it->second->waitingThreadConditionVariable.notify_all();
+        // Now we've finished with all of our updates and notifications and can remove everything from our map.
+        // Note that erasing an empty range (i.e., from() begin to begin()) is tested to be a no-op. The documentation I've
+        // found for multimap is unclear on this, though the documentation for `std::list` specifies:
+        // "The iterator first does not need to be dereferenceable if first==last: erasing an empty range is a no-op."
+        //
+        // I think it's reasonable to assume this is the intention for multimap as well, and in my testing, that was the
+        // case.
+        valueThreadMap.erase(valueThreadMap.begin(), lastToDelete);
     }
-
-    // Now we've finished with all of our updates and notifications and can remove everything from our map.
-    // Note that erasing an empty range (i.e., from() begin to begin()) is tested to be a no-op. The documentation I've
-    // found for multimap is unclear on this, though the documentation for `std::list` specifies:
-    // "The iterator first does not need to be dereferenceable if first==last: erasing an empty range is a no-op."
-    //
-    // I think it's reasonable to assume this is the intention for multimap as well, and in my testing, that was the
-    // case.
-    _valueToPendingThreadMap.erase(_valueToPendingThreadMap.begin(), lastToDelete);
 }
 
 void SQLiteSequentialNotifier::cancel(uint64_t cancelAfter) {
@@ -80,24 +87,27 @@ void SQLiteSequentialNotifier::cancel(uint64_t cancelAfter) {
     _cancelAfter = cancelAfter;
     _globalResult = RESULT::CANCELED;
 
-    // If cancelAfter is specified, start from that value. Otherwise, we start from the beginning.
-    auto start = _cancelAfter ? _valueToPendingThreadMap.upper_bound(_cancelAfter) : _valueToPendingThreadMap.begin();
-    if (start == _valueToPendingThreadMap.end()) {
-        // There's nothing to remove.
-        return;
-    }
+    for (auto valueThreadMapPtr : {&_valueToPendingThreadMap, &_valueToPendingThreadMapNoCurrentTransaction}) {
+        auto& valueThreadMap = *valueThreadMapPtr;
+        // If cancelAfter is specified, start from that value. Otherwise, we start from the beginning.
+        auto start = _cancelAfter ? valueThreadMap.upper_bound(_cancelAfter) : valueThreadMap.begin();
+        if (start == valueThreadMap.end()) {
+            // There's nothing to remove.
+            return;
+        }
 
-    // Now iterate across whatever's remaining and mark it canceled.
-    auto current = start;
-    while(current != _valueToPendingThreadMap.end()) {
-        lock_guard<mutex> lock(current->second->waitingThreadMutex);
-        current->second->result = RESULT::CANCELED;
-        current->second->waitingThreadConditionVariable.notify_all();
-        current++;
-    }
+        // Now iterate across whatever's remaining and mark it canceled.
+        auto current = start;
+        while(current != valueThreadMap.end()) {
+            lock_guard<mutex> lock(current->second->waitingThreadMutex);
+            current->second->result = RESULT::CANCELED;
+            current->second->waitingThreadConditionVariable.notify_all();
+            current++;
+        }
 
-    // And remove these items entirely.
-    _valueToPendingThreadMap.erase(start, _valueToPendingThreadMap.end());
+        // And remove these items entirely.
+        valueThreadMap.erase(start, valueThreadMap.end());
+    }
 }
 
 void SQLiteSequentialNotifier::checkpointRequired() {

--- a/sqlitecluster/SQLiteSequentialNotifier.h
+++ b/sqlitecluster/SQLiteSequentialNotifier.h
@@ -32,7 +32,7 @@ class SQLiteSequentialNotifier : public SQLite::CheckpointRequiredListener {
 
     // Blocks until `_value` meets or exceeds `value`, unless an exceptional case (CANCELED, CHEKPOINT_REQUIRED) is
     // hit, and returns the corresponding RESULT.
-    SQLiteSequentialNotifier::RESULT waitFor(uint64_t value);
+    SQLiteSequentialNotifier::RESULT waitFor(uint64_t value, bool insideTransaction);
 
     // Causes any threads waiting for a value up to and including `value` to return `true`.
     void notifyThrough(uint64_t value);
@@ -68,6 +68,7 @@ class SQLiteSequentialNotifier : public SQLite::CheckpointRequiredListener {
 
     mutex _internalStateMutex;
     multimap<uint64_t, shared_ptr<WaitState>> _valueToPendingThreadMap;
+    multimap<uint64_t, shared_ptr<WaitState>> _valueToPendingThreadMapNoCurrentTransaction;
     uint64_t _value;
 
     // If there is a global result for all pending operations (i.e., they've been canceled or a checkpoint needs to

--- a/sqlitecluster/SQLiteSequentialNotifier.h
+++ b/sqlitecluster/SQLiteSequentialNotifier.h
@@ -47,8 +47,8 @@ class SQLiteSequentialNotifier : public SQLite::CheckpointRequiredListener {
     uint64_t getValue();
 
     // Implement the base class to notify for checkpoints
-    void checkpointRequired(SQLite& db) override;
-    void checkpointComplete(SQLite& db) override;
+    void checkpointRequired() override;
+    void checkpointComplete() override;
 
     // After calling `reset`, all calls to `waitFor` return `false` until this is called, and then they will wait
     // again. This allows for a caller to call `cancel`, wait for the completion of their threads, and then call


### PR DESCRIPTION
Fixes:
$ https://github.com/Expensify/Expensify/issues/147432

## Tests:
adding logging to `SQLiteSequentialNotifier::checkpointRequired` was able to show the new code running and working, which is pretty basic, admittedly.

```
2021-04-01T12:59:18.074078+00:00 expensidev bedrock10025: xxxxxx (SQLiteSequentialNotifier.cpp:125) checkpointRequired [checkpoint] [info] Not unblocking threads waiting with no transaction.
```

Running the tests (except BadCommand, because it makes it hard to check for crashes in the logs) a bunch of times:
```
[==============]
[ TEST RESULTS ] Passed: 430, Failed: 0
[==============]
```

## Deployment Idea:

1. Turn off multi-rep everywhere.
2. Deploy this change.
3. Turn on multi-rep on the perma-follower.
4. re-run benchmarks
5. If everything is good, re-enable multi-rep everywhere.