### PR TITLE
Add back 'FAILED' in test output

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -395,7 +395,7 @@ void tpunit::TestFixture::tpunit_detail_do_tests(TestFixture* f) {
 
           // Dump the test buffer if the test included any log lines.
           f->printTestBuffer();
-          printf("\xE2\x9D\x8C %s\n", t->_name);
+          printf("\xE2\x9D\x8C !FAILED! \xE2\x9D\x8C %s\n", t->_name);
           tpunit_detail_stats()._failures++;
           tpunit_detail_stats()._failureNames.emplace(t->_name);
        }


### PR DESCRIPTION
### Details

When 1 test out of 1600 fail, it's hard to find which one (specifically which assertion and line). This brings back a string to search for. More context [here](https://expensify.slack.com/archives/C03TQ48KC/p1630590043184000). 

### Tests

<img width="555" alt="Screen Shot 2021-09-02 at 3 51 11 PM" src="https://user-images.githubusercontent.com/4164921/131866211-2832014f-910c-4ae1-b310-fe30f21bbfab.png">
