### PR TITLE
Add option to have tests run bedrock in valgrind

### DIFF
--- a/libstuff/SRandom.cpp
+++ b/libstuff/SRandom.cpp
@@ -1,6 +1,12 @@
 #include <libstuff/libstuff.h>
 
+#ifdef VALGRIND
+// random_device breaks valgrind.
+mt19937_64 SRandom::_generator = mt19937_64();
+#else
 mt19937_64 SRandom::_generator = mt19937_64(random_device()());
+#endif
+
 uniform_int_distribution<uint64_t> SRandom::_distribution64 = uniform_int_distribution<uint64_t>();
 
 uint64_t SRandom::limitedRand64(uint64_t minNum, uint64_t maxNum) {

--- a/libstuff/SSignal.cpp
+++ b/libstuff/SSignal.cpp
@@ -80,7 +80,7 @@ void SInitializeSignals() {
     sigprocmask(SIG_BLOCK, &signals, 0);
 
     // This is the signal action structure we'll use to specify what to listen for.
-    struct sigaction newAction;
+    struct sigaction newAction = {0};
 
     // The old style handler is explicitly null
     newAction.sa_handler = nullptr;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -136,16 +136,7 @@ string BedrockTester::startServer(bool wait) {
             }
         }
 
-        // Convert our c++ strings to old-school C strings for exec.
-        char* cargs[args.size() + 1];
-        int count = 0;
-        for(string arg : args) {
-            char* newstr = (char*)malloc(arg.size() + 1);
-            strcpy(newstr, arg.c_str());
-            cargs[count] = newstr;
-            count++;
-        }
-        cargs[count] = 0;
+
 
         // Make sure the ports we need are free.
         int portsFree = 0;
@@ -157,6 +148,35 @@ string BedrockTester::startServer(bool wait) {
             cout << "At least one port wasn't free (of: " << _serverPort << ", " << _nodePort << ", "
                  << _controlPort << ") to start server, things will probably fail." << endl;
         }
+
+#ifdef VALGRIND
+    #define xstr(a) str(a)
+    #define str(a) #a
+
+    list<string> valgrind = SParseList(xstr(VALGRIND), ' ');
+    if (valgrind.size()) {
+        serverName = valgrind.front();
+        cout << "Starting bedrock server in '" << serverName << "' with args: " << endl;
+        auto it = valgrind.rbegin();
+        while (it != valgrind.rend()) {
+            args.push_front(*it);
+            it++;
+        }
+        cout << SComposeList(args, " ") << endl;
+        cout << "==========================" << endl;
+    }
+#endif
+
+        // Convert our c++ strings to old-school C strings for exec.
+        char* cargs[args.size() + 1];
+        int count = 0;
+        for(string arg : args) {
+            char* newstr = (char*)malloc(arg.size() + 1);
+            strcpy(newstr, arg.c_str());
+            cargs[count] = newstr;
+            count++;
+        }
+        cargs[count] = 0;
 
         // And then start the new server!
         execvp(serverName.c_str(), cargs);


### PR DESCRIPTION
Want to analyze things like memory leaks or accesses to freed memory? Valgrind is a great tool for that. But the way our tests work don't give you easy access to start bedrock in a container app like valgrind (or gdb, for that matter). You can easily start the tests themselves in valgrind, but they will spin up a bedrock server not running in valgrind.

This change makes it possible to have your tests run bedrock in valgrind.

You need to set a macro at compile time to enable valgrind debugging, because `random_device` doesn't work with valgrind, and so we turn that off.

To set the macro in your VM, run something like:
```
export BEDROCK_OPTIM_COMPILE_FLAG="-O0 -DVALGRIND=\"valgrind --leak-check=full --show-leak-kinds=all\""
```

You can add as many valgrind options there as you like, they will be passed to valgrind when it's invoked. You will need to rebuild bedrock after making this change (you can `make clean`, or you can just `touch libstuff/SRandom.cpp && touch test/lib/BedrockTester.cpp` to only rebuild the relevant files).

Also, you need to install valgrind in your VM:
```
sudo apt-get install valgrind
```

Once you've built your new binary, run your tests, you should see stuff like this in the output:
```
==17620== 304 bytes in 1 blocks are possibly lost in loss record 5 of 6
==17620==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17620==    by 0x40138E4: allocate_dtv (dl-tls.c:322)
==17620==    by 0x40138E4: _dl_allocate_tls (dl-tls.c:539)
==17620==    by 0x525026E: allocate_stack (allocatestack.c:588)
==17620==    by 0x525026E: pthread_create@@GLIBC_2.2.5 (pthread_create.c:539)
==17620==    by 0x574FDC4: std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==17620==    by 0x6A96B6: std::thread::thread<void (&)(), , void>(void (&)()) (thread:130)
==17620==    by 0x6A6CA0: SInitializeSignals() (SSignal.cpp:106)
==17620==    by 0x6D62F3: SInitialize(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, char const*) (libstuff.cpp:107)
==17620==    by 0x53346E: main (main.cpp:199)
```

And:
```
==17620== LEAK SUMMARY:
==17620==    definitely lost: 0 bytes in 0 blocks
==17620==    indirectly lost: 0 bytes in 0 blocks
==17620==      possibly lost: 304 bytes in 1 blocks
==17620==    still reachable: 72,816 bytes in 5 blocks
==17620==         suppressed: 0 bytes in 0 blocks
```

I also fixed the two most obvious errors reported by Valgrind in the pr (an uninitialized struct, and a `new` without a corresponding `delete`).