### PR TITLE
Mark infinitely retrying jobs as FAILED

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -770,6 +770,11 @@ void BedrockJobsCommand::process(SQLite& db) {
                 job["cancelledChildJobs"] = SComposeJSONArray(cancelledChildJobArray);
             }
 
+            STable jobData = SParseJSONObject(job["data"]);
+            if (SToInt(jobData["retryAfterCount"]) >= 10) {
+                // We will fail this job, don't return it.
+                continue;
+            }
             jobList.push_back(SComposeJSONObject(job));
         }
 
@@ -796,7 +801,6 @@ void BedrockJobsCommand::process(SQLite& db) {
                     if (!db.writeIdempotent(failQuery)) {
                         STHROW("502 Update failed");
                     }
-                    // TODO: Remove job from returned jobs...?
                     continue;
                 }
                 string currentTime = SUNQUOTED_CURRENT_TIMESTAMP();
@@ -820,7 +824,13 @@ void BedrockJobsCommand::process(SQLite& db) {
         // Format the results as is appropriate for what was requested
         if (SIEquals(requestVerb, "GetJob")) {
             // Single response
-            SASSERT(jobList.size() == 1);
+            if (jobList.size() != 1) {
+                if (jobList.size() > 1) {
+                    STHROW("500 More than 1 job to return, how is this possible?");
+                }
+                response.content = "{}";
+                return;
+            }
             response.content = jobList.front();
         } else {
             // Multiple responses
@@ -1014,6 +1024,11 @@ void BedrockJobsCommand::process(SQLite& db) {
             if (!db.writeIdempotent("UPDATE jobs SET data=" + SQ(data) + " WHERE jobID=" + SQ(jobID) + ";")) {
                 STHROW("502 Failed to update job data");
             }
+        }
+
+        // Reset the retryAfterCount (set by GetJob(s)).
+        if (!db.writeIdempotent("UPDATE jobs SET data = JSON_REMOVE(data, '$.retryAfterCount') WHERE jobID=" + SQ(jobID) + ";")) {
+            STHROW("502 Failed to update job retryAfterCount");
         }
 
         // If we are finishing a job that has child jobs, set its state to paused.

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -60,12 +60,12 @@ class BedrockTester {
     // Sends a single request, returning the response content.
     // If the response method line doesn't begin with the expected result, throws.
     // Convenience wrapper around executeWaitMultipleData.
-    string executeWaitVerifyContent(SData request, const string& expectedResult = "200", bool control = false, uint64_t retryTimeoutUS = 0);
+    string executeWaitVerifyContent(SData request, const string& expectedResult = "200 OK", bool control = false, uint64_t retryTimeoutUS = 0);
 
     // Sends a single request, returning the response content as a STable.
     // If the response method line doesn't begin with the expected result, throws.
     // Convenience wrapper around executeWaitMultipleData.
-    STable executeWaitVerifyContentTable(SData request, const string& expectedResult = "200");
+    STable executeWaitVerifyContentTable(SData request, const string& expectedResult = "200 OK");
 
     // Read from the DB file, without going through the bedrock server. Two interfaces are provided to maintain
     // compatibility with the `SQLite` class.

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -354,7 +354,7 @@ struct CreateJobTest : tpunit::TestFixture {
             try {
                 // Let it repeat until it works or we run out of retries.
                 response = tester->executeWaitVerifyContentTable(command);
-                ASSERT_EQUAL(response["data"], "{\"originalNextRun\":\"" + originalJob[0][4] + "\"}");
+                ASSERT_EQUAL(response["data"], "{\"retryAfterCount\":1,\"originalNextRun\":\"" + originalJob[0][4] + "\"}");
                 ASSERT_EQUAL(response["jobID"], jobID);
                 ASSERT_EQUAL(response["name"], jobName);
             } catch (...) {
@@ -468,7 +468,7 @@ struct CreateJobTest : tpunit::TestFixture {
                 usleep(100'000);
                 continue;
             }
-            ASSERT_EQUAL(response["data"], "{}");
+            ASSERT_EQUAL(response["data"], "{\"retryAfterCount\":1}");
             ASSERT_EQUAL(response["jobID"], jobID);
             ASSERT_EQUAL(response["name"], jobName);
             assertionsChecked = true;

--- a/test/tests/jobs/InifiniteRetryAfterTest.cpp
+++ b/test/tests/jobs/InifiniteRetryAfterTest.cpp
@@ -1,19 +1,22 @@
 #include <unistd.h>
 
 #include <libstuff/SData.h>
+#include <libstuff/SQResult.h>
 #include <test/lib/BedrockTester.h>
 
 struct InfiniteRetryAfterJobTest : tpunit::TestFixture {
     InfiniteRetryAfterJobTest()
         : tpunit::TestFixture("InfiniteRetryAfter",
-                              TEST(InfiniteRetryAfterJobTest::test))
+                              TEST(InfiniteRetryAfterJobTest::testInfiniteTries),
+                              TEST(InfiniteRetryAfterJobTest::testRepeatJobWithThreeTries)
+                              )
     {}
 
     /**
      * This tests that a job with a retryAfter won't get requeued forever.
      * We want it to fail after 10 tries.
      */
-    void test() {
+    void testInfiniteTries() {
         BedrockTester tester = BedrockTester({{"-plugins", "Jobs,DB"}}, {});
 
         // Create a job
@@ -27,21 +30,73 @@ struct InfiniteRetryAfterJobTest : tpunit::TestFixture {
             SData getJobs("GetJob");
             getJobs["name"] = "infinite-job";
             STable getJobResponse = tester.executeWaitVerifyContentTable(getJobs);
-            ASSERT_EQUAL(getJobResponse["jobID"], jobID);
 
             // Verify the job state:
-            string state = tester.readDB("SELECT state FROM jobs WHERE jobID = " + SQ(jobID) + ";");
+            SQResult result;
+            tester.readDB("SELECT state, JSON_EXTRACT(data, '$.retryAfterCount') FROM jobs WHERE jobID = " + SQ(jobID) + ";", result);
+            ASSERT_FALSE(result.empty());
+            const string state = result[0][0];
+            const size_t retryAfterCount = SToInt(result[0][1]);
             if (i == 10) {
-                // For the last loop, after the 10th time, it should be FAILED
-                ASSERT_EQUAL(state, "FAILED");
+                // For the last loop, after the 10th time, it should be FAILED (and the jobs isn't returned, since it gets failed)
+                EXPECT_EQUAL(state, "FAILED");
             } else {
                 // For the first 10 times, it should be in the RUNQUEUED state
-                ASSERT_EQUAL(state, "RUNQUEUED");
+                EXPECT_EQUAL(retryAfterCount, i + 1);
+                EXPECT_EQUAL(state, "RUNQUEUED");
+                EXPECT_EQUAL(getJobResponse["jobID"], jobID);
 
                 // Wait for the retryAfter to kick in
                 sleep(2);
             }
         }
+    }
 
+    /**
+     * This tests that a job with a retryAfter finished after 5 tries will have its retryAfterCount unset.
+     */
+    void testRepeatJobWithThreeTries() {
+        BedrockTester tester = BedrockTester({{"-plugins", "Jobs,DB"}}, {});
+
+        // Create a job
+        SData createJob("CreateJob");
+        createJob["name"] = "not-infinite-job";
+        createJob["retryAfter"] = "+1 SECOND";
+        createJob["repeat"] = "SCHEDULED, +1 DAY";
+        const string jobID = tester.executeWaitVerifyContentTable(createJob)["jobID"];
+
+        // Get the job 3 times in a row
+        for (size_t i = 0; i <= 3; ++i) {
+            SData getJobs("GetJob");
+            getJobs["name"] = "not-infinite-job";
+            STable getJobResponse = tester.executeWaitVerifyContentTable(getJobs);
+            EXPECT_EQUAL(getJobResponse["jobID"], jobID);
+
+            // Verify the job state:
+            SQResult result;
+            tester.readDB("SELECT state, JSON_EXTRACT(data, '$.retryAfterCount') FROM jobs WHERE jobID = " + SQ(jobID) + ";", result);
+            ASSERT_FALSE(result.empty());
+            const string state = result[0][0];
+            const size_t retryAfterCount = SToInt(result[0][1]);
+            EXPECT_EQUAL(retryAfterCount, i + 1);
+            EXPECT_EQUAL(state, "RUNQUEUED");
+
+            // Wait for the retryAfter to kick in
+            sleep(2);
+        }
+
+        // Finish the job
+        SData finishJob("FinishJob");
+        finishJob["jobID"] = jobID;
+        tester.executeWaitVerifyContentTable(finishJob)["jobID"];
+        SQResult result;
+        tester.readDB( "SELECT state, JSON_EXTRACT(data, '$.retryAfterCount') FROM jobs WHERE jobID = " + SQ(jobID) + ";", result);
+        ASSERT_FALSE(result.empty());
+
+        // State is QUEUED and retryAfterCount has been removed
+        const string state = result[0][0];
+        const string retryAfterCount = result[0][1];
+        EXPECT_TRUE(retryAfterCount.empty());
+        EXPECT_EQUAL(state, "QUEUED");
     }
 } __InfiniteRetryAfterJobTest;

--- a/test/tests/jobs/InifiniteRetryAfterTest.cpp
+++ b/test/tests/jobs/InifiniteRetryAfterTest.cpp
@@ -1,0 +1,44 @@
+#include <unistd.h>
+
+#include <libstuff/SData.h>
+#include <test/lib/BedrockTester.h>
+
+struct InfiniteRetryAfterJobTest : tpunit::TestFixture {
+    InfiniteRetryAfterJobTest()
+        : tpunit::TestFixture("InfiniteRetryAfter",
+                              TEST(InfiniteRetryAfterJobTest::test))
+    {}
+
+    /**
+     * This tests that a job with a retryAfter won't get requeued forever.
+     * We want it to fail after 10 tries.
+     */
+    void test() {
+        BedrockTester tester = BedrockTester({{"-plugins", "Jobs,DB"}}, {});
+
+        // Create a job
+        SData createJob("CreateJob");
+        createJob["name"] = "infinite-job";
+        createJob["retryAfter"] = "+1 SECOND";
+        const string jobID = tester.executeWaitVerifyContentTable(createJob)["jobID"];
+
+        // Get the job 10 times in a row
+        for (size_t i = 0; i < 10; ++i) {
+            SData getJobs("GetJob");
+            getJobs["name"] = "infinite-job";
+            STable getJobResponse = tester.executeWaitVerifyContentTable(getJobs);
+
+            // Verify we get the job and it is in the RUNQUEUED state
+            ASSERT_EQUAL(getJobResponse["jobID"], jobID);
+            string state = tester.readDB("SELECT state FROM jobs WHERE jobID = " + SQ(jobID) + ";");
+            ASSERT_EQUAL(state, "RUNQUEUED");
+
+            // Wait for the retryAfter to kick in
+            sleep(2);
+        }
+
+        // After the 10th time, it should be FAILED
+        const string state = tester.readDB("SELECT state FROM jobs WHERE jobID = " + SQ(jobID) + ";");
+        ASSERT_EQUAL(state, "FAILED");
+    }
+} __InfiniteRetryAfterJobTest;

--- a/test/tests/jobs/InifiniteRetryAfterTest.cpp
+++ b/test/tests/jobs/InifiniteRetryAfterTest.cpp
@@ -27,15 +27,15 @@ struct InfiniteRetryAfterJobTest : tpunit::TestFixture {
             SData getJobs("GetJob");
             getJobs["name"] = "infinite-job";
             STable getJobResponse = tester.executeWaitVerifyContentTable(getJobs);
-
-            // Verify we get the job and it is in the RUNQUEUED state
             ASSERT_EQUAL(getJobResponse["jobID"], jobID);
-            string state = tester.readDB("SELECT state FROM jobs WHERE jobID = " + SQ(jobID) + ";");
 
-            // Except for the last loop: after the 10th time, it should be FAILED
+            // Verify the job state:
+            string state = tester.readDB("SELECT state FROM jobs WHERE jobID = " + SQ(jobID) + ";");
             if (i == 10) {
+                // For the last loop, after the 10th time, it should be FAILED
                 ASSERT_EQUAL(state, "FAILED");
             } else {
+                // For the first 10 times, it should be in the RUNQUEUED state
                 ASSERT_EQUAL(state, "RUNQUEUED");
 
                 // Wait for the retryAfter to kick in


### PR DESCRIPTION
### Details

Some jobs can retry forever (if no one ever calls FinishJob / FailJob, but keeps calling GetJob(s)). This fixes that by adding a maximum number of 10 retries. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/179455

### Tests

Automated