### PR TITLE
Update GetJobs query to support new Job priorities

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1406,7 +1406,8 @@ void BedrockJobsCommand::_validatePriority(const int64_t priority) {
     // here so that the caller can know that he did something wrong rather
     // than having his job sit unprocessed in the queue forever. Hopefully
     // we can remove this restriction in the future.
-    if (priority != 0 && priority != 250 && priority != 500 && priority != 750 && priority != 850 && priority != 1000) {
+    list<int64_t> validPriorities = {0, 250, 500, 750, 850, 1000};
+    if (!SContains(validPriorities, priority)) {
         STHROW("402 Invalid priority value");
     }
 }

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -672,7 +672,40 @@ void BedrockJobsCommand::process(SQLite& db) {
                         "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun "
                         "FROM jobs "
                         "WHERE state IN ('QUEUED', 'RUNQUEUED') "
+                            "AND priority=850 "
+                            "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                            "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
+                            string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                        "ORDER BY nextRun ASC LIMIT " + safeNumResults +
+                    ") "
+                "UNION ALL "
+                    "SELECT * FROM ("
+                        "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun "
+                        "FROM jobs "
+                        "WHERE state IN ('QUEUED', 'RUNQUEUED') "
+                            "AND priority=750 "
+                            "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                            "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
+                            string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                        "ORDER BY nextRun ASC LIMIT " + safeNumResults +
+                    ") "
+                "UNION ALL "
+                    "SELECT * FROM ("
+                        "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun "
+                        "FROM jobs "
+                        "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                             "AND priority=500 "
+                            "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                            "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
+                            string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                        "ORDER BY nextRun ASC LIMIT " + safeNumResults +
+                    ") "
+                "UNION ALL "
+                    "SELECT * FROM ("
+                        "SELECT jobID, name, data, priority, parentJobID, retryAfter, created, repeat, lastRun, nextRun "
+                        "FROM jobs "
+                        "WHERE state IN ('QUEUED', 'RUNQUEUED') "
+                            "AND priority=250 "
                             "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                             "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                             string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
@@ -1373,7 +1406,7 @@ void BedrockJobsCommand::_validatePriority(const int64_t priority) {
     // here so that the caller can know that he did something wrong rather
     // than having his job sit unprocessed in the queue forever. Hopefully
     // we can remove this restriction in the future.
-    if (priority != 0 && priority != 500 && priority != 1000) {
+    if (priority != 0 && priority != 250 && priority != 500 && priority != 750 && priority != 850 && priority != 1000) {
         STHROW("402 Invalid priority value");
     }
 }


### PR DESCRIPTION
### Details
Add new job priorities 250, 750 and 850.

cc @MonilBhavsar 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/188718

### Tests
1. In your vm, run `nc localhost 8888`.
2. Create a bedrock job following the template below:
```
CreateJob
name:www-prod/<jobName>
repeat:FINISHED, +30 SECONDS
priority:<250, 750 or 850>
retryAfter:+10 MINUTES
```
3. Press enter twice and verify that the job was successfully created.
4. Exit your vm and run `./scripts/bwm.sh`
5. Verify that the job is picked up by BWM.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
