### PR TITLE
Add workaround for failed bind

### DIFF
--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -333,11 +333,30 @@ bool STCPManager::Socket::recv() {
     return result;
 }
 
-unique_ptr<STCPManager::Port> STCPManager::openPort(const string& host) {
+unique_ptr<STCPManager::Port> STCPManager::openPort(const string& host, int remainingTries) {
     // Open a port on the requested host
     SASSERT(SHostIsValid(host));
-    int s = S_socket(host, true, true, false);
-    SASSERT(s >= 0);
+    int s;
+    while (remainingTries--) {
+        s = S_socket(host, true, true, false);
+        if (s == -1) {
+            SWARN("Couldn't open port " << host << " with " << remainingTries << " retries remaining.");
+
+            // If we have any tries left, sleep for a second. We skip the sleep after the last try.
+            if (remainingTries) {
+                sleep(1);
+            }
+        } else {
+            // Socket succeeded.
+            break;
+        }
+    }
+
+    if (s == -1) {
+        // If we don't return in the while loop, we die.
+        SERROR("Failed to open port " << host << " and no more retries.");
+    }
+
     return make_unique<Port>(s, host);
 }
 

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -84,5 +84,5 @@ struct STCPManager {
     static void prePoll(fd_map& fdm, Socket& socket);
     static void postPoll(fd_map& fdm, Socket& socket);
 
-    static unique_ptr<Port> openPort(const string& host);
+    static unique_ptr<Port> openPort(const string& host, int remainingTries = 1);
 };

--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -15,7 +15,7 @@ STCPNode::STCPNode(const string& name_, const string& host, const vector<Peer*> 
 {
     // Initialize
     if (!host.empty()) {
-        port = openPort(host);
+        port = openPort(host, 30);
     }
 }
 


### PR DESCRIPTION
### Details
This is a workaraound but hopefully helps with the case where we can't bind to the node port after running a backup.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/194700

### Tests
Existing tests.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
