### PR TITLE
Revert "Add wal2 mode (off by default)"

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -180,7 +180,7 @@ void BedrockServer::sync()
     // We use fewer FDs on test machines that have other resource restrictions in place.
     int fdLimit = args.isSet("-live") ? 25'000 : 250;
     SINFO("Setting dbPool size to: " << fdLimit);
-    _dbPool = make_shared<SQLitePool>(fdLimit, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.test("-pageLogging"), args.isSet("-wal2"));
+    _dbPool = make_shared<SQLitePool>(fdLimit, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.test("-pageLogging"));
     SQLite& db = _dbPool->getBase();
 
     // Initialize the command processor.

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -34,7 +34,7 @@ string SQLite::initializeFilename(const string& filename) {
     }
 }
 
-SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames, bool enableWAL2) {
+SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames) {
     static struct SharedDataLookupMapType {
         map<string, SharedData*> m;
         ~SharedDataLookupMapType() {
@@ -51,26 +51,9 @@ SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, const string& file
     if (sharedDataIterator == sharedDataLookupMap.m.end()) {
         SharedData* sharedData = new SharedData(); // This is never deleted.
 
-        // Save the intended wal2 setting for this DB.
-        sharedData->wal2 = enableWAL2;
-
-        // Look up the existing wal setting for this DB.
-        SQResult result;
-        SQuery(db, "", "PRAGMA journal_mode;", result);
-        bool isDBCurrentlyUsingWAL2 = result.rows.size() && result.rows[0][0] == "wal2";
-
-        // If the intended wal setting doesn't match the existing wal setting, change it.
-        string walType = sharedData->wal2 ? "wal2" : "wal";
-        if (isDBCurrentlyUsingWAL2 != sharedData->wal2) {
-            SASSERT(!SQuery(db, "", "PRAGMA journal_mode = delete;", result));
-            SASSERT(!SQuery(db, "", "PRAGMA journal_mode = " + walType + ";", result));
-            SINFO("Set wal mode to: " << walType);
-        } else {
-            SINFO("wal mode unchanged: " << walType);
-        }
-
         // Read the highest commit count from the database, and store it in commitCount.
         string query = "SELECT MAX(maxIDs) FROM (" + _getJournalQuery(journalNames, {"SELECT MAX(id) as maxIDs FROM"}, true) + ")";
+        SQResult result;
         SASSERT(!SQuery(db, "getting commit count", query, result));
         uint64_t commitCount = result.empty() ? 0 : SToUInt64(result[0][0]);
         sharedData->commitCount = commitCount;
@@ -170,7 +153,7 @@ uint64_t SQLite::initializeJournalSize(sqlite3* db, const vector<string>& journa
     return max - min;
 }
 
-void SQLite::commonConstructorInitialization(bool enableWAL2) {
+void SQLite::commonConstructorInitialization() {
     // Perform sanity checks.
     SASSERT(!_filename.empty());
     SASSERT(_cacheSize > 0);
@@ -182,8 +165,7 @@ void SQLite::commonConstructorInitialization(bool enableWAL2) {
     }
 
     // WAL is what allows simultaneous read/writing.
-    string walMode = enableWAL2 ? "wal2" : "wal";
-    SASSERT(!SQuery(_db, ("enabling write ahead logging (" + walMode + ")").c_str(), "PRAGMA journal_mode = " + walMode + ";"));
+    SASSERT(!SQuery(_db, "enabling write ahead logging", "PRAGMA journal_mode = WAL;"));
 
     if (_mmapSizeGB) {
         SASSERT(!SQuery(_db, "enabling memory-mapped I/O", "PRAGMA mmap_size=" + to_string(_mmapSizeGB * 1024 * 1024 * 1024) + ";"));
@@ -215,12 +197,12 @@ void SQLite::commonConstructorInitialization(bool enableWAL2) {
 }
 
 SQLite::SQLite(const string& filename, int cacheSize, int maxJournalSize,
-               int minJournalTables, const string& synchronous, int64_t mmapSizeGB, bool pageLoggingEnabled, bool enableWAL2) :
+               int minJournalTables, const string& synchronous, int64_t mmapSizeGB, bool pageLoggingEnabled) :
     _filename(initializeFilename(filename)),
     _maxJournalSize(maxJournalSize),
     _db(initializeDB(_filename, mmapSizeGB)),
     _journalNames(initializeJournal(_db, minJournalTables)),
-    _sharedData(initializeSharedData(_db, _filename, _journalNames, enableWAL2)),
+    _sharedData(initializeSharedData(_db, _filename, _journalNames)),
     _journalName(_journalNames[0]),
     _journalSize(initializeJournalSize(_db, _journalNames)),
     _pageLoggingEnabled(pageLoggingEnabled),
@@ -228,7 +210,7 @@ SQLite::SQLite(const string& filename, int cacheSize, int maxJournalSize,
     _synchronous(synchronous),
     _mmapSizeGB(mmapSizeGB)
 {
-    commonConstructorInitialization(enableWAL2);
+    commonConstructorInitialization();
 }
 
 SQLite::SQLite(const SQLite& from) :
@@ -244,7 +226,7 @@ SQLite::SQLite(const SQLite& from) :
     _synchronous(from._synchronous),
     _mmapSizeGB(from._mmapSizeGB)
 {
-    commonConstructorInitialization(_sharedData.wal2);
+    commonConstructorInitialization();
 }
 
 int SQLite::_progressHandlerCallback(void* arg) {
@@ -283,12 +265,6 @@ int SQLite::_sqliteTraceCallback(unsigned int traceCode, void* c, void* p, void*
 int SQLite::_sqliteWALCallback(void* data, sqlite3* db, const char* dbName, int pageCount) {
     SQLite* object = static_cast<SQLite*>(data);
     object->_sharedData._currentPageCount.store(pageCount);
-
-    if (object->_sharedData.wal2) {
-        SINFO("[checkpoint] skipping straight to passive checkpoint in wal2 mode.");
-        return SQLITE_OK;
-    }
-
     // Try a passive checkpoint if full checkpoints aren't enabled, *or* if the page count is less than the required
     // size for a full checkpoint.
     if (pageCount >= fullCheckpointPageMin.load()) {

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -75,7 +75,7 @@ class SQLite {
     //
     // mmapSizeGB: address space to use for memory-mapped IO, in GB.
     SQLite(const string& filename, int cacheSize, int maxJournalSize, int minJournalTables,
-           const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false, bool enableWAL2 = false);
+           const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false);
 
     // Compatibility constructor. Remove when AuthTester::getStripeSQLiteDB no longer uses this outdated version.
     SQLite(const string& filename, int cacheSize, int maxJournalSize, int minJournalTables, int synchronous) :
@@ -354,9 +354,6 @@ class SQLite {
         // checkpoints to not more often than every N commits.
         atomic<uint64_t> lastCompleteCheckpointCommitCount;
 
-        // True if we should use wal2 mode.
-        atomic<bool> wal2 = false;
-
       private:
         // The data required to replicate transactions, in two lists, depending on whether this has only been prepared
         // or if it's been committed.
@@ -373,11 +370,11 @@ class SQLite {
 
     // Initializers to support RAII-style allocation in constructors.
     static string initializeFilename(const string& filename);
-    static SharedData& initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames, bool enableWAL2);
+    static SharedData& initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames);
     static sqlite3* initializeDB(const string& filename, int64_t mmapSizeGB);
     static vector<string> initializeJournal(sqlite3* db, int minJournalTables);
     static uint64_t initializeJournalSize(sqlite3* db, const vector<string>& journalNames);
-    void commonConstructorInitialization(bool enableWAL2);
+    void commonConstructorInitialization();
 
     // The filename of this DB, canonicalized to its full path on disk.
     const string _filename;

--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -9,10 +9,9 @@ SQLitePool::SQLitePool(size_t maxDBs,
                        int minJournalTables,
                        const string& synchronous,
                        int64_t mmapSizeGB,
-                       bool pageLoggingEnabled,
-                       bool wal2)
+                       bool pageLoggingEnabled)
 : _maxDBs(max(maxDBs, 1ul)),
-  _baseDB(filename, cacheSize, maxJournalSize, minJournalTables, synchronous, mmapSizeGB, pageLoggingEnabled, wal2),
+  _baseDB(filename, cacheSize, maxJournalSize, minJournalTables, synchronous, mmapSizeGB, pageLoggingEnabled),
   _objects(_maxDBs, nullptr)
 {
 }

--- a/sqlitecluster/SQLitePool.h
+++ b/sqlitecluster/SQLitePool.h
@@ -6,7 +6,7 @@ class SQLitePool {
   public:
     // Create a pool of DB handles.
     SQLitePool(size_t maxDBs, const string& filename, int cacheSize, int maxJournalSize, int minJournalTables,
-               const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false, bool wal2 = false);
+               const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false);
     ~SQLitePool();
 
     // Get the base object (the first one created, which uses the `journal` table). Note that if called by multiple

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -61,7 +61,6 @@ BedrockTester::BedrockTester(const map<string, string>& args,
         {"-quorumCheckpoint", "50"},
         {"-enableMultiWrite", "true"},
         {"-cacheSize", "1000"},
-        {"-wal2", ""},
         {"-parallelReplication", "true"},
         // Currently breaks only in Travis and needs debugging, which has been removed, maybe?
         //{"-logDirectlyToSyslogSocket", ""},
@@ -490,8 +489,7 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
 SQLite& BedrockTester::getSQLiteDB()
 {
     if (!_db) {
-        // Assumes wal2 mode.
-        _db = new SQLite(_args["-db"], 1000000, 3000000, -1, "", 0, false, true);
+        _db = new SQLite(_args["-db"], 1000000, 3000000, -1);
     }
     return *_db;
 }


### PR DESCRIPTION
Reverts Expensify/Bedrock#1135

It broke the keysplitter tests. Reverting until we figure out why.