### PR TITLE
Add size to blocking commit queue log line

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1119,7 +1119,7 @@ void BedrockServer::worker(int threadId)
                 --retry;
 
                 if (!retry) {
-                    SINFO("Max retries hit in worker, sending '" << command->request.methodLine << "' to blocking queue.");
+                    SINFO("Max retries hit in worker, sending '" << command->request.methodLine << "' to blocking queue with size " << _blockingCommandQueue.size());
                    _blockingCommandQueue.push(move(command));
                 }
             }


### PR DESCRIPTION
### Details
Adds the size of the queue to a log line so we can verify if this is true: https://github.com/Expensify/Expensify/issues/195007#issuecomment-1033157566

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/195007

### Tests
None.

