### PR TITLE
Move stuff out of libstuff.h to improve compile times.

### DIFF
--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <libstuff/SHTTPSManager.h>
 #include <sqlitecluster/SQLiteCommand.h>
 
 class BedrockPlugin;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1,13 +1,17 @@
 // Manages connections to a single instance of the bedrock server.
-#include <bedrockVersion.h>
-#include <libstuff/libstuff.h>
 #include "BedrockServer.h"
-#include "BedrockPlugin.h"
-#include "BedrockCore.h"
-#include <iomanip>
 
-#include <sys/time.h>
+#include <arpa/inet.h>
+#include <iomanip>
 #include <sys/resource.h>
+#include <sys/time.h>
+#include <signal.h>
+
+#include <bedrockVersion.h>
+#include <BedrockCore.h>
+#include <BedrockPlugin.h>
+#include <libstuff/libstuff.h>
+#include <libstuff/SRandom.h>
 
 set<string>BedrockServer::_blacklistedParallelCommands;
 shared_timed_mutex BedrockServer::_blacklistedParallelCommandMutex;

--- a/BedrockTimeoutCommandQueue.h
+++ b/BedrockTimeoutCommandQueue.h
@@ -1,5 +1,10 @@
-#include <libstuff/libstuff.h>
+#pragma once
+#include <list>
+#include <map>
+#include <memory>
+
 #include <BedrockCommand.h>
+#include <libstuff/SSynchronizedQueue.h>
 
 class BedrockTimeoutCommandQueue : public SSynchronizedQueue<unique_ptr<BedrockCommand>> {
   public:

--- a/libstuff/SData.cpp
+++ b/libstuff/SData.cpp
@@ -1,4 +1,6 @@
-#include "libstuff.h"
+#include "SData.h"
+
+#include <libstuff/SFastBuffer.h>
 
 const string SData::placeholder;
 
@@ -6,6 +8,9 @@ SData::SData() {
     // Nothing to do here
 }
 
+SData::SData(const STable& from) : nameValueMap(from)
+{
+}
 
 SData::SData(const string& fromString) {
     if(!SParseHTTP(fromString, methodLine, nameValueMap, content)){
@@ -107,4 +112,8 @@ SData SData::create(const string& fromString) {
         data.content = fromString.substr(header);
     }
     return data;
+}
+
+int SData::deserialize(const SFastBuffer& buf) {
+    return deserialize(buf.c_str(), buf.size());
 }

--- a/libstuff/SData.h
+++ b/libstuff/SData.h
@@ -1,4 +1,9 @@
 #pragma once
+#include <string>
+
+#include <libstuff/libstuff.h>
+
+using namespace std;
 
 // --------------------------------------------------------------------------
 // A very simple HTTP-like structure consisting of a method line, a table,
@@ -16,6 +21,9 @@ struct SData {
     // Initializes a new SData from a string. If the string provided is not
     // an entire HTTPs like message, the string is used as the methodLine.
     SData(const string& fromString);
+
+    // Allow conversion from STable.
+    SData(const STable& from);
 
     // Allow forwarding emplacements directly so SData can act like `std::map`.
     template <typename... Ts>
@@ -95,9 +103,7 @@ struct SData {
     int deserialize(const char* buffer, size_t length);
 
     // Deserializes from an SFastBuffer.
-    int deserialize(const SFastBuffer& buf) {
-        return deserialize(buf.c_str(), buf.size());
-    }
+    int deserialize(const SFastBuffer& buf);
 
     // Initializes a new SData from a string. If there is no content provided,
     // then use whatever data remains in the string as the content

--- a/libstuff/SFastBuffer.cpp
+++ b/libstuff/SFastBuffer.cpp
@@ -1,4 +1,6 @@
-#include <libstuff/libstuff.h>
+#include "SFastBuffer.h"
+
+#include <cstring>
 
 SFastBuffer::SFastBuffer() : front(0) {
 }

--- a/libstuff/SFastBuffer.h
+++ b/libstuff/SFastBuffer.h
@@ -1,4 +1,10 @@
 #pragma once
+
+#include <string>
+#include <ostream>
+
+using namespace std;
+
 class SFastBuffer {
   public:
     SFastBuffer();

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -1,6 +1,9 @@
-#include "libstuff.h"
+#include "SHTTPSManager.h"
+
 #include <BedrockPlugin.h>
 #include <BedrockServer.h>
+#include <libstuff/libstuff.h>
+#include <libstuff/SX509.h>
 #include <sqlitecluster/SQLiteNode.h>
 
 SHTTPSManager::SHTTPSManager(BedrockPlugin& plugin_) : plugin(plugin_)

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -1,5 +1,8 @@
 #pragma once
-#include <libstuff/libstuff.h>
+
+#include <libstuff/SData.h>
+#include <libstuff/STCPManager.h>
+
 class BedrockPlugin;
 
 class SStandaloneHTTPSManager : public STCPManager {

--- a/libstuff/SRandom.cpp
+++ b/libstuff/SRandom.cpp
@@ -1,4 +1,4 @@
-#include <libstuff/libstuff.h>
+#include "SRandom.h"
 
 mt19937_64 SRandom::_generator = mt19937_64(random_device()());
 uniform_int_distribution<uint64_t> SRandom::_distribution64 = uniform_int_distribution<uint64_t>();

--- a/libstuff/SRandom.h
+++ b/libstuff/SRandom.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <random>
+#include <string>
+
+using namespace std;
+
 // Random number generator class.
 class SRandom {
   public:

--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -1,6 +1,11 @@
-#include "libstuff.h"
+#include "SSSLState.h"
+
 #include <mbedtls/error.h>
 #include <mbedtls/net.h>
+
+#include <libstuff/libstuff.h>
+#include <libstuff/SFastBuffer.h>
+#include <libstuff/SX509.h>
 
 SSSLState::SSSLState() {
     mbedtls_ssl_init(&ssl);

--- a/libstuff/SSSLState.h
+++ b/libstuff/SSSLState.h
@@ -1,8 +1,14 @@
 #pragma once
-#include <libstuff/libstuff.h>
-#include <mbedtls/ssl.h>
-#include <mbedtls/entropy.h>
+
 #include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ssl.h>
+#include <string>
+
+using namespace std;
+
+class SX509;
+class SFastBuffer;
 
 struct SSSLState {
     // Attributes

--- a/libstuff/SSignal.cpp
+++ b/libstuff/SSignal.cpp
@@ -1,5 +1,10 @@
 #include "libstuff.h"
-#include <execinfo.h> // for backtrace
+
+#include <execinfo.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
 
 thread_local function<void()> SSignalHandlerDieFunc;
 void SSetSignalHandlerDieFunc(function<void()>&& func) {

--- a/libstuff/SSynchronizedQueue.h
+++ b/libstuff/SSynchronizedQueue.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <unistd.h>
+#include <fcntl.h>
+
 template <typename T>
 class SSynchronizedQueue {
   public:

--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -1,4 +1,10 @@
-#include "libstuff.h"
+#include "STCPManager.h"
+
+#include <unistd.h>
+
+#include <libstuff/libstuff.h>
+#include <libstuff/SSSLState.h>
+#include <libstuff/SX509.h>
 
 atomic<uint64_t> STCPManager::Socket::socketCount(1);
 

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -1,4 +1,18 @@
 #pragma once
+#include <atomic>
+#include <list>
+#include <mutex>
+#include <netinet/in.h>
+#include <poll.h>
+#include <string>
+
+#include <libstuff/libstuff.h>
+#include <libstuff/SFastBuffer.h>
+
+class SSSLState;
+class SX509;
+
+using namespace std;
 
 // Convenience base class for managing a series of TCP sockets. This includes filling receive buffers, emptying send
 // buffers, completing connections, performing graceful shutdowns, etc.

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -1,5 +1,11 @@
-#include "libstuff.h"
-#include <execinfo.h> // for backtrace
+#include "STCPNode.h"
+
+#include <execinfo.h>
+
+#include <libstuff/libstuff.h>
+#include <libstuff/SData.h>
+#include <libstuff/SRandom.h>
+
 #undef SLOGPREFIX
 #define SLOGPREFIX "{" << name << "} "
 

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -1,5 +1,6 @@
 #pragma once
-#include <libstuff/libstuff.h>
+
+#include <libstuff/STCPServer.h>
 
 // Convenience class for maintaining connections with a mesh of peers
 #define PDEBUG(_MSG_) SDEBUG("->{" << peer->name << "} " << _MSG_)

--- a/libstuff/STCPServer.cpp
+++ b/libstuff/STCPServer.cpp
@@ -1,4 +1,8 @@
-#include "libstuff.h"
+#include "STCPServer.h"
+
+#include <unistd.h>
+
+#include <libstuff/libstuff.h>
 
 STCPServer::STCPServer(const string& host) {
     // Initialize

--- a/libstuff/STCPServer.h
+++ b/libstuff/STCPServer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <libstuff/STCPManager.h>
 
 // Convenience class for listening on a port and accepting sockets.
 struct STCPServer : public STCPManager {

--- a/libstuff/STime.cpp
+++ b/libstuff/STime.cpp
@@ -1,5 +1,7 @@
 #include "libstuff.h"
 
+#include <sys/time.h>
+
 uint64_t STimeNow() {
     // Get the time = microseconds since 00:00:00 UTC, January 1, 1970
     timeval time;

--- a/libstuff/SX509.cpp
+++ b/libstuff/SX509.cpp
@@ -1,5 +1,9 @@
-#include "libstuff.h"
+#include "SX509.h"
+
+#include <cstring>
 #include <mbedtls/certs.h>
+
+#include <libstuff/libstuff.h>
 
 // --------------------------------------------------------------------------
 SX509* SX509Open() {

--- a/libstuff/SX509.h
+++ b/libstuff/SX509.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <mbedtls/pk.h>
 #include <mbedtls/x509_crt.h>
+#include <string>
+
+using namespace std;
 
 // Wraps a X509 Cert
 struct SX509 {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1,6 +1,15 @@
 // --------------------------------------------------------------------------
 // libstuff.cpp
 // --------------------------------------------------------------------------
+// C library
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <execinfo.h>
+#include <sys/un.h>
+#include <cxxabi.h>
+#include <sys/ioctl.h>
+
 #include "libstuff.h"
 #include <sys/stat.h>
 #include <zlib.h>
@@ -9,6 +18,11 @@
 #include <mbedtls/base64.h>
 #include <mbedtls/sha1.h>
 #include <mbedtls/sha256.h>
+
+#include <libstuff/SQResult.h>
+#include <libstuff/SData.h>
+#include <libstuff/SFastBuffer.h>
+#include <libstuff/sqlite3.h>
 
 // Additional headers
 #include <netdb.h>
@@ -24,6 +38,8 @@
 #define MSG_NOSIGNAL 0
 #endif
 #endif
+
+#include <pcrecpp.h> // sudo apt-get install libpcre++-dev
 
 // Common error definitions
 #define S_errno errno
@@ -58,6 +74,8 @@
 #define S_EHOSTUNREACH EHOSTUNREACH
 #define S_EALREADY EALREADY
 #define S_EPIPE EPIPE
+
+#define S_COOKIE_SEPARATOR ((char)0xFF)
 
 thread_local string SThreadLogPrefix;
 thread_local string SThreadLogName;
@@ -255,6 +273,11 @@ string SToHex(const string& value) {
     }
     return working;
 }
+
+string SToHex(uint32_t value) {
+    return SToHex(value, 8);
+}
+
 // --------------------------------------------------------------------------
 uint64_t SFromHex(const string& value) {
     // Convert one digit at a time
@@ -664,10 +687,9 @@ bool SParseList(const char* ptr, list<string>& valueList, char separator) {
     return (!component.empty());
 }
 
-// --------------------------------------------------------------------------
-SData SParseCommandLine(int argc, char* argv[]) {
+STable SParseCommandLine(int argc, char* argv[]) {
     // Just walk across and find the pairs, then put the remainder on a list in the method
-    SData results;
+    STable results;
     string name;
     for (int c = 1; c < argc; ++c) {
         // Does this look like a name or value?
@@ -676,11 +698,6 @@ SData SParseCommandLine(int argc, char* argv[]) {
             // We're not already processing a name, either start or add
             if (isName) {
                 name = argv[c];
-            } else {
-                list<string> valueList;
-                SParseList(results.methodLine, valueList);
-                valueList.push_back(argv[c]);
-                results.methodLine = SComposeList(valueList);
             }
         } else {
             // Processing a name, do we have a value or another name?
@@ -697,8 +714,10 @@ SData SParseCommandLine(int argc, char* argv[]) {
     }
 
     // If any leftover name, just set empty
-    if (!name.empty())
+    if (!name.empty()) {
         results[name] = "";
+    }
+
     return results;
 }
 
@@ -1017,7 +1036,10 @@ int _SDecodeURIChar(const char* buffer, int length, string& out) {
     return 3;
 }
 
-// --------------------------------------------------------------------------
+bool SParseURI(const string& uri, string& host, string& path) {
+    return SParseURI(uri.c_str(), (int)uri.size(), host, path);
+}
+
 bool SParseURI(const char* buffer, int length, string& host, string& path) {
     // Clear the output
     host.clear();
@@ -1052,7 +1074,10 @@ bool SParseURI(const char* buffer, int length, string& host, string& path) {
     return true; // Success
 }
 
-// --------------------------------------------------------------------------
+bool SParseURIPath(const string& uri, string& path, STable& nameValueMap) {
+    return SParseURIPath(uri.c_str(), (int)uri.size(), path, nameValueMap);
+}
+
 bool SParseURIPath(const char* buffer, int length, string& path, STable& nameValueMap) {
     // Clear the output
     path.clear();
@@ -2647,3 +2672,295 @@ bool SIsValidSQLiteDateModifier(const string& modifier) {
     // Matched all parts, valid syntax
     return true;
 }
+
+bool SREMatch(const string& regExp, const string& s) {
+    return pcrecpp::RE(regExp).FullMatch(s);
+}
+
+bool SREMatch(const string& regExp, const string& s, string& match) {
+    return pcrecpp::RE(regExp).FullMatch(s, &match);
+}
+
+SStopwatch::SStopwatch() {
+    start();
+    alarmDuration.store(0);
+}
+
+SStopwatch::SStopwatch(uint64_t alarm) {
+    startTime.store(0);
+    alarmDuration.store(alarm);
+}
+
+uint64_t SStopwatch::elapsed() {
+    return STimeNow() - startTime.load();
+}
+
+uint64_t SStopwatch::ringing() {
+    return alarmDuration.load() && (elapsed() > alarmDuration.load());
+}
+
+void SStopwatch::start() {
+    startTime.store(STimeNow());
+}
+
+bool SStopwatch::ding() {
+    if (!ringing())
+        return false;
+    start();
+    return true;
+}
+
+void SLogLevel(int level) {
+    _g_SLogMask = LOG_UPTO(level);
+    setlogmask(_g_SLogMask);
+}
+
+SAutoThreadPrefix::SAutoThreadPrefix(const SData& request) {
+    // Retain the old prefix
+    oldPrefix = SThreadLogPrefix;
+    const string requestID = request.isSet("requestID") ? request["requestID"] : "xxxxxx";
+    SLogSetThreadPrefix(requestID + (request.isSet("logParam") ? " " + request["logParam"] : "") + " ");
+}
+
+SAutoThreadPrefix::SAutoThreadPrefix(const string& rID) {
+    oldPrefix = SThreadLogPrefix;
+    const string requestID = rID.empty() ? "xxxxxx" : rID;
+    SLogSetThreadPrefix(requestID + " ");
+}
+
+SAutoThreadPrefix::~SAutoThreadPrefix() {
+    SLogSetThreadPrefix(oldPrefix);
+}
+
+float SToFloat(const string& val) {
+    return (float)atof(val.c_str());
+}
+
+int SToInt(const string& val) {
+    return atoi(val.c_str());
+}
+
+int64_t SToInt64(const string& val) {
+    return atoll(val.c_str());
+}
+
+uint64_t SToUInt64(const string& val) {
+    return strtoull(val.c_str(), NULL, 10);
+}
+
+bool SContains(const list<string>& valueList, const char* value) {
+    return ::find(valueList.begin(), valueList.end(), string(value)) != valueList.end();
+}
+
+bool SContains(const string& haystack, const string& needle) {
+    return haystack.find(needle) != string::npos;
+}
+
+bool SContains(const string& haystack, char needle) {
+    return haystack.find(needle) != string::npos;
+}
+
+bool SContains(const STable& nameValueMap, const string& name) {
+    return (nameValueMap.find(name) != nameValueMap.end());
+}
+
+bool SIEquals(const string& lhs, const string& rhs) {
+    return !strcasecmp(lhs.c_str(), rhs.c_str());
+}
+
+bool SEndsWith(const string& haystack, const string& needle) {
+    if (needle.size() > haystack.size())
+        return false;
+    else
+        return (haystack.substr(haystack.size() - needle.size()) == needle);
+}
+
+string SStripAllBut(const string& lhs, const string& chars) {
+    return SStrip(lhs, chars, true);
+}
+
+string SStripNonNum(const string& lhs) {
+    return SStripAllBut(lhs, "0123456789");
+}
+
+string SEscape(const string& lhs, const string& unsafe, char escaper) {
+    return SEscape(lhs.c_str(), unsafe, escaper);
+}
+
+string SUnescape(const string& lhs, char escaper) {
+    return SUnescape(lhs.c_str(), escaper);
+}
+
+string SStripTrim(const string& lhs) {
+    return STrim(SStrip(lhs));
+}
+
+string SBefore(const string& value, const string& needle) {
+    size_t pos = value.find(needle);
+    if (pos == string::npos)
+        return "";
+    else
+        return value.substr(0, pos);
+}
+
+string SAfter(const string& value, const string& needle) {
+    size_t pos = value.find(needle);
+    if (pos == string::npos)
+        return "";
+    else
+        return value.substr(pos + needle.size());
+}
+
+string SAfterLastOf(const string& value, const string& needle) {
+    size_t pos = value.find_last_of(needle);
+    if (pos == string::npos)
+        return "";
+    else
+        return value.substr(pos + 1);
+}
+
+string SAfterUpTo(const string& value, const string& after, const string& upTo) {
+    return (SBefore(SAfter(value, after), upTo));
+}
+
+void SAppend(string& lhs, const void* rhs, int num) {
+    size_t oldSize = lhs.size();
+    lhs.resize(oldSize + num);
+    memcpy(&lhs[oldSize], rhs, num);
+}
+
+void SAppend(string& lhs, const string& rhs) {
+    lhs += rhs;
+}
+
+int SParseHTTP(const string& buffer, string& methodLine, STable& nameValueMap, string& content) {
+    return SParseHTTP(buffer.c_str(), (int)buffer.size(), methodLine, nameValueMap, content);
+}
+
+string SComposeHTTP(const string& methodLine, const STable& nameValueMap, const string& content) {
+    string buffer;
+    SComposeHTTP(buffer, methodLine, nameValueMap, content);
+    return buffer;
+}
+
+string SComposeHost(const string& host, int port) {
+    return (host + ":" + SToStr(port));
+}
+
+bool SHostIsValid(const string& host) {
+    string domain;
+    uint16_t port = 0;
+    return SParseHost(host, domain, port);
+}
+
+string SGetDomain(const string& host) {
+    string domain;
+    uint16_t ignore;
+    if (SParseHost(host, domain, ignore))
+        return domain;
+    else
+        return host;
+}
+
+string SDecodeURIComponent(const string& value) {
+    return SDecodeURIComponent(value.c_str(), (int)value.size());
+}
+
+bool SParseList(const string& value, list<string>& valueList, char separator) {
+    return SParseList(value.c_str(), valueList, separator);
+}
+
+list<string> SParseList(const string& value, char separator) {
+    list<string> valueList;
+    SParseList(value, valueList, separator);
+    return valueList;
+}
+
+string SGetJSONArrayFront(const string& jsonArray) {
+    list<string> l = SParseJSONArray(jsonArray);
+    return l.empty() ? "" : l.front();
+};
+
+string SToStr(const sockaddr_in& addr) {
+    return SToStr(inet_ntoa(addr.sin_addr)) + ":" + SToStr(ntohs(addr.sin_port));
+}
+
+ostream& operator<<(ostream& os, const sockaddr_in& addr) {
+    return os << SToStr(addr);
+}
+
+string SQ(const char* val) {
+    return "'" + SEscape(val, "'", '\'') + "'";
+}
+
+string SQ(const string& val) {
+    return SQ(val.c_str());
+}
+
+string SQ(int val) {
+    return SToStr(val);
+}
+
+string SQ(unsigned val) {
+    return SToStr(val);
+}
+
+string SQ(uint64_t val) {
+    return SToStr(val);
+}
+
+string SQ(int64_t val) {
+    return SToStr(val);
+}
+
+string SQ(double val) {
+    return SToStr(val);
+}
+
+int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold, bool skipWarn) {
+    SQResult ignore;
+    return SQuery(db, e, sql, ignore, warnThreshold, skipWarn);
+}
+
+string SUNQUOTED_TIMESTAMP(uint64_t when) {
+    return SComposeTime("%Y-%m-%d %H:%M:%S", when);
+}
+
+string STIMESTAMP(uint64_t when) {
+    return SQ(SUNQUOTED_TIMESTAMP(when));
+}
+
+string SUNQUOTED_CURRENT_TIMESTAMP() {
+    return SUNQUOTED_TIMESTAMP(STimeNow());
+}
+
+string SCURRENT_TIMESTAMP() {
+    return STIMESTAMP(STimeNow());
+}
+
+bool STableComp::operator()(const string& s1, const string& s2) const {
+    return lexicographical_compare(s1.begin(), s1.end(), s2.begin(), s2.end(), nocase_compare());
+}
+
+bool STableComp::nocase_compare::operator()(const unsigned char& c1, const unsigned char& c2) const {
+    return tolower(c1) < tolower(c2);
+}
+
+SString::SString() {
+}
+
+SString& SString::operator=(const char& from) {
+    string::operator=(from);
+    return *this;
+}
+
+SString& SString::operator=(const unsigned char& from) {
+    string::operator=(from);
+    return *this;
+}
+
+SString& SString::operator=(const bool from) {
+    string::operator=(from ? "true" : "false");
+    return *this;
+}
+

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <vector>
 
 // Forward declarations of types only used by reference.
 struct sockaddr_in;

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -326,7 +326,7 @@ namespace std {
 // --------------------------------------------------------------------------
 // Converting between various bases
 string SToHex(uint64_t value, int digits = 16);
-inline string SToHex(uint32_t value);
+string SToHex(uint32_t value);
 string SToHex(const string& buffer);
 uint64_t SFromHex(const string& value);
 string SStrFromHex(const string& buffer);

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -1,49 +1,31 @@
 #ifndef LIBSTUFF_H
 #define LIBSTUFF_H
 
-// C library
-#include <arpa/inet.h>
-#include <cxxabi.h>
-#include <execinfo.h> // for backtrace
-#include <fcntl.h>
-#include <libgen.h>   // for basename()
-#include <netinet/in.h>
 #include <poll.h>
-#include <signal.h>
-#include <stdio.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
-#include <sys/time.h> // for gettimeofday()
-#include <sys/types.h>
-#include <sys/un.h>
+#include <libgen.h>
 #include <syslog.h>
-#include <stdlib.h>
-#include <time.h>
-#include <unistd.h>
 
-// STL
-#include <algorithm>
 #include <atomic>
-#include <cctype>
-#include <chrono>
-#include <condition_variable>
+#include <functional>
 #include <iomanip>
-#include <iostream>
 #include <list>
 #include <map>
 #include <mutex>
-#include <random>
 #include <set>
 #include <shared_mutex>
 #include <sstream>
 #include <string>
 #include <thread>
-#include <vector>
-#include <functional>
-using namespace std;
 
-// Custom libraries.
-#include <pcrecpp.h> // sudo apt-get install libpcre++-dev
+// Forward declarations of types only used by reference.
+struct sockaddr_in;
+struct pollfd;
+struct sqlite3;
+class SQResult;
+class SFastBuffer;
+class SData;
+
+using namespace std;
 
 // Initialize libstuff on every thread before calling any of its functions
 void SInitialize(string threadName = "", const char* processName = 0);
@@ -87,14 +69,12 @@ void SSetSignalHandlerDieFunc(function<void()>&& func);
 // See: http://stackoverflow.com/questions/1801892/making-mapfind-operation-case-insensitive
 class STableComp : binary_function<string, string, bool> {
   public:
-    bool operator()(const string& s1, const string& s2) const {
-        return lexicographical_compare(s1.begin(), s1.end(), s2.begin(), s2.end(), nocase_compare());
-    }
+    bool operator()(const string& s1, const string& s2) const;
 
   private:
     class nocase_compare : public binary_function<unsigned char, unsigned char, bool> {
       public:
-        bool operator()(const unsigned char& c1, const unsigned char& c2) const { return tolower(c1) < tolower(c2); }
+        bool operator()(const unsigned char& c1, const unsigned char& c2) const;
     };
 };
 
@@ -111,7 +91,7 @@ class SString : public string {
 
     template <typename T>
     SString(const T& from) : string(from) {}
-    SString() {}
+    SString();
 
     // Templated assignment operator for non-arithmetic types.
     template <typename T>
@@ -121,30 +101,16 @@ class SString : public string {
     }
 
     // Chars are special, we don't treat them as integral types, even though they'd normally count.
-    SString& operator=(const char& from) {
-        string::operator=(from);
-        return *this;
-    }
+    SString& operator=(const char& from);
 
     // The above is also true for unsigned chars.
-    SString& operator=(const unsigned char& from) {
-        string::operator=(from);
-        return *this;
-    }
+    SString& operator=(const unsigned char& from);
 
     // Booleans get converted to strings.
-    SString& operator=(const bool from) {
-        string::operator=(from ? "true" : "false");
-        return *this;
-    }
+    SString& operator=(const bool from);
 };
 
 typedef map<string, SString, STableComp> STable;
-
-// Libstuff items that must be included here so they are available in the rest of the file
-// However it must be included AFTER the STable definition because SData uses this type.
-#include "SFastBuffer.h"
-#include "SData.h"
 
 // An SException is an exception class that can represent an HTTP-like response, with a method line, headers, and a
 // body. The STHROW and STHROW_STACK macros will create an SException that logs it's file and line of creation, and
@@ -205,27 +171,16 @@ struct SStopwatch {
     // Constructors -- If constructed with an alarm, starts out in the
     // ringing state.  If constructed without an alarm, starts out timing
     // from construction.
-    SStopwatch() {
-        start();
-        alarmDuration.store(0);
-    }
-    SStopwatch(uint64_t alarm) {
-        startTime.store(0);
-        alarmDuration.store(alarm);
-    }
+    SStopwatch();
+    SStopwatch(uint64_t alarm);
 
     // Accessors
-    uint64_t elapsed() { return STimeNow() - startTime.load(); }
-    uint64_t ringing() { return alarmDuration.load() && (elapsed() > alarmDuration.load()); }
+    uint64_t elapsed();
+    uint64_t ringing();
 
     // Mutators
-    void start() { startTime.store(STimeNow()); }
-    bool ding() {
-        if (!ringing())
-            return false;
-        start();
-        return true;
-    }
+    void start();
+    bool ding();
 };
 
 // --------------------------------------------------------------------------
@@ -259,10 +214,7 @@ void STerminateHandler(void);
 // --------------------------------------------------------------------------
 // Log level management
 extern atomic<int> _g_SLogMask;
-inline void SLogLevel(int level) {
-    _g_SLogMask = LOG_UPTO(level);
-    setlogmask(_g_SLogMask);
-}
+void SLogLevel(int level);
 
 // Stack trace logging
 void SLogStackTrace();
@@ -315,18 +267,9 @@ void SLogSetThreadName(const string& name);
 
 struct SAutoThreadPrefix {
     // Set on construction; reset on destruction
-    SAutoThreadPrefix(const SData& request) {
-        // Retain the old prefix
-        oldPrefix = SThreadLogPrefix;
-        const string requestID = request.isSet("requestID") ? request["requestID"] : "xxxxxx";
-        SLogSetThreadPrefix(requestID + (request.isSet("logParam") ? " " + request["logParam"] : "") + " ");
-    }
-    SAutoThreadPrefix(const string& rID) {
-        oldPrefix = SThreadLogPrefix;
-        const string requestID = rID.empty() ? "xxxxxx" : rID;
-        SLogSetThreadPrefix(requestID + " ");
-    }
-    ~SAutoThreadPrefix() { SLogSetThreadPrefix(oldPrefix); }
+    SAutoThreadPrefix(const SData& request);
+    SAutoThreadPrefix(const string& rID);
+    ~SAutoThreadPrefix();
 
   private:
     // Attributes
@@ -383,7 +326,7 @@ namespace std {
 // --------------------------------------------------------------------------
 // Converting between various bases
 string SToHex(uint64_t value, int digits = 16);
-inline string SToHex(uint32_t value) { return SToHex(value, 8); }
+inline string SToHex(uint32_t value);
 string SToHex(const string& buffer);
 uint64_t SFromHex(const string& value);
 string SStrFromHex(const string& buffer);
@@ -405,10 +348,10 @@ template <class T> inline string SToStr(const T& t) {
 }
 
 // Numeric conversion
-inline float SToFloat(const string& val) { return (float)atof(val.c_str()); }
-inline int SToInt(const string& val) { return atoi(val.c_str()); }
-inline int64_t SToInt64(const string& val) { return atoll(val.c_str()); }
-inline uint64_t SToUInt64(const string& val) { return strtoull(val.c_str(), NULL, 10); }
+float SToFloat(const string& val);
+int SToInt(const string& val);
+int64_t SToInt64(const string& val);
+uint64_t SToUInt64(const string& val);
 
 // General utility for testing map containment
 template <class A, class B, class C> inline bool SContains(const map<A, B, C>& nameValueMap, const A& name) {
@@ -421,33 +364,25 @@ template <class A> inline bool SContains(const set<A>& valueList, const A& value
     return valueList.find(value) != valueList.end();
 }
 
-inline bool SContains(const list<string>& valueList, const char* value) { return ::find(valueList.begin(), valueList.end(), string(value)) != valueList.end(); }
-inline bool SContains(const string& haystack, const string& needle) { return haystack.find(needle) != string::npos; }
-inline bool SContains(const string& haystack, char needle) { return haystack.find(needle) != string::npos; }
-inline bool SContains(const STable& nameValueMap, const string& name) {
-    return (nameValueMap.find(name) != nameValueMap.end());
-}
+bool SContains(const list<string>& valueList, const char* value);
+bool SContains(const string& haystack, const string& needle);
+bool SContains(const string& haystack, char needle); 
+bool SContains(const STable& nameValueMap, const string& name);
+
 bool SIsValidSQLiteDateModifier(const string& modifier);
 
 // General testing functions
-inline bool SIEquals(const string& lhs, const string& rhs) { return !strcasecmp(lhs.c_str(), rhs.c_str()); }
+bool SIEquals(const string& lhs, const string& rhs);
 bool SIContains(const string& haystack, const string& needle);
 bool SStartsWith(const string& haystack, const string& needle);
 bool SStartsWith(const char* haystack, size_t haystackSize, const char* needle, size_t needleSize);
-inline bool SEndsWith(const string& haystack, const string& needle) {
-    if (needle.size() > haystack.size())
-        return false;
-    else
-        return (haystack.substr(haystack.size() - needle.size()) == needle);
-}
+bool SEndsWith(const string& haystack, const string& needle); 
 bool SConstantTimeEquals(const string& secret, const string& userInput);
 bool SConstantTimeIEquals(const string& secret, const string& userInput);
 
 // Perform a full regex match. The '^' and '$' symbols are implicit.
-inline bool SREMatch(const string& regExp, const string& s) { return pcrecpp::RE(regExp).FullMatch(s); }
-inline bool SREMatch(const string& regExp, const string& s, string& match) {
-    return pcrecpp::RE(regExp).FullMatch(s, &match);
-}
+bool SREMatch(const string& regExp, const string& s);
+bool SREMatch(const string& regExp, const string& s, string& match);
 
 // Case testing and conversion
 string SToLower(string value);
@@ -458,91 +393,42 @@ string SCollapse(const string& lhs);
 string STrim(const string& lhs);
 string SStrip(const string& lhs);
 string SStrip(const string& lhs, const string& chars, bool charsAreSafe);
-inline string SStripAllBut(const string& lhs, const string& chars) { return SStrip(lhs, chars, true); }
-inline string SStripNonNum(const string& lhs) { return SStripAllBut(lhs, "0123456789"); }
+string SStripAllBut(const string& lhs, const string& chars);
+string SStripNonNum(const string& lhs);
 string SEscape(const char* lhs, const string& unsafe, char escaper);
-inline string SEscape(const string& lhs, const string& unsafe, char escaper = '\\') {
-    return SEscape(lhs.c_str(), unsafe, escaper);
-}
+string SEscape(const string& lhs, const string& unsafe, char escaper = '\\');
 string SUnescape(const char* lhs, char escaper);
-inline string SUnescape(const string& lhs, char escaper = '\\') { return SUnescape(lhs.c_str(), escaper); }
-inline string SStripTrim(const string& lhs) { return STrim(SStrip(lhs)); }
-inline string SBefore(const string& value, const string& needle) {
-    size_t pos = value.find(needle);
-    if (pos == string::npos)
-        return "";
-    else
-        return value.substr(0, pos);
-}
-inline string SAfter(const string& value, const string& needle) {
-    size_t pos = value.find(needle);
-    if (pos == string::npos)
-        return "";
-    else
-        return value.substr(pos + needle.size());
-}
-inline string SAfterLastOf(const string& value, const string& needle) {
-    size_t pos = value.find_last_of(needle);
-    if (pos == string::npos)
-        return "";
-    else
-        return value.substr(pos + 1);
-}
-
-inline string SAfterUpTo(const string& value, const string& after, const string& upTo) {
-    return (SBefore(SAfter(value, after), upTo));
-}
+string SUnescape(const string& lhs, char escaper = '\\');
+string SStripTrim(const string& lhs);
+string SBefore(const string& value, const string& needle);
+string SAfter(const string& value, const string& needle);
+string SAfterLastOf(const string& value, const string& needle);
+string SAfterUpTo(const string& value, const string& after, const string& upTo);
 string SReplace(const string& value, const string& find, const string& replace);
 string SReplaceAllBut(const string& value, const string& safeChars, char replaceChar);
 string SReplaceAll(const string& value, const string& unsafeChars, char replaceChar);
 int SStateNameToInt(const char* states[], const string& stateName, unsigned int numStates);
-inline void SAppend(string& lhs, const void* rhs, int num) {
-    size_t oldSize = lhs.size();
-    lhs.resize(oldSize + num);
-    memcpy(&lhs[oldSize], rhs, num);
-}
-inline void SAppend(string& lhs, const string& rhs) { lhs += rhs; }
+void SAppend(string& lhs, const void* rhs, int num);
+void SAppend(string& lhs, const string& rhs);
 
 // HTTP message management
-#define S_COOKIE_SEPARATOR ((char)0xFF)
 int SParseHTTP(const char* buffer, size_t length, string& methodLine, STable& nameValueMap, string& content);
-inline int SParseHTTP(const string& buffer, string& methodLine, STable& nameValueMap, string& content) {
-    return SParseHTTP(buffer.c_str(), (int)buffer.size(), methodLine, nameValueMap, content);
-}
+int SParseHTTP(const string& buffer, string& methodLine, STable& nameValueMap, string& content);
 bool SParseRequestMethodLine(const string& methodLine, string& method, string& uri);
 bool SParseResponseMethodLine(const string& methodLine, string& protocol, int& code, string& reason);
 bool SParseURI(const char* buffer, int length, string& host, string& path);
-inline bool SParseURI(const string& uri, string& host, string& path) {
-    return SParseURI(uri.c_str(), (int)uri.size(), host, path);
-}
+bool SParseURI(const string& uri, string& host, string& path);
 bool SParseURIPath(const char* buffer, int length, string& path, STable& nameValueMap);
-inline bool SParseURIPath(const string& uri, string& path, STable& nameValueMap) {
-    return SParseURIPath(uri.c_str(), (int)uri.size(), path, nameValueMap);
-}
+bool SParseURIPath(const string& uri, string& path, STable& nameValueMap);
 void SComposeHTTP(string& buffer, const string& methodLine, const STable& nameValueMap, const string& content);
-inline string SComposeHTTP(const string& methodLine, const STable& nameValueMap, const string& content) {
-    string buffer;
-    SComposeHTTP(buffer, methodLine, nameValueMap, content);
-    return buffer;
-}
+string SComposeHTTP(const string& methodLine, const STable& nameValueMap, const string& content);
 string SComposePOST(const STable& nameValueMap);
-inline string SComposeHost(const string& host, int port) { return (host + ":" + SToStr(port)); }
+string SComposeHost(const string& host, int port);
 bool SParseHost(const string& host, string& domain, uint16_t& port);
-inline bool SHostIsValid(const string& host) {
-    string domain;
-    uint16_t port = 0;
-    return SParseHost(host, domain, port);
-}
-inline string SGetDomain(const string& host) {
-    string domain;
-    uint16_t ignore;
-    if (SParseHost(host, domain, ignore))
-        return domain;
-    else
-        return host;
-}
+bool SHostIsValid(const string& host);
+string SGetDomain(const string& host);
 string SDecodeURIComponent(const char* buffer, int length);
-inline string SDecodeURIComponent(const string& value) { return SDecodeURIComponent(value.c_str(), (int)value.size()); }
+string SDecodeURIComponent(const string& value);
 string SEncodeURIComponent(const string& value);
 
 // --------------------------------------------------------------------------
@@ -551,14 +437,8 @@ string SEncodeURIComponent(const string& value);
 // List management
 list<int64_t> SParseIntegerList(const string& value, char separator = ',');
 bool SParseList(const char* value, list<string>& valueList, char separator = ',');
-inline bool SParseList(const string& value, list<string>& valueList, char separator = ',') {
-    return SParseList(value.c_str(), valueList, separator);
-}
-inline list<string> SParseList(const string& value, char separator = ',') {
-    list<string> valueList;
-    SParseList(value, valueList, separator);
-    return valueList;
-}
+bool SParseList(const string& value, list<string>& valueList, char separator = ',');
+list<string> SParseList(const string& value, char separator = ',');
 
 // Concatenates things into a string. "Things" can mean essentially any
 // standard STL container of any type of object that "stringstream" can handle.
@@ -597,20 +477,15 @@ string SComposeJSONArray(const T& valueList) {
 string SComposeJSONObject(const STable& nameValueMap, const bool forceString = false);
 STable SParseJSONObject(const string& object);
 list<string> SParseJSONArray(const string& array);
-inline string SGetJSONArrayFront(const string& jsonArray) {
-    list<string> l = SParseJSONArray(jsonArray);
-    return l.empty() ? "" : l.front();
-};
+string SGetJSONArrayFront(const string& jsonArray);
 
 // --------------------------------------------------------------------------
 // Network stuff
 // --------------------------------------------------------------------------
 
 // Converts a sockaddr_in to a string of the form "aaa.bbb.ccc.ddd:port"
-inline string SToStr(const sockaddr_in& addr) {
-    return SToStr(inet_ntoa(addr.sin_addr)) + ":" + SToStr(ntohs(addr.sin_port));
-}
-inline ostream& operator<<(ostream& os, const sockaddr_in& addr) { return os << SToStr(addr); }
+string SToStr(const sockaddr_in& addr);
+ostream& operator<<(ostream& os, const sockaddr_in& addr);
 
 // map of FDs to pollfds
 typedef map<int, pollfd> fd_map;
@@ -630,11 +505,6 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking);
 int S_accept(int port, sockaddr_in& fromAddr, bool isBlocking);
 ssize_t S_recvfrom(int s, char* recvBuffer, int recvBufferSize, sockaddr_in& fromAddr);
 bool S_recvappend(int s, SFastBuffer& recvBuffer);
-inline SFastBuffer S_recv(int s) {
-    SFastBuffer buf;
-    S_recvappend(s, buf);
-    return buf;
-}
 bool S_sendconsume(int s, SFastBuffer& sendBuffer);
 int S_poll(fd_map& fdm, uint64_t timeout);
 
@@ -687,15 +557,13 @@ string SAESDecryptNoStrip(const string& buffer, const size_t& bufferSize, const 
 // --------------------------------------------------------------------------
 // SQLite Stuff
 // --------------------------------------------------------------------------
-#include "sqlite3.h"
-#include "SQResult.h"
-inline string SQ(const char* val) { return "'" + SEscape(val, "'", '\'') + "'"; }
-inline string SQ(const string& val) { return SQ(val.c_str()); }
-inline string SQ(int val) { return SToStr(val); }
-inline string SQ(unsigned val) { return SToStr(val); }
-inline string SQ(uint64_t val) { return SToStr(val); }
-inline string SQ(int64_t val) { return SToStr(val); }
-inline string SQ(double val) { return SToStr(val); }
+string SQ(const char* val);
+string SQ(const string& val);
+string SQ(int val);
+string SQ(unsigned val);
+string SQ(uint64_t val);
+string SQ(int64_t val);
+string SQ(double val);
 string SQList(const string& val, bool integersOnly = true);
 
 template <typename Container> string SQList(const Container& valueList) {
@@ -710,21 +578,16 @@ void SQueryLogOpen(const string& logFilename);
 void SQueryLogClose();
 
 // Returns an SQLite result code.
-int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result,
-           int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
-inline int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false) {
-    SQResult ignore;
-    return SQuery(db, e, sql, ignore, warnThreshold, skipWarn);
-}
-
+int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
+int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
 bool SQVerifyTable(sqlite3* db, const string& tableName, const string& sql);
 bool SQVerifyTableExists(sqlite3* db, const string& tableName);
 
 // --------------------------------------------------------------------------
-inline string SUNQUOTED_TIMESTAMP(uint64_t when) { return SComposeTime("%Y-%m-%d %H:%M:%S", when); }
-inline string STIMESTAMP(uint64_t when) { return SQ(SUNQUOTED_TIMESTAMP(when)); }
-inline string SUNQUOTED_CURRENT_TIMESTAMP() { return SUNQUOTED_TIMESTAMP(STimeNow()); }
-inline string SCURRENT_TIMESTAMP() { return STIMESTAMP(STimeNow()); }
+string SUNQUOTED_TIMESTAMP(uint64_t when);
+string STIMESTAMP(uint64_t when);
+string SUNQUOTED_CURRENT_TIMESTAMP();
+string SCURRENT_TIMESTAMP();
 string SCURRENT_TIMESTAMP_MS();
 
 // --------------------------------------------------------------------------
@@ -735,82 +598,6 @@ string SGZip(const string& content);
 string SGUnzip(const string& content);
 
 // Command-line helpers
-SData SParseCommandLine(int argc, char* argv[]);
-
-// --------------------------------------------------------------------------
-// Testing Stuff
-// --------------------------------------------------------------------------
-// Logs the start and end of a given test, as well as elapsed time.
-#define STESTLOG(_MSG_)                                                                                                \
-    do {                                                                                                               \
-        cout << _MSG_ << endl;                                                                                         \
-        cout.flush();                                                                                                  \
-        SSYSLOG(LOG_DEBUG, "[test] " << SLOGPREFIX << _MSG_);                                                          \
-    } while (false)
-#define STESTASSERT(_COND_)                                                                                            \
-    do {                                                                                                               \
-        if (!(_COND_)) {                                                                                               \
-            STESTLOG((test.success ? "\n" : "") << "\tAssertion failed: " << #_COND_);                                 \
-            test.success = false;                                                                                      \
-        }                                                                                                              \
-    } while (false)
-#define STESTEQUALS(_LHS_, _RHS_)                                                                                      \
-    do {                                                                                                               \
-        if ((_LHS_) != (_RHS_)) {                                                                                      \
-            STESTLOG((test.success ? "\n" : "") << "\tAssertion failed: (" << #_LHS_ << ") != (" << #_RHS_ << "): ("   \
-                                                << _LHS_ << ") != (" << _RHS_ << ")");                                 \
-            test.success = false;                                                                                      \
-        }                                                                                                              \
-    } while (false)
-struct STestGroup {
-    bool success;
-    STestGroup() : success(true){};
-};
-
-struct STestTimer {
-    // Attributes
-    uint64_t begin;
-    bool success;
-    STestGroup* testGroup;
-
-    // Starts a new test
-    STestTimer(const string& message, STestGroup* testGroup = 0)
-        : begin(STimeNow()), success(true), testGroup(testGroup) {
-        // Log to the logfile and output
-        SINFO("################# " << message << " ###################");
-        cout << message << "...";
-        cout.flush();
-    }
-
-    // Test complete
-    ~STestTimer() {
-        // Update the test group, if any
-        if (testGroup) {
-            testGroup->success &= success;
-        }
-
-        // Calculate and log elapsed
-        uint64_t elapsed = (STimeNow() - begin) / STIME_US_PER_MS;
-        string result = (success ? "Pass." : "FAIL!");
-        SINFO("################# " << result << " (" << elapsed << "ms)  ###################");
-        cout << result << " (" << elapsed << "ms)" << endl;
-    }
-};
-
-// --------------------------------------------------------------------------
-// Networking stuff
-// --------------------------------------------------------------------------
-// Networking includes
-#include "SX509.h"
-#include "SSSLState.h"
-#include "STCPManager.h"
-#include "STCPServer.h"
-#include "STCPNode.h"
-#include "SHTTPSManager.h"
-
-// Other libstuff headers.
-#include "SRandom.h"
-#include "SPerformanceTimer.h"
-#include "SSynchronizedQueue.h"
+STable SParseCommandLine(int argc, char* argv[]);
 
 #endif	// LIBSTUFF_H

--- a/main.cpp
+++ b/main.cpp
@@ -2,18 +2,21 @@
 /// =================
 /// Process entry point for Bedrock server.
 ///
-#include <libstuff/libstuff.h>
-#include <bedrockVersion.h>
-#include "BedrockServer.h"
-#include "BedrockPlugin.h"
-#include "plugins/Cache.h"
-#include "plugins/DB.h"
-#include "plugins/Jobs.h"
-#include "plugins/MySQL.h"
-#include "sqlitecluster/SQLite.h"
-#include <sys/stat.h> // for umask()
 #include <dlfcn.h>
+#include <iostream>
+#include <signal.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
+
+#include <bedrockVersion.h>
+#include <BedrockServer.h>
+#include <BedrockPlugin.h>
+#include <plugins/Cache.h>
+#include <plugins/DB.h>
+#include <plugins/Jobs.h>
+#include <plugins/MySQL.h>
+#include <libstuff/libstuff.h>
+#include <sqlitecluster/SQLite.h>
 
 /////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////

--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -1,5 +1,7 @@
 #include "Cache.h"
-#include "BedrockServer.h"
+
+#include <BedrockServer.h>
+#include <libstuff/SQResult.h>
 
 const string BedrockPlugin_Cache::name("Cache");
 const string& BedrockPlugin_Cache::getName() const {

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -1,5 +1,9 @@
 #include "DB.h"
-#include "BedrockServer.h"
+
+#include <string.h>
+
+#include <BedrockServer.h>
+#include <libstuff/SQResult.h>
 
 #undef SLOGPREFIX
 #define SLOGPREFIX "{" << getName() << "} "

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1,5 +1,7 @@
 #include "Jobs.h"
-#include "../BedrockServer.h"
+
+#include <BedrockServer.h>
+#include <libstuff/SQResult.h>
 #include <sqlitecluster/SQLiteUtils.h>
 
 #undef SLOGPREFIX

--- a/plugins/MySQL.cpp
+++ b/plugins/MySQL.cpp
@@ -1,5 +1,9 @@
-#include <bedrockVersion.h>
 #include "MySQL.h"
+
+#include <pcrecpp.h>
+
+#include <bedrockVersion.h>
+#include <libstuff/SQResult.h>
 
 #undef SLOGPREFIX
 #define SLOGPREFIX "{" << getName() << "} "

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1,5 +1,10 @@
-#include <libstuff/libstuff.h>
 #include "SQLite.h"
+
+#include <linux/limits.h>
+#include <string.h>
+
+#include <libstuff/libstuff.h>
+#include <libstuff/SQResult.h>
 
 #define DBINFO(_MSG_) SINFO("{" << _filename << "} " << _MSG_)
 

--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -1,5 +1,7 @@
-#include <libstuff/libstuff.h>
 #include "SQLiteCommand.h"
+
+#include <libstuff/libstuff.h>
+#include <libstuff/SRandom.h>
 
 SData SQLiteCommand::preprocessRequest(SData&& request) {
     // If the request doesn't specify an execution time, default to right now.

--- a/sqlitecluster/SQLiteCommand.h
+++ b/sqlitecluster/SQLiteCommand.h
@@ -1,5 +1,7 @@
 #pragma once
-#include "SQLiteNode.h"
+
+#include <libstuff/SData.h>
+#include <sqlitecluster/SQLiteNode.h>
 
 class SQLiteCommand {
   public:

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1,7 +1,12 @@
-#include <libstuff/libstuff.h>
 #include "SQLiteNode.h"
-#include "SQLiteServer.h"
-#include "SQLiteCommand.h"
+
+#include <unistd.h>
+
+#include <libstuff/libstuff.h>
+#include <libstuff/SRandom.h>
+#include <libstuff/SQResult.h>
+#include <sqlitecluster/SQLiteCommand.h>
+#include <sqlitecluster/SQLiteServer.h>
 
 // Introduction
 // ------------

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -1,9 +1,11 @@
 #pragma once
-#include "SQLite.h"
-#include "SQLitePool.h"
-#include "SQLiteSequentialNotifier.h"
-#include "WallClockTimer.h"
-#include "../SynchronizedMap.h"
+#include <libstuff/STCPNode.h>
+#include <sqlitecluster/SQLite.h>
+#include <sqlitecluster/SQLitePool.h>
+#include <sqlitecluster/SQLiteSequentialNotifier.h>
+#include <WallClockTimer.h>
+#include <SynchronizedMap.h>
+
 class SQLiteCommand;
 class SQLiteServer;
 

--- a/sqlitecluster/SQLiteUtils.cpp
+++ b/sqlitecluster/SQLiteUtils.cpp
@@ -1,6 +1,8 @@
-#include <libstuff/libstuff.h>
 #include "SQLiteUtils.h"
-#include "SQLite.h"
+
+#include <libstuff/libstuff.h>
+#include <libstuff/SRandom.h>
+#include <sqlitecluster/SQLite.h>
 
 int64_t SQLiteUtils::getRandomID(SQLite& db, const string& tableName, const string& column) {
     int64_t newID = 0;

--- a/sqlitecluster/SQLiteUtils.h
+++ b/sqlitecluster/SQLiteUtils.h
@@ -1,5 +1,10 @@
 #pragma once
+#include <cstdint>
+#include <string>
+
 class SQLite;
+
+using namespace std;
 
 class SQLiteUtils {
   public:

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -1,3 +1,7 @@
+#pragma once
+#include <iostream>
+#include <unistd.h>
+
 #include <test/lib/BedrockTester.h>
 
 enum class ClusterSize {

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <unistd.h>
 
+#include <libstuff/SData.h>
 #include <test/lib/BedrockTester.h>
 
 enum class ClusterSize {

--- a/test/clustertest/main.cpp
+++ b/test/clustertest/main.cpp
@@ -1,6 +1,9 @@
-#include <libstuff/libstuff.h>
-#include <test/clustertest/BedrockClusterTester.h>
+#include <iostream>
 #include <unistd.h>
+
+#include <libstuff/libstuff.h>
+#include <libstuff/SData.h>
+#include <test/lib/BedrockTester.h>
 
 /*
  * This is based on the 'test' application in the parent directory to this one, but specifically aims to test the

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -1,5 +1,11 @@
 #include "TestPlugin.h"
+
+#include <iostream>
 #include <sys/file.h>
+#include <string.h>
+
+#include <libstuff/SQResult.h>
+#include <libstuff/SX509.h>
 
 mutex BedrockPlugin_TestPlugin::dataLock;
 map<string, string> BedrockPlugin_TestPlugin::arbitraryData;

--- a/test/clustertest/tests/BadCommandTest.cpp
+++ b/test/clustertest/tests/BadCommandTest.cpp
@@ -1,4 +1,5 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct BadCommandTest : tpunit::TestFixture {
     BadCommandTest()

--- a/test/clustertest/tests/BroadcastTest.cpp
+++ b/test/clustertest/tests/BroadcastTest.cpp
@@ -1,4 +1,7 @@
-#include "../BedrockClusterTester.h"
+#include <iostream>
+
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct BroadcastCommandTest : tpunit::TestFixture {
     BroadcastCommandTest()

--- a/test/clustertest/tests/ConflictSpamTest.cpp
+++ b/test/clustertest/tests/ConflictSpamTest.cpp
@@ -1,4 +1,5 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct ConflictSpamTest : tpunit::TestFixture {
     ConflictSpamTest()

--- a/test/clustertest/tests/ControlCommandTest.cpp
+++ b/test/clustertest/tests/ControlCommandTest.cpp
@@ -1,5 +1,7 @@
+#include <iostream>
 
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct ControlCommandTest : tpunit::TestFixture {
     ControlCommandTest()

--- a/test/clustertest/tests/EscalateTest.cpp
+++ b/test/clustertest/tests/EscalateTest.cpp
@@ -1,4 +1,5 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct EscalateTest : tpunit::TestFixture {
     EscalateTest() : tpunit::TestFixture("EscalateTest", TEST(EscalateTest::test)) { }

--- a/test/clustertest/tests/FinishJobTest.cpp
+++ b/test/clustertest/tests/FinishJobTest.cpp
@@ -1,4 +1,6 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SQResult.h>
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 #include <test/tests/jobs/JobTestHelper.h>
 
 struct FinishJobTest : tpunit::TestFixture {

--- a/test/clustertest/tests/FutureExecutionTest.cpp
+++ b/test/clustertest/tests/FutureExecutionTest.cpp
@@ -1,5 +1,7 @@
-#include "../BedrockClusterTester.h"
 #include <fstream>
+
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct FutureExecutionTest : tpunit::TestFixture {
     FutureExecutionTest()

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -1,4 +1,6 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <libstuff/SRandom.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct GracefulFailoverTest : tpunit::TestFixture {
     GracefulFailoverTest()

--- a/test/clustertest/tests/HTTPSTest.cpp
+++ b/test/clustertest/tests/HTTPSTest.cpp
@@ -1,4 +1,5 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 /* This test is inherently a non-conclusive test. It aims to submit conflicting HTTPS requests, but there's no simple
  * way to prove, conclusively that any of our commands actually conflicted. This test is constructed such that it has

--- a/test/clustertest/tests/JobIDTest.cpp
+++ b/test/clustertest/tests/JobIDTest.cpp
@@ -1,4 +1,5 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct JobIDTest : tpunit::TestFixture {
     JobIDTest()

--- a/test/clustertest/tests/LeadingTest.cpp
+++ b/test/clustertest/tests/LeadingTest.cpp
@@ -1,4 +1,6 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <libstuff/SRandom.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct LeadingTest : tpunit::TestFixture {
     LeadingTest()

--- a/test/clustertest/tests/MultipleLeaderSyncTest.cpp
+++ b/test/clustertest/tests/MultipleLeaderSyncTest.cpp
@@ -1,4 +1,5 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct MultipleLeaderSyncTest : tpunit::TestFixture {
     MultipleLeaderSyncTest()

--- a/test/clustertest/tests/PermafollowerTest.cpp
+++ b/test/clustertest/tests/PermafollowerTest.cpp
@@ -1,4 +1,5 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct PermafollowerTest : tpunit::TestFixture {
     PermafollowerTest()

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -1,4 +1,5 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct StatusHandlingCommandsTest : tpunit::TestFixture {
     StatusHandlingCommandsTest()

--- a/test/clustertest/tests/StatusTest.cpp
+++ b/test/clustertest/tests/StatusTest.cpp
@@ -1,4 +1,5 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct StatusTest : tpunit::TestFixture {
     StatusTest()

--- a/test/clustertest/tests/TimeoutTest.cpp
+++ b/test/clustertest/tests/TimeoutTest.cpp
@@ -1,5 +1,5 @@
-
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct TimeoutTest : tpunit::TestFixture {
     TimeoutTest()

--- a/test/clustertest/tests/TimingTest.cpp
+++ b/test/clustertest/tests/TimingTest.cpp
@@ -1,5 +1,5 @@
-
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct TimingTest : tpunit::TestFixture {
     TimingTest()

--- a/test/clustertest/tests/UniqueConstraintsTest.cpp
+++ b/test/clustertest/tests/UniqueConstraintsTest.cpp
@@ -1,4 +1,5 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct UniqueConstraintsTest : tpunit::TestFixture {
     UniqueConstraintsTest()

--- a/test/clustertest/tests/UpgradeDBTest.cpp
+++ b/test/clustertest/tests/UpgradeDBTest.cpp
@@ -1,4 +1,5 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct UpgradeDBTest : tpunit::TestFixture {
     UpgradeDBTest()

--- a/test/clustertest/tests/VersionMismatchTest.cpp
+++ b/test/clustertest/tests/VersionMismatchTest.cpp
@@ -1,4 +1,5 @@
-#include "../BedrockClusterTester.h"
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
 
 struct VersionMismatchTest : tpunit::TestFixture {
     VersionMismatchTest()

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -1,5 +1,15 @@
 #include "BedrockTester.h"
+
+#include <cstring>
+#include <iostream>
+#include <netinet/in.h>
 #include <sys/wait.h>
+#include <unistd.h>
+
+#include <libstuff/SData.h>
+#include <libstuff/SFastBuffer.h>
+#include <sqlitecluster/SQLite.h>
+#include <test/lib/BedrockTester.h>
 
 PortMap BedrockTester::ports;
 mutex BedrockTester::_testersMutex;

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -1,9 +1,10 @@
 #pragma once
-#include <libstuff/libstuff.h>
-#include <sqlitecluster/SQLite.h>
-#include <test/lib/TestHTTPS.h>
-#include <test/lib/tpunit++.hpp>
+#include <signal.h>
+
 #include <test/lib/PortMap.h>
+#include <test/lib/tpunit++.hpp>
+
+class SQLite;
 
 class BedrockTester {
   public:

--- a/test/lib/PortMap.cpp
+++ b/test/lib/PortMap.cpp
@@ -1,4 +1,8 @@
 #include "PortMap.h"
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <iostream>
 
 PortMap::PortMap(uint16_t from) : _from(from)
     {}

--- a/test/lib/TestHTTPS.h
+++ b/test/lib/TestHTTPS.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <libstuff/libstuff.h>
+#include <libstuff/SHTTPSManager.h>
 
 class TestHTTPS : public SHTTPSManager {
   public:

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,3 +1,6 @@
+#include <iostream>
+
+#include <libstuff/SData.h>
 #include <libstuff/libstuff.h>
 #include <test/lib/BedrockTester.h>
 

--- a/test/tests/ChainedHTTPTest.cpp
+++ b/test/tests/ChainedHTTPTest.cpp
@@ -1,4 +1,7 @@
+#include <unistd.h>
+
 #include <libstuff/libstuff.h>
+#include <libstuff/SData.h>
 #include <sqlitecluster/SQLiteNode.h>
 #include <test/lib/BedrockTester.h>
 

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -1,4 +1,8 @@
+#include <cstring>
+
 #include <libstuff/libstuff.h>
+#include <libstuff/SData.h>
+#include <libstuff/SRandom.h>
 #include <test/lib/BedrockTester.h>
 
 struct LibStuff : tpunit::TestFixture {

--- a/test/tests/ReadTest.cpp
+++ b/test/tests/ReadTest.cpp
@@ -1,3 +1,4 @@
+#include <libstuff/SData.h>
 #include <test/lib/BedrockTester.h>
 
 struct ReadTest : tpunit::TestFixture {

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -4,6 +4,9 @@
 #include <sqlitecluster/SQLiteServer.h>
 #include <test/lib/BedrockTester.h>
 
+#include <unistd.h>
+#include <cstring>
+
 class SQLiteNodeTester {
   public:
     static SQLiteNode::Peer* getSyncPeer(SQLiteNode& node) {

--- a/test/tests/SSLTest.cpp
+++ b/test/tests/SSLTest.cpp
@@ -1,4 +1,7 @@
+#include <unistd.h>
+
 #include <libstuff/libstuff.h>
+#include <libstuff/SData.h>
 #include <sqlitecluster/SQLiteNode.h>
 #include <test/lib/BedrockTester.h>
 

--- a/test/tests/StatusTest.cpp
+++ b/test/tests/StatusTest.cpp
@@ -1,3 +1,4 @@
+#include <libstuff/SData.h>
 #include <test/lib/BedrockTester.h>
 
 struct StatusTest : tpunit::TestFixture {

--- a/test/tests/WriteTest.cpp
+++ b/test/tests/WriteTest.cpp
@@ -1,3 +1,4 @@
+#include <libstuff/SData.h>
 #include <test/lib/BedrockTester.h>
 
 struct WriteTest : tpunit::TestFixture {

--- a/test/tests/jobs/CancelJobTest.cpp
+++ b/test/tests/jobs/CancelJobTest.cpp
@@ -1,3 +1,5 @@
+#include <libstuff/SQResult.h>
+#include <libstuff/SData.h>
 #include <test/lib/BedrockTester.h>
 
 struct CancelJobTest : tpunit::TestFixture {

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -1,3 +1,8 @@
+#include <iostream>
+#include <unistd.h>
+
+#include <libstuff/SData.h>
+#include <libstuff/SQResult.h>
 #include <test/lib/BedrockTester.h>
 #include <test/tests/jobs/JobTestHelper.h>
 

--- a/test/tests/jobs/CreateJobsTest.cpp
+++ b/test/tests/jobs/CreateJobsTest.cpp
@@ -1,3 +1,5 @@
+#include <libstuff/SData.h>
+#include <libstuff/SQResult.h>
 #include <test/lib/BedrockTester.h>
 
 struct CreateJobsTest : tpunit::TestFixture {

--- a/test/tests/jobs/DeleteJobTest.cpp
+++ b/test/tests/jobs/DeleteJobTest.cpp
@@ -1,3 +1,5 @@
+#include <libstuff/SData.h>
+#include <libstuff/SQResult.h>
 #include <test/lib/BedrockTester.h>
 
 struct DeleteJobTest : tpunit::TestFixture {

--- a/test/tests/jobs/FailJobTest.cpp
+++ b/test/tests/jobs/FailJobTest.cpp
@@ -1,3 +1,5 @@
+#include <libstuff/SData.h>
+#include <libstuff/SQResult.h>
 #include <test/lib/BedrockTester.h>
 #include <test/tests/jobs/JobTestHelper.h>
 

--- a/test/tests/jobs/FailedJobReplyTest.cpp
+++ b/test/tests/jobs/FailedJobReplyTest.cpp
@@ -1,3 +1,7 @@
+#include <iostream>
+#include <unistd.h>
+
+#include <libstuff/SData.h>
 #include <test/lib/BedrockTester.h>
 
 struct FailedJobReplyTest : tpunit::TestFixture {

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -1,3 +1,8 @@
+#include <iostream>
+#include <unistd.h>
+
+#include <libstuff/SData.h>
+#include <libstuff/SQResult.h>
 #include <test/lib/BedrockTester.h>
 
 bool isBetweenSecondsInclusive(uint64_t startTimestamp, uint64_t endTimestamp, string timestampString) {

--- a/test/tests/jobs/GetJobsTest.cpp
+++ b/test/tests/jobs/GetJobsTest.cpp
@@ -1,6 +1,10 @@
+#include <time.h>
+#include <unistd.h>
+
+#include <libstuff/SData.h>
+#include <libstuff/SQResult.h>
 #include <test/lib/BedrockTester.h>
 #include <test/tests/jobs/JobTestHelper.h>
-#include <time.h>
 
 // Get the difference in seconds between a and b
 uint64_t absoluteDiff(time_t a, time_t b) {

--- a/test/tests/jobs/QueryJobTest.cpp
+++ b/test/tests/jobs/QueryJobTest.cpp
@@ -1,3 +1,4 @@
+#include <libstuff/SData.h>
 #include <test/lib/BedrockTester.h>
 
 struct QueryJobTest : tpunit::TestFixture {

--- a/test/tests/jobs/RequeueJobsTest.cpp
+++ b/test/tests/jobs/RequeueJobsTest.cpp
@@ -1,3 +1,5 @@
+#include <libstuff/SData.h>
+#include <libstuff/SQResult.h>
 #include <test/lib/BedrockTester.h>
 #include <test/tests/jobs/JobTestHelper.h>
 

--- a/test/tests/jobs/RetryJobTest.cpp
+++ b/test/tests/jobs/RetryJobTest.cpp
@@ -1,3 +1,5 @@
+#include <libstuff/SData.h>
+#include <libstuff/SQResult.h>
 #include <test/lib/BedrockTester.h>
 #include <test/tests/jobs/JobTestHelper.h>
 

--- a/test/tests/jobs/UpdateJobTest.cpp
+++ b/test/tests/jobs/UpdateJobTest.cpp
@@ -1,3 +1,5 @@
+#include <libstuff/SData.h>
+#include <libstuff/SQResult.h>
 #include <test/lib/BedrockTester.h>
 #include <test/tests/jobs/JobTestHelper.h>
 


### PR DESCRIPTION
~HOLD for: 
https://github.com/Expensify/FuzzyBot/pull/104
https://github.com/Expensify/ExpensifyBackupManager/pull/32~

This moves as much stuff out of libstuff.h as possible and rearranges includes with the intention of improving compile times.

Fewer monolithic includes in less likely to require lots of recompilation when a single file changes, but also, since libstuff.h is needed by almost every file (it defines the log macros, for instance), having it be smaller can save a lot.

Here's timing info for this change compared to master. This explicitly excludes `mbedtls` from timing, as no change is expected there.

```
// Command to run:
make clean && ccache -C && cd mbedtls && make -j8 no_test && cd - && sleep 90 && time make -j8 bedrock

This branch timing:
real	0m51.652s
real	0m51.337s
real	0m52.467s
real	0m52.387s
real	0m53.005s

Average: 52.17s

Master timing:
real	1m3.616s
real	1m2.661s
real	1m3.174s
real	1m3.080s
real	1m3.817s

Average 63.27s
```

Improvement:
*17.5%*

In bedrock, where this saves barely 11 seconds, it may seem not worth the effort, but I'm hoping for similar speedups across auth, which could save several minutes. I'm sure this PR breaks auth though, so that change will need to be made and merged before this one can be.