### PR TITLE
Added test case where SQL keywords are passed as values

### DIFF
--- a/test/tests/WriteTest.cpp
+++ b/test/tests/WriteTest.cpp
@@ -184,10 +184,11 @@ struct WriteTest : tpunit::TestFixture {
         SData query2("query: INSERT INTO stuff VALUES ( NULL, 12, 'Do not delete the test' );");
         tester->executeWaitVerifyContent(query2);
 
-        // Monil B - 05/26/21
-        // Uncomment this test once https://github.com/Expensify/Expensify/issues/165207 is solved
-        // SData query3("query: UPDATE stuff SET info = 'This is not a where clause';");
-        // tester->executeWaitVerifyContent(query3, "502 Query aborted");
+        // This is a false test case, This query should't get executed. This is currently a limitation of our parsing
+        // As "nowhere" parameter is not provided, this query should get aborted and prevent all rows from updating
+        // Change the expected result to "502 Query aborted" once https://github.com/Expensify/Expensify/issues/165207 is solved
+        SData query3("query: UPDATE stuff SET info = 'This is not a where clause';");
+        tester->executeWaitVerifyContent(query3);
     }
 
 } __WriteTest;

--- a/test/tests/WriteTest.cpp
+++ b/test/tests/WriteTest.cpp
@@ -184,7 +184,7 @@ struct WriteTest : tpunit::TestFixture {
         SData query2("query: INSERT INTO stuff VALUES ( NULL, 12, 'Do not delete the test' );");
         tester->executeWaitVerifyContent(query2);
 
-        // This is a false test case, This query should't get executed. This is currently a limitation of our parsing
+        // This is a false test case, This query shouldn't get executed. This is currently a limitation of our parsing
         // As "nowhere" parameter is not provided, this query should get aborted and prevent all rows from updating
         // Change the expected result to "502 Query aborted" once https://github.com/Expensify/Expensify/issues/165207 is solved
         SData query3("query: UPDATE stuff SET info = 'This is not a where clause';");


### PR DESCRIPTION
### Details
Added a couple of tricky test cases which can bypass the query parser 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/165143

### Tests
All `Write` Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
