### PR TITLE
Revert "Skip chekpoints with external DB reader"

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -258,16 +258,7 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
             SINFO("[checkpoint] Ready for complete checkpoint but skipping because less than 100 commits since last complete checkpoint.");
             return SQLITE_OK;
         }
-
-        int dbInUse = 0;
-        int useCheckResult = sqlite3_file_control(db, "main", SQLITE_FCNTL_EXTERNAL_READER, (void*)&dbInUse);
-        if (useCheckResult == SQLITE_OK && dbInUse) {
-            SINFO("Skipping complete checkpoint because external transaction in progress.");
-            return SQLITE_OK;
-        }
-
-        // If we get here, then full checkpoints are enabled, we have enough pages in the WAL file to perform one, and
-        // nothing else is stopping us from running one.
+        // If we get here, then full checkpoints are enabled, and we have enough pages in the WAL file to perform one.
         SINFO("[checkpoint] " << pageCount << " pages behind, beginning complete checkpoint.");
 
         // This thread will run independently. We capture the variables we need here and pass them by value.


### PR DESCRIPTION
Reverts Expensify/Bedrock#985

We're investigating this as a potential reason that rno webrock nodes have been seeing backups the last few days.