### PR TITLE
Add test name as bedrock parameter

### DIFF
--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -47,6 +47,12 @@ BedrockTester::BedrockTester(const map<string, string>& args,
         _testers.insert(this);
     }
 
+    string currentTestName;
+    {
+        lock_guard<mutex> lock(tpunit::currentTestNameMutex);
+        currentTestName = tpunit::currentTestName;
+    }
+
     map <string, string> defaultArgs = {
         {"-db", getTempFileName()},
         {"-serverHost", "127.0.0.1:" + to_string(_serverPort)},
@@ -66,7 +72,7 @@ BedrockTester::BedrockTester(const map<string, string>& args,
         {"-parallelReplication", "true"},
         // Currently breaks only in Travis and needs debugging, which has been removed, maybe?
         //{"-logDirectlyToSyslogSocket", ""},
-        {"-testName", tpunit::currentTestName},
+        {"-testName", currentTestName},
     };
 
     // Set defaults.

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -10,6 +10,7 @@
 #include <libstuff/SFastBuffer.h>
 #include <sqlitecluster/SQLite.h>
 #include <test/lib/BedrockTester.h>
+#include <test/lib/tpunit++.hpp>
 
 PortMap BedrockTester::ports;
 mutex BedrockTester::_testersMutex;
@@ -65,6 +66,7 @@ BedrockTester::BedrockTester(const map<string, string>& args,
         {"-parallelReplication", "true"},
         // Currently breaks only in Travis and needs debugging, which has been removed, maybe?
         //{"-logDirectlyToSyslogSocket", ""},
+        {"-testName", tpunit::currentTestName},
     };
 
     // Set defaults.

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -217,7 +217,12 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
                    }
                    {
                        lock_guard<mutex> lock(currentTestNameMutex);
-                       currentTestName = f->_name;
+                       if (f->_name) {
+                           currentTestName = f->_name;
+                       } else {
+                           cout << "test has no name???" << endl;
+                           currentTestName = "UNSPECIFIED";
+                       }
                    }
                    tpunit_detail_do_methods(f->_before_classes);
                    tpunit_detail_do_tests(f);

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -6,6 +6,7 @@ using namespace tpunit;
 
 bool tpunit::TestFixture::exitFlag = false;
 thread_local string tpunit::currentTestName;
+thread_local mutex tpunit::currentTestNameMutex;
 
 tpunit::TestFixture::method::method(TestFixture* obj, void (TestFixture::*addr)(), const char* name, unsigned char type)
     : _this(obj)
@@ -214,7 +215,10 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
                    if (!f->_multiThreaded) {
                        printf("--------------\n");
                    }
-                   currentTestName = f->_name;
+                   {
+                       lock_guard<mutex> lock(currentTestNameMutex);
+                       currentTestName = f->_name;
+                   }
                    tpunit_detail_do_methods(f->_before_classes);
                    tpunit_detail_do_tests(f);
                    tpunit_detail_do_methods(f->_after_classes);

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -5,6 +5,7 @@
 using namespace tpunit;
 
 bool tpunit::TestFixture::exitFlag = false;
+thread_local string tpunit::currentTestName;
 
 tpunit::TestFixture::method::method(TestFixture* obj, void (TestFixture::*addr)(), const char* name, unsigned char type)
     : _this(obj)
@@ -213,6 +214,7 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
                    if (!f->_multiThreaded) {
                        printf("--------------\n");
                    }
+                   currentTestName = f->_name;
                    tpunit_detail_do_methods(f->_before_classes);
                    tpunit_detail_do_tests(f);
                    tpunit_detail_do_methods(f->_after_classes);

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -188,8 +188,8 @@ using namespace std;
 
 namespace tpunit {
     // Make the current test name in the current thread globally accessible.
-    // Note that this is not synchronized.
     extern thread_local string currentTestName;
+    extern thread_local mutex currentTestNameMutex;
 
     // Doesn't do anything except allow us to detect when the program wants to shutdown.
     class ShutdownException{};

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -187,6 +187,9 @@ using namespace std;
 #endif
 
 namespace tpunit {
+    // Make the current test name in the current thread globally accessible.
+    // Note that this is not synchronized.
+    extern thread_local string currentTestName;
 
     // Doesn't do anything except allow us to detect when the program wants to shutdown.
     class ShutdownException{};


### PR DESCRIPTION
### Details
This adds the name of the currently running test to the parameter list of the bedrock process started in a `BedrockTester` object. This results in a command line that looks something like:
```
vagrant   251684  2.5  0.5 874564 34708 pts/1    Sl+  14:54   0:00 bedrock -cacheSize 1000 \
-controlPort localhost:10008 -credentialsFile ../credentials.txt -db /tmp/bedrocktest_qPYvnY.db -debugKeys \
-enableMultiWrite true -isRunningTests true -maxJournalSize 25000 -mmapSizeGB 1 -nodeHost localhost:10007 \
-nodeName bedrock_test -overridePasswordHash test:86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 \
-overrideReadOnlySupportPasswordHash 84a516841ba77a5b4648de2cd0dfcb30ea46dbb4 \
-overrideSupportPasswordHash 70ccd9007338d6d81dd3b6271621b9cf9a97ea00 -parallelReplication true \
-plugins ../auth/auth.so -priority 200 -quorumCheckpoint 50 -serverHost 127.0.0.1:10006 \
-stripeTestDB /tmp/auth_stripe_db_bedrocktest_hvYjQZ.db -testName ConfigureExpensifyCard \
-v -wal2 -workerThreads 8
```

Specifically, notice the `-testName` flag.

This doesn't actually *do* anything, bedrock ignores this parameter entirely. However, it makes it *much* easier to diagnose test problems when running massively parallel tests. If `authtest` is running 16 parallel tests and segfaults, it's impossible to know what test caused it, except that it's not one of the tests that has already logged that it completed.

However, as a segfault in the test application will leave behind a bedrock process, you can look at the orphaned bedrock processes and see what tests they were running when the process died, and it's very likely that one of those tests is the one that contains the problem.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/182745

### Tests
Is tests.
