### PR TITLE
Stop using heuristics to detect writes

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2583,14 +2583,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
     // Only OK and commit conflicts are allowed without warning.
     if (error != SQLITE_OK && extErr != SQLITE_BUSY_SNAPSHOT) {
         if (!skipWarn) {
-            if (error == SQLITE_READONLY) {
-                // We make this exception because the `DB` plugin specifically tests query for read/write by attempting
-                // them in `peek`. They should fail in `peek` and get escalated to `process` and we don't need a
-                // million warnings for that.
-                SINFO("Attempted to write to a read-only DB, should escalate to `process`.");
-            } else {
-                SWARN("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
-            }
+            SWARN("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
         }
     }
 

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -46,7 +46,7 @@ bool BedrockDBCommand::peek(SQLite& db) {
 
     if (!SEndsWith(query, ";")) {
         SALERT("Query aborted, query must end in ';'");
-        STHROW("502 Query aborted");
+        STHROW("502 Query Missing Semicolon");
     }
 
     // Get a list of prepared statements from the database.

--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -28,7 +28,7 @@ BedrockDBCommand::BedrockDBCommand(SQLiteCommand&& baseCommand, BedrockPlugin_DB
     // in the method line as follows:
     //
     //      Query: ...sql...
-  query(SStartsWith(SToLower(request.methodLine), "query:") ? request.methodLine.substr(strlen("query:")) : request["query"])
+  query(STrim(SStartsWith(SToLower(request.methodLine), "query:") ? request.methodLine.substr(strlen("query:")) : request["query"]))
 {
 }
 
@@ -43,64 +43,60 @@ bool BedrockDBCommand::peek(SQLite& db) {
     if (query.size() < 1 || query.size() > BedrockPlugin::MAX_SIZE_QUERY) {
         STHROW("402 Missing query");
     }
-    BedrockPlugin::verifyAttributeBool(request, "nowhere",  false);
 
-    // See if it's read-only (and thus safely peekable) or read-write
-    // (and thus requires processing).
-    //
-    // **NOTE: This isn't intended to be foolproof, and attempts to err on the
-    //         side of caution (eg, assuming read-write unless clearly read-
-    //         only).  A not-so-clever client could easily bypass this.  But
-    //         that same person could also easily wreck havoc in a bunch of
-    //         other ways, too.  That said, the worst-case scenario is that a
-    //         read-write command is mis-classified as read-only and executed in
-    //         the peek, but even then we'll detect it after the fact and shut
-    //         the node down.
-    const string& upperQuery = SToUpper(STrim(query));
-    bool shouldRequireWhere = !request.test("nowhere");
-
-    if (!SEndsWith(upperQuery, ";")) {
+    if (!SEndsWith(query, ";")) {
         SALERT("Query aborted, query must end in ';'");
         STHROW("502 Query aborted");
     }
 
-    // Attempt the read-only query
-    SQResult result;
-    int preChangeCount = db.getChangeCount();
-    if (!db.read(query, result)) {
-        if (shouldRequireWhere &&
-            (SStartsWith(upperQuery, "UPDATE") || SStartsWith(upperQuery, "DELETE")) &&
-            !SContains(upperQuery, " WHERE ")) {
-            SALERT("Query aborted, it has no 'where' clause: '" << query << "'");
-            STHROW("502 Query aborted");
-        }
+    // Get a list of prepared statements from the database.
+    list<sqlite3_stmt*> statements;
+    int prepareResult = db.getPreparedStatements(query, statements);
 
-        // Assume it's write or bad query, escalating it to process
-        // If it's a bad query, it will fail in the process too
-        SINFO("Query appears to be read/write, queuing for processing.");
+    // Check each one to see if it's a write, and then release it.
+    bool write = false;
+    for (sqlite3_stmt* statement : statements) {
+        if (!sqlite3_stmt_readonly(statement)) {
+            write = true;
+        }
+        sqlite3_finalize(statement);
+    }
+
+    // If we got any errors while preparing, we're calling this a bad command.
+    if (prepareResult != SQLITE_OK) {
+        STHROW("402 Bad query");
+    }
+
+    // If anything was a write, escalate to `process`.
+    if (write) {
         return false;
     }
 
-    // Verify it didn't change anything -- assert because if we did, we did so
-    // outside of a replicated transaction and that's REALLY bad.
-    if (preChangeCount != db.getChangeCount()) {
-        // This database is fucked -- we made a change outside of a transaction
-        // so we can't roll back, and outside of a *distributed* transaction so
-        // now it's out of sync with the rest of the cluster.  This database
-        // needs to be destroyed and recovered from a peer.
-        SERROR("Read query actually managed to write; database is corrupt "
-               << "and must be recovered from backup or peer.  Offending query: '" << query << "'");
+    // Attempt the read-only query
+    SQResult result;
+    if (!db.read(query, result)) {
+        STHROW("402 Bad query");
     }
 
-    // Worked!  What format do we want the output?
+    // Worked! Set the output and return.
     response.content = result.serialize(request["Format"]);
-    return true; // Successfully peeked
+
+    return true;
 }
 
 void BedrockDBCommand::process(SQLite& db) {
     if (db.getUpdateNoopMode()) {
         SINFO("Query run in mocked request, just ignoring.");
         return;
+    }
+    BedrockPlugin::verifyAttributeBool(request, "nowhere",  false);
+
+    const string upperQuery = SToUpper(query);
+    if (!request.test("nowhere") &&
+        (SStartsWith(upperQuery, "UPDATE") || SStartsWith(upperQuery, "DELETE")) &&
+        !SContains(upperQuery, " WHERE ")) {
+        SALERT("Query aborted, it has no 'where' clause: '" << query << "'");
+        STHROW("502 Query aborted");
     }
 
     // Attempt the query
@@ -111,8 +107,7 @@ void BedrockDBCommand::process(SQLite& db) {
         STHROW("502 Query failed");
     }
 
-    // Worked!  Let's save the last inserted row id
-    const string& upperQuery = SToUpper(STrim(query));
+    // Worked! Let's save the last inserted row id
     if (SStartsWith(upperQuery, "INSERT ")) {
         response["lastInsertRowID"] = SToStr(db.getLastInsertRowID());
     }

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -265,6 +265,14 @@ class SQLite {
     // no commits can happen "late" from slow threads that could otherwise write to a DB being shutdown.
     void setCommitEnabled(bool enable);
 
+    // This gets a set of sqlite3 prepared statements from a query string, to allow for the methods here to be called
+    // without actually running a query:
+    // https://www.sqlite.org/c3ref/stmt.html
+    //
+    // For instance, you can determine if a query is read-only with this information. This returns a list as it's
+    // possible that a string contains multiple queries separated by semicolons.
+    // Note: It's up to the caller to free these prepared statements by calling `sqlite3_finalize()` on them.
+    // This returns an sqlite error code. It will stop parsing multiple statements after the first error.
     int getPreparedStatements(const string& query, list<sqlite3_stmt*>& statements);
 
   private:

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -265,6 +265,8 @@ class SQLite {
     // no commits can happen "late" from slow threads that could otherwise write to a DB being shutdown.
     void setCommitEnabled(bool enable);
 
+    int getPreparedStatements(const string& query, list<sqlite3_stmt*>& statements);
+
   private:
     // This structure contains all of the data that's shared between a set of SQLite objects that share the same
     // underlying database file.

--- a/test/tests/QueryTest.cpp
+++ b/test/tests/QueryTest.cpp
@@ -1,0 +1,89 @@
+#include <libstuff/SData.h>
+#include <test/lib/BedrockTester.h>
+
+struct QueryTest : tpunit::TestFixture {
+    QueryTest()
+        : tpunit::TestFixture("Query",
+                              BEFORE_CLASS(QueryTest::setup),
+                              TEST(QueryTest::testMissing),
+                              TEST(QueryTest::testNoSemicolon),
+                              TEST(QueryTest::testBad),
+                              TEST(QueryTest::testOK),
+                              TEST(QueryTest::testWrite),
+                              TEST(QueryTest::testWriteInSecondStatement),
+                              TEST(QueryTest::testNoWhere),
+                              AFTER_CLASS(QueryTest::tearDown)) { }
+
+    BedrockTester* tester;
+
+    void setup() {
+        tester = new BedrockTester({}, {
+            "CREATE TABLE queryTest (key INTEGER, value TEXT);",
+        });
+    }
+
+    void tearDown() {
+        delete tester;
+    }
+
+    void testMissing() {
+        SData query("Query");
+        query["Format"] = "json";
+        query["query"] = "";
+        tester->executeWaitVerifyContent(query, "402 Missing query");
+    }
+
+    void testNoSemicolon() {
+        SData query("Query");
+        query["Format"] = "json";
+        query["query"] = "SELECT MAX(key) FROM queryTest";
+        tester->executeWaitVerifyContent(query, "502 Query Missing Semicolon");
+    }
+
+    void testBad() {
+        SData query("Query");
+        query["Format"] = "json";
+        query["query"] = "this is a garbage query;";
+        tester->executeWaitVerifyContent(query, "402 Bad query");
+    }
+
+    void testOK() {
+        SData query("Query");
+        query["Format"] = "json";
+        query["query"] = "SELECT 1;";
+        tester->executeWaitVerifyContent(query, "200 OK");
+    }
+
+    void testWrite() {
+        SData query("Query");
+        query["Format"] = "json";
+        query["query"] = "INSERT INTO queryTest VALUES(1, 'first value');";
+        tester->executeWaitVerifyContent(query);
+
+        query["query"] = "SELECT value FROM queryTest WHERE key = 1;";
+        STable result = tester->executeWaitVerifyContentTable(query);
+
+        // Parse the first item in the first row of results and check that.
+        ASSERT_EQUAL(SParseJSONArray(SParseJSONArray(result["rows"]).front()).front(), "first value");
+    }
+
+    void testWriteInSecondStatement() {
+        SData query("Query");
+        query["Format"] = "json";
+        query["query"] = "SELECT 1; INSERT INTO queryTest VALUES(2, 'second value');";
+        tester->executeWaitVerifyContent(query);
+
+        query["query"] = "SELECT value FROM queryTest WHERE key = 2;";
+        STable result = tester->executeWaitVerifyContentTable(query);
+
+        // Parse the first item in the first row of results and check that.
+        ASSERT_EQUAL(SParseJSONArray(SParseJSONArray(result["rows"]).front()).front(), "second value");
+    }
+
+    void testNoWhere() {
+        SData query("Query");
+        query["Format"] = "json";
+        query["query"] = "DELETE FROM queryTest;";
+        tester->executeWaitVerifyContent(query, "502 Query aborted");
+    }
+} __QueryTest;

--- a/test/tests/WriteTest.cpp
+++ b/test/tests/WriteTest.cpp
@@ -7,7 +7,6 @@ struct WriteTest : tpunit::TestFixture {
                               BEFORE_CLASS(WriteTest::setup),
                               TEST(WriteTest::insert),
                               TEST(WriteTest::parallelInsert),
-                              TEST(WriteTest::failedInsertNoSemiColon),
                               TEST(WriteTest::failedDeleteNoWhere),
                               TEST(WriteTest::deleteNoWhereFalse),
                               TEST(WriteTest::deleteNoWhereTrue),
@@ -84,13 +83,6 @@ struct WriteTest : tpunit::TestFixture {
         string secondLine = response.substr(response.find('\n') + 1);
         int val = SToInt(secondLine);
         ASSERT_EQUAL(val, numCommands);
-    }
-
-    void failedInsertNoSemiColon() {
-        SData query("Query");
-        query["writeConsistency"] = "ASYNC";
-        query["query"] = "INSERT INTO foo VALUES ( RANDOM() )";
-        tester->executeWaitVerifyContent(query, "502 Query aborted");
     }
 
     void failedDeleteNoWhere() {


### PR DESCRIPTION
### Details
This makes the DB plugin *actually check if there are writes in a query* and escalate to `process` if appropriate.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/165934

### Tests
New tests added. Existing tests pass. Also tested against the FuzzyBot plugin which is what uses this functionality the most (and all tests pass there).