### PR TITLE
Make _dbPool persist until the syncNode is destroyed

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -180,7 +180,7 @@ void BedrockServer::sync()
     // We use fewer FDs on test machines that have other resource restrictions in place.
     int fdLimit = args.isSet("-live") ? 25'000 : 250;
     SINFO("Setting dbPool size to: " << fdLimit);
-    _dbPool = make_unique<SQLitePool>(fdLimit, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.test("-pageLogging"));
+    _dbPool = make_shared<SQLitePool>(fdLimit, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.test("-pageLogging"));
     SQLite& db = _dbPool->getBase();
 
     // Initialize the command processor.
@@ -190,7 +190,7 @@ void BedrockServer::sync()
     uint64_t firstTimeout = STIME_US_PER_M * 2 + SRandom::rand64() % STIME_US_PER_S * 30;
 
     // Initialize the shared pointer to our sync node object.
-    atomic_store(&_syncNode, make_shared<SQLiteNode>(*this, *_dbPool, args["-nodeName"], args["-nodeHost"],
+    atomic_store(&_syncNode, make_shared<SQLiteNode>(*this, _dbPool, args["-nodeName"], args["-nodeHost"],
                                                             args["-peerList"], args.calc("-priority"), firstTimeout,
                                                             _version, args.test("-parallelReplication")));
 
@@ -721,6 +721,7 @@ void BedrockServer::sync()
     // Release the current DB pool, and zero out our pointer.
     // Note: This is not an atomic operation but should not matter. Nothing should use this that can happen with no
     // sync thread.
+    // If there are socket threads in existance, they can be looking at this through a syncThread copy.
     _dbPool = nullptr;
 
     // We're really done, store our flag so main() can be aware.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -482,7 +482,9 @@ class BedrockServer : public SQLiteServer {
     // the current control command).
     shared_mutex _controlPortExclusionMutex;
 
-    // A pointer to the current pool of DB handles we can use. Only valid during the lifetime of the sync thread, and
-    // destroyed when it does not exist. This releases all DB handles so we can take backups.
-    unique_ptr<SQLitePool> _dbPool;
+    // A pointer to the current pool of DB handles we can use. This is created by the sync thread and destroyed when it
+    // exits. However, because the syncNode stores this, and it's possible for socket threads to hold a handle to the
+    // syncNode while the sync thread exists, it's a shared pointer to allow for the last socket thread using it to
+    // destroy the pool at shutdown.
+    shared_ptr<SQLitePool> _dbPool;
 };

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -40,7 +40,7 @@ class SQLiteNode : public STCPNode {
     };
 
     // Constructor/Destructor
-    SQLiteNode(SQLiteServer& server, SQLitePool& dbPool, const string& name, const string& host,
+    SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, const string& name, const string& host,
                const string& peerList, int priority, uint64_t firstTimeout, const string& version, const bool useParallelReplication = false);
     ~SQLiteNode();
 
@@ -114,7 +114,7 @@ class SQLiteNode : public STCPNode {
 
     // This is a pool of DB handles that this node can use for any DB access it needs. Currently, it hands them out to
     // replication threads as required. It's passed in via the constructor.
-    SQLitePool& _dbPool;
+    shared_ptr<SQLitePool> _dbPool;
 
     // Handle to the underlying database that we write to. This should also be passed to an SQLiteCore object that can
     // actually perform some action on the DB. When those action are complete, you can call SQLiteNode::startCommit()

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -47,7 +47,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         strcpy(filename, filenameTemplate);
         int fd = mkstemp(filename);
         close(fd);
-        SQLitePool dbPool(10, filename, 1000000, 5000, 0);
+        shared_ptr<SQLitePool> dbPool = make_shared<SQLitePool>(10, filename, 1000000, 5000, 0);
         TestServer server("");
         string peerList = "host1.fake:15555?nodeName=peer1,host2.fake:16666?nodeName=peer2,host3.fake:17777?nodeName=peer3,host4.fake:18888?nodeName=peer4";
         SQLiteNode testNode(server, dbPool, "test", "localhost:19998", peerList, 1, 1000000000, "1.0");


### PR DESCRIPTION
### Details

`syncNodeCopy` allows a socket thread (or any thread) to hold a reference to the sync node. The sync node, in turn, maintains a reference to _dbPool. However, when the sync node shuts down, it deletes `_dbPool`. If the sync node shuts down while a socket thread is still finishing up, it may happen that the socket thread is where the `syncNode` destructor gets called (because the sync thread has already exited). If that was the case, the destructor would try to clean up the already-deleted `_dbPool` and crash.

This change makes `_dbPool` a shared pointer and has the sync node keep it's own copy, so that the underlying object isn't deleted until the sync node is deleted.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/181759

### Tests
No new tests.