### PR TITLE
implement console log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ sqlitecluster/sqlitecluster
 libstuff/libstuff.d
 libstuff/libstuff.h.gch
 .idea
+bedrock.db

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "files.associations": {
+        "regex": "cpp",
+        "string": "cpp",
+        "string_view": "cpp",
+        "iostream": "cpp",
+        "iosfwd": "cpp",
+        "*.tcc": "cpp",
+        "cstdio": "cpp",
+        "thread": "cpp",
+        "bitset": "cpp",
+        "ostream": "cpp",
+        "atomic": "cpp"
+    }
+}

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2,6 +2,7 @@
 #include "BedrockServer.h"
 
 #include <arpa/inet.h>
+#include <iostream>
 #include <iomanip>
 #include <sys/resource.h>
 #include <sys/time.h>
@@ -1251,6 +1252,7 @@ BedrockServer::BedrockServer(const SData& args_)
 
     // Enable the requested plugins, and update our version string if required.
     list<string> pluginNameList = SParseList(args["-plugins"]);
+    cout << "Loading plugins: " << args["-plugins"];
     SINFO("Loading plugins: " << args["-plugins"]);
     vector<string> versions = {_version};
     for (string& pluginName : pluginNameList) {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -9,6 +9,7 @@
 #include <sys/un.h>
 #include <cxxabi.h>
 #include <sys/ioctl.h>
+#include <iostream>
 
 #include "libstuff.h"
 #include <sys/stat.h>
@@ -92,8 +93,21 @@ atomic<size_t> SLogSocketCurrentOffset(0);
 struct sockaddr_un SLogSocketAddr;
 atomic_flag SLogSocketsInitialized = ATOMIC_FLAG_INIT;
 
+bool g_isSyslog = false;
+
 // Set to `syslog` or `SSyslogSocketDirect`.
 atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc = &syslog;
+
+
+void bclog(int priority, const char *fmt, const char* msg )
+{    
+    cout << msg;
+}
+
+void SLogSetType(bool isSyslog)
+{
+    g_isSyslog = isSyslog;
+}
 
 void SInitialize(string threadName, const char* processName) {
     // This is not really thread safe. It's guaranteed to run only once, because of the atomic flag, but it's not

--- a/main.cpp
+++ b/main.cpp
@@ -143,6 +143,7 @@ set<string> loadPlugins(SData& args) {
 int main(int argc, char* argv[]) {
     // Process the command line
     SData args = SParseCommandLine(argc, argv);
+    SLogSetType(false);
     if (args.empty()) {
         // It's valid to run bedrock with no parameters provided, but unusual
         // -- let's provide some help just in case
@@ -174,6 +175,7 @@ int main(int argc, char* argv[]) {
     // Fork if requested
     if (args.isSet("-fork")) {
         // Do the fork
+        SLogSetType(true);
         int pid = fork();
         SASSERT(pid >= 0);
         if (pid > 0) {


### PR DESCRIPTION
### Details
This change enhances the logging so that when starting with without `-fork`, Bedrock logs to the console/STDOUT. This keeps you from having to run a syslog process when running in a Docker container and/or a Kubernetes environment.

### Fixed Issues
Fixes #101 

Let me know if I need to make any changes to this that will help it get merged in.

Thanks!