### PR TITLE
Remove blocking commit queue

### DIFF
--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -14,8 +14,7 @@ class BedrockCore : public SQLiteCore {
         SHOULD_PROCESS = 2,
         NEEDS_COMMIT = 3,
         NO_COMMIT_REQUIRED = 4,
-        ABANDONED_FOR_CHECKPOINT = 5,
-        SERVER_NOT_LEADING = 6
+        SERVER_NOT_LEADING = 5
     };
 
     // Automatic timing class that records an entry corresponding to its lifespan.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -88,7 +88,6 @@ bool BedrockServer::canStandDown() {
     // If we have any commands anywhere but the stand-down queue, let's log that.
     if (count && count != standDownQueueSize) {
         size_t mainQueueSize = _commandQueue.size();
-        size_t blockingQueueSize = _blockingCommandQueue.size();
         size_t syncNodeQueueSize = _syncNodeQueuedCommands.size();
         size_t completedCommandsSize = _completedCommands.size();
 
@@ -106,7 +105,6 @@ bool BedrockServer::canStandDown() {
 
         SINFO("Can't stand down with " << count << " commands remaining. Queue sizes are: "
               << "mainQueueSize: " << mainQueueSize << ", "
-              << "blockingQueueSize: " << blockingQueueSize << ", "
               << "syncNodeQueueSize: " << syncNodeQueueSize << ", "
               << "completedCommandsSize: " << completedCommandsSize << ", "
               << "outstandingHTTPSCommandsSize: " << outstandingHTTPSCommandsSize << ", "
@@ -592,10 +590,6 @@ void BedrockServer::sync()
                         } else if (result == BedrockCore::RESULT::SHOULD_PROCESS) {
                             // This is sort of the "default" case after checking if this command was complete above. If so,
                             // we'll fall through to calling processCommand below.
-                        } else if (result == BedrockCore::RESULT::ABANDONED_FOR_CHECKPOINT) {
-                            SINFO("[checkpoint] Re-queuing abandoned command (from peek) in sync thread");
-                            _commandQueue.push(move(command));
-                            break;
                         } else {
                             SERROR("peekCommand (" << command->request.getVerb() << ") returned invalid result code: " << (int)result);
                         }
@@ -642,10 +636,6 @@ void BedrockServer::sync()
                         } else {
                             _reply(command);
                         }
-                    } else if (result == BedrockCore::RESULT::ABANDONED_FOR_CHECKPOINT) {
-                        SINFO("[checkpoint] Re-queuing abandoned command (from process) in sync thread");
-                        _commandQueue.push(move(command));
-                        break;
                     } else {
                         SERROR("processCommand (" << command->request.getVerb() << ") returned invalid result code: " << (int)result);
                     }
@@ -712,13 +702,6 @@ void BedrockServer::sync()
         _commandQueue.clear();
     }
 
-    // Same for the blocking queue.
-    if (_blockingCommandQueue.size()) {
-        SWARN("Sync thread shut down with " << _blockingCommandQueue.size() << " blocking queued commands. Commands were: "
-              << SComposeList(_blockingCommandQueue.getRequestMethodLines()) << ". Clearing.");
-        _blockingCommandQueue.clear();
-    }
-
     // Release our handle to this pointer. Any other functions that are still using it will keep the object alive
     // until they return.
     atomic_store(&_syncNode, shared_ptr<SQLiteNode>(nullptr));
@@ -735,8 +718,7 @@ void BedrockServer::sync()
 
 void BedrockServer::worker(int threadId)
 {
-    // Worker 0 is the "blockingCommit" thread.
-    SInitialize(threadId ? "worker" + to_string(threadId) : "blockingCommit");
+    SInitialize("worker" + to_string(threadId));
 
     // Get a DB handle to work on. This will automatically be returned when dbScope goes out of scope.
     if (!_dbPool) {
@@ -749,27 +731,26 @@ void BedrockServer::worker(int threadId)
     // Command to work on. This default command is replaced when we find work to do.
     unique_ptr<BedrockCommand> command(nullptr);
 
-    // Which command queue do we use? The blockingCommit thread special and does blocking commits from the blocking queue.
-    BedrockCommandQueue& commandQueue = threadId ? _commandQueue : _blockingCommandQueue;
-
     // We just run this loop looking for commands to process forever. There's a check for appropriate exit conditions
     // at the bottom, which will cause our loop and thus this thread to exit when that becomes true.
     while (true) {
         try {
             // Set a signal handler function that we can call even if we die early with no command.
             SSetSignalHandlerDieFunc([&](){
-                SWARN("Die function called early with no command, probably died in `commandQueue.get`.");
+                SWARN("Die function called early with no command, probably died in `_commandQueue.get`.");
             });
 
             // Reset this to blank. This releases the existing command and allows it to get cleaned up.
             command = unique_ptr<BedrockCommand>(nullptr);
 
             // And get another one.
-            command = commandQueue.get(1000000);
+            command = _commandQueue.get(1000000);
+
+            // All commands start as non-blocking, and switch to blocking when they've had too many conflicts.
+            bool blocking = false;
 
             SAUTOPREFIX(command->request);
-            SINFO("Dequeued command " << command->request.methodLine << " in worker, "
-                  << commandQueue.size() << " commands in " << (threadId ? "" : "blocking") << " queue.");
+            SINFO("Dequeued command " << command->request.methodLine << " in worker, " << _commandQueue.size() << " commands in queue.");
 
             // Set the function that lets the signal handler know which command caused a problem, in case that happens.
             // If a signal is caught on this thread, which should only happen for unrecoverable, yet synchronous
@@ -959,14 +940,8 @@ void BedrockServer::worker(int threadId)
                 bool calledPeek = false;
                 BedrockCore::RESULT peekResult = BedrockCore::RESULT::INVALID;
                 if (command->repeek || !command->httpsRequests.size()) {
-                    peekResult = core.peekCommand(command, threadId == 0);
+                    peekResult = core.peekCommand(command, blocking);
                     calledPeek = true;
-                }
-
-                // This drops us back to the top of the loop.
-                if (peekResult == BedrockCore::RESULT::ABANDONED_FOR_CHECKPOINT) {
-                    SINFO("[checkpoint] Re-trying abandoned command (from peek) in worker thread");
-                    continue;
                 }
 
                 if (!calledPeek || peekResult == BedrockCore::RESULT::SHOULD_PROCESS) {
@@ -1000,7 +975,7 @@ void BedrockServer::worker(int threadId)
                             } else if (command->repeek) {
                                 // Otherwise, it needs to be re-peeked, but had no outstanding requests, so it goes
                                 // back in the main queue.
-                                commandQueue.push(move(command));
+                                _commandQueue.push(move(command));
                             }
 
                             // Move on to the next command until this one finishes.
@@ -1027,7 +1002,7 @@ void BedrockServer::worker(int threadId)
                     }
 
                     // In this case, there's nothing blocking us from processing this in a worker, so let's try it.
-                    BedrockCore::RESULT result = core.processCommand(command, threadId == 0);
+                    BedrockCore::RESULT result = core.processCommand(command, blocking);
                     if (result == BedrockCore::RESULT::NEEDS_COMMIT) {
                         // If processCommand returned true, then we need to do a commit. Otherwise, the command is
                         // done, and we just need to respond. Before we commit, we need to grab the sync thread
@@ -1063,8 +1038,7 @@ void BedrockServer::worker(int threadId)
                             }
                         }
                         if (commitSuccess) {
-                            SINFO("Successfully committed " << command->request.methodLine << " on worker thread. blocking: "
-                                  << (threadId ? "false" : "true"));
+                            SINFO("Successfully committed " << command->request.methodLine << " on worker thread. blocking: " << (blocking ? "true" : "false"));
                             // So we must still be leading, and at this point our commit has succeeded, let's
                             // mark it as complete. We add the currentCommit count here as well.
                             command->response["commitCount"] = to_string(db.getCommitCount());
@@ -1073,10 +1047,6 @@ void BedrockServer::worker(int threadId)
                             SINFO("Conflict or state change committing " << command->request.methodLine
                                   << " on worker thread with " << retry << " retries remaining.");
                         }
-                    } else if (result == BedrockCore::RESULT::ABANDONED_FOR_CHECKPOINT) {
-                        SINFO("[checkpoint] Re-trying abandoned command (from process) in worker thread");
-                        // Add a retry so that we don't hit out conflict limit for checkpoints.
-                        ++retry;
                     } else if (result == BedrockCore::RESULT::NO_COMMIT_REQUIRED) {
                         // Nothing to do in this case, `command->complete` will be set and we'll finish as we fall out
                         // of this block.
@@ -1092,7 +1062,7 @@ void BedrockServer::worker(int threadId)
                             _reply(command);
                             break;
                         } else {
-                            // Allow for an extra retry and start from the top, like with ABANDONED_FOR_CHECKPOINT.
+                            // Allow for an extra retry and start from the top.
                             SINFO("State changed before 'processCommand' but no HTTPS requests so retrying.");
                             ++retry;
                         }
@@ -1119,8 +1089,9 @@ void BedrockServer::worker(int threadId)
                 --retry;
 
                 if (!retry) {
-                    SINFO("Max retries hit in worker, sending '" << command->request.methodLine << "' to blocking queue.");
-                   _blockingCommandQueue.push(move(command));
+                    SINFO("Max retries hit in worker, marking '" << command->request.methodLine << "' as blocking and trying again.");
+                    blocking = true;
+                    retry++;
                 }
             }
         } catch (const BedrockCommandQueue::timeout_error& e) {
@@ -1368,33 +1339,9 @@ bool BedrockServer::shutdownComplete() {
     // (_syncThreadComplete) in the next loop or two.
     if (_gracefulShutdownTimeout.ringing()) {
         // Timing out. Log some info and return true.
-        string commandCounts;
-        string blockingCommandCounts;
-        list<pair<string*, BedrockCommandQueue*>> queuesToCount = {
-            {&commandCounts, &_commandQueue},
-            {&blockingCommandCounts, &_blockingCommandQueue}
-        };
-        for (auto queueCountPair : queuesToCount) {
-            map<string, int> commandsInQueue;
-            auto methods = queueCountPair.second->getRequestMethodLines();
-            for (auto method : methods) {
-                auto it = commandsInQueue.find(method);
-                if (it != commandsInQueue.end()) {
-                    (it->second)++;
-                } else {
-                    commandsInQueue[method] = 1;
-                }
-            }
-            for (auto cmdPair : commandsInQueue) {
-                *(queueCountPair.first) += cmdPair.first + ":" + to_string(cmdPair.second) + ", ";
-            }
-        }
         SWARN("Graceful shutdown timed out. "
               << "Replication State: " << SQLiteNode::stateName(_replicationState.load()) << ". "
               << "Command queue size: " << _commandQueue.size() << ". "
-              << "Blocking command queue size: " << _blockingCommandQueue.size() << ". "
-              << "Commands queued: " << commandCounts << ". "
-              << "Blocking commands queued: " << blockingCommandCounts << ". "
               << "Killing non-gracefully.");
     }
 
@@ -1947,8 +1894,7 @@ void BedrockServer::_beginShutdown(const string& reason, bool detach) {
             _commandPort = nullptr;
         }
         _shutdownState.store(START_SHUTDOWN);
-        SINFO("START_SHUTDOWN. Ports shutdown, will perform final socket read. Commands queued: " << _commandQueue.size()
-              << ", blocking commands queued: " << _blockingCommandQueue.size());
+        SINFO("START_SHUTDOWN. Ports shutdown, will perform final socket read. Commands queued: " << _commandQueue.size());
     }
 }
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -253,9 +253,6 @@ class BedrockServer : public SQLiteServer {
     // Commands that aren't currently being processed are kept here.
     BedrockCommandQueue _commandQueue;
 
-    // These are commands that will be processed in a blacking fashion.
-    BedrockCommandQueue _blockingCommandQueue;
-
     // Each time we read a new request from a client, we give it a unique ID.
     atomic<uint64_t> _requestCount;
 
@@ -380,7 +377,7 @@ class BedrockServer : public SQLiteServer {
     unique_ptr<Port> _controlPort;
     unique_ptr<Port> _commandPort;
 
-    // The maximum number of conflicts we'll accept before forwarding a command to the sync thread.
+    // The maximum number of conflicts we'll accept before blocking other threads to commit a command.
     atomic<int> _maxConflictRetries;
 
     mutex _httpsCommandMutex;


### PR DESCRIPTION
### Details
Removes the blocking commit queue and it's own special thread. Any worker thread can now perform a blocking write.

This also cleans up some leftover references to `ABANDONED_FOR_CHECKPOINT`.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/193888

### Tests
Existing tests. Verified the collision tests log a bunch of lines like:
```
2022-01-28T14:20:48.859579+00:00 expensidev2004 bedrock10001: Z8yzIP (BedrockServer.cpp:1041) worker [worker2] [info] Successfully committed idcollision r_21039_r on worker thread. blocking: true
```

Which indicates the blocking code is still being hit.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes

Done:
```
[ TEST RESULTS ] Passed: 1672, Failed: 0
```
