### PR TITLE
Fix shutdown race condition

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -182,6 +182,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
     // leading but were following when we peeked, we may try to read HTTPS requests we never made).
     if ((command->lastPeekedOrProcessedInState != SQLiteNode::LEADING && command->lastPeekedOrProcessedInState != SQLiteNode::STANDINGDOWN) ||
         (_server.getState() != SQLiteNode::LEADING && _server.getState() != SQLiteNode::STANDINGDOWN)) {
+        SINFO("Server no longer LEADING or STANDINGDOWN, can't process command");
         return RESULT::SERVER_NOT_LEADING;
     }
     command->lastPeekedOrProcessedInState = _server.getState();

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -132,7 +132,9 @@ struct GracefulFailoverTest : tpunit::TestFixture {
         // Bring leader back up.
         tester->getTester(0).startServer();
         ASSERT_TRUE(tester->getTester(0).waitForState("LEADING"));
-        sleep(15);
+
+        // Give the spammers time to spam the new leader.
+        sleep(3);
 
         // Now let's  stop a follower and make sure everything keeps working.
         tester->stopNode(2);
@@ -216,6 +218,12 @@ struct GracefulFailoverTest : tpunit::TestFixture {
         allresults->clear();
         allresults->resize(60);
         done.store(false);
+
+        // Verify everything was either a 202 or a 756.
+        for (auto& p : *counts) {
+            ASSERT_TRUE(p.first == "202" || p.first == "756");
+            cout << "[FailoverTimeoutTest] method: " << p.first << ", count: " << p.second << endl;
+        }
 
         delete counts;
         delete threads;


### PR DESCRIPTION
Note: rebased version of https://github.com/Expensify/Bedrock/pull/1137

### Details
To prevent a failed shutdown when Auth servers switch from STANDINGDOWN to SEARCHING with commands in the early part of the "processCommand" function, we need to catch an additional edge case, otherwise we get stuck with the command endlessly retrying.

### Fixed Issues
Fixes [Expensify/Expensify#176212](https://github.com/Expensify/Expensify/issues/176212)

### Tests
Ran GracefulFailoverTest repeatedly.

To reproduce the failure, I changed the Graceful shutdown timeout _gracefulShutdownTimeout.alarmDuration from 60s to 15s and added a random 30s sleep to the top of BedrockCore::processCommand. This fix resolved that issue. Ran the test 10x to make sure it was good and fixed.
Unwound the 15s shutdown timeout and ran the test again 10x to make sure it was still good.
Unwound the 30s random processCommand timeout and all debug logging and ran the test again 10x to make sure it was still good. Interestingly, this one had a shutdown failure in one of the follower nodes on the 7th test pass, but it was in a different part of the code, so I believe it's distinct, and a repeat of the tests passed all 10x.

Had issues with BadCommandTest and StatusHandlingCommandsTest failing intermittently. Most recent test I did 10x with "-only BadCommand,StatusHandlingCommands" and "-repeatCount 10", so 100 total runs, with no issues. Testing with full clustertest again now.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
