### PR TITLE
Return all data from job

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -724,7 +724,12 @@ void BedrockJobsCommand::process(SQLite& db) {
             job["jobID"] = result[c][0];
             job["name"] = result[c][1];
             job["data"] = result[c][2];
+            job["priority"] = result[c][3];
+            job["retryAfter"] = result[c][4];
             job["created"] = result[c][5];
+            job["repeat"] = result[c][6];
+            job["lastRun"] = result[c][7];
+            job["nextRun"] = result[c][8];
             int64_t parentJobID = SToInt64(result[c][3]);
 
             if (parentJobID) {
@@ -735,10 +740,6 @@ void BedrockJobsCommand::process(SQLite& db) {
 
             // Add jobID to the respective list depending on if retryAfter is set
             if (result[c][4] != "") {
-                job["retryAfter"] = result[c][4];
-                job["repeat"] = result[c][6];
-                job["lastRun"] = result[c][7];
-                job["nextRun"] = result[c][8];
                 retriableJobs.push_back(job);
             } else {
                 nonRetriableJobs.push_back(result[c][0]);

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -81,6 +81,10 @@ struct GetJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(response["jobID"], jobID);
         ASSERT_EQUAL(response["name"], jobName);
         ASSERT_EQUAL(response["data"], "{}");
+        ASSERT_EQUAL(response["priority"], originalJob[0][8]);
+        ASSERT_EQUAL(response["repeat"], originalJob[0][6]);
+        ASSERT_EQUAL(response["nextRun"], originalJob[0][4]);
+        ASSERT_EQUAL(response["lastRun"], originalJob[0][5]);
         SASSERT(!response["created"].empty());
 
         // Check that nothing changed after we created the job except for the state and lastRun value
@@ -406,7 +410,7 @@ struct GetJobTest : tpunit::TestFixture {
         tester->executeWaitVerifyContent(command);
 
         // Confirm the child has data about the parent in the response
-        ASSERT_EQUAL(response.size(), 6);
+        ASSERT_EQUAL(response.size(), 11);
         ASSERT_EQUAL(response["jobID"], finishedChildID);
         ASSERT_EQUAL(response["name"], "child_finished");
         ASSERT_EQUAL(response["data"], finishedChildData);


### PR DESCRIPTION
### Details

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/180926

### Tests
```
CreateJob
name:caca

200 OK
commitCount: 13262
nodeName: bedrock
peekTime: 844
processTime: 10087
totalTime: 22801
unaccountedTime: 8562
Content-Length: 29

{"jobID":2280372574954921040}

GetJob
name:caca

200 OK
commitCount: 13263
nodeName: bedrock
peekTime: 147
processTime: 2010
totalTime: 6996
unaccountedTime: 4769
Content-Length: 171

{"created":"2021-10-13 09:56:23","data":{},"jobID":2280372574954921040,"lastRun":"","name":"caca","nextRun":"2021-10-13 09:56:23","priority":0,"repeat":"","retryAfter":""}^C
```
Create a non retryable non repeatable job and run it in BWM, check it did not error.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
