### PR TITLE
Revert "Make Bedrock Tests ASSERT/EXPECT failures print to cout with details"

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -187,7 +187,7 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
                             }
                         }
                     }
-
+                    
                     // Similar for excluding. If it has no name, or there's no exclude list, it's not excluded.
                     else if (f->_name && _exclude.size()) {
                         for (string excludedName : _exclude) {
@@ -335,19 +335,16 @@ bool tpunit::TestFixture::tpunit_detail_fp_equal(double lhs, double rhs, unsigne
 void tpunit::TestFixture::tpunit_detail_assert(TestFixture* f, const char* _file, int _line) {
     lock_guard<recursive_mutex> lock(*(f->_mutex));
     printf("   assertion #%i at %s:%i\n", ++f->_stats._assertions, _file, _line);
-    f->printTestBuffer();
 }
 
 void tpunit::TestFixture::tpunit_detail_exception(TestFixture* f, method* _method, const char* _message) {
     lock_guard<recursive_mutex> lock(*(f->_mutex));
     printf("   exception #%i from %s with cause: %s\n", ++f->_stats._exceptions, _method->_name, _message);
-    f->printTestBuffer();
 }
 
 void tpunit::TestFixture::tpunit_detail_trace(TestFixture* f, const char* _file, int _line, const char* _message) {
     lock_guard<recursive_mutex> lock(*(f->_mutex));
     printf("   trace #%i at %s:%i: %s\n", ++f->_stats._traces, _file, _line, _message);
-    f->printTestBuffer();
 }
 
 void tpunit::TestFixture::tpunit_detail_do_method(tpunit::TestFixture::method* m) {
@@ -382,7 +379,6 @@ void tpunit::TestFixture::tpunit_detail_do_tests(TestFixture* f) {
     while(t) {
        int _prev_assertions = f->_stats._assertions;
        int _prev_exceptions = f->_stats._exceptions;
-       f->testOutputBuffer = "";
        tpunit_detail_do_methods(f->_befores);
        tpunit_detail_do_method(t);
        tpunit_detail_do_methods(f->_afters);
@@ -392,27 +388,12 @@ void tpunit::TestFixture::tpunit_detail_do_tests(TestFixture* f) {
           tpunit_detail_stats()._passes++;
        } else {
           lock_guard<recursive_mutex> lock(m);
-
-          // Dump the test buffer if the test included any log lines.
-          f->printTestBuffer();
           printf("\xE2\x9D\x8C %s\n", t->_name);
           tpunit_detail_stats()._failures++;
           tpunit_detail_stats()._failureNames.emplace(t->_name);
        }
        t = t->_next;
     }
-}
-
-void tpunit::TestFixture::testLog(const string& newLog) {
-    lock_guard<recursive_mutex> lock(*(_mutex));
-
-    // Format the buffer with an indent as we print it out.
-    testOutputBuffer += "    " + newLog + "\n";
-}
-
-void tpunit::TestFixture::printTestBuffer() {
-    cout << testOutputBuffer;
-    testOutputBuffer = "";
 }
 
 tpunit::TestFixture::stats& tpunit::TestFixture::tpunit_detail_stats() {

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -75,22 +75,22 @@ using namespace std;
  * executing test function to continue if the supplied predicate
  * is not satisified.
  */
-#define ASSERT_TRUE(condition) if(condition) { PASS(); } else { testLog("assertion failed: " + SToStr(#condition) + " resolved to " + (condition ? "TRUE" : "FALSE")); ABORT(); }
-#define EXPECT_TRUE(condition) if(condition) { PASS(); } else { testLog("expect failed: " + SToStr(#condition) + " resolved to " + (condition ? "TRUE" : "FALSE")); FAIL(); }
-#define ASSERT_FALSE(condition) if(condition) { testLog("assertion failed: " + SToStr(#condition) + " resolved to " + (condition ? "TRUE" : "FALSE")); ABORT(); } else { PASS(); }
-#define EXPECT_FALSE(condition) if(condition) { testLog("expect failed: " + SToStr(#condition) + " resolved to " + (condition ? "TRUE" : "FALSE")); FAIL(); } else { PASS(); }
-#define ASSERT_EQUAL(lhs, rhs) if((lhs) == (rhs)) { PASS(); } else { testLog("incorrectly asserted " + SToStr(lhs) + " = " + SToStr(rhs)); ABORT(); }
-#define EXPECT_EQUAL(lhs, rhs) if((lhs) == (rhs)) { PASS(); } else { testLog("incorrectly expected " + SToStr(lhs) + " = " + SToStr(rhs)); FAIL(); }
-#define ASSERT_NOT_EQUAL(lhs, rhs) if((lhs) != (rhs)) { PASS(); } else { testLog("incorrectly asserted " + SToStr(lhs) + " != " + SToStr(rhs)); ABORT(); }
-#define EXPECT_NOT_EQUAL(lhs, rhs) if((lhs) != (rhs)) { PASS(); } else { testLog("incorrectly expected " + SToStr(lhs) + " != " + SToStr(rhs)); FAIL(); }
-#define ASSERT_GREATER_THAN(lhs, rhs) if((lhs) > (rhs)) { PASS(); } else { testLog("incorrectly asserted " + SToStr(lhs) + " > " + SToStr(rhs)); ABORT(); }
-#define EXPECT_GREATER_THAN(lhs, rhs) if((lhs) > (rhs)) { PASS(); } else { testLog("incorrectly expected " + SToStr(lhs) + " > " + SToStr(rhs)); FAIL(); }
-#define ASSERT_GREATER_THAN_EQUAL(lhs, rhs) if((lhs) >= (rhs)) { PASS(); } else { testLog("incorrectly asserted " + SToStr(lhs) + " >= " + SToStr(rhs)); ABORT(); }
-#define EXPECT_GREATER_THAN_EQUAL(lhs, rhs) if((lhs) >= (rhs)) { PASS(); } else { testLog("incorrectly expected " + SToStr(lhs) + " >= " + SToStr(rhs)); FAIL(); }
-#define ASSERT_LESS_THAN(lhs, rhs) if((lhs) < (rhs)) { PASS(); } else { testLog("incorrectly asserted " + SToStr(lhs) + " < " + SToStr(rhs)); ABORT(); }
-#define EXPECT_LESS_THAN(lhs, rhs) if((lhs) < (rhs)) { PASS(); } else { testLog("incorrectly expected " + SToStr(lhs) + " < " + SToStr(rhs)); FAIL(); }
-#define ASSERT_LESS_THAN_EQUAL(lhs, rhs) if((lhs) <= (rhs)) { PASS(); } else { testLog("incorrectly asserted " + SToStr(lhs) + " <= " + SToStr(rhs)); ABORT(); }
-#define EXPECT_LESS_THAN_EQUAL(lhs, rhs) if((lhs) <= (rhs)) { PASS(); } else { testLog("incorrectly expected " + SToStr(lhs) + " <= " + SToStr(rhs)); FAIL(); }
+#define ASSERT_TRUE(condition) if(condition) { PASS(); } else { ABORT(); }
+#define EXPECT_TRUE(condition) if(condition) { PASS(); } else { FAIL(); }
+#define ASSERT_FALSE(condition) if(condition) { ABORT(); } else { PASS(); }
+#define EXPECT_FALSE(condition) if(condition) { FAIL(); } else { PASS(); }
+#define ASSERT_EQUAL(lhs, rhs) if((lhs) == (rhs)) { PASS(); } else { ABORT(); }
+#define EXPECT_EQUAL(lhs, rhs) if((lhs) == (rhs)) { PASS(); } else { FAIL(); }
+#define ASSERT_NOT_EQUAL(lhs, rhs) if((lhs) != (rhs)) { PASS(); } else { ABORT(); }
+#define EXPECT_NOT_EQUAL(lhs, rhs) if((lhs) != (rhs)) { PASS(); } else { FAIL(); }
+#define ASSERT_GREATER_THAN(lhs, rhs) if((lhs) > (rhs)) { PASS(); } else { ABORT(); }
+#define EXPECT_GREATER_THAN(lhs, rhs) if((lhs) > (rhs)) { PASS(); } else { FAIL(); }
+#define ASSERT_GREATER_THAN_EQUAL(lhs, rhs) if((lhs) >= (rhs)) { PASS(); } else { ABORT(); }
+#define EXPECT_GREATER_THAN_EQUAL(lhs, rhs) if((lhs) >= (rhs)) { PASS(); } else { FAIL(); }
+#define ASSERT_LESS_THAN(lhs, rhs) if((lhs) < (rhs)) { PASS(); } else { ABORT(); }
+#define EXPECT_LESS_THAN(lhs, rhs) if((lhs) < (rhs)) { PASS(); } else { FAIL(); }
+#define ASSERT_LESS_THAN_EQUAL(lhs, rhs) if((lhs) <= (rhs)) { PASS(); } else { ABORT(); }
+#define EXPECT_LESS_THAN_EQUAL(lhs, rhs) if((lhs) <= (rhs)) { PASS(); } else { FAIL(); }
 
 /**
  * The set of floating-point macros used to compare double/float values.
@@ -100,10 +100,10 @@ using namespace std;
  * ASSERT|EXPECT_FLOAT_NEAR(lhs, rhs, abs_error); generates a failure if
  * the given floating-point values exceed the absolute error.
  */
-#define ASSERT_FLOAT_EQUAL(lhs, rhs) if(tpunit_detail_fp_equal(lhs, rhs, 4)) { PASS(); } else { "incorrectly asserted " + SToStr(lhs) + " = " + SToStr(rhs); ABORT(); }
-#define EXPECT_FLOAT_EQUAL(lhs, rhs) if(tpunit_detail_fp_equal(lhs, rhs, 4)) { PASS(); } else { "incorrectly expected " + SToStr(lhs) + " = " + SToStr(rhs); FAIL(); }
-#define ASSERT_FLOAT_NEAR(lhs, rhs, abs_error) if((((lhs) > (rhs)) ? (lhs) - (rhs) : (rhs) - (lhs)) <= (abs_error)) { PASS(); } else { "incorrectly asserted " + SToStr(lhs) + " near " + SToStr(rhs); ABORT(); }
-#define EXPECT_FLOAT_NEAR(lhs, rhs, abs_error) if((((lhs) > (rhs)) ? (lhs) - (rhs) : (rhs) - (lhs)) <= (abs_error)) { PASS(); } else { "incorrectly expected " + SToStr(lhs) + " near " + SToStr(rhs); FAIL(); }
+#define ASSERT_FLOAT_EQUAL(lhs, rhs) if(tpunit_detail_fp_equal(lhs, rhs, 4)) { PASS(); } else { ABORT(); }
+#define EXPECT_FLOAT_EQUAL(lhs, rhs) if(tpunit_detail_fp_equal(lhs, rhs, 4)) { PASS(); } else { FAIL(); }
+#define ASSERT_FLOAT_NEAR(lhs, rhs, abs_error) if((((lhs) > (rhs)) ? (lhs) - (rhs) : (rhs) - (lhs)) <= (abs_error)) { PASS(); } else { ABORT(); }
+#define EXPECT_FLOAT_NEAR(lhs, rhs, abs_error) if((((lhs) > (rhs)) ? (lhs) - (rhs) : (rhs) - (lhs)) <= (abs_error)) { PASS(); } else { FAIL(); }
 
 /**
  * The set of macros for checking whether a statement will throw or not
@@ -213,8 +213,6 @@ namespace tpunit {
          int _threadID;
 
       protected:
-         // Test buffer for printing to stdout if a test were to fail.
-         string testOutputBuffer;
 
          /**
           * Internal class encapsulating a registered test method.
@@ -307,19 +305,13 @@ namespace tpunit {
                                          const std::list<std::string>& before, const std::list<std::string>& after, int threads,
                                          std::function<void()> threadInitFunction);
 
-         /**
-          * This method writes to a temporary buffer and formats the message nicely for debugging
-          * purposes if a test were to fail.
-          */
-         void testLog(const string& newLog);
-
       protected:
 
          /**
           * Determine if two binary32 single precision IEEE 754 floating-point
           * numbers are equal using unit in the last place (ULP) analysis.
           *
-          * http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
+          * http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm 
           */
          static bool tpunit_detail_fp_equal(float lhs, float rhs, unsigned char ulps);
 
@@ -327,7 +319,7 @@ namespace tpunit {
           * Determine if two binary64 double precision IEEE 754 floating-point
           * numbers are equal using unit in the last place (ULP) analysis.
           *
-          * http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
+          * http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm 
           */
          static bool tpunit_detail_fp_equal(double lhs, double rhs, unsigned char ulps);
 
@@ -349,12 +341,7 @@ namespace tpunit {
 
          static stats& tpunit_detail_stats();
 
-         static std::list<TestFixture*>* tpunit_detail_fixture_list();
-
-         /**
-          * Takes the test buffer and outputs it to cout
-          */
-         void printTestBuffer();
+          static std::list<TestFixture*>* tpunit_detail_fixture_list();
 
          method* _afters;
          method* _after_classes;


### PR DESCRIPTION
Reverts Expensify/Bedrock#998

This didn't get tested against auth, auth doesn't compile with this change.