### PR TITLE
Updates query parsing in peek to make it robust

### DIFF
--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -64,30 +64,19 @@ bool BedrockDBCommand::peek(SQLite& db) {
         STHROW("502 Query aborted");
     }
 
-    if (SStartsWith(upperQuery, "SELECT ")) {
-        // Seems to be read-only
-        SINFO("Query appears to be read-only, peeking.");
-    } else {
-        if (shouldRequireWhere &&
-           (SStartsWith(upperQuery, "UPDATE") || SStartsWith(upperQuery, "DELETE")) &&
-           !SContains(upperQuery, " WHERE ")) {
-            SALERT("Query aborted, it has no 'where' clause: '" << query << "'");
-            STHROW("502 Query aborted");
-        }
-
-        // Assume it's read/write
-        SINFO("Query appears to be read/write, queuing for processing.");
-        return false;
-    }
-
     // Attempt the read-only query
     SQResult result;
     int preChangeCount = db.getChangeCount();
     if (!db.read(query, result)) {
-        // Query failed
-        SALERT("Query failed: '" << query << "'");
-        response["error"] = db.getLastError();
-        STHROW("502 Query failed");
+        if (shouldRequireWhere && !SContains(upperQuery, " WHERE ")) {
+            SALERT("Query aborted, it has no 'where' clause: '" << query << "'");
+            STHROW("502 Query aborted");
+        }
+
+        // Assume it's write or bad query, escalating it to process
+        // If it's a bad query, it will fail in the process too
+        SINFO("Query appears to be read/write, queuing for processing.");
+        return false;
     }
 
     // Verify it didn't change anything -- assert because if we did, we did so

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -68,7 +68,9 @@ bool BedrockDBCommand::peek(SQLite& db) {
     SQResult result;
     int preChangeCount = db.getChangeCount();
     if (!db.read(query, result)) {
-        if (shouldRequireWhere && !SContains(upperQuery, " WHERE ")) {
+        if (shouldRequireWhere &&
+            (SContains(upperQuery, "UPDATE ") || SContains(upperQuery, "DELETE ")) &&
+            !SContains(upperQuery, " WHERE ")) {
             SALERT("Query aborted, it has no 'where' clause: '" << query << "'");
             STHROW("502 Query aborted");
         }


### PR DESCRIPTION
### Details

Updates query parsing in `peek` function to execute a query using `db.read()`. If it fails, it escalates it to `process`. If it's a bad query, it will fail in `process` too. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/161171

### Tests

- All Bedrock `Write` tests
- Identifies this query as a read and executes it in `peek`, which was escalated to `process` before

```
query: PRAGMA cache_size = 0; select 'caca';
format: json

200 OK
commitCount: 1874
nodeName: bedrock
peekTime: 3156
totalTime: 4363
unaccountedTime: 1007
Content-Length: 40

{"headers":["'caca'"],"rows":[["caca"]]}
``` 
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes

cc @flodnv 