### PR TITLE
Allow for individual test files to run in parallel.

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -8,6 +8,10 @@ bool tpunit::TestFixture::exitFlag = false;
 thread_local string tpunit::currentTestName;
 thread_local mutex tpunit::currentTestNameMutex;
 
+thread_local int tpunit::TestFixture::perFixtureStats::_threadAssertions = 0;
+thread_local int tpunit::TestFixture::perFixtureStats::_threadExceptions = 0;
+thread_local int tpunit::TestFixture::perFixtureStats::_threadTraces = 0;
+
 tpunit::TestFixture::method::method(TestFixture* obj, void (TestFixture::*addr)(), const char* name, unsigned char type)
     : _this(obj)
     , _addr(addr)
@@ -30,10 +34,8 @@ tpunit::TestFixture::stats::stats()
     {}
 
 tpunit::TestFixture::perFixtureStats::perFixtureStats()
-    : _assertions(0)
-    , _exceptions(0)
-    , _traces(0)
-    {}
+{
+}
 
 tpunit::TestFixture::TestFixture(method* m0,  method* m1,  method* m2,  method* m3,  method* m4,
                          method* m5,  method* m6,  method* m7,  method* m8,  method* m9,
@@ -45,8 +47,9 @@ tpunit::TestFixture::TestFixture(method* m0,  method* m1,  method* m2,  method* 
                          method* m35, method* m36, method* m37, method* m38, method* m39,
                          method* m40, method* m41, method* m42, method* m43, method* m44,
                          method* m45, method* m46, method* m47, method* m48, method* m49,
-                         const char* name)
-  : _name(name)
+                         const char* name, bool parallel)
+  : _name(name),
+    _parallel(parallel)
 {
     tpunit_detail_fixture_list()->push_back(this);
 
@@ -342,22 +345,21 @@ bool tpunit::TestFixture::tpunit_detail_fp_equal(double lhs, double rhs, unsigne
            ((lhs_u.c[lsb] > rhs_u.c[lsb]) ? lhs_u.c[lsb] - rhs_u.c[lsb] : rhs_u.c[lsb] - lhs_u.c[lsb]) <= ulps;
 }
 
-// TODO: These three functions need to be updated to act on the current TestFixture.
 void tpunit::TestFixture::tpunit_detail_assert(TestFixture* f, const char* _file, int _line) {
     lock_guard<recursive_mutex> lock(*(f->_mutex));
-    printf("   assertion #%i at %s:%i\n", ++f->_stats._assertions, _file, _line);
+    printf("   assertion #%i at %s:%i\n", ++f->_stats._threadAssertions, _file, _line);
     f->printTestBuffer();
 }
 
 void tpunit::TestFixture::tpunit_detail_exception(TestFixture* f, method* _method, const char* _message) {
     lock_guard<recursive_mutex> lock(*(f->_mutex));
-    printf("   exception #%i from %s with cause: %s\n", ++f->_stats._exceptions, _method->_name, _message);
+    printf("   exception #%i from %s with cause: %s\n", ++f->_stats._threadExceptions, _method->_name, _message);
     f->printTestBuffer();
 }
 
 void tpunit::TestFixture::tpunit_detail_trace(TestFixture* f, const char* _file, int _line, const char* _message) {
     lock_guard<recursive_mutex> lock(*(f->_mutex));
-    printf("   trace #%i at %s:%i: %s\n", ++f->_stats._traces, _file, _line, _message);
+    printf("   trace #%i at %s:%i: %s\n", ++f->_stats._threadTraces, _file, _line, _message);
     f->printTestBuffer();
 }
 
@@ -389,28 +391,43 @@ void tpunit::TestFixture::tpunit_detail_do_methods(tpunit::TestFixture::method* 
 
 void tpunit::TestFixture::tpunit_detail_do_tests(TestFixture* f) {
     method* t = f->_tests;
-    recursive_mutex& m = *(f->_mutex);
+    list<thread> testThreads;
     while(t) {
-       int _prev_assertions = f->_stats._assertions;
-       int _prev_exceptions = f->_stats._exceptions;
-       f->testOutputBuffer = "";
-       tpunit_detail_do_methods(f->_befores);
-       tpunit_detail_do_method(t);
-       tpunit_detail_do_methods(f->_afters);
-       if(_prev_assertions == f->_stats._assertions && _prev_exceptions == f->_stats._exceptions) {
-          lock_guard<recursive_mutex> lock(m);
-          printf("\xE2\x9C\x85 %s\n", t->_name);
-          tpunit_detail_stats()._passes++;
-       } else {
-          lock_guard<recursive_mutex> lock(m);
+        testThreads.push_back(thread([t, f]() {
+            recursive_mutex& m = *(f->_mutex);
+            f->_stats._threadAssertions = 0;
+            f->_stats._threadExceptions = 0;
+            f->testOutputBuffer = "";
+            tpunit_detail_do_methods(f->_befores);
+            tpunit_detail_do_method(t);
+            tpunit_detail_do_methods(f->_afters);
 
-          // Dump the test buffer if the test included any log lines.
-          f->printTestBuffer();
-          printf("\xE2\x9D\x8C !FAILED! \xE2\x9D\x8C %s\n", t->_name);
-          tpunit_detail_stats()._failures++;
-          tpunit_detail_stats()._failureNames.emplace(t->_name);
-       }
-       t = t->_next;
+            // No new assertions or exceptions. This not currently synchronized correctly. They can cause tests that
+            // passed to appear failed when another test failed while this test was running. They cannot cause failed
+            // tests to appear to have passed.
+            if(!f->_stats._threadAssertions && !f->_stats._threadExceptions) {
+                lock_guard<recursive_mutex> lock(m);
+                printf("\xE2\x9C\x85 %s\n", t->_name);
+                tpunit_detail_stats()._passes++;
+            } else {
+                lock_guard<recursive_mutex> lock(m);
+
+                // Dump the test buffer if the test included any log lines.
+                f->printTestBuffer();
+                printf("\xE2\x9D\x8C !FAILED! \xE2\x9D\x8C %s\n", t->_name);
+                tpunit_detail_stats()._failures++;
+                tpunit_detail_stats()._failureNames.emplace(t->_name);
+            }
+        }));
+        if (!f->_parallel) {
+            // If it's not set to parallel, we finish each test in order.
+            testThreads.front().join();
+            testThreads.clear();
+        }
+        t = t->_next;
+    }
+    for (auto& thread : testThreads) {
+        thread.join();
     }
 }
 

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -21,7 +21,6 @@
  */
 #pragma once
 
-#include <atomic>
 #include <cstdio>
 #include <set>
 #include <string>
@@ -188,7 +187,6 @@ using namespace std;
 #endif
 
 namespace tpunit {
-
     // Make the current test name in the current thread globally accessible.
     extern thread_local string currentTestName;
     extern thread_local mutex currentTestNameMutex;
@@ -209,9 +207,9 @@ namespace tpunit {
          struct perFixtureStats {
             perFixtureStats();
 
-            static thread_local int _threadAssertions;
-            static thread_local int _threadExceptions;
-            static thread_local int _threadTraces;
+            static thread_local int _assertions;
+            static thread_local int _exceptions;
+            static thread_local int _traces;
          };
 
          perFixtureStats  _stats;

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <atomic>
 #include <cstdio>
 #include <set>
 #include <string>
@@ -187,6 +188,7 @@ using namespace std;
 #endif
 
 namespace tpunit {
+
     // Make the current test name in the current thread globally accessible.
     extern thread_local string currentTestName;
     extern thread_local mutex currentTestNameMutex;
@@ -207,9 +209,9 @@ namespace tpunit {
          struct perFixtureStats {
             perFixtureStats();
 
-            int _assertions;
-            int _exceptions;
-            int _traces;
+            static thread_local int _threadAssertions;
+            static thread_local int _threadExceptions;
+            static thread_local int _threadTraces;
          };
 
          perFixtureStats  _stats;
@@ -274,6 +276,24 @@ namespace tpunit {
                                   m20, m21, m22, m23, m24, m25, m26, m27, m28, m29,
                                   m30, m31, m32, m33, m34, m35, m36, m37, m38, m39,
                                   m40, m41, m42, m43, m44, m45, m46, m47, m48, m49, name) { }
+
+         TestFixture(bool parallel, const char* name,
+                     method* m0,      method* m1  = 0, method* m2  = 0, method* m3  = 0, method* m4  = 0,
+                     method* m5  = 0, method* m6  = 0, method* m7  = 0, method* m8  = 0, method* m9  = 0,
+                     method* m10 = 0, method* m11 = 0, method* m12 = 0, method* m13 = 0, method* m14 = 0,
+                     method* m15 = 0, method* m16 = 0, method* m17 = 0, method* m18 = 0, method* m19 = 0,
+                     method* m20 = 0, method* m21 = 0, method* m22 = 0, method* m23 = 0, method* m24 = 0,
+                     method* m25 = 0, method* m26 = 0, method* m27 = 0, method* m28 = 0, method* m29 = 0,
+                     method* m30 = 0, method* m31 = 0, method* m32 = 0, method* m33 = 0, method* m34 = 0,
+                     method* m35 = 0, method* m36 = 0, method* m37 = 0, method* m38 = 0, method* m39 = 0,
+                     method* m40 = 0, method* m41 = 0, method* m42 = 0, method* m43 = 0, method* m44 = 0,
+                     method* m45 = 0, method* m46 = 0, method* m47 = 0, method* m48 = 0, method* m49 = 0)
+                     : TestFixture( m0,  m1,  m2,  m3,  m4,  m5,  m6,  m7,  m8,  m9,
+                                  m10, m11, m12, m13, m14, m15, m16, m17, m18, m19,
+                                  m20, m21, m22, m23, m24, m25, m26, m27, m28, m29,
+                                  m30, m31, m32, m33, m34, m35, m36, m37, m38, m39,
+                                  m40, m41, m42, m43, m44, m45, m46, m47, m48, m49, name, parallel) { }
+
          /**
           * Base constructor to register methods with the test fixture. A test
           * fixture can register up to 50 methods.
@@ -290,7 +310,7 @@ namespace tpunit {
                      method* m35 = 0, method* m36 = 0, method* m37 = 0, method* m38 = 0, method* m39 = 0,
                      method* m40 = 0, method* m41 = 0, method* m42 = 0, method* m43 = 0, method* m44 = 0,
                      method* m45 = 0, method* m46 = 0, method* m47 = 0, method* m48 = 0, method* m49 = 0,
-                     const char* name = 0);
+                     const char* name = 0, bool parallel = false);
 
          ~TestFixture();
 
@@ -342,6 +362,8 @@ namespace tpunit {
          static void tpunit_detail_trace(TestFixture* f, const char* _file, int _line, const char* _message);
 
          const char* _name;
+
+         bool _parallel = false;
 
       private:
 

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -6,7 +6,7 @@
 #include <test/lib/BedrockTester.h>
 
 struct LibStuff : tpunit::TestFixture {
-    LibStuff() : tpunit::TestFixture("LibStuff",
+    LibStuff() : tpunit::TestFixture(true, "LibStuff",
                                     TEST(LibStuff::testEncryptDecrpyt),
                                     TEST(LibStuff::testSHMACSHA1),
                                     TEST(LibStuff::testSHMACSHA256),


### PR DESCRIPTION
### Details
This allows a test class to run all its tests in parallel by adding an extra parameter to the base class constructor. It is enabled only for LibStuffTest so far.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/193304

### Tests
Is tests.

Run against existing auth tests with no issues.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
