### PR TITLE
Fix shutdown race condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ sqlitecluster/sqlitecluster
 libstuff/libstuff.d
 libstuff/libstuff.h.gch
 .idea
+
+*.[do]
+perftest/perftest
+*.db
+*.db-wal
+*.db-shm

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -175,6 +175,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
     // leading but were following when we peeked, we may try to read HTTPS requests we never made).
     if ((command->lastPeekedOrProcessedInState != SQLiteNode::LEADING && command->lastPeekedOrProcessedInState != SQLiteNode::STANDINGDOWN) ||
         (_server.getState() != SQLiteNode::LEADING && _server.getState() != SQLiteNode::STANDINGDOWN)) {
+        SINFO("Server no longer LEADING or STANDINGDOWN, can't process command");
         return RESULT::SERVER_NOT_LEADING;
     }
     command->lastPeekedOrProcessedInState = _server.getState();

--- a/perftest/Makefile
+++ b/perftest/Makefile
@@ -1,0 +1,19 @@
+
+OPTS=-g -O2
+#OPTS=-g
+
+all: perftest
+
+sqlite3.o: ../libstuff/sqlite3.c
+	gcc-9 $(OPTS) -c -Wno-unused-but-set-variable -DSQLITE_ENABLE_STAT4 -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_SESSION -DSQLITE_ENABLE_PREUPDATE_HOOK -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT -DSQLITE_THREADSAFE=2 -DSQLITE_MAX_MMAP_SIZE=1099511627776 -DSQLITE_SHARED_MAPPING  ../libstuff/sqlite3.c;
+
+perftest.o: perftest.cpp
+	g++-9 -std=c++14 $(OPTS) -c perftest.cpp;
+
+perftest: perftest.o sqlite3.o
+	g++-9 -std=c++14 $(OPTS) -o perftest perftest.o sqlite3.o -ldl -lpthread -lnuma;
+
+clean:
+	rm -f sqlite3.o
+	rm -f perftest.o
+	rm -f perftest

--- a/perftest/bigtest.sh
+++ b/perftest/bigtest.sh
@@ -1,0 +1,144 @@
+TEST_SECONDS=30
+echo "==================================================================="
+echo "   Starting new test: " `date`
+
+echo "-------------------------------------------------------------------"
+cat perftest.cpp
+
+echo "-------------------------------------------------------------------"
+cat bigtest.sh
+
+echo "-------------------------------------------------------------------"
+echo "Building db..."
+time sqlite3 /var/lib/bedrock/perftest.30B.db < perftest.sql
+
+echo "-------------------------------------------------------------------"
+echo "cpupower -c all set -b 0"
+cpupower -c all set -b 0
+
+echo "-------------------------------------------------------------------"
+free -h
+sh -c "echo 3 > /proc/sys/vm/drop_caches"
+free -h
+md5sum /var/lib/bedrock/perftest.30B.db > /dev/null
+./perftest.make_SQLITE_SHARED_MAPPING -csv -numa -numastats -mmap -testSeconds 120 -maxNumThreads 256 -dbFilename /var/lib/bedrock/perftest.30B.db
+
+echo "-------------------------------------------------------------------"
+free -h
+sh -c "echo 3 > /proc/sys/vm/drop_caches"
+free -h
+md5sum /var/lib/bedrock/perftest.30B.db > /dev/null
+./perftest.make -csv -numa -numastats -mmap -testSeconds 120 -maxNumThreads 256 -dbFilename /var/lib/bedrock/perftest.30B.db
+
+echo "-------------------------------------------------------------------"
+free -h
+sh -c "echo 3 > /proc/sys/vm/drop_caches"
+free -h
+md5sum /var/lib/bedrock/perftest.30B.db > /dev/null
+./perftest.build -csv -numa -numastats -mmap -testSeconds 120 -maxNumThreads 256 -dbFilename /var/lib/bedrock/perftest.30B.db
+
+#echo "-------------------------------------------------------------------"
+#free -h
+#sh -c "echo 3 > /proc/sys/vm/drop_caches"
+#free -h
+#./perftest -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -customQuery "SLEEP"
+
+#echo "-------------------------------------------------------------------"
+#free -h
+#sh -c "echo 3 > /proc/sys/vm/drop_caches"
+#free -h
+#./perftest.make_SQLITE_SHARED_MAPPING -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -customQuery "NOOP"
+
+#echo "-------------------------------------------------------------------"
+#free -h
+#sh -c "echo 3 > /proc/sys/vm/drop_caches"
+#free -h
+#./perftest.make_SQLITE_SHARED_MAPPING -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -customQuery "SELECT 1;"
+
+#echo "-------------------------------------------------------------------"
+#free -h
+#sh -c "echo 3 > /proc/sys/vm/drop_caches"
+#free -h
+#md5sum perftest.1.db > /dev/null
+#./perftest -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename perftest.1.db -customQuery "SELECT * FROM perfTest;"
+
+#echo "-------------------------------------------------------------------"
+#free -h
+#sh -c "echo 3 > /proc/sys/vm/drop_caches"
+#free -h
+#md5sum perftest.1.db > /dev/null
+#./perftest -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename perftest.1.db
+
+#echo "-------------------------------------------------------------------"
+#free -h
+#sh -c "echo 3 > /proc/sys/vm/drop_caches"
+#free -h
+#md5sum perftest.1M.db > /dev/null
+#./perftest -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename perftest.1M.db
+
+#echo "-------------------------------------------------------------------"
+#free -h
+#sh -c "echo 3 > /proc/sys/vm/drop_caches"
+#free -h
+#md5sum perftest.10M.db > /dev/null
+#./perftest -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename perftest.10M.db
+
+#echo "-------------------------------------------------------------------"
+#free -h
+#sh -c "echo 3 > /proc/sys/vm/drop_caches"
+#free -h
+#md5sum perftest.1B.db > /dev/null
+#./perftest -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename perftest.1B.db
+
+echo "-------------------------------------------------------------------"
+free -h
+sh -c "echo 3 > /proc/sys/vm/drop_caches"
+free -h
+md5sum /var/lib/bedrock/perftest.10B.db > /dev/null
+echo "./perftest.make_SQLITE_SHARED_MAPPING -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename /var/lib/bedrock/perftest.10B.db"
+./perftest.make_SQLITE_SHARED_MAPPING -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename /var/lib/bedrock/perftest.10B.db
+
+echo "-------------------------------------------------------------------"
+free -h
+sh -c "echo 3 > /proc/sys/vm/drop_caches"
+free -h
+md5sum /var/lib/bedrock/perftest.10B.db > /dev/null
+echo "./perftest.make -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename /var/lib/bedrock/perftest.10B.db"
+./perftest.make -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename /var/lib/bedrock/perftest.10B.db
+
+echo "-------------------------------------------------------------------"
+free -h
+sh -c "echo 3 > /proc/sys/vm/drop_caches"
+free -h
+md5sum /var/lib/bedrock/perftest.10B.db > /dev/null
+echo "./perftest.build -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename /var/lib/bedrock/perftest.10B.db"
+./perftest.build -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename /var/lib/bedrock/perftest.10B.db
+
+echo "-------------------------------------------------------------------"
+free -h
+sh -c "echo 3 > /proc/sys/vm/drop_caches"
+free -h
+md5sum perftest.10B.db > /dev/null
+echo "./perftest.make_SQLITE_SHARED_MAPPING -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename perftest.10B.db"
+./perftest.make_SQLITE_SHARED_MAPPING -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename perftest.10B.db
+
+echo "-------------------------------------------------------------------"
+echo "cpupower -c all set -b 7"
+cpupower -c all set -b 7
+free -h
+sh -c "echo 3 > /proc/sys/vm/drop_caches"
+free -h
+md5sum /var/lib/bedrock/perftest.10B.db > /dev/null
+echo "./perftest.make_SQLITE_SHARED_MAPPING -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename /var/lib/bedrock/perftest.10B.db"
+./perftest.make_SQLITE_SHARED_MAPPING -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename /var/lib/bedrock/perftest.10B.db
+echo "cpupower -c all set -b 0"
+cpupower -c all set -b 0
+
+echo "-------------------------------------------------------------------"
+free -h
+sh -c "echo 3 > /proc/sys/vm/drop_caches"
+free -h
+md5sum /var/lib/bedrock/perftest.30B.db > /dev/null
+./perftest -csv -numa -numastats -mmap -testSeconds $TEST_SECONDS -maxNumThreads 256 -linear -dbFilename /var/lib/bedrock/perftest.30B.db
+
+echo "==================================================================="

--- a/perftest/perftest.cpp
+++ b/perftest/perftest.cpp
@@ -1,0 +1,412 @@
+#include "../libstuff/sqlite3.h"
+#include <string>
+#include <sstream>
+#include <list>
+#include <vector>
+#include <thread>
+#include <iostream>
+#include <fstream>
+#include <atomic>
+#include <random>
+#include <sys/time.h>
+#include <unistd.h>
+#include <numa.h> // requires libnuma-dev
+using namespace std;
+
+// Overall test settings
+static int global_bMmap = 0;
+static const char* global_dbFilename = "test.db";
+static int global_cacheSize = -1000000;
+static int global_readSize = 10;
+static int global_writeSize = 10;
+static int global_writePercent = 0;
+static int global_numa = 0;
+static int global_numaPack = 0;
+static int64_t global_noopResult = 0;
+static int global_testSeconds = 10;
+static int global_secondsRemaining = 0;
+static int global_linear = 0;
+static int global_csv = 0;
+static int global_begin_concurrent = 0;
+static const char* global_vms = "unix";
+static const char* global_locking_mode = "NORMAL";
+
+// Data about the database
+static uint64_t global_dbRows = 0;
+
+// Returns the current time down to the microsecond
+uint64_t STimeNow() {
+    timeval time;
+    gettimeofday(&time, 0);
+    return ((uint64_t)time.tv_sec * 1000000 + (uint64_t)time.tv_usec);
+}
+
+// Gets the current virtual memory usage and resident set
+// From: https://stackoverflow.com/a/19770392
+void getMemUsage(double& vm_usage, double& resident_set)
+{
+    // the two fields we want
+    vm_usage     = 0.0;
+    resident_set = 0.0;
+    unsigned long vsize;
+    long rss;
+    {
+        std::string ignore;
+        std::ifstream ifs("/proc/self/stat", std::ios_base::in);
+        ifs >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore
+                >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore
+                >> ignore >> ignore >> vsize >> rss;
+    }
+    long page_size_kb = sysconf(_SC_PAGE_SIZE) / 1024; // in case x86-64 is configured to use 2MB pages
+    vm_usage = vsize / 1024.0;
+    resident_set = rss * page_size_kb;
+}
+
+// This is called by sqlite for each row of the result
+int queryCallback(void* data, int columns, char** columnText, char** columnName) {
+    list<vector<string>>* results = (list<vector<string>>*)data;
+    vector<string> row;
+    row.reserve(columns);
+    for (int i = 0; i < columns; i++) {
+        row.push_back(columnText[i] ? columnText[i] : "NULL");
+    }
+    results->push_back(move(row));
+    return SQLITE_OK;
+}
+
+// This just increments a value every second to signal to threads that they should
+// record another QPS measure.  This is to avoid having every thread poll the system
+// clock at high frequency, as that is an expensive kernel call that triggers a context
+// switch and thus will distort the results if done at high frequency.
+void countDownTimer()
+{
+    // Keep incrementing once per second until done
+    do {
+        sleep(1);
+    }
+    while (--global_secondsRemaining);
+}
+
+// This runs a test query some number of times, optionally showing progress
+void runTestQueries(sqlite3* db, int threadNum, vector<uint64_t>* queriesPerSecond, const string& testQuery, bool showProgress) {
+    // If we're numa aware, spread the memory across all nodes
+    if (global_numa) {
+        if (global_numaPack) {
+            // Pack into the fewest numa nodes
+            numa_run_on_node(numa_node_of_cpu(threadNum%numa_num_task_cpus()));
+            numa_set_preferred(numa_node_of_cpu(threadNum%numa_num_task_cpus()));
+        } else {
+            // Spread across all nodes
+            numa_run_on_node(threadNum%numa_num_task_nodes());
+            numa_set_preferred(threadNum%numa_num_task_nodes());
+        }
+    }
+
+    // Initialize our query counters
+    uint64_t numQueriesLastSecond = 0;
+    int lastSampleSecond = global_secondsRemaining;
+
+    // Run however many queries are requested
+    uint64_t noopResult = 0;
+    while (global_secondsRemaining) {
+        // See if it's a special query
+        if (testQuery=="SLEEP") {
+            // Waits 10ms
+            usleep(10*1000);
+        } else if (testQuery=="NOOP") {
+            // Does a simple calculation
+            int c=1000000;
+            while(c--) { noopResult+=c; }
+        } else if (testQuery=="NOOP_MEMORY") {
+            // Does a simple memory-intensive operation
+            int c=22;
+            string str = "asdf";
+            while(c--) { str += str; }
+            noopResult += str.size();
+        } else {
+            // Run the query
+            list<vector<string>> results;
+            int error = sqlite3_exec(db, testQuery.c_str(), queryCallback, &results, 0);
+            if (error != SQLITE_OK) {
+                cout << "Error running test query: " << sqlite3_errmsg(db) << ", query: " << testQuery << endl;
+            }
+        }
+
+        // Update timers
+        numQueriesLastSecond++;
+        if (lastSampleSecond != global_secondsRemaining) {
+            // Record QPS
+            lastSampleSecond = global_secondsRemaining;
+            queriesPerSecond->push_back(numQueriesLastSecond);
+            numQueriesLastSecond = 0;
+
+            // Optionally show progress
+            if (showProgress && !global_csv) {
+                cout << "." << flush;
+            }
+        }
+    }
+
+    // Do this at the end to avoid any kind of contention while the thread is running
+    global_noopResult += noopResult;
+}
+
+sqlite3* openDatabase(int threadNum) {
+    // If we're numa aware
+    if (global_numa) {
+        if (global_numaPack) {
+            // pack into the fewest numa nodes
+            numa_set_preferred(numa_node_of_cpu(threadNum%numa_num_task_cpus()));
+        } else {
+            // spread the memory across all nodes
+            numa_set_preferred(threadNum%numa_num_task_nodes());
+        }
+
+    }
+
+    // Open it per the global settings
+    sqlite3* db = 0;
+    if (SQLITE_OK != sqlite3_open_v2(global_dbFilename, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX, global_vms)) {
+        cout << "Error: Can't open '" << global_dbFilename << "'." << endl;
+        exit(1);
+    }
+    char locking_mode[256];
+    sprintf(locking_mode, "PRAGMA locking_mode=%s", global_locking_mode);
+    sqlite3_exec(db, locking_mode, 0, 0, 0);
+    sqlite3_exec(db, "PRAGMA legacy_file_format = OFF;", 0, 0, 0);
+    sqlite3_exec(db, "PRAGMA journal_mode = WAL;", 0, 0, 0);
+    sqlite3_exec(db, "PRAGMA synchronous = OFF;", 0, 0, 0);
+    sqlite3_exec(db, "PRAGMA count_changes = OFF;", 0, 0, 0);
+    char *zSql = sqlite3_mprintf("PRAGMA cache_size(%d)", global_cacheSize);
+    sqlite3_exec(db, zSql, 0, 0, 0);
+    sqlite3_free(zSql);
+    sqlite3_wal_autocheckpoint(db, 10000);
+    if( global_bMmap ){
+      sqlite3_exec(db, "PRAGMA mmap_size = 1099511627776;", 0, 0, 0); // 1TB
+    } else {
+      sqlite3_exec(db, "PRAGMA mmap_size = 0;", 0, 0, 0); // Disable
+    }
+    return db;
+}
+
+void test(int threadCount, const string& testQuery) {
+    // Open a separate database handle for each thread
+    if (global_csv) {
+        cout << threadCount;
+    } else {
+        cout << "Testing with " << threadCount << " threads: ";
+    }
+    vector<sqlite3*> dbs(threadCount);
+    for (int i = 0; i < threadCount; i++) {
+        dbs[i] = openDatabase(i);
+    }
+
+    // Start a thread that just harvests QPS every second
+    global_secondsRemaining = global_testSeconds;
+    thread timerCounter(countDownTimer);
+    vector<vector<uint64_t>> queriesPerSecondPerThread;
+    queriesPerSecondPerThread.resize(threadCount);
+
+    // Run the actual test
+    list <thread> threads;
+    auto start = STimeNow();
+    for (int i = 0; i < threadCount; i++) {
+        bool showProgress = (i == (threadCount - 1)); // Only show progress on the last thread
+        threads.emplace_back(runTestQueries, dbs[i], i, &queriesPerSecondPerThread[i], testQuery, showProgress);
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+    threads.clear();
+    auto end = STimeNow();
+
+    // Stop the timer and calculate max QPS
+    timerCounter.join();
+    uint64_t maxQPS = 0;
+    for(int sec=1; sec<queriesPerSecondPerThread[0].size(); sec++) { // skip the first second
+       uint64_t qps = 0;
+       for(int t=0; t<threadCount; t++) {
+           qps += queriesPerSecondPerThread[t][sec];
+       }
+       if (qps>maxQPS) {
+           maxQPS = qps;
+       }
+    }
+
+    // Output the results
+    double vm, rss;
+    getMemUsage(vm, rss);
+    if (global_csv) {
+        cout << ", " << maxQPS << ", " << (double)maxQPS/(double)threadCount << endl;
+    } else {
+        cout << "Done! (" << ((end - start) / 1000000.0) << " seconds, vm=" << vm << ", rss=" << rss << ", maxQPS=" << maxQPS << ", maxQPS/t=" << (double)maxQPS/(double)threadCount << ")" << endl;
+    }
+
+    // Close all the database handles
+    for (int i = 0; i < threadCount; i++) {
+        sqlite3_close(dbs[i]);
+    }
+}
+
+
+int main(int argc, char *argv[]) {
+    // Log the command line
+    for (int i = 0; i < argc; i++) { cout << argv[i] << " "; }
+    cout << endl;
+
+    // Disable memory status tracking as this has a known concurrency problem
+    sqlite3_config(SQLITE_CONFIG_MEMSTATUS, 0);
+
+    // Process the command line
+    int numThreads = -1;
+    int maxNumThreads = 16;
+    int showStats = 0;
+    const char* customQuery = 0;
+    for (int i = 1; i < argc; i++) {
+        char *z = argv[i];
+        if( z[0]=='-' && z[1]=='-' ) z++;
+        if (z == string("-cacheSize")) {
+            global_cacheSize = atoi(argv[++i]);
+        }else
+        if (z == string("-numThreads")) {
+            numThreads = atoi(argv[++i]);
+        }else
+        if (z == string("-readSize")) {
+            global_readSize = atoi(argv[++i]);
+        }else
+        if (z == string("-writeSize")) {
+            global_writeSize = atoi(argv[++i]);
+        }else
+        if (z == string("-writePercent")) {
+            global_writePercent = atoi(argv[++i]);
+        }else
+        if (z == string("-maxNumThreads")) {
+            maxNumThreads = atoi(argv[++i]);
+        }else
+        if (z == string("-testSeconds")) {
+            global_testSeconds = atoi(argv[++i]);
+        }else
+        if (z == string("-mmap")) {
+          global_bMmap = 1;
+        }else
+        if (z == string("-linear")) {
+          global_linear = 1;
+        }else
+        if (z == string("-csv")) {
+          global_csv = 1;
+        }else
+        if (z == string("-begin_concurrent")) {
+          global_begin_concurrent = 1;
+        }else
+        if (z == string("-dbFilename")) {
+          global_dbFilename = argv[++i];
+        } else
+        if (z == string("-vms")) {
+          global_vms = argv[++i];
+        } else
+        if (z == string("-locking_mode")) {
+          global_locking_mode = argv[++i];
+        } else
+        if (z == string("-dbFilename")) {
+          global_dbFilename = argv[++i];
+        } else
+        if (z == string("-customQuery")) {
+          customQuery = argv[++i];
+        } else
+        if (z == string("-numa")) {
+            // Output numa information about this system
+            global_numa = 1;
+        } else
+        if (z == string("-numaPack")) {
+            // Pack into the fewest CPUs and numa nodes
+            global_numaPack = 1;
+        } else
+        if (z == string("-numastats")) {
+            cout << "Enabling NUMA awareness:" << endl;
+            cout << "numa_available=" << numa_available() << endl;
+            cout << "numa_max_node=" << numa_max_node() << endl;
+            cout << "numa_pagesize=" << numa_pagesize() << endl;
+            cout << "numa_num_configured_cpus=" << numa_num_configured_cpus() << endl;
+            cout << "numa_num_task_cpus=" << numa_num_task_cpus() << endl;
+            cout << "numa_num_task_nodes=" << numa_num_task_nodes() << endl;
+        } else
+        {
+            cerr << "unknown option: " << argv[i] << "\n";
+            exit(1);
+        }
+    }
+
+    // Figure out what query to use
+    string testQuery;
+    if (customQuery) {
+        // Use the query supplied on the command line
+        testQuery = customQuery;
+    } else {
+        // If transactions are requested, begin one
+        if (global_begin_concurrent || global_writePercent) {
+            testQuery += "BEGIN CONCURRENT;";
+        }
+
+        // The test dataset is simply two columns filled with RANDOM(), one
+        // indexed, one not.  Let's pick a random location from inside the
+        // database, and then pick the next 10 rows.
+        testQuery += "SELECT COUNT(*), AVG(nonIndexedColumn) FROM "
+            "(SELECT nonIndexedColumn FROM perfTest WHERE indexedColumn > RANDOM() LIMIT " + to_string(global_readSize) + ");";
+
+        // If writes requested, add one
+        if (global_writePercent > rand()%100) {
+            testQuery += "UPDATE perfTest SET indexedColumn=RANDOM(), nonIndexedColumn=RANDOM() WHERE indexedColumn > RANDOM() LIMIT " + to_string(global_writeSize) + ");";
+        }
+
+
+        // If transactions are requested, commit
+        if (global_begin_concurrent || global_writePercent) {
+            testQuery += "COMMIT;";
+        }
+    }
+    cout << "global_bMmap: " << global_bMmap << endl;
+    cout << "global_dbFilename: " << global_dbFilename << endl;
+    cout << "global_cacheSize: " << global_cacheSize << endl;
+    cout << "global_readSize: " << global_readSize << endl;
+    cout << "global_writeSize: " << global_writeSize << endl;
+    cout << "global_writePercent: " << global_writePercent << endl;
+    cout << "global_numa: " << global_numa << endl;
+    cout << "global_numaPack: " << global_numaPack << endl;
+    cout << "global_testSeconds: " << global_testSeconds << endl;
+    cout << "global_linear: " << global_linear << endl;
+    cout << "global_csv: " << global_csv << endl;
+    cout << "global_vms: " << global_vms << endl;
+    cout << "global_locking_mode: " << global_locking_mode << endl;
+    cout << "global_begin_concurrent: " << global_begin_concurrent << endl;
+    cout << "testQuery: " << testQuery << endl;
+
+    // Run the test for however many configurations were requested
+    if (global_csv) {
+        cout << "numThreads, maxQPS, maxQPSpT" << endl;
+    }
+    if( numThreads<0 ){
+      // Ramp up to the test desired test size
+      int threads = 1;
+      while (threads <= maxNumThreads) {
+        test(threads, testQuery);
+        if (global_linear) {
+            threads++;
+        } else {
+            threads *= 2;
+        }
+      }
+
+      // Now ramp back down to the original to make sure it matches the first timings
+      while (threads >= 2) {
+        threads /= 2;
+        test(threads, testQuery);
+      }
+    }else{
+      test(numThreads, testQuery);
+    }
+
+    // Output the NOOP number, if availble, so compiler doesn't throw it out
+    if (global_noopResult) {
+        cout << "NOOP=" << global_noopResult << endl;
+    }
+}

--- a/perftest/perftest.sql
+++ b/perftest/perftest.sql
@@ -7,11 +7,10 @@ WITH RECURSIVE
         SELECT RANDOM(), RANDOM()
             UNION ALL
         SELECT RANDOM(), RANDOM() FROM randdata
-        LIMIT 1000*1000*1
+        LIMIT 100000*100000*1 -- makes 10b row, roughly a 250gb, database
     )
 
 INSERT INTO perfTest ( indexedColumn, nonIndexedColumn )
     SELECT * FROM randdata;
 
 CREATE INDEX perfTestIndexedColumn ON perfTest ( indexedColumn );
-

--- a/perftest/perftest.sql
+++ b/perftest/perftest.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS perfTest;
+
+CREATE TABLE perfTest ( indexedColumn, nonIndexedColumn );
+
+WITH RECURSIVE
+    randdata(x, y) AS (
+        SELECT RANDOM(), RANDOM()
+            UNION ALL
+        SELECT RANDOM(), RANDOM() FROM randdata
+        LIMIT 1000*1000*1
+    )
+
+INSERT INTO perfTest ( indexedColumn, nonIndexedColumn )
+    SELECT * FROM randdata;
+
+CREATE INDEX perfTestIndexedColumn ON perfTest ( indexedColumn );
+

--- a/perftest/runtest.sh
+++ b/perftest/runtest.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+OUT=runTestResults.txt
+FULL=$OUT.full
+LINEAR=
+EXCLUSIVITY=
+function runTest {
+	# Get the params
+	BIN=$1
+	DB=$2
+	NOTE=$3
+
+	# Capture the results in a temp file
+	rm -f $OUT
+	echo `date` " Starting: $NOTE ($BIN, $DB)" >> $OUT
+
+	# Run the test
+	$BIN -csv -numa -numastats -mmap $LINEAR $EXCLUSIVITY -testSeconds 60 -maxNumThreads 256 -dbFilename $DB >> $OUT
+
+	# Share the results
+	echo `date` " Done" >> $OUT
+	cat $OUT | mail -s "runTest: $NOTE ($BIN, $DB)" dbarrett@expensify.com
+	cat $OUT >> $FULL
+}
+
+# Reset the caches
+#echo `date` " Resetting cache and precaching..." >> $FULL
+#free -h >> $FULL
+#sh -c "echo 3 > /proc/sys/vm/drop_caches"
+#md5sum /var/lib/bedrock/perftest.30B.db > /dev/null
+#free -h >> $FULL
+#echo | mail -s "runTest: Prefetched ($DB)" dbarrett@expensify.com
+
+
+# Test vs non-exclusive
+LINEAR=-linear
+#EXCLUSIVITY='-vms unix-excl -locking_mode NORMAL'
+#runTest ./perftest_customLockVFS /var/lib/bedrock/perftest.30B.db "$EXCLUSIVITY"
+#EXCLUSIVITY='-vms unix-none -locking_mode EXCLUSIVE'
+#runTest ./perftest_customLockVFS /var/lib/bedrock/perftest.30B.db "$EXCLUSIVITY"
+#EXCLUSIVITY='-vms unix -locking_mode NORMAL'
+#runTest ./perftest_customLockVFS /var/lib/bedrock/perftest.30B.db "$EXCLUSIVITY"
+EXCLUSIVITY='-vms unix-excl -locking_mode NORMAL'
+runTest ./perftest_lockfix /var/lib/bedrock/perftest.30B.db "$EXCLUSIVITY"

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -132,7 +132,9 @@ struct GracefulFailoverTest : tpunit::TestFixture {
         // Bring leader back up.
         tester->getTester(0).startServer();
         ASSERT_TRUE(tester->getTester(0).waitForState("LEADING"));
-        sleep(15);
+
+        // Give the spammers time to spam the new leader.
+        sleep(3);
 
         // Now let's  stop a follower and make sure everything keeps working.
         tester->stopNode(2);
@@ -216,6 +218,12 @@ struct GracefulFailoverTest : tpunit::TestFixture {
         allresults->clear();
         allresults->resize(60);
         done.store(false);
+
+        // Verify everything was either a 202 or a 756.
+        for (auto& p : *counts) {
+            ASSERT_TRUE(p.first == "202" || p.first == "756");
+            cout << "[FailoverTimeoutTest] method: " << p.first << ", count: " << p.second << endl;
+        }
 
         delete counts;
         delete threads;


### PR DESCRIPTION
### Details
To prevent a failed shutdown when Auth servers switch from STANDINGDOWN to SEARCHING with commands in the early part of the "processCommand" function, we need to catch an additional edge case, otherwise we get stuck with the command endlessly retrying.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/176212

### Tests
Ran GracefulFailoverTest repeatedly. 
- To reproduce the failure, I changed the Graceful shutdown timeout `_gracefulShutdownTimeout.alarmDuration` from 60s to 15s and added a random 30s sleep to the top of `BedrockCore::processCommand`. This fix resolved that issue. Ran the test 10x to make sure it was good and fixed.
- Unwound the 15s shutdown timeout and ran the test again 10x to make sure it was still good.
- Unwound the 30s random processCommand timeout and all debug logging and ran the test again 10x to make sure it was still good. Interestingly, this one had a shutdown failure in one of the follower nodes on the 7th test pass, but it was in a different part of the code, so I believe it's distinct, and a repeat of the tests passed all 10x.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
