### PR TITLE
Fixes PHP Integration Tests caused by UPDATE query parsing

### DIFF
--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -69,7 +69,7 @@ bool BedrockDBCommand::peek(SQLite& db) {
     int preChangeCount = db.getChangeCount();
     if (!db.read(query, result)) {
         if (shouldRequireWhere &&
-            (SContains(upperQuery, "UPDATE ") || SContains(upperQuery, "DELETE ")) &&
+            (SStartsWith(upperQuery, "UPDATE") || SStartsWith(upperQuery, "DELETE")) &&
             !SContains(upperQuery, " WHERE ")) {
             SALERT("Query aborted, it has no 'where' clause: '" << query << "'");
             STHROW("502 Query aborted");


### PR DESCRIPTION
### Details
Context here - https://expensify.slack.com/archives/C03TQ48KC/p1621953197258100
### Fixed Issues
PHP Integration tests were failing because of the query like `INSERT INTO foo(a, b) VALUES('I update a', 'query')` was aborted as it was identified as `UPDATE` query without `WHERE` clause.

So, instead of using `SContains()` used `SStartWith()`
### Tests
- All Write Tests
- PHP Integration EgenciaFeedTest
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
