### PR TITLE
Adding a getDBHandle method

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -17,6 +17,10 @@ atomic<int> SQLite::fullCheckpointPageMin(25000); // Approx 100mb (pages are ass
 // Tracing can only be enabled or disabled globally, not per object.
 atomic<bool> SQLite::enableTrace(false);
 
+sqlite3* SQLite::getDBHandle() {
+    return _db;
+}
+
 string SQLite::initializeFilename(const string& filename) {
     // Canonicalize our filename and save that version.
     if (filename == ":memory:") {

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -90,6 +90,8 @@ class SQLite {
     // Returns the canonicalized filename for this database
     const string& getFilename() { return _filename; }
 
+    sqlite3* getDBHandle();
+
     // Performs a read-only query (eg, SELECT). This can be done inside or outside a transaction. Returns true on
     // success, and fills the 'result' with the result of the query.
     bool read(const string& query, SQResult& result);


### PR DESCRIPTION
@tylerkaraszewski @Expensify/pullerbear will you please review?

### Details
We are running into a situation where we need to get the database handle of a database object in order to properly run the fraud checks (see [this PR](https://github.com/Expensify/Auth/pull/5589)). This PR adds a method that allows us to get the database handle of the database object that is passed to an auth command.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/190701

### Tests
1. In conjunction with the PR linked above, I confirmed that the database handle was correctly retrieved and used in the fraud checks.
