### PR TITLE
Fix `COMMIT_WORKER` timing

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1058,7 +1058,7 @@ void BedrockServer::worker(int threadId)
                                        << " during worker commit. Rolling back transaction!");
                                 core.rollback();
                             } else {
-                                BedrockCore::AutoTimer(command, BedrockCommand::COMMIT_WORKER);
+                                BedrockCore::AutoTimer timer(command, BedrockCommand::COMMIT_WORKER);
                                 commitSuccess = core.commit(SQLiteNode::stateName(_replicationState));
                             }
                         }


### PR DESCRIPTION
### Details
This temporary object was too temporary. Having no name, it was being destroyed at the end of the line that created it, rather than then end of the block it was scoped to. Thus, `COMMIT_WORKER` time always showed up as 0.

Noted here: 
https://github.com/Expensify/Expensify/issues/195007#issuecomment-1032891759

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/195541

### Tests
Tested by watching logs.