### PR TITLE
Skip chekpoints with external DB reader

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -258,7 +258,16 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
             SINFO("[checkpoint] Ready for complete checkpoint but skipping because less than 100 commits since last complete checkpoint.");
             return SQLITE_OK;
         }
-        // If we get here, then full checkpoints are enabled, and we have enough pages in the WAL file to perform one.
+
+        int dbInUse = 0;
+        int useCheckResult = sqlite3_file_control(db, "main", SQLITE_FCNTL_EXTERNAL_READER, (void*)&dbInUse);
+        if (useCheckResult == SQLITE_OK && dbInUse) {
+            SINFO("Skipping complete checkpoint because external transaction in progress.");
+            return SQLITE_OK;
+        }
+
+        // If we get here, then full checkpoints are enabled, we have enough pages in the WAL file to perform one, and
+        // nothing else is stopping us from running one.
         SINFO("[checkpoint] " << pageCount << " pages behind, beginning complete checkpoint.");
 
         // This thread will run independently. We capture the variables we need here and pass them by value.


### PR DESCRIPTION
~HOLD for: https://github.com/Expensify/Bedrock/pull/984~

This lets us skip complete checkpointing entirely when `readdb.sh` is running (or any other external process is using the DB).

## Tests
Existing automated tests, though those don't really hit this case very hard. The best test for this is going to be to deploy one node and run `readdb` on that node to verify that we get the expected log line and no performance problems in the middle of a long query.