### PR TITLE
Don't log buffer as it may contain sensitive keys we don't want logged

### DIFF
--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -291,7 +291,7 @@ bool STCPManager::Socket::send(const string& buffer) {
     if (state.load() < Socket::State::SHUTTINGDOWN) {
         sendBuffer += buffer;
     } else if (!sendBuffer.empty()) {
-        SWARN("Not appending to sendBuffer in socket state " << state.load() << ", tried to send: " << buffer);
+        SWARN("Not appending to sendBuffer in socket state " << state.load());
     }
 
     // Send anything we've got.


### PR DESCRIPTION
### Details
This warn resulted in us logging an authToken so we are the logging of the buffer so we don't accidentally do it again. 

cc @tylerkaraszewski 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/193046#issuecomment-1020117371

### Tests
None
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
