### PR TITLE
Exempt 'read-only' error from warning

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2583,7 +2583,14 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
     // Only OK and commit conflicts are allowed without warning.
     if (error != SQLITE_OK && extErr != SQLITE_BUSY_SNAPSHOT) {
         if (!skipWarn) {
-            SWARN("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
+            if (error == SQLITE_READONLY) {
+                // We make this exception because the `DB` plugin specifically tests query for read/write by attempting
+                // them in `peek`. They should fail in `peek` and get escalated to `process` and we don't need a
+                // million warnings for that.
+                SINFO("Attempted to write to a read-only DB, should escalate to `process`.");
+            } else {
+                SWARN("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
+            }
         }
     }
 


### PR DESCRIPTION
### Details
The fix introduced here: https://github.com/Expensify/Bedrock/pull/1027 ended up being really noisy because of how much of Concierge is implemented with the `Query` command.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/161171

### Tests
Run the normal tests while tailing logs, watch for lines like:
```
2021-06-02T17:26:29.722318+00:00 expensidev bedrock: QZJcTw (libstuff.cpp:2586) SQuery [worker5] [warn] 'read only query', query failed with error #8 (attempt to write a readonly database): DELETE FROM jobs WHERE jobID > 0;
```

These should exist without this change, but not after this change.