### PR TITLE
Kill old WAL1 checkpoint code

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -571,8 +571,6 @@ void BedrockServer::sync()
 
                 // And now we'll decide how to handle it.
                 if (nodeState == SQLiteNode::LEADING || nodeState == SQLiteNode::STANDINGDOWN) {
-                    db.waitForCheckpoint();
-
                     // We peek commands here in the sync thread to be able to run peek and process as part of the same
                     // transaction. This guarantees that any checks made in peek are still valid in process, as the DB can't
                     // have changed in the meantime.
@@ -955,9 +953,6 @@ void BedrockServer::worker(int threadId)
             // We'll retry on conflict up to this many times.
             int retry = _maxConflictRetries.load();
             while (retry) {
-                // Block if a checkpoint is happening so we don't interrupt it.
-                db.waitForCheckpoint();
-
                 // If the command has any httpsRequests from a previous `peek`, we won't peek it again unless the
                 // command has specifically asked for that.
                 // If peek succeeds, then it's finished, and all we need to do is respond to the command at the bottom.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -180,7 +180,7 @@ void BedrockServer::sync()
     // We use fewer FDs on test machines that have other resource restrictions in place.
     int fdLimit = args.isSet("-live") ? 25'000 : 250;
     SINFO("Setting dbPool size to: " << fdLimit);
-    _dbPool = make_shared<SQLitePool>(fdLimit, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.test("-pageLogging"), !args.isSet("-legacyWAL"));
+    _dbPool = make_shared<SQLitePool>(fdLimit, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.test("-pageLogging"));
     SQLite& db = _dbPool->getBase();
 
     // Initialize the command processor.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -56,7 +56,7 @@ class SQLite {
     //
     // mmapSizeGB: address space to use for memory-mapped IO, in GB.
     SQLite(const string& filename, int cacheSize, int maxJournalSize, int minJournalTables,
-           const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false, bool enableWAL2 = true);
+           const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false);
 
     // Compatibility constructor. Remove when AuthTester::getStripeSQLiteDB no longer uses this outdated version.
     SQLite(const string& filename, int cacheSize, int maxJournalSize, int minJournalTables, int synchronous) :
@@ -293,9 +293,6 @@ class SQLite {
 
         SPerformanceTimer _commitLockTimer;
 
-        // True if we should use wal2 mode.
-        atomic<bool> wal2 = true;
-
       private:
         // The data required to replicate transactions, in two lists, depending on whether this has only been prepared
         // or if it's been committed.
@@ -309,11 +306,11 @@ class SQLite {
 
     // Initializers to support RAII-style allocation in constructors.
     static string initializeFilename(const string& filename);
-    static SharedData& initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames, bool enableWAL2);
+    static SharedData& initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames);
     static sqlite3* initializeDB(const string& filename, int64_t mmapSizeGB);
     static vector<string> initializeJournal(sqlite3* db, int minJournalTables);
     static uint64_t initializeJournalSize(sqlite3* db, const vector<string>& journalNames);
-    void commonConstructorInitialization(bool enableWAL2);
+    void commonConstructorInitialization();
 
     // The filename of this DB, canonicalized to its full path on disk.
     const string _filename;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -243,9 +243,7 @@ class SQLiteNode : public STCPNode {
     // BEGIN_TRANSACTION is where the interesting case is. This starts all transactions in parallel, and then waits
     // until each previous transaction is committed such that the final commit order matches LEADER. It also handles
     // commit conflicts by re-running the transaction from the beginning. Most of the logic for making sure
-    // transactions are ordered correctly is done in `SQLiteSequentialNotifier`, which is worth reading. Also worth
-    // noting is that a checkpoint can interrupt a transaction, forcing it to restart. See
-    // SQLite::CheckpointRequiredListener for more information on that process.
+    // transactions are ordered correctly is done in `SQLiteSequentialNotifier`, which is worth reading.
     //
     // This thread exits on completion of handling the command or when node._replicationThreadsShouldExit is set,
     // which happens when a node stops FOLLOWING.

--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -9,10 +9,9 @@ SQLitePool::SQLitePool(size_t maxDBs,
                        int minJournalTables,
                        const string& synchronous,
                        int64_t mmapSizeGB,
-                       bool pageLoggingEnabled,
-                       bool wal2)
+                       bool pageLoggingEnabled)
 : _maxDBs(max(maxDBs, 1ul)),
-  _baseDB(filename, cacheSize, maxJournalSize, minJournalTables, synchronous, mmapSizeGB, pageLoggingEnabled, wal2),
+  _baseDB(filename, cacheSize, maxJournalSize, minJournalTables, synchronous, mmapSizeGB, pageLoggingEnabled),
   _objects(_maxDBs, nullptr)
 {
 }

--- a/sqlitecluster/SQLitePool.h
+++ b/sqlitecluster/SQLitePool.h
@@ -6,7 +6,7 @@ class SQLitePool {
   public:
     // Create a pool of DB handles.
     SQLitePool(size_t maxDBs, const string& filename, int cacheSize, int maxJournalSize, int minJournalTables,
-               const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false, bool wal2 = true);
+               const string& synchronous = "", int64_t mmapSizeGB = 0, bool pageLoggingEnabled = false);
     ~SQLitePool();
 
     // Get the base object (the first one created, which uses the `journal` table). Note that if called by multiple

--- a/sqlitecluster/SQLiteSequentialNotifier.h
+++ b/sqlitecluster/SQLiteSequentialNotifier.h
@@ -2,21 +2,7 @@
 #include <libstuff/libstuff.h>
 #include "SQLite.h"
 
-// This implements the CheckpointRequiredListener interface because we potentially need to interrupt transactions in
-// the following situation:
-//
-// 1. Transaction B begins (for commit N).
-// 2. A restart checkpoint begins, blocking new trasnactions.
-// 3. Transaction A (for commit N - 1) attempts to begin (but blocks on the checkpoint).
-//
-// Transaction B can't finish until transaction A does, but transaction A can't start until the checkpoint completes.
-// However, the checkpoint can't run until all pending transactions (B) complete, thus creating a deadlock.
-//
-// So SQLiteSequentialNotifier implements `CheckpointRequiredListener` so that when a checkpoint is required, calls to
-// `waitFor` in transaction B will be interrupted and throw checkpoint_required_error, causing the transaction to be
-// aborted and restarted, which unblocks the checkpoint. Then, the checkpoint will complete, transaction A can run, and
-// checkpoint B can complete.
-class SQLiteSequentialNotifier : public SQLite::CheckpointRequiredListener {
+class SQLiteSequentialNotifier {
   public:
 
     // Enumeration of all the possible states to result from waiting.
@@ -24,7 +10,6 @@ class SQLiteSequentialNotifier : public SQLite::CheckpointRequiredListener {
         UNKNOWN,
         COMPLETED,
         CANCELED,
-        CHECKPOINT_REQUIRED,
     };
 
     // Constructor
@@ -45,10 +30,6 @@ class SQLiteSequentialNotifier : public SQLite::CheckpointRequiredListener {
 
     // Returns the current value of this notifier.
     uint64_t getValue();
-
-    // Implement the base class to notify for checkpoints
-    void checkpointRequired() override;
-    void checkpointComplete() override;
 
     // After calling `reset`, all calls to `waitFor` return `false` until this is called, and then they will wait
     // again. This allows for a caller to call `cancel`, wait for the completion of their threads, and then call

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -500,7 +500,7 @@ SQLite& BedrockTester::getSQLiteDB()
 {
     if (!_db) {
         // Assumes wal2 mode.
-        _db = new SQLite(_args["-db"], 1000000, 3000000, -1, "", 0, false, true);
+        _db = new SQLite(_args["-db"], 1000000, 3000000, -1, "", 0, false);
     }
     return *_db;
 }


### PR DESCRIPTION
### Details
This kills all the old WAL1 code.

Co-requisite with: https://github.com/Expensify/Auth/pull/6316

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/192631

### Tests
Existing tests. Additional manual runs of checkpointing large amount of data and verifying it continues to function.