### PR TITLE
Update SIsValidSQLiteDateModifier to allow for 8 digits numbers for seconds

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2654,7 +2654,10 @@ bool SIsValidSQLiteDateModifier(const string& modifier) {
     list<string> parts = SParseList(SToUpper(modifier));
     for (const string& part : parts) {
         // Simple regexp validation
-        if (SREMatch("^(\\+|-)\\d{1,3} (YEAR|MONTH|DAY|HOUR|MINUTE|SECOND)S?$", part)) {
+        if (SREMatch("^(\\+|-)\\d{1,8} (SECOND)S?$", part)) {
+            continue;
+        }
+        if (SREMatch("^(\\+|-)\\d{1,3} (YEAR|MONTH|DAY|HOUR|MINUTE)S?$", part)) {
             continue;
         }
         if (SREMatch("^START OF (DAY|MONTH|YEAR)$", part)) {

--- a/test/tests/SIsValidSQLiteDateModifierTest.cpp
+++ b/test/tests/SIsValidSQLiteDateModifierTest.cpp
@@ -1,0 +1,71 @@
+#include <libstuff/libstuff.h>
+#include <test/lib/tpunit++.hpp>
+
+struct SIsValidSQLiteDateModifierTest : tpunit::TestFixture {
+    SIsValidSQLiteDateModifierTest()
+    : tpunit::TestFixture("SIsValidSQLiteDateModifier",
+                          TEST(SIsValidSQLiteDateModifierTest::test)) { }
+    void test()
+    {
+        // +1 for every timeframe
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+1 SECOND"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+1 MINUTE"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+1 HOUR"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+1 DAY"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+1 MONTH"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+1 YEAR"));
+
+        // -1 for every timeframe
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-1 SECOND"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-1 MINUTE"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-1 HOUR"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-1 DAY"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-1 MONTH"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-1 YEAR"));
+
+        // +999 for every timeframe (singular)
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+999 SECOND"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+999 MINUTE"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+999 HOUR"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+999 DAY"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+999 MONTH"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+999 YEAR"));
+
+        // -999 for every timeframe (singular)
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-999 SECOND"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-999 MINUTE"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-999 HOUR"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-999 DAY"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-999 MONTH"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-999 YEAR"));
+
+        // +999 for every timeframe (plural)
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+999 SECONDS"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+999 MINUTES"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+999 HOURS"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+999 DAYS"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+999 MONTHS"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+999 YEARS"));
+        
+        // -999 for every timeframe (plural)
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-999 SECONDS"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-999 MINUTES"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-999 HOURS"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-999 DAYS"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-999 MONTHS"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-999 YEARS"));
+
+        // We can go up to 8 digits with seconds
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("+99999999 SECONDS"));
+        EXPECT_FALSE(SIsValidSQLiteDateModifier("+999999999 SECONDS"));
+        EXPECT_TRUE(SIsValidSQLiteDateModifier("-99999999 SECONDS"));
+        EXPECT_FALSE(SIsValidSQLiteDateModifier("-999999999 SECONDS"));
+
+        // We can't go above 3 digits for others
+        EXPECT_FALSE(SIsValidSQLiteDateModifier("+9999 MINUTES"));
+        EXPECT_FALSE(SIsValidSQLiteDateModifier("+9999 HOURS"));
+        EXPECT_FALSE(SIsValidSQLiteDateModifier("+9999 DAYS"));
+        EXPECT_FALSE(SIsValidSQLiteDateModifier("+9999 MONTHS"));
+        EXPECT_FALSE(SIsValidSQLiteDateModifier("+9999 YEARS"));
+    }
+} __SIsValidSQLiteDateModifierTest;

--- a/test/tests/jobs/RetryJobTest.cpp
+++ b/test/tests/jobs/RetryJobTest.cpp
@@ -300,7 +300,7 @@ struct RetryJobTest : tpunit::TestFixture {
         command.clear();
         command.methodLine = "RetryJob";
         command["jobID"] = jobID;
-        command["delay"] = "1000";
+        command["delay"] = "100000000";
         tester->executeWaitVerifyContent(command, "402 Malformed delay");
     }
 


### PR DESCRIPTION


### Details
```
sqlite> SELECT DATETIME('now', '+99999999 SECONDS');
DATETIME('now', '+99999999 SECONDS')
------------------------------------
2025-01-04 22:14:06                 
sqlite> 
```

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/183879

### Tests

Automated
