### PR TITLE
Fix BR crash

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -646,6 +646,10 @@ void BedrockServer::sync()
                         SINFO("[checkpoint] Re-queuing abandoned command (from process) in sync thread");
                         _commandQueue.push(move(command));
                         break;
+                    } else if (result == BedrockCore::RESULT::SERVER_NOT_LEADING) {
+                        SINFO("Server stopped leading, re-queueing commad");
+                        _commandQueue.push(move(command));
+                        break;
                     } else {
                         SERROR("processCommand (" << command->request.getVerb() << ") returned invalid result code: " << (int)result);
                     }

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -11,9 +11,12 @@ bool SQLiteClusterMessenger::sendToLeader(BedrockCommand& command) {
     string leaderAddress;
     auto _nodeCopy = atomic_load(&_node);
     if (_nodeCopy) {
+        // peerList is const, so we can safely read from it in  multiple threads without locking, similarly,
+        // peer->commandAddress is atomic.
         for (SQLiteNode::Peer* peer : _nodeCopy->peerList) {
-            if (peer->state == STCPNode::LEADING && !peer->commandAddress.load().empty()) {
-                leaderAddress = peer->commandAddress;
+            string peerCommandAddress = peer->commandAddress;
+            if (peer->state == STCPNode::LEADING && !peerCommandAddress.empty()) {
+                leaderAddress = peerCommandAddress;
                 break;
             }
         }
@@ -29,13 +32,16 @@ bool SQLiteClusterMessenger::sendToLeader(BedrockCommand& command) {
     // Create a new transaction. This can throw if `validate` fails. We explicitly do this *before* creating a socket.
     Transaction* transaction = new Transaction(*this);
 
-    // I don't trust this not to ever leak currently, but for the moment, this is OK.
-    _transactionCommands[transaction] = make_pair(&command, STimeNow());
+    {
+        lock_guard<mutex> lock(_transactionCommandMutex);
+        _transactionCommands[transaction] = make_pair(&command, STimeNow());
+    }
 
     Socket* s = nullptr;
     try {
         s = new Socket(host, nullptr);
     } catch (const SException& exception) {
+        lock_guard<mutex> lock(_transactionCommandMutex);
         _transactionCommands.erase(transaction);
         delete transaction;
         return false;
@@ -55,6 +61,7 @@ bool SQLiteClusterMessenger::sendToLeader(BedrockCommand& command) {
 bool SQLiteClusterMessenger::_onRecv(Transaction* transaction)
 {
     transaction->response = getHTTPResponseCode(transaction->fullResponse.methodLine);
+    lock_guard<mutex> lock(_transactionCommandMutex);
     auto cmdIt = _transactionCommands.find(transaction);
     if (cmdIt != _transactionCommands.end()) {
         BedrockCommand* command = cmdIt->second.first;

--- a/sqlitecluster/SQLiteClusterMessenger.h
+++ b/sqlitecluster/SQLiteClusterMessenger.h
@@ -15,6 +15,7 @@ class SQLiteClusterMessenger : public SStandaloneHTTPSManager {
   private:
     shared_ptr<SQLiteNode>& _node;
 
-    // Map of transactions to their commands and escalation start times
+    // Map of transactions to their commands and escalation start times, and a mutex to use for protecting access to it.
+    mutex _transactionCommandMutex;
     map<Transaction*, pair<BedrockCommand*, uint64_t>> _transactionCommands;
 };


### PR DESCRIPTION
### Details
Fixes unprotected access by multiple threads to a map of commands, and adds han dling of the case where leader stops leading as it tries to commit a command.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/196525

### Tests
Existing tests run 10x locally with `-escalateOverHTTP` enabled.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
