### PR TITLE
Explicitly use 10 digit git hash length

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 
 # Pull some variables from the git repo itself. Note that this means this build does not work if Bedrock isn't
 # contained in a git repo.
-GIT_REVISION = -DGIT_REVISION=$(shell git rev-parse --short HEAD)
+GIT_REVISION = -DGIT_REVISION=$(shell git rev-parse HEAD | grep -o '^.\{10\}')
 PROJECT = $(shell git rev-parse --show-toplevel)
 
 # Set our include paths. We need this for the pre-processor to use to generate dependencies.


### PR DESCRIPTION
### Fixed Issues
TLDR: 20.04's git rev-parse --short HEAD behaves differently than 16.04's.

### Tests
See https://github.com/Expensify/Auth/pull/5551
