### PR TITLE
Use HTTP escalation for immediate escalations

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -864,7 +864,7 @@ void BedrockServer::worker(int threadId)
                         SWARN("Couldn't immediately escalate command " << command->request.methodLine << " to leader, queuing normally.");
                         _commandQueue.push(move(command));
                     }
-                else {
+                } else {
                     SINFO("Immediately escalating " << command->request.methodLine << " to leader. Sync thread has " << _syncNodeQueuedCommands.size() << " queued commands.");
                     _syncNodeQueuedCommands.push(move(command));
                 }


### PR DESCRIPTION
### Details
The issue describes the problem.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/197176

### Tests
Existing tests run with `-escalateOverHTTP` set to `true`.
