### PR TITLE
Remove reference to installing Bedrock from our apt repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,18 +58,6 @@ You can build from scratch as follows:
     # Type "Status" and then enter twice to verify it's working
     # See here to use the default DB plugin: http://bedrockdb.com/db.html
 
-Or you can install an older binary by copy/pasting this whole section into your terminal:
-
-    # Add the Bedrock repo to apt sources for your distro:
-    sudo wget -O /etc/apt/sources.list.d/bedrock.list https://apt.bedrockdb.com/ubuntu/dists/$(lsb_release -cs)/bedrock.list
-
-    # Add the Bedrock repo key:
-    wget -O - https://apt.bedrockdb.com/bedrock.gpg | sudo apt-key add -
-
-    # Update the apt-get and install Bedrock
-    sudo apt-get update
-    sudo apt-get install bedrock
-
 ### Arch Linux
 Copy/paste this command into your terminal:
 


### PR DESCRIPTION
It is being decommissioned, per https://github.com/Expensify/Expensify/issues/170058

cc @quinthar 