### PR TITLE
Fix processTimeout being used when not processing.

### DIFF
--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -65,7 +65,7 @@ class BedrockCore : public SQLiteCore {
     // Gets the amount of time remaining until this command times out. This is the difference between the command's
     // 'timeout' value (or the default timeout, if not set) and the time the command was initially scheduled to run. If
     // this time is already expired, this throws `555 Timeout`
-    uint64_t _getRemainingTime(const unique_ptr<BedrockCommand>& command);
+    uint64_t _getRemainingTime(const unique_ptr<BedrockCommand>& command, bool isProcessing);
 
     void _handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e);
     const BedrockServer& _server;

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -52,7 +52,7 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture {
         // leader is brought back up, it will be STANDINGDOWN until it finishes
         thread slowQueryThread([this, &follower](){
             SData slow("slowquery");
-            slow["processTimeout"] = "5000"; // 5s
+            slow["timeout"] = "5000"; // 5s
             follower.executeWaitVerifyContent(slow, "555 Timeout peeking command");
         });
 

--- a/test/clustertest/tests/TimeoutTest.cpp
+++ b/test/clustertest/tests/TimeoutTest.cpp
@@ -46,6 +46,7 @@ struct TimeoutTest : tpunit::TestFixture {
         // Run a (read-only) query that takes longer than the default process timeout, without changing the process
         // timeout.
         SData slow("slowquery");
+        slow["size"] = "1000000000";
         slow["timeout"] = to_string(BedrockCommand::DEFAULT_PROCESS_TIMEOUT + 5'000);
         auto start = STimeNow();
         brtester.executeWaitVerifyContent(slow, "555 Timeout peeking command");

--- a/test/clustertest/tests/TimeoutTest.cpp
+++ b/test/clustertest/tests/TimeoutTest.cpp
@@ -50,9 +50,6 @@ struct TimeoutTest : tpunit::TestFixture {
         auto start = STimeNow();
         brtester.executeWaitVerifyContent(slow, "555 Timeout peeking command");
         auto end = STimeNow();
-
-        cout << ((end - start) / 1000) << ", " << (BedrockCommand::DEFAULT_PROCESS_TIMEOUT + 5'000) << endl;
-
         ASSERT_GREATER_THAN((end - start) / 1000, BedrockCommand::DEFAULT_PROCESS_TIMEOUT + 5'000);
     }
 

--- a/test/clustertest/tests/TimeoutTest.cpp
+++ b/test/clustertest/tests/TimeoutTest.cpp
@@ -1,3 +1,4 @@
+#include <BedrockCommand.h>
 #include <libstuff/SData.h>
 #include <test/clustertest/BedrockClusterTester.h>
 
@@ -7,6 +8,7 @@ struct TimeoutTest : tpunit::TestFixture {
                               BEFORE_CLASS(TimeoutTest::setup),
                               AFTER_CLASS(TimeoutTest::teardown),
                               TEST(TimeoutTest::test),
+                              TEST(TimeoutTest::longerThanDefaultProcess),
                               TEST(TimeoutTest::testprocess),
                               TEST(TimeoutTest::totalTimeout),
                               TEST(TimeoutTest::quorumHTTPS),
@@ -24,18 +26,34 @@ struct TimeoutTest : tpunit::TestFixture {
 
     void test()
     {
-        // Test write commands.
         BedrockTester& brtester = tester->getTester(0);
 
         // Run one long query.
         SData slow("slowquery");
-        slow["processTimeout"] = "1000"; // 1s
+        slow["timeout"] = "1000"; // 1s
         brtester.executeWaitVerifyContent(slow, "555 Timeout peeking command");
 
         // And a bunch of faster ones.
         slow["size"] = "10000";
         slow["count"] = "10000";
         brtester.executeWaitVerifyContent(slow, "555 Timeout peeking command");
+    }
+
+    void longerThanDefaultProcess()
+    {
+        BedrockTester& brtester = tester->getTester(0);
+
+        // Run a (read-only) query that takes longer than the default process timeout, without changing the process
+        // timeout.
+        SData slow("slowquery");
+        slow["timeout"] = to_string(BedrockCommand::DEFAULT_PROCESS_TIMEOUT + 5'000);
+        auto start = STimeNow();
+        brtester.executeWaitVerifyContent(slow, "555 Timeout peeking command");
+        auto end = STimeNow();
+
+        cout << ((end - start) / 1000) << ", " << (BedrockCommand::DEFAULT_PROCESS_TIMEOUT + 5'000) << endl;
+
+        ASSERT_GREATER_THAN((end - start) / 1000, BedrockCommand::DEFAULT_PROCESS_TIMEOUT + 5'000);
     }
 
     void quorumHTTPS () {


### PR DESCRIPTION
### Details
If `timeout` is longer than `processTimeout` then we will timeout when we hit the `processTimeout` even in `peek`. This is confusing and leads to specifying both timeouts for commands, even that do no writes. This also means that `timeout` can't be set above the default for `processTimeout` by itself, you need to set both.

The fix is to only check `processTimeout` in process.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/194179

### Tests
New test added.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
