### PR TITLE
Add #prama once where missing

### DIFF
--- a/BedrockTimeoutCommandQueue.h
+++ b/BedrockTimeoutCommandQueue.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <libstuff/libstuff.h>
 #include <BedrockCommand.h>
 

--- a/plugins/Cache.h
+++ b/plugins/Cache.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <libstuff/libstuff.h>
 #include "../BedrockPlugin.h"
 

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <libstuff/libstuff.h>
 #include "../BedrockPlugin.h"
 

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <test/lib/BedrockTester.h>
 
 enum class ClusterSize {

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <libstuff/libstuff.h>
 #include <BedrockPlugin.h>
 #include <BedrockServer.h>


### PR DESCRIPTION
I was updating the precompiled headers in auth and noticed that `BedrockTimeoutCommandQueue.h ` was missing a `#pragma once` at the top, so I added it there and also audited the rest of the header files in the repo and added it to a couple others.

### Tests:
Existing tests