### PR TITLE
Fix noisy issues when running valgrind

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -222,6 +222,7 @@ SStandaloneHTTPSManager::Transaction* SStandaloneHTTPSManager::_httpsSend(const 
     Socket* s = openSocket(host, x509);
     if (!s) {
         delete transaction;
+        delete x509;
         return _createErrorTransaction();
     }
 

--- a/libstuff/SSignal.cpp
+++ b/libstuff/SSignal.cpp
@@ -16,6 +16,9 @@ void _SSignal_StackTrace(int signum, siginfo_t *info, void *ucontext);
 // A boolean indicating whether or not we've initialized our signal thread.
 atomic_flag _SSignal_threadInitialized = ATOMIC_FLAG_INIT;
 
+// Set to true to stop the signal thread.
+atomic<bool> _SSignal_threadStopFlag(false);
+
 // The signals we've received since the last time this was cleared.
 atomic<uint64_t> _SSignal_pendingSignalBitMask(0);
 
@@ -104,7 +107,6 @@ void SInitializeSignals() {
     bool threadAlreadyStarted = _SSignal_threadInitialized.test_and_set();
     if (!threadAlreadyStarted) {
         _SSignal_signalThread = thread(_SSignal_signalHandlerThreadFunc);
-        _SSignal_signalThread.detach();
     }
 }
 
@@ -119,10 +121,24 @@ void _SSignal_signalHandlerThreadFunc() {
 
     // Now we wait for any signal to occur.
     while (true) {
+
         // Wait for a signal to appear.
-        int signum = 0;
-        int result = sigwait(&signals, &signum);
-        if (!result) {
+        siginfo_t siginfo = {0};
+        struct timespec timeout;
+        timeout.tv_sec = 1;
+        timeout.tv_nsec = 0;
+        int result = -1;
+        while (result == -1) {
+            result = sigtimedwait(&signals, &siginfo, &timeout);
+            if (_SSignal_threadStopFlag) {
+                // Done.
+                SINFO("Stopping signal handler thread.");
+                return;
+            }
+        }
+        int signum = siginfo.si_signo;
+
+        if (result > 0) {
             // Do the same handling for these functions here as any other thread.
             if (signum == SIGSEGV || signum == SIGABRT || signum == SIGFPE || signum == SIGILL || signum == SIGBUS) {
                 _SSignal_StackTrace(signum, nullptr, nullptr);
@@ -132,6 +148,16 @@ void _SSignal_signalHandlerThreadFunc() {
                 _SSignal_pendingSignalBitMask.fetch_or(1 << signum);
             }
         }
+    }
+}
+
+void SStopSignalThread() {
+    _SSignal_threadStopFlag = true;
+    if (_SSignal_threadInitialized.test_and_set()) {
+        // Send ourselves a singnal to interrupt our thread.
+        SINFO("Joining signal thread.");
+        _SSignal_signalThread.join();
+        _SSignal_threadInitialized.clear();
     }
 }
 

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -250,6 +250,8 @@ string SGetSignalDescription();
 // Clear all outstanding signals.
 void SClearSignals();
 
+void SStopSignalThread();
+
 // And also exception stuff.
 string SGetCurrentExceptionName();
 void STerminateHandler(void);

--- a/main.cpp
+++ b/main.cpp
@@ -194,11 +194,6 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    // Start libstuff. Generally, we want to initialize libstuff immediately on any new thread, but we wait until after
-    // the `fork` above has completed, as we can get strange behaviors from signal handlers across forked processes.
-    SInitialize("main", (args.isSet("-overrideProcessName") ? args["-overrideProcessName"].c_str() : 0));
-    SLogLevel(LOG_INFO);
-
     if (args.isSet("-version")) {
         // Just output the version
         cout << VERSION << endl;
@@ -274,6 +269,12 @@ int main(int argc, char* argv[]) {
         cout << endl;
         return 1;
     }
+
+    // Start libstuff. Generally, we want to initialize libstuff immediately on any new thread, but we wait until after
+    // the `fork` above has completed, as we can get strange behaviors from signal handlers across forked processes.
+    SInitialize("main", (args.isSet("-overrideProcessName") ? args["-overrideProcessName"].c_str() : 0));
+    SLogLevel(LOG_INFO);
+
     if (args.isSet("-v")) {
         // Verbose logging
         SINFO("Enabling verbose logging");
@@ -391,6 +392,9 @@ int main(int argc, char* argv[]) {
     SINFO("Deleting BedrockServer");
     delete _server;
     SINFO("BedrockServer deleted");
+
+    // Finished with our signal handler.
+    SStopSignalThread();
 
     // All done
     SINFO("Graceful process shutdown complete");

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -63,6 +63,7 @@ const string SQLiteNode::consistencyLevelNames[] = {"ASYNC",
 atomic<int64_t> SQLiteNode::_currentCommandThreadID(0);
 
 const vector<STCPNode::Peer*> SQLiteNode::initPeers(const string& peerListString) {
+    _state = UNKNOWN;
     vector<Peer*> peerList;
     list<string> parsedPeerList = SParseList(peerListString);
     for (const string& peerString : parsedPeerList) {
@@ -93,6 +94,7 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, SQLitePool& dbPool, const string& n
     : STCPNode(name, host, initPeers(peerList), max(SQL_NODE_DEFAULT_RECV_TIMEOUT, SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT)),
       _dbPool(dbPool),
       _db(_dbPool.getBase()),
+      _state(UNKNOWN),
       _commitState(CommitState::UNINITIALIZED),
       _server(server),
       _stateChangeCount(0),


### PR DESCRIPTION
I was running another change in valgrind and found some noisy but minor errors, but figured I'd fix them.

1. libstuff/SHTTPSManager.cpp : fix a leak if we fail to successfully open a ssl socket.
2. sqlitecluster/SQLiteNode.cpp : fix an uninitialized variable.
3. Everything else : explicitly close the signal thread at shutdown, rather than just letting it get cleaned up by the OS.

Existing tests (including auth).