### PR TITLE
Add ReturnValueList to timing log line.

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -196,8 +196,21 @@ void BedrockCommand::finalizeTimingInfo() {
         }
     }
 
+    // This is a hack to support Auth's old `Get` format where we have a `returnValueList` of items to return rather
+    // than a specific name. The timing profile of every version of this command is wildly different and it's impossible
+    // to reason about which ones cause performance issues when they're all globbed together.
+    // In the future, let's find a better way to do this. For now, this gets us the data we need.
+    string methodName = request.methodLine + (request.isSet("returnValueList") ? "_" + request["returnValueList"] : ""s);
+
+    // This makes these look like valid command names given all our existing log handling.
+    for (size_t i = 0; i < methodName.size(); i++) {
+        if (methodName[i] == ',') {
+            methodName[i] = '_';
+        }
+    }
+
     // Log all this info.
-    SINFO("command '" << request.methodLine << "' timing info (ms): "
+    SINFO("command '" << methodName << "' timing info (ms): "
           << peekTotal/1000 << " (" << peekCount << "), "
           << processTotal/1000 << " (" << processCount << "), "
           << commitWorkerTotal/1000 << ", "


### PR DESCRIPTION
### Details
This is a hack and it's done "wrong" because bedrock shouldn't need to know about how auth commands are structured, but it's entirely self-contained, so no other code will depend on this, it's easy to rip out, and it really will help with diagnosing some current performance issues. I'd like to merge it at least for a week or two to collect data. We can kill it after that if we like.

The reasoning for replacing commas with underscores is to make it work with the existing `logsToStatsd.pl` and anything based on that, that uses this regex:
```
...command '(\w+)' timing info...
```

`\w` matches `_` but does not match `,` and I don't want to try and make all the changed to statsd and anything that depends on it for a temporary throwaway change.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/179482

### Tests
Running the auth tests and verifying output:
```
2021-11-03T01:18:16.746426+00:00 expensidev2004 bedrock: KBLFmC (BedrockCommand.cpp:212) finalizeTimingInfo [worker1] [info] command 'Get_transactionList' timing info (ms): 1 (1), 0 (0), 0, 0, 0, 0, 2, 0, 0. Upstream: 0, 0, 0, 0.
```
