### PR TITLE
Add wal2 mode (off by default)

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -180,7 +180,7 @@ void BedrockServer::sync()
     // We use fewer FDs on test machines that have other resource restrictions in place.
     int fdLimit = args.isSet("-live") ? 25'000 : 250;
     SINFO("Setting dbPool size to: " << fdLimit);
-    _dbPool = make_shared<SQLitePool>(fdLimit, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.test("-pageLogging"));
+    _dbPool = make_shared<SQLitePool>(fdLimit, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.test("-pageLogging"), args.test("-wal2"));
     SQLite& db = _dbPool->getBase();
 
     // Initialize the command processor.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -180,7 +180,7 @@ void BedrockServer::sync()
     // We use fewer FDs on test machines that have other resource restrictions in place.
     int fdLimit = args.isSet("-live") ? 25'000 : 250;
     SINFO("Setting dbPool size to: " << fdLimit);
-    _dbPool = make_shared<SQLitePool>(fdLimit, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.test("-pageLogging"), args.test("-wal2"));
+    _dbPool = make_shared<SQLitePool>(fdLimit, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.test("-pageLogging"), args.isSet("-wal2"));
     SQLite& db = _dbPool->getBase();
 
     // Initialize the command processor.

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -274,9 +274,9 @@ int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int 
     SQLite* object = static_cast<SQLite*>(data);
     object->_sharedData._currentPageCount.store(pageCount);
 
-    if (object->sharedData.wal2) {
+    if (object->_sharedData.wal2) {
         SINFO("[checkpoint] skipping straight to passive checkpoint in wal2 mode.");
-        return;
+        return SQLITE_OK;
     }
 
     // Try a passive checkpoint if full checkpoints aren't enabled, *or* if the page count is less than the required

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -55,8 +55,12 @@ SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, const string& file
         SQResult result;
         sharedData->wal2 = _wal2;
         if (sharedData->wal2) {
-            SASSERT(!SQuery(db, "", "PRAGMA journal_mode = delete;", result));
-            SASSERT(!SQuery(db, "", "PRAGMA journal_mode = wal2;", result));
+            // if it's missing or anything but `wal2`, set it to wal2.
+            SQuery(db, "", "PRAGMA journal_mode;", result);
+            if (!result.rows.size() || result.rows[0][0] != "wal2") {
+                SASSERT(!SQuery(db, "", "PRAGMA journal_mode = delete;", result));
+                SASSERT(!SQuery(db, "", "PRAGMA journal_mode = wal2;", result));
+            }
         }
 
         // Read the highest commit count from the database, and store it in commitCount.

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -60,10 +60,13 @@ SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, const string& file
         bool dbCurrentlyWAL2 = result.rows.size() && result.rows[0][0] == "wal2";
 
         // If the intended wal setting doesn't match the existing wal setting, change it.
+        string walType = sharedData->wal2 ? "wal2" : "wal";
         if (dbCurrentlyWAL2 != sharedData->wal2) {
-            string walType = sharedData->wal2 ? "wal2" : "wal";
             SASSERT(!SQuery(db, "", "PRAGMA journal_mode = delete;", result));
             SASSERT(!SQuery(db, "", "PRAGMA journal_mode = " + walType + ";", result));
+            SINFO("Set wal mode to: " << walType);
+        } else {
+            SINFO("wal mode unchanged: " << walType);
         }
 
         // Read the highest commit count from the database, and store it in commitCount.

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -273,6 +273,12 @@ int SQLite::_sqliteTraceCallback(unsigned int traceCode, void* c, void* p, void*
 int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int pageCount) {
     SQLite* object = static_cast<SQLite*>(data);
     object->_sharedData._currentPageCount.store(pageCount);
+
+    if (object->sharedData.wal2) {
+        SINFO("[checkpoint] skipping straight to passive checkpoint in wal2 mode.");
+        return;
+    }
+
     // Try a passive checkpoint if full checkpoints aren't enabled, *or* if the page count is less than the required
     // size for a full checkpoint.
     if (pageCount >= fullCheckpointPageMin.load()) {

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -75,7 +75,7 @@ class SQLite {
     //
     // mmapSizeGB: address space to use for memory-mapped IO, in GB.
     SQLite(const string& filename, int cacheSize, int maxJournalSize, int minJournalTables,
-           const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false);
+           const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false, bool wal2 = false);
 
     // Compatibility constructor. Remove when AuthTester::getStripeSQLiteDB no longer uses this outdated version.
     SQLite(const string& filename, int cacheSize, int maxJournalSize, int minJournalTables, int synchronous) :
@@ -354,6 +354,9 @@ class SQLite {
         // checkpoints to not more often than every N commits.
         atomic<uint64_t> lastCompleteCheckpointCommitCount;
 
+        // True if we should use wal2 mode.
+        atomic<bool> wal2 = false;
+
       private:
         // The data required to replicate transactions, in two lists, depending on whether this has only been prepared
         // or if it's been committed.
@@ -370,11 +373,11 @@ class SQLite {
 
     // Initializers to support RAII-style allocation in constructors.
     static string initializeFilename(const string& filename);
-    static SharedData& initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames);
+    static SharedData& initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames, bool _wal2);
     static sqlite3* initializeDB(const string& filename, int64_t mmapSizeGB);
     static vector<string> initializeJournal(sqlite3* db, int minJournalTables);
     static uint64_t initializeJournalSize(sqlite3* db, const vector<string>& journalNames);
-    void commonConstructorInitialization();
+    void commonConstructorInitialization(bool wal2);
 
     // The filename of this DB, canonicalized to its full path on disk.
     const string _filename;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -75,7 +75,7 @@ class SQLite {
     //
     // mmapSizeGB: address space to use for memory-mapped IO, in GB.
     SQLite(const string& filename, int cacheSize, int maxJournalSize, int minJournalTables,
-           const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false, bool wal2 = false);
+           const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false, bool enableWAL2 = false);
 
     // Compatibility constructor. Remove when AuthTester::getStripeSQLiteDB no longer uses this outdated version.
     SQLite(const string& filename, int cacheSize, int maxJournalSize, int minJournalTables, int synchronous) :
@@ -373,11 +373,11 @@ class SQLite {
 
     // Initializers to support RAII-style allocation in constructors.
     static string initializeFilename(const string& filename);
-    static SharedData& initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames, bool _wal2);
+    static SharedData& initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames, bool enableWAL2);
     static sqlite3* initializeDB(const string& filename, int64_t mmapSizeGB);
     static vector<string> initializeJournal(sqlite3* db, int minJournalTables);
     static uint64_t initializeJournalSize(sqlite3* db, const vector<string>& journalNames);
-    void commonConstructorInitialization(bool wal2);
+    void commonConstructorInitialization(bool enableWAL2);
 
     // The filename of this DB, canonicalized to its full path on disk.
     const string _filename;

--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -9,9 +9,10 @@ SQLitePool::SQLitePool(size_t maxDBs,
                        int minJournalTables,
                        const string& synchronous,
                        int64_t mmapSizeGB,
-                       bool pageLoggingEnabled)
+                       bool pageLoggingEnabled,
+                       bool wal2)
 : _maxDBs(max(maxDBs, 1ul)),
-  _baseDB(filename, cacheSize, maxJournalSize, minJournalTables, synchronous, mmapSizeGB, pageLoggingEnabled),
+  _baseDB(filename, cacheSize, maxJournalSize, minJournalTables, synchronous, mmapSizeGB, pageLoggingEnabled, wal2),
   _objects(_maxDBs, nullptr)
 {
 }

--- a/sqlitecluster/SQLitePool.h
+++ b/sqlitecluster/SQLitePool.h
@@ -6,7 +6,7 @@ class SQLitePool {
   public:
     // Create a pool of DB handles.
     SQLitePool(size_t maxDBs, const string& filename, int cacheSize, int maxJournalSize, int minJournalTables,
-               const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false);
+               const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false, bool wal2 = false);
     ~SQLitePool();
 
     // Get the base object (the first one created, which uses the `journal` table). Note that if called by multiple

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -490,7 +490,8 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
 SQLite& BedrockTester::getSQLiteDB()
 {
     if (!_db) {
-        _db = new SQLite(_args["-db"], 1000000, 3000000, -1);
+        // Assumes wal2 mode.
+        _db = new SQLite(_args["-db"], 1000000, 3000000, -1, "", 0, false, true);
     }
     return *_db;
 }

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -61,6 +61,7 @@ BedrockTester::BedrockTester(const map<string, string>& args,
         {"-quorumCheckpoint", "50"},
         {"-enableMultiWrite", "true"},
         {"-cacheSize", "1000"},
+        {"-wal2", ""},
         {"-parallelReplication", "true"},
         // Currently breaks only in Travis and needs debugging, which has been removed, maybe?
         //{"-logDirectlyToSyslogSocket", ""},


### PR DESCRIPTION
### Details
This adds a command line flag for wal2.

HOLD: https://github.com/Expensify/ExpensifyBackupManager/pull/43

~TODO: I want to verify we can turn wal2 back off.~ Done, works.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/183858

### Deploy plan
1. deploy as normal.
2. Wait a day to verify nothing is broken.
3. Change config for on node to add the `-wal2` flag.
4. Restart that node.
5. Watch to make sure it uses both wal files and it still checkpoints and the wal file doesn't grow huge. See if there are any performance differences.
6. Turn it on everywhere.


### Tests
Existing bedrock tests.

It seems to be writing both files in tests:
```
-rw-------  1 vagrant vagrant      0 Dec  1 13:03 bedrocktest_jTT7eC.db
-rw-------  1 vagrant vagrant      0 Dec  1 18:16 bedrocktest_jh2oyj.db
-rw-------  1 vagrant vagrant  45056 Dec  7 14:13 bedrocktest_l3o2BN.db
-rw-------  1 vagrant vagrant  32768 Dec  7 14:13 bedrocktest_l3o2BN.db-shm
-rw-------  1 vagrant vagrant  41232 Dec  7 14:13 bedrocktest_l3o2BN.db-wal
-rw-------  1 vagrant vagrant      0 Dec  7 14:13 bedrocktest_l3o2BN.db-wal2
-rw-------  1 vagrant vagrant      0 Dec  1 12:45 bedrocktest_ls1R6j.db
-rw-------  1 vagrant vagrant      0 Nov 29 18:02 bedrocktest_oZEays.db
-rw-------  1 vagrant vagrant      0 Dec  1 12:24 bedrocktest_oyiPJL.db
-rw-------  1 vagrant vagrant  45056 Dec  7 14:13 bedrocktest_qLOFWQ.db
-rw-------  1 vagrant vagrant  32768 Dec  7 14:13 bedrocktest_qLOFWQ.db-shm
-rw-------  1 vagrant vagrant  24752 Dec  7 14:13 bedrocktest_qLOFWQ.db-wal
-rw-------  1 vagrant vagrant      0 Dec  7 14:13 bedrocktest_qLOFWQ.db-wal2
-rw-------  1 vagrant vagrant      0 Dec  1 18:59 bedrocktest_sd1oSf.db
-rw-------  1 vagrant vagrant  45056 Dec  7 14:13 bedrocktest_sik8JN.db
-rw-------  1 vagrant vagrant  32768 Dec  7 14:13 bedrocktest_sik8JN.db-shm
-rw-------  1 vagrant vagrant  41232 Dec  7 14:13 bedrocktest_sik8JN.db-wal
-rw-------  1 vagrant vagrant      0 Dec  7 14:13 bedrocktest_sik8JN.db-wal2
```

Both auth and bvedrock in the VM seem to start up with the new setting:
```
root      157231  0.1  0.4 481656 28792 ?        Ssl  15:53   0:00 /usr/sbin/bedrock -fork -db /var/auth/main.db -pidFile /var/run/auth.pid -serverHost 0.0.0.0:4444 -nodeName auth -nodeHost 0.0.0.0:4445 -keyHost 127.0.0.1:4001 -priority 200 -cacheSize 10001 -credentialsFile /vagrant/Auth/credentials.txt -debugKeys -v -wal2 -plugins db,auth,expensifyBackupManager -overrideSupportPasswordHash 70ccd9007338d6d81dd3b6271621b9cf9a97ea00 -synchronousCommands BatchReimbursements,CancelReimbursement
root      157331  0.4  0.2 456812 17604 ?        Ssl  15:54   0:00 /usr/sbin/bedrock -fork -db /var/bedrock/main.db -pidFile /var/run/bedrock.pid -serverHost 0.0.0.0:8888 -nodeName bedrock -nodeHost 0.0.0.0:8889 -priority 200 -v -wal2 -cache 10001 -plugins db,jobs,cache,concierge,expensifyTableManager,expensifyBackupManager -controlPort localhost:7999
```
```
vagrant@expensidev2004:/vagrant/Auth$ ls /var/auth/
main.db  main.db-shm  main.db-wal  main.db-wal2
vagrant@expensidev2004:/vagrant/Auth$ ls /var/bedrock/
main.db  main.db-shm  main.db-wal  main.db-wal2
vagrant@expensidev2004:/vagrant/Auth$
```

Auth tests have passed locally in my VM.