### PR TITLE
Get rid of legacy state names

### DIFF
--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -43,21 +43,16 @@ const string& STCPNode::stateName(STCPNode::State state) {
 }
 
 STCPNode::State STCPNode::stateFromName(const string& name) {
-    string normalizedName = SToUpper(name);
-
-    // Accept both old and new state names, but map them all to the new states.
-    // We can delete the old names once the entire cluster is using the new names.
+    const string normalizedName = SToUpper(name);
     static map<string, State> lookup = {
         {"SEARCHING", SEARCHING},
         {"SYNCHRONIZING", SYNCHRONIZING},
         {"WAITING", WAITING},
         {"STANDINGUP", STANDINGUP},
         {"LEADING", LEADING},
-        {"MASTERING", LEADING},
         {"STANDINGDOWN", STANDINGDOWN},
         {"SUBSCRIBING", SUBSCRIBING},
         {"FOLLOWING", FOLLOWING},
-        {"SLAVING", FOLLOWING},
     };
     auto it = lookup.find(normalizedName);
     if (it == lookup.end()) {

--- a/test/clustertest/tests/LeadingTest.cpp
+++ b/test/clustertest/tests/LeadingTest.cpp
@@ -63,7 +63,7 @@ struct LeadingTest : tpunit::TestFixture {
             SData cmd("Status");
             string response = newMaster.executeWaitVerifyContent(cmd);
             STable json = SParseJSONObject(response);
-            if (json["state"] == "LEADING" || json["state"] == "MASTERING") {
+            if (json["state"] == "LEADING") {
                 success = true;
                 break;
             }
@@ -116,9 +116,9 @@ struct LeadingTest : tpunit::TestFixture {
             STable json1 = SParseJSONObject(responses[1]);
             STable json2 = SParseJSONObject(responses[2]);
 
-            if ((json0["state"] == "LEADING" || json0["state"] == "MASTERING") && 
-                (json1["state"] == "FOLLOWING" || json1["state"] == "SLAVING") && 
-                (json2["state"] == "FOLLOWING" || json2["state"] == "SLAVING")) {
+            if (json0["state"] == "LEADING" &&
+                json1["state"] == "FOLLOWING" &&
+                json2["state"] == "FOLLOWING") {
 
                 break;
             }
@@ -169,7 +169,7 @@ struct LeadingTest : tpunit::TestFixture {
                     continue;
                 }
             }
-            if(json["state"] == "FOLLOWING" || json["state"] == "SLAVING") {
+            if(json["state"] == "FOLLOWING") {
                 // Make sure it was following before it was synchronizing.
                 ASSERT_TRUE(wasSynchronizing);
                 wasFollowing = true;


### PR DESCRIPTION
Found this coming from somewhere else. I believe we can finish removing this now? This is what this PR does. 