### PR TITLE
Support for selective synchronization as a startup flag

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1626,7 +1626,7 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                         string query = STrim(SToUpper(command->request["query"]));
                         if (SStartsWith(SToUpper(query),"INSERT") || SStartsWith(SToUpper(query),"DELETE") || SStartsWith(SToUpper(query),"UPDATE")) {
                             command->writeConsistency = (SQLiteNode::ConsistencyLevel)_syncType;
-                            SINFO("Forcing " << syncType << " consistency for command " << command->request.methodLine);
+                            SINFO("Forcing " << _syncType << " consistency for command " << command->request.methodLine);
                         }
                     }
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -6,6 +6,10 @@
 #include "BedrockCommandQueue.h"
 #include "BedrockTimeoutCommandQueue.h"
 
+#define SC_ONE "ONE"
+#define SC_QUORUM "QUORUM"
+#define SC_ASYNC "ASYNC"
+
 class BedrockServer : public SQLiteServer {
   public:
 
@@ -483,4 +487,8 @@ class BedrockServer : public SQLiteServer {
     // This is a snapshot of the state of the node taken at the beginning of any call to peekCommand or processCommand
     // so that the state can't change for the lifetime of that call, from the view of that function.
     static thread_local atomic<SQLiteNode::State> _nodeStateSnapshot;
+
+    // These allow for the ability to startup with -syncType while specifying ONE/ASYNC/QUORUM
+    bool _isSyncSet;
+    int _syncType;
 };

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,8 @@ To see a full list of Bedrock's configuration options, just run `bedrock -?` on 
 	-readThreads    <#>         Number of read threads to start (min 1, defaults to 1)
 	-queryLog       <filename>  Set the query log filename (default 'queryLog.csv', SIGUSR2/SIGQUIT to enable/disable)
 	-maxJournalSize <#commits>  Number of commits to retainin the historical journal (default 1000000)
+    -syncType       <value>     Selective synchronization (QUORUM, ONE, ASYNC) and (defaults to QUORUM)
+    -synchronous    <value>     Set the PRAGMA schema.synchronous
 
 	Quick Start Tips:
 	-----------------

--- a/main.cpp
+++ b/main.cpp
@@ -239,6 +239,7 @@ int main(int argc, char* argv[]) {
              << endl;
         cout << "-maxJournalSize <#commits>  Number of commits to retain in the historical journal (default 1000000)"
              << endl;
+        cout << "-syncType       <value>     Selective synchronization (QUORUM, ONE, ASYNC) and (defaults to QUORUM) " << endl;
         cout << "-synchronous    <value>     Set the PRAGMA schema.synchronous "
                 "(defaults see https://sqlite.org/pragma.html#pragma_synchronous)"
              << endl;


### PR DESCRIPTION
### Details
This handy feature allows for specifying a startup flag `-syncType ONE | ASYNC | QUORUM`
When no `-syncType` specified, it defaults to QUORUM. This is handy for people using MySQL clients and for anyone that doesn't want to have to specify on every INSERT/UPDATE/DELETE.

### Fixed Issues


### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
