### PR TITLE
Add second command port that doesn't close with `SuppressCommandPort`.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1754,6 +1754,7 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         content["state"]    = SQLiteNode::stateName(state);
         content["version"]  = _version;
         content["host"]     = args["-nodeHost"];
+        content["escalateOverHTTP"] = _escalateOverHTTP ? "true" : "false";
 
         {
             // Make it known if anything is known to cause crashes.
@@ -1926,6 +1927,8 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
                 SINFO("Escalate over HTTP: " << (_escalateOverHTTP ? "enabled" : "disabled"));
                 command->response.methodLine = "200 "s + (_escalateOverHTTP ? "Enabled" : "Disabled");
             }
+        } else {
+            command->response.methodLine = "400 Must Specify Enable";
         }
     }
 }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2181,9 +2181,9 @@ unique_ptr<BedrockCommand> BedrockServer::buildCommandFromRequest(SData&& reques
     return command;
 }
 
-void BedrockServer::handleSocket(Socket&& socket, bool isControl) {
+void BedrockServer::handleSocket(Socket&& socket, bool isControlPort) {
     shared_lock<shared_mutex> controlPortLock(_controlPortExclusionMutex, defer_lock);
-    if (isControl) {
+    if (isControlPort) {
         controlPortLock.lock();
     }
     // Initialize and get a unique thread ID.
@@ -2265,7 +2265,7 @@ void BedrockServer::handleSocket(Socket&& socket, bool isControl) {
                     // If it's a status or control command, we handle it specially above. If not, we'll queue it for
                     // later processing below.
 
-                    if (isControl && _shutdownState != RUNNING) {
+                    if (isControlPort && _shutdownState != RUNNING) {
                         // Don't handle non-control commands on the control port if we're shutting down. As the control
                         // port can remain open through shutdown (in the case of detaching) and can expect DB access,
                         // which is being turned off, these could cause weird crashes. Instead, just return an error.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -245,7 +245,7 @@ class BedrockServer : public SQLiteServer {
     const SData args;
 
     // This is the thread that handles a new socket, parses a command, and queues it for work.
-    void handleSocket(Socket&& s, bool isControl);
+    void handleSocket(Socket&& s, bool isControlPort);
 
   private:
     // The name of the sync thread.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -382,8 +382,22 @@ class BedrockServer : public SQLiteServer {
 
     // Pointers to the ports on which we accept commands.
     mutex _portMutex;
+
+    // The "control port" is intended to be open to privileged clients (i.e., localhost and other nodes i the Bedrock
+    // cluster) it can be used to run any command including commands meant for cluster operations, changing server
+    // settings, etc. It is never closed except upon shutting down the server.
+    // Note: In the future, two physical ports may need to be opened to support this, one on localhost, and one on an
+    // externally available IP address.
     unique_ptr<Port> _controlPort;
-    unique_ptr<Port> _commandPort;
+
+    // Both of these commands ports act identically and accept unprivileged commands. One (public) should be made
+    // available to the network as a whole (i.e., clients in general), and the other should only be made available to
+    // other nodes in the bedrock cluster. The only difference between the two is that when calling
+    // `SuppressCommandPort`, only the public port is closed. The private port remains open so that inter-cluster
+    // traffic continues to flow. Suppressing the command port is intended to lower load by directing traffic away from
+    // a node, but the node may still need to receive commands from the rest of the cluster.
+    unique_ptr<Port> _commandPortPublic;
+    unique_ptr<Port> _commandPortPrivate;
 
     // The maximum number of conflicts we'll accept before forwarding a command to the sync thread.
     atomic<int> _maxConflictRetries;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -383,7 +383,7 @@ class BedrockServer : public SQLiteServer {
     // Pointers to the ports on which we accept commands.
     mutex _portMutex;
 
-    // The "control port" is intended to be open to privileged clients (i.e., localhost and other nodes i the Bedrock
+    // The "control port" is intended to be open to privileged clients (i.e., localhost and other nodes in the Bedrock
     // cluster) it can be used to run any command including commands meant for cluster operations, changing server
     // settings, etc. It is never closed except upon shutting down the server.
     // Note: In the future, two physical ports may need to be opened to support this, one on localhost, and one on an

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -176,6 +176,8 @@ struct STCPNode : public STCPManager {
     // Inverse of the above function. If the peer is not found, returns 0.
     uint64_t getIDByPeer(Peer* peer);
 
+    unique_ptr<Port> port;
+
   private:
     // Override dead function
     void postPoll(fd_map& ignore) { SERROR("Don't call."); }
@@ -186,8 +188,6 @@ struct STCPNode : public STCPManager {
     AutoTimer _deserializeTimer;
     AutoTimer _sConsumeFrontTimer;
     AutoTimer _sAppendTimer;
-
-    unique_ptr<Port> port;
 };
 
 // serialization for Responses.

--- a/main.cpp
+++ b/main.cpp
@@ -296,6 +296,7 @@ int main(int argc, char* argv[]) {
     SETDEFAULT("-db", "bedrock.db");
     SETDEFAULT("-serverHost", "localhost:8888");
     SETDEFAULT("-nodeHost", "localhost:8889");
+    SETDEFAULT("-commandPortPrivate", "localhost:8890");
     SETDEFAULT("-controlPort", "localhost:9999");
     SETDEFAULT("-nodeName", SGetHostName());
     SETDEFAULT("-cacheSize", SToStr(1024 * 1024)); // 1024 * 1024KB = 1GB.

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -39,6 +39,8 @@ bool SQLiteClusterMessenger::sendToLeader(BedrockCommand& command) {
 
     Socket* s = nullptr;
     try {
+        // TODO: Future improvement - socket pool so these are reused.
+        // TODO: Also, allow S_socket to take a parsed address instead of redoing all the parsing above.
         s = new Socket(host, nullptr);
     } catch (const SException& exception) {
         lock_guard<mutex> lock(_transactionCommandMutex);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -41,7 +41,8 @@ class SQLiteNode : public STCPNode {
 
     // Constructor/Destructor
     SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, const string& name, const string& host,
-               const string& peerList, int priority, uint64_t firstTimeout, const string& version, const bool useParallelReplication = false);
+               const string& peerList, int priority, uint64_t firstTimeout, const string& version, const bool useParallelReplication = false,
+               const string& commandPort = "localhost:8890");
     ~SQLiteNode();
 
     const vector<Peer*> initPeers(const string& peerList);
@@ -106,7 +107,9 @@ class SQLiteNode : public STCPNode {
     // This will broadcast a message to all peers, or a specific peer.
     void broadcast(const SData& message, Peer* peer = nullptr);
 
-    void setCommandAddress(const string& commandAddress);
+    // Takes two string in the form of `host:port` (i.e., `www.expensify.com:80` or `127.0.0.1:443`) and creates a
+    // similar string with the host from hostPart and the port from portPart .
+    string replaceAddressPort(const string& hostPart, const string& portPart);
 
   private:
     // STCPNode API: Peer handling framework functions
@@ -280,5 +283,5 @@ class SQLiteNode : public STCPNode {
 
     // A string representing an address (i.e., `127.0.0.1:80`) where this server accepts commands. I.e., "the command
     // port".
-    atomic<string> _commandAddress;
+    const string _commandAddress;
 };

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -67,6 +67,7 @@ BedrockTester::BedrockTester(const map<string, string>& args,
         {"-v", ""},
         {"-quorumCheckpoint", "50"},
         {"-enableMultiWrite", "true"},
+        {"-escalateOverHTTP", "true"},
         {"-cacheSize", "1000"},
         {"-parallelReplication", "true"},
         // Currently breaks only in Travis and needs debugging, which has been removed, maybe?

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -40,7 +40,8 @@ BedrockTester::BedrockTester(const map<string, string>& args,
                              bool startImmediately) :
     _serverPort(serverPort ?: ports.getPort()),
     _nodePort(nodePort ?: ports.getPort()),
-    _controlPort(controlPort ?: ports.getPort())
+    _controlPort(controlPort ?: ports.getPort()),
+    _commandPortPrivate(ports.getPort())
 {
     {
         lock_guard<decltype(_testersMutex)> lock(_testersMutex);
@@ -59,6 +60,7 @@ BedrockTester::BedrockTester(const map<string, string>& args,
         {"-nodeName", "bedrock_test"},
         {"-nodeHost", "localhost:" + to_string(_nodePort)},
         {"-controlPort", "localhost:" + to_string(_controlPort)},
+        {"-commandPortPrivate", "0.0.0.0:" + to_string(_commandPortPrivate)},
         {"-priority", "200"},
         {"-plugins", "db"},
         {"-workerThreads", "8"},

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -107,5 +107,6 @@ class BedrockTester {
     uint16_t _serverPort;
     uint16_t _nodePort;
     uint16_t _controlPort;
+    uint16_t _commandPortPrivate;
 };
 


### PR DESCRIPTION
### Details
To support escalations on the command port, and all future inter-cluster commands, we need a port to which we can send commands that does not close when traffic gets high. Historically, we close the command port on leader to keep it from servicing read traffic when it's overloaded. This works because commands are escalated to leader on the node port. In a world where traffic escalates to leader on the command port, we either need to leave this open all the time (risky), or have a second port that stays open to cluster traffic even if the public port is closed. This change implements this additional port, which acts identically to the main command port, except that it doesn't close with `SuppressCommandPort`.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/197487 https://github.com/Expensify/Expensify/issues/193926

### Tests
Tests updated, auth and bedrock tests run against the latest changes.