### PR TITLE
Update PID file to /run instead of /var/run

### DIFF
--- a/configs/bedrock.service
+++ b/configs/bedrock.service
@@ -9,13 +9,13 @@ Requires=bedrock_prerequisites.service
 
 [Service]
 EnvironmentFile=/etc/bedrock/bedrock.conf
-PIDFile=/var/run/bedrock.pid
+PIDFile=/run/bedrock.pid
 
 Type=forking
 
 ExecStart=/usr/sbin/bedrock \
         -fork \
-        -pidFile /var/run/bedrock.pid \
+        -pidFile /run/bedrock.pid \
         -nodeName ${THISNODE} \
         -db ${BEDROCK_DB_PATH} \
         -serverHost ${SERVER_HOST} \


### PR DESCRIPTION
### Details

`/var/run/` has been deprecated in favor of `/run/`. systemd currently warns around this, and updates the unit on-the-fly:

```
/etc/systemd/system/bedrock.service:17: PIDFile= references a path below legacy directory /var/run/, updating /var/run/bedrock.pid → /run/bedrock.pid; please update the unit file accordingly.
```

`/var/run/` is a symlink to `/run/` anyway, so everything works, but the warnings are annoying.

```
phs@virt1.lax ~  $ ls /var/run -l
lrwxrwxrwx 1 root root 4 Sep 14  2018 /var/run -> /run
phs@virt1.lax ~  $
```

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
