### PR TITLE
Fix race condition in SComposeTime

### DIFF
--- a/libstuff/STime.cpp
+++ b/libstuff/STime.cpp
@@ -13,7 +13,9 @@ string SComposeTime(const string& format, uint64_t when) {
     // Convert from high-precision time (usec) to standard low-precision time (sec), then format and return
     const time_t loWhen = (time_t)(when / STIME_US_PER_S);
     char buf[256] = {};
-    size_t length = strftime(buf, sizeof(buf), format.c_str(), gmtime(&loWhen));
+    struct tm result = {};
+    gmtime_r(&loWhen, &result);
+    size_t length = strftime(buf, sizeof(buf), format.c_str(), &result);
     return string(buf, length);
 }
 


### PR DESCRIPTION
### Details
Explanation:

This replaces `gmtime` with `gmtime_r`.

Why does this work?

From the `gmtime` manpage:
```
       The gmtime() function converts the calendar time timep to broken-down time  representation,
       expressed  in  Coordinated Universal Time (UTC).  It may return NULL when the year does not
       fit into an integer.  The return value points to a statically allocated struct which  might
       be  overwritten  by subsequent calls to any of the date and time functions.  The gmtime_r()
       function does the same, but stores the data in a user-supplied struct.
```

Key:
```
might  be  overwritten  by subsequent calls..
```

What happens is every call to `gmtime` stores the output in the same place in memory. In multi-threaded code, this means that different threads can be writing new data to this single `struct tm` while other threads are trying to read it to compose a timestamp string. When these two things overlap in the wrong way, the result gets corrupted. We have only noticed it with `00:00:00` timestamps, but other errors are also possible. I doubt they're significant, though, as I think we either see correct values or zero'ed values, and two concurrent calls to this function can't be off by more than 1 seconds from each other.

We replace this with `gmtime_r` which lets each calling thread supply its own `struct tm` to use, so that they won't overwrite each other. The problem should be fixed.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/194388
Fixes https://github.com/Expensify/Expensify/issues/167579

### Tests

Ran auth tests and verified I didn't break timestamps entirely by checking loglines:
```
2022-02-02T22:54:56.606239+00:00 expensidev2004 bedrock: IhHnVl (Purchase.cpp:9) add [worker6] [info] Purchase::add 1 into purchases with timestamp '2022-02-02 22:54:56'
```
