### PR TITLE
Fix and un-revert parallel networking.

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -14,6 +14,8 @@ BedrockCommand::BedrockCommand(SQLiteCommand&& baseCommand, BedrockPlugin* plugi
     repeek(false),
     crashIdentifyingValues(*this),
     escalateImmediately(escalateImmediately_),
+    destructionCallback(nullptr),
+    socket(nullptr),
     _plugin(plugin),
     _inProgressTiming(INVALID, 0, 0),
     _timeout(_getTimeout(request))
@@ -72,6 +74,9 @@ int64_t BedrockCommand::_getTimeout(const SData& request) {
 BedrockCommand::~BedrockCommand() {
     for (auto request : httpsRequests) {
         request->manager.closeTransaction(request);
+    }
+    if (destructionCallback) {
+        (*destructionCallback)();
     }
     _commandCount--;
 }

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -154,6 +154,14 @@ class BedrockCommand : public SQLiteCommand {
     // Record the state we were acting under in the last call to `peek` or `process`.
     SQLiteNode::State lastPeekedOrProcessedInState = SQLiteNode::UNKNOWN;
 
+    // If someone is waiting for this command to complete, this will be called in the destructor.
+    function<void()>* destructionCallback;
+
+    // The socket that this command was read from. Can be null if the command didn't come from a client socket (i.e.,
+    // it was escalated to leader or generated internally) or if it was a `fire and forget` command for which no client
+    // is awaiting a reply.
+    STCPManager::Socket* socket;
+
   protected:
     // The plugin that owns this command.
     BedrockPlugin* _plugin;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -248,7 +248,7 @@ class BedrockServer : public SQLiteServer {
     STCPManager::Socket* acceptUnlistedSocket(Port*& portOut);
 
     // This is the thread that handles a new socket, parses a command, and queues it for work.
-    void handleSocket(Socket* s);
+    void handleSocket(Socket* s, bool isControl);
 
   private:
     // The name of the sync thread.
@@ -490,4 +490,9 @@ class BedrockServer : public SQLiteServer {
 
     // This records how many outstanding socket threads there are so we can wait for them to complete before exiting.
     atomic<uint64_t> _outstandingSocketThreads;
+
+    // This mutex prevents the check for whether there are outstanding commands preventing shutdown from running at the
+    // same time a control port command is running (which would indicate that there is a command blocking shutdown -
+    // the current control command).
+    shared_mutex _controlPortExclusionMutex;
 };

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -243,6 +243,13 @@ class BedrockServer : public SQLiteServer {
     // Arguments passed on the command line.
     const SData args;
 
+    // This does the same as STCPManager::acceptSocket, but does not put the new socket in `socketList` because it
+    // will not be managed by that poll loop, instead, it starts a new thread.
+    STCPManager::Socket* acceptUnlistedSocket(Port*& portOut);
+
+    // This is the thread that handles a new socket, parses a command, and queues it for work.
+    void handleSocket(Socket* s);
+
   private:
     // The name of the sync thread.
     static constexpr auto _syncThreadName = "sync";
@@ -255,21 +262,6 @@ class BedrockServer : public SQLiteServer {
 
     // Each time we read a new request from a client, we give it a unique ID.
     uint64_t _requestCount;
-
-    // Each time we read a command off a socket, we put the socket in this map, so that we can respond to it when the
-    // command completes. We remove the socket from the map when we reply to the command, even if the socket is still
-    // open. It will be re-inserted in this set when another command is read from it.
-    map <uint64_t, Socket*> _socketIDMap;
-
-    // The above _socketIDMap is modified by multiple threads, so we lock this mutex around operations that access it.
-    // We don't need to lock around access to the base class's `socketList` because we carefully control access to it
-    // to the main thread.
-    // The only functions that access `socketList` are prePoll, postPoll, openSocket, and closeSocket, in STCPManager,
-    // and acceptSocket in STCPServer.
-    // prePoll and postPoll are only ever called by the main thread.
-    // openSocket is never called by bedrockServer (it is called in SHTTPSManager and STCPNode).
-    // closeSocket and acceptSocket are only called inside postPoll.
-    recursive_mutex _socketIDMutex;
 
     // This is the replication state of the sync node. It's updated after every SQLiteNode::update() iteration. A
     // reference to this object is passed to the sync thread to allow this update.
@@ -483,4 +475,19 @@ class BedrockServer : public SQLiteServer {
     // This is a snapshot of the state of the node taken at the beginning of any call to peekCommand or processCommand
     // so that the state can't change for the lifetime of that call, from the view of that function.
     static thread_local atomic<SQLiteNode::State> _nodeStateSnapshot;
+
+    // Setup a new command from a bare request.
+    unique_ptr<BedrockCommand> buildCommandFromRequest(SData&& request, Socket* s);
+
+    // This is a timestamp, after which we'll start giving up on any sockets that don't seem to be giving us any data.
+    // The case for this is that once we start shutting down, we'll close any sockets when we respond to a command on
+    // them, and we'll stop accepting any new sockets, but if existing sockets just sit around giving us nothing, we
+    // need to figure out some way to handle them. We'll wait 5 seconds and then start killing them.
+    atomic<uint64_t> _lastChance;
+
+    // This is a monotonically incrementing integer just used to uniquely identify socket threads.
+    atomic<uint64_t> _socketThreadNumber;
+
+    // This records how many outstanding socket threads there are so we can wait for them to complete before exiting.
+    atomic<uint64_t> _outstandingSocketThreads;
 };


### PR DESCRIPTION
Fixes https://github.com/Expensify/Expensify/issues/166043

So, we merged parallel networking and it broke EBM.

Here's what happened:

We used to run `Status` commands (or any control commands) inside `postPoll` immediately, letting them skip the command queue. But with parallel networking, we changed this, they now run in their own thread just like any other commands. However, this creates a race condition. At the end of `postPoll`, if we're shutting down, we check to see if there are any outstanding commands, and don't shut down yet if there are. However, in the EBM tests, we keep sending `Status` commands to see when the DB is detached, and so these trigger postPoll to run, and each time create a new command, which is still running when we check if we can shut down, so we can't. Unlike the command port, we don't shut the control port during shutdown, because we want to support this case of getting the status of a detached node, so we keep accepting these commands, which keeps stopping the detach from competing.

The fix is here https://github.com/Expensify/Bedrock/pull/1048/commits/2eb3469807e631467603320caf93e1a09a80fc0f and adds a shared mutex such that the check for outstanding commands can't happen at the same time a control command is running.

### Tests

Dev VM:
```
vagrant@expensidev:/vagrant/ExpensifyBackupManager/test$ ./expensifyBackupManagerTest -repeatCount 5
--------------
✅ BackupTest::keyLoading
✅ BackupTest::upload
✅ BackupTest::download
✅ BackupTest::flagFile
--------------
✅ ClusterBackupTest::testFullClusterUp
✅ ClusterBackupTest::testHalfClusterStateCheck

[ TEST RESULTS ] Passed: 6, Failed: 0
--------------
✅ BackupTest::keyLoading
Failed to send! Probably disconnected. Should we reconnect?
✅ BackupTest::upload
✅ BackupTest::download
✅ BackupTest::flagFile
--------------
✅ ClusterBackupTest::testFullClusterUp
✅ ClusterBackupTest::testHalfClusterStateCheck

[ TEST RESULTS ] Passed: 12, Failed: 0
--------------
✅ BackupTest::keyLoading
✅ BackupTest::upload
✅ BackupTest::download
✅ BackupTest::flagFile
--------------
✅ ClusterBackupTest::testFullClusterUp
✅ ClusterBackupTest::testHalfClusterStateCheck

[ TEST RESULTS ] Passed: 18, Failed: 0
--------------
✅ BackupTest::keyLoading
Failed to send! Probably disconnected. Should we reconnect?
✅ BackupTest::upload
✅ BackupTest::download
✅ BackupTest::flagFile
--------------
✅ ClusterBackupTest::testFullClusterUp
✅ ClusterBackupTest::testHalfClusterStateCheck

[ TEST RESULTS ] Passed: 24, Failed: 0
--------------
✅ BackupTest::keyLoading
✅ BackupTest::upload
✅ BackupTest::download
✅ BackupTest::flagFile
--------------
✅ ClusterBackupTest::testFullClusterUp
✅ ClusterBackupTest::testHalfClusterStateCheck

[ TEST RESULTS ] Passed: 30, Failed: 0
```

Travis: https://travis-ci.com/github/Expensify/ExpensifyBackupManager/builds/227908480