### PR TITLE
Remove most shutdown latency

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -328,7 +328,7 @@ void BedrockServer::sync()
         }
 
         // And set our next timeout for 1 second from now.
-        nextActivity = STimeNow() + STIME_US_PER_S;
+        nextActivity = STimeNow() + 1'000'000;
 
         // Process any network traffic that happened. Scope this so that we can change the log prefix and have it
         // auto-revert when we're finished.
@@ -760,7 +760,7 @@ void BedrockServer::worker(int threadId)
             command = unique_ptr<BedrockCommand>(nullptr);
 
             // And get another one.
-            command = commandQueue.get(1000000);
+            command = commandQueue.get(100'000);
 
             SAUTOPREFIX(command->request);
             SINFO("Dequeued command " << command->request.methodLine << " in worker, "

--- a/main.cpp
+++ b/main.cpp
@@ -367,7 +367,7 @@ int main(int argc, char* argv[]) {
             const uint64_t now = STimeNow();
             auto timeBeforePoll = chrono::steady_clock::now();
             S_poll(fdm, max(nextActivity, now) - now);
-            nextActivity = STimeNow() + STIME_US_PER_S; // 1s max period
+            nextActivity = STimeNow() + 1'000'000;
             auto timeAfterPoll = chrono::steady_clock::now();
             server.postPoll(fdm, nextActivity);
             auto timeAfterPostPoll = chrono::steady_clock::now();

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -7,8 +7,10 @@
 
 bool isBetweenSecondsInclusive(uint64_t startTimestamp, uint64_t endTimestamp, string timestampString) {
     uint64_t testTime = startTimestamp;
+    list<string> stamps;
     while (true) {
         string testTimeString = SComposeTime("%Y-%m-%d %H:%M:%S", testTime);
+        stamps.push_back(testTimeString);
         if (timestampString == testTimeString) {
             return true;
         }
@@ -21,6 +23,10 @@ bool isBetweenSecondsInclusive(uint64_t startTimestamp, uint64_t endTimestamp, s
             // this is the last possible test.
             testTime = endTimestamp;
         }
+    }
+    cout << "FAILED: " << startTimestamp << ", " << endTimestamp << ", " << timestampString << endl;
+    for (auto& a : stamps) {
+        cout << a << endl;
     }
     return false;
 }


### PR DESCRIPTION
### Details
When bedrock shuts down, there are a series of points at which it waits on things like network activity. These tend to have a 1 second timeout.

The shutdown procedure works by sending a signal, which sets a flag, and then waits for each of these loops to notice. Generally it takes a second for one loop to notice, which then does something, and it takes another loop a second to notice, etc.

This means it generally takes about 4 seconds to shut bedrock down. This change mostly just makes these loops shorter, to 100ms, and now it takes about 0.4 seconds to shut bedrock down. in production, this hardly matters, but in tests, where we start and stop a thousand bedrock processes, the 3.5 seconds per test makes a real difference. Auth tests run about 20% faster with this change.

For whatever reason Travis hates this change.

### Fixed Issues
Fixes GH_LINK

### Tests

Improved:
```
vagrant@expensidev2004:/vagrant/Auth/test$ time ./authtest -threads 16

Three run results:
real	5m20.448s
real	5m47.631s
real	5m31.428s
```

Before:
```
real	6m56.730s
real	7m18.563s
real	6m31.615s
```

Approximately 20% faster to run tests.
