### PR TITLE
Shutdown the port socket before closing

### DIFF
--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -348,6 +348,7 @@ STCPManager::Port::Port(int _s, string _host) : s(_s), host(_host)
 STCPManager::Port::~Port()
 {
     if (s != -1) {
+        ::shutdown(s, SHUT_RDWR);
         ::close(s);
     }
 }


### PR DESCRIPTION
### Details
We have observed a crash that comes with the following sequence of events:
* Shutdown (detach) the server
* Start it back up right away
* Kernel does not have time to finish closing the socket (we think)
* Bedrock tries to open the socket and crashes because it is already open (we think due to not being fully closed)

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/194700

### Tests
Was unable to reproduce the crash in dev, we identified this by tracing the shutdown logic.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
