### PR TITLE
Add LibStuff util for current date

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2938,6 +2938,10 @@ string SCURRENT_TIMESTAMP() {
     return STIMESTAMP(STimeNow());
 }
 
+string SCURRENT_DATE() {
+    return SCURRENT_TIMESTAMP().substr(1, 10);
+}
+
 bool STableComp::operator()(const string& s1, const string& s2) const {
     return lexicographical_compare(s1.begin(), s1.end(), s2.begin(), s2.end(), nocase_compare());
 }

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -592,6 +592,7 @@ string STIMESTAMP(uint64_t when);
 string SUNQUOTED_CURRENT_TIMESTAMP();
 string SCURRENT_TIMESTAMP();
 string SCURRENT_TIMESTAMP_MS();
+string SCURRENT_DATE();
 
 // --------------------------------------------------------------------------
 // Miscellaneous stuff

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <regex>
 
 #include <libstuff/libstuff.h>
 #include <libstuff/SData.h>
@@ -29,7 +30,8 @@ struct LibStuff : tpunit::TestFixture {
                                     TEST(LibStuff::testHexConversion),
                                     TEST(LibStuff::testBase32Conversion),
                                     TEST(LibStuff::testContains),
-                                    TEST(LibStuff::testFirstOfMonth))
+                                    TEST(LibStuff::testFirstOfMonth),
+                                    TEST(LibStuff::testCurrentDate))
     { }
 
     void testEncryptDecrpyt() {
@@ -632,5 +634,9 @@ struct LibStuff : tpunit::TestFixture {
         ASSERT_EQUAL(SFirstOfMonth(timeStamp4, -7), "2019-12-01");
         ASSERT_EQUAL(SFirstOfMonth(timeStamp4, -13), "2019-06-01");
         ASSERT_EQUAL(SFirstOfMonth(timeStamp4, -25), "2018-06-01");
+    }
+
+    void testCurrentDate() {
+        ASSERT_TRUE(std::regex_match(SCURRENT_DATE(), std::regex("\\d{4}-\\d{2}-\\d{2}")));
     }
 } __LibStuff;


### PR DESCRIPTION
### Details
Adds a LibStuff util for current date.

### Fixed Issues
n/a – part of https://github.com/Expensify/Expensify/issues/181819

### Tests
Added a new unit test for this function.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
