### PR TITLE
Fix nextRun < created - Flakey tests

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -500,8 +500,10 @@ void BedrockJobsCommand::process(SQLite& db) {
                 SINFO("Job specified run time or repeat, not suitable for immediate scheduling.");
             }
 
+            const string& currentTime = SCURRENT_TIMESTAMP();
+
             // If no "firstRun" was provided, use right now
-            const string& safeFirstRun = !SContains(job, "firstRun") || job["firstRun"].empty() ? SCURRENT_TIMESTAMP() : SQ(job["firstRun"]);
+            const string& safeFirstRun = !SContains(job, "firstRun") || job["firstRun"].empty() ? currentTime : SQ(job["firstRun"]);
 
             // If no data was provided, use an empty object
             const string& safeData = !SContains(job, "data") || job["data"].empty() ? SQ("{}") : SQ(job["data"]);
@@ -597,7 +599,7 @@ void BedrockJobsCommand::process(SQLite& db) {
                 if (!db.writeIdempotent("INSERT INTO jobs ( jobID, created, state, name, nextRun, repeat, data, priority, parentJobID, retryAfter ) "
                          "VALUES( " +
                             SQ(jobIDToUse) + ", " +
-                            SCURRENT_TIMESTAMP() + ", " +
+                            currentTime + ", " +
                             SQ(initialState) + ", " +
                             SQ(job["name"]) + ", " +
                             safeFirstRun + ", " +


### PR DESCRIPTION
### Details

Fix rare case when `job.nextRun` can be one second earlier than `job.created`, which make some tests fail.


### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/193740

### Tests

Make sure that tests run
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
