### PR TITLE
Fix regex for auth tokens

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2563,11 +2563,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
     string sqlToLog = sql;
     if ((int64_t)elapsed > warnThreshold) {
         // This code removing authTokens is a quick fix and should be removed once https://github.com/Expensify/Expensify/issues/144185 is done.
-        string match;
-        const bool hasAuthToken = SREMatch(".*(\"authToken\"\\:\"[0-9A-F]{400,1024}\").*", sql, match);
-        if (hasAuthToken) {
-            sqlToLog = SReplace(sql, match, "<REDACTED_AUTHTOKEN>");
-        }
+        pcrecpp::RE("\"authToken\":\"[0-9A-F]{400,1024}\"").GlobalReplace("<REDACTED_AUTHTOKEN>", &sqlToLog);
         SWARN("Slow query (" << elapsed / 1000 << "ms): " << sqlToLog);
     }
 

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2563,7 +2563,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
     string sqlToLog = sql;
     if ((int64_t)elapsed > warnThreshold) {
         // This code removing authTokens is a quick fix and should be removed once https://github.com/Expensify/Expensify/issues/144185 is done.
-        pcrecpp::RE("\"authToken\":\"[0-9A-F]{400,1024}\"").GlobalReplace("<REDACTED_AUTHTOKEN>", &sqlToLog);
+        pcrecpp::RE("\"authToken\":\"[0-9A-F]{400,1024}\"").GlobalReplace("\"authToken\":<REDACTED>", &sqlToLog);
         SWARN("Slow query (" << elapsed / 1000 << "ms): " << sqlToLog);
     }
 


### PR DESCRIPTION
### Details

So, this is essentially a problem where we call `SREMatch` which matches a single thing, on a logline with multiple matches. If there are 4 authTokens in a logline, we'd only replace the first one.

It's actually more nuanced that that, but that's what would have happened if the existing code worked as expected, this would still have been a bug, and it still would have affected the same lines with more than one authToken, but it would have redacted the first one but not the following ones.

I also removed the literal backslash before the `:` in the regex which wasn't necessary. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/186211

### Tests

Tested by modifying test/main.cpp to use this code:
```
    int replaced = pcrecpp::RE("\"authToken\":\"[0-9A-F]{400,1024}\"").GlobalReplace("<REDACTED_AUTHTOKEN>", &sql);
    cout << "replaced " << replaced << " occurences." << endl;
    cout << sql << endl;
```

On a real-life logline containing the tokens. It output:
```
vagrant@expensidev2004:/vagrant/Bedrock/test$ ./test
replaced 4 occurences.
2021-11-22T23:46:41.688466+00:00 db2.rno bedrock: xxxxxx (libstuff.cpp:2571) SQuery [replicate11819284] [warn] Slow query (2773ms): UPDATE reimbursements SET state = 1 WHERE debitBankAccountID IN (1369287) AND debitPosted IS NULL AND state != 2 AND type NOT IN (5, 10, 9, 11, 12, 8, 7);UPDATE bankAccounts SET additionalData = JSON_SET(COALESCE(NULLIF(additionalData, ''), '{}'), '$.possibleFraud', JSON_INSERT('[]', '$[0]', JSON_OBJECT('type','suspicious amount','date','2021-11-22 23:46:33','reason', ''))) WHERE bankAccountID IN (1369287);UPDATE reimbursements SET state = 1 WHERE debitBankAccountID IN (1347629, 1347948) AND debitPosted IS NULL AND state != 2 AND type NOT IN (5, 10, 9, 11, 12, 8, 7);UPDATE bankAccounts SET additionalData = JSON_SET(COALESCE(NULLIF(additionalData, ''), '{}'), '$.possibleFraud', JSON_INSERT('[]', '$[0]', JSON_OBJECT('type','suspicious amount','date','2021-11-22 23:46:34','reason', ''))) WHERE bankAccountID IN (1347629, 1347948);UPDATE reimbursements SET state = 1 WHERE debitBankAccountID IN (1246211, 1284071, 1352120) AND debitPosted IS NULL AND state != 2 AND type NOT IN (5, 10, 9, 11, 12, 8, 7);UPDATE bankAccounts SET additionalData = JSON_SET(COALESCE(NULLIF(additionalData, ''), '{}'), '$.possibleFraud', JSON_INSERT('[]', '$[0]', JSON_OBJECT('type','suspicious amount','date','2021-11-22 23:46:34','reason', ''))) WHERE bankAccountID IN (1246211, 1284071, 1352120);UPDATE reimbursements SET state = 1 WHERE debitBankAccountID IN (1369476) AND debitPosted IS NULL AND state != 2 AND type NOT IN (5, 10, 9, 11, 12, 8, 7);UPDATE bankAccounts SET additionalData = JSON_SET(COALESCE(NULLIF(additionalData, ''), '{}'), '$.possibleFraud', JSON_INSERT('[]', '$[0]', JSON_OBJECT('type','suspicious amount','date','2021-11-22 23:46:34','reason', ''))) WHERE bankAccountID IN (1369476);UPDATE reimbursements SET state = 1 WHERE debitBankAccountID IN (1052128) AND debitPosted IS NULL AND state != 2 AND type NOT IN (5, 10, 9, 11, 12, 8, 7);UPDATE bankAccounts SET additionalData = JSON_SET(COALESCE(NULLIF(additionalData, ''), '{}'), '$.possibleFraud', JSON_INSERT('[{"date":"2020-10-02 00:00:47","notFraudReason":"A bit more digging occurred here due to immense amounts and multiple expenses having the same amount. However, phone number within the invocing receipts connects to lan lou(maggie is her american name), emailage score is low 129 and the email has been around for 2.8 years, the invoices are always for I Fly Funds but they have a 1099 filing for the company in one of the withdrawing reports. Reviewing all reports they seem to have decreased their use of us a lot and are mainly using us for Quarterly expenses right now. Expenses in the past were less similar but nothing has changed in the account that i can seen since the last time we paid out a 10K report for them. Giving this the all clear.","type":"suspicious amount"}]', '$[1]', JSON_OBJECT('type','suspicious amount','date','2021-11-22 23:46:34','reason', ''))) WHERE bankAccountID IN (1052128);INSERT INTO notifications (json, priority, created) VALUES ( JSON('{"accountID":2543349,<REDACTED_AUTHTOKEN>,"reportID":84035592,"template":"Report_DelayedReimbursement","to":"etienne@7ctos.com"}'), 100, '2021-11-22 23:46:35');INSERT INTO notifications (json, priority, created) VALUES ( JSON('{"accountID":10692475,<REDACTED_AUTHTOKEN>,"reportID":84035592,"template":"Report_DelayedReimbursement","to":"beth@7ctos.com"}'), 100, '2021-11-22 23:46:35');INSERT INTO reportActions ( created, reportID, accountID, action, message ) VALUES ( '2021-11-22 23:46:35', 84035592, 10692475, 'REIMBURSEMENTDELAYED', REPLACE ('{"automaticAction":true}', '%reportActionID%', (SELECT COALESCE(MAX(ROWID), 0) + 1 FROM reportActions)));INSERT INTO notifications (json, priority, created) VALUES ( JSON('{"accountID":2543349,<REDACTED_AUTHTOKEN>,"reportID":83620639,"template":"Report_DelayedReimbursement","to":"etienne@7ctos.com"}'), 100, '2021-11-22 23:46:35');INSERT INTO notifications (json, priority, created) VALUES ( JSON('{"accountID":10692475,<REDACTED_AUTHTOKEN>,"reportID":83620639,"template":"Report_DelayedReimbursement","to":"beth@7ctos.com"}'), 100, '2021-11-22 23:46:35');INSERT INTO reportActions ( created, reportID, accountID, action, message ) VALUES ( '2021-11-22 23:46:35', 83620639, 10692475, 'REIMBURSEMENTDELAYED', REPLACE ('{"automaticAction":true}', '%reportActionID%', (SELECT COALESCE(MAX(ROWID), 0) + 1 FROM reportActions)));INSERT INTO notifications (json, priority, created) VALUES ( JSON('{"accountID":10457364,"authToken":"TRUNCATED_IN_ORIGINAL_LOG_LINE_SO_NOT_MATCHED_HERE_BECAUSE_OF_MISSING_CLOSING_QUOTE
```