### PR TITLE
Added support for console log

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -9,6 +9,7 @@
 #include <sys/un.h>
 #include <cxxabi.h>
 #include <sys/ioctl.h>
+#include <iostream>
 
 #include "libstuff.h"
 #include <sys/stat.h>
@@ -92,8 +93,18 @@ atomic<size_t> SLogSocketCurrentOffset(0);
 struct sockaddr_un SLogSocketAddr;
 atomic_flag SLogSocketsInitialized = ATOMIC_FLAG_INIT;
 
+bool g_isSyslog = false;
+
 // Set to `syslog` or `SSyslogSocketDirect`.
 atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc = &syslog;
+
+void bclog(int priority, const char *fmt, const char* msg ) {
+    cout << msg;
+}
+
+void SLogSetType(bool isSyslog) {
+    g_isSyslog = isSyslog;
+}
 
 void SInitialize(string threadName, const char* processName) {
     // This is not really thread safe. It's guaranteed to run only once, because of the atomic flag, but it's not

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -219,6 +219,9 @@ void STerminateHandler(void);
 extern atomic<int> _g_SLogMask;
 void SLogLevel(int level);
 
+void bclog(int priority, const char *fmt, const char* msg );
+void SLogSetType(bool isSyslog);
+
 // Stack trace logging
 void SLogStackTrace();
 
@@ -227,6 +230,7 @@ void SSyslogSocketDirect(int priority, const char* format, ...);
 
 // Atomic pointer to the syslog function that we'll actually use. Easy to change to `syslog` or `SSyslogSocketDirect`.
 extern atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc;
+extern bool g_isSyslog;
 
 // **NOTE: rsyslog default max line size is 8k bytes. We split on 7k byte boundaries in order to fit the syslog line prefix and the expanded \r\n to #015#012
 #define SWHEREAMI SThreadLogPrefix + "(" + basename((char*)__FILE__) + ":" + SToStr(__LINE__) + ") " + __FUNCTION__ + " [" + SThreadLogName + "] "
@@ -238,7 +242,10 @@ extern atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc;
             const string s = __out.str();                                       \
             const string prefix = SWHEREAMI;                                    \
             for (size_t i = 0; i < s.size(); i += 7168) {                       \
-                (*SSyslogFunc)(_PRI_, "%s", (prefix + s.substr(i, 7168)).c_str()); \
+                if (g_isSyslog)                                                 \
+                    SSyslogFunc(_PRI_, "%s", (prefix + s.substr(i, 7168)).c_str()); \
+                else                                                            \
+                    bclog(_PRI_, "%s", (prefix + s.substr(i, 7168)).c_str());    \
             }                                                                   \
         }                                                                       \
     } while (false)

--- a/main.cpp
+++ b/main.cpp
@@ -143,6 +143,7 @@ set<string> loadPlugins(SData& args) {
 int main(int argc, char* argv[]) {
     // Process the command line
     SData args = SParseCommandLine(argc, argv);
+    SLogSetType(false);
     if (args.empty()) {
         // It's valid to run bedrock with no parameters provided, but unusual
         // -- let's provide some help just in case
@@ -174,6 +175,7 @@ int main(int argc, char* argv[]) {
     // Fork if requested
     if (args.isSet("-fork")) {
         // Do the fork
+        SLogSetType(true);
         int pid = fork();
         SASSERT(pid >= 0);
         if (pid > 0) {


### PR DESCRIPTION
### Details
This feature adds support for console logging when running Bedrock without the `-fork` startup flag. This prevents the need to have to run an additional Syslog process when Bedrock is deployed in a Docker/Kubernetes environment.

### Fixed Issues
Fixes #101

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
