### PR TITLE
fixing race condition in the "Attach" command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -734,6 +734,7 @@ void BedrockServer::sync(const SData& args,
 
     // We're really done, store our flag so main() can be aware.
     server._syncThreadComplete.store(true);
+
 }
 
 void BedrockServer::worker(SQLitePool& dbPool,
@@ -2031,6 +2032,8 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
         }
         if (blockingPlugins.size()) {
             response.methodLine = "401 Attaching prevented by " + SComposeList(blockingPlugins);
+        } else if (_shutdownState.load() != RUNNING) {
+            response.methodLine = "401 Attaching prevented by server not ready";
         } else {
             response.methodLine = "204 ATTACHING";
             _detach = false;


### PR DESCRIPTION
### Details
Found a race condition that was making a test flakey, (seemingly) exacerbated by the parallel bedrock code.

### Fixed Issues
Related to https://github.com/Expensify/Expensify/issues/157709

### Tests
<details><summary>Bedrock tests</summary>
<p>
```
vagrant@expensidev2004:/vagrant/Bedrock/test$ ./test -repeatCount 3
--------------
✅ CancelJobTest::cancelNonExistentJob
✅ CancelJobTest::cancelJobWithChild
✅ CancelJobTest::cancelRunningJob
✅ CancelJobTest::cancelFinishedJob
✅ CancelJobTest::cancelPausedJob
...
[ TEST RESULTS ] Passed: 126, Failed: 0
--------------
✅ CancelJobTest::cancelNonExistentJob
✅ CancelJobTest::cancelJobWithChild
✅ CancelJobTest::cancelRunningJob
✅ CancelJobTest::cancelFinishedJob
✅ CancelJobTest::cancelPausedJob
...
[ TEST RESULTS ] Passed: 252, Failed: 0
--------------
✅ CancelJobTest::cancelNonExistentJob
✅ CancelJobTest::cancelJobWithChild
✅ CancelJobTest::cancelRunningJob
✅ CancelJobTest::cancelFinishedJob
✅ CancelJobTest::cancelPausedJob
...
[ TEST RESULTS ] Passed: 378, Failed: 0
```

</p>
</details>

<details><summary>Bedrock cluster tests</summary>
<p>

```
vagrant@expensidev2004:/vagrant/Bedrock/test/clustertest$ ./clustertest -repeatCount 3
--------------
✅ BadCommandTest::test
--------------
✅ BroadcastCommandTest::test
--------------
✅ ConflictSpamTest::slow
[ConflictSpamTest] Results didn't match, waiting for journals to equalize.
✅ ConflictSpamTest::spam
--------------
✅ ControlCommandTest::testPreventAttach
...
[ TEST RESULTS ] Passed: 44, Failed: 0
--------------
✅ BadCommandTest::test
--------------
✅ BroadcastCommandTest::test
--------------
✅ ConflictSpamTest::slow
[ConflictSpamTest] Results didn't match, waiting for journals to equalize.
✅ ConflictSpamTest::spam
--------------
✅ ControlCommandTest::testPreventAttach
...
[ TEST RESULTS ] Passed: 88, Failed: 0
--------------
✅ BadCommandTest::test
--------------
✅ BroadcastCommandTest::test
--------------
✅ ConflictSpamTest::slow
[ConflictSpamTest] Results didn't match, waiting for journals to equalize.
✅ ConflictSpamTest::spam
--------------
✅ ControlCommandTest::testPreventAttach
...
[ TEST RESULTS ] Passed: 132, Failed: 0
```

</p>
</details>

<details><summary>Auth tests</summary>
<p>

```
vagrant@expensidev2004:/vagrant/Auth/test$ ./authtest -repeatCount 3
✅ AccountTest::testGetDeletedAccount
✅ ActivateWalletTest::testCommand
✅ AddRNVPLastRead::testAddingRNVPLastRead
✅ AddLoginTest::testAddLogin
✅ AddRNVPLastRead::testOnlyDeletingOldRNVP
✅ ActivateExpensifyCardTest::testCommand
✅ AddLoginTest::testAddLoginToUnvalidatedAccount
✅ AddCommercialFeedTest::testFailureType
...
[ TEST RESULTS ] Passed: 1568, Failed: 0
✅ AccountTest::testGetDeletedAccount
✅ ActivateWalletTest::testCommand
✅ AddRNVPLastRead::testAddingRNVPLastRead
✅ AddLoginTest::testAddLogin
✅ AddRNVPLastRead::testOnlyDeletingOldRNVP
✅ ActivateExpensifyCardTest::testCommand
✅ AddLoginTest::testAddLoginToUnvalidatedAccount
✅ AddCommercialFeedTest::testFailureType
...
[ TEST RESULTS ] Passed: 3136, Failed: 0
✅ AccountTest::testGetDeletedAccount
✅ ActivateExpensifyCardTest::testCommand
✅ AddRNVPLastRead::testAddingRNVPLastRead
✅ AddRNVPLastRead::testOnlyDeletingOldRNVP
✅ ActivateWalletTest::testCommand
✅ AddLoginTest::testAddLogin
✅ AccountTest::testDeleteAccountAndGetChatReportIDs
✅ AddLoginTest::testAddLoginToUnvalidatedAccount
✅ AccountTest::testVerifySupportAccess
✅ ActivateExpensifyCardTest::testActivateSuspendedCard
✅ AddLoginTest::testAddLoginToUnvalidatedAccountWithoutPrimarySwitch
✅ AddCommercialFeedTest::testFailureType
...
[ TEST RESULTS ] Passed: 4704, Failed: 0
```

</p>
</details>

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
