### PR TITLE
Don't log entire message

### DIFF
--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -241,8 +241,7 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                     // Warn if the message is set. Otherwise, the error is that we got no message (we timed out), just
                     // reconnect without complaining about it.
                     if (message.methodLine.size()) {
-                        PWARN("Error processing message '" << message.methodLine << "' (" << e.what()
-                                                           << "), reconnecting:" << message.serialize());
+                        PWARN("Error processing message '" << message.methodLine << "' (" << e.what() << "), reconnecting.");
                     }
                     SData reconnect("RECONNECT");
                     reconnect["Reason"] = e.what();


### PR DESCRIPTION
### Details
Logging entire messages can contain sensitive info.

### Fixed Issues
N/A

### Tests
Existing tests.