### PR TITLE
Add mutex around port vars

### DIFF
--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -376,6 +376,7 @@ class BedrockServer : public SQLiteServer {
     atomic<bool> _detach;
 
     // Pointers to the ports on which we accept commands.
+    mutex _portMutex;
     unique_ptr<Port> _controlPort;
     unique_ptr<Port> _commandPort;
 


### PR DESCRIPTION
### Details
Do this in case they get set to null in another thread, otherwise we can segfault (i.e. when the command port gets suppressed in the middle of `_acceptSockets()`)

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/193308

### Tests
Tested against https://github.com/Expensify/Bedrock/compare/fix-socket-crash - running `./test -only SupporessCommandPortCrash` on that branch will crash pretty quickly without the fix. 

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
