### PR TITLE
39% Fewer logs

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -98,7 +98,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
             SDEBUG("Plugin '" << command->getName() << "' peeked command '" << request.methodLine << "'");
 
             if (!completed) {
-                SINFO("Command '" << request.methodLine << "' not finished in peek, re-queuing.");
+                SDEBUG("Command '" << request.methodLine << "' not finished in peek, re-queuing.");
                 _db.resetTiming();
                 _db.setQueryOnly(false);
                 return RESULT::SHOULD_PROCESS;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1615,13 +1615,13 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
             }
         } else {
             // Otherwise we send the standard response.
-            SINFO("About to reply to command " << command->request.methodLine);
+            SDEBUG("About to reply to command " << command->request.methodLine);
             if (!command->socket->send(command->response.serialize())) {
                 // If we can't send (client closed the socket?), alert our plugin it's response was never sent.
                 SINFO("No socket to reply for: '" << command->request.methodLine << "' #" << command->initiatingClientID);
                 command->handleFailedReply();
             } else {
-                SINFO("Replied");
+                SDEBUG("Replied");
             }
         }
 
@@ -2165,7 +2165,7 @@ unique_ptr<BedrockCommand> BedrockServer::buildCommandFromRequest(SData&& reques
 
     // Create a command.
     unique_ptr<BedrockCommand> command = getCommandFromPlugins(move(request));
-    SINFO("Deserialized command " << command->request.methodLine);
+    SDEBUG("Deserialized command " << command->request.methodLine);
     command->socket = fireAndForget ? nullptr : &socket;
 
     if (command->writeConsistency != SQLiteNode::QUORUM && _syncCommands.find(command->request.methodLine) != _syncCommands.end()) {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2017,9 +2017,6 @@ bool S_sendconsume(int s, SFastBuffer& sendBuffer) {
         SINFO("Sending an ESCALATE_RESPONSE for id " << id);
     }
 
-    // Timer for tracking how long the call to send is taking to debug slow ESCALATE_RESPONSEs
-    chrono::steady_clock::time_point start = chrono::steady_clock::now();
-
     // Send as much as we can
     ssize_t numSent = send(s, sendBuffer.c_str(), sendBuffer.size(), MSG_NOSIGNAL);
     string errorMessage;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1972,8 +1972,6 @@ bool S_recvappend(int s, SFastBuffer& recvBuffer) {
 
     if (ret < 0) {
         SHMMM("Unable to get length of socket buffer error: " << strerror(S_errno));
-    } else {
-        SINFO("[performance] " << bytesInBuffer << " bytes in the socket buffer before receiving.");
     }
 
     // Keep trying to receive as long as we can
@@ -2028,8 +2026,6 @@ bool S_sendconsume(int s, SFastBuffer& sendBuffer) {
     if (numSent == -1) {
         errorMessage = " Error: "s + strerror(errno);
     }
-    SINFO("[performance] Send() took " << chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - start).count()
-        << " ms and sent " << numSent << " of " << sendBuffer.size() << " bytes." << errorMessage);
 
     if (numSent > 0) {
         sendBuffer.consumeFront(numSent);

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -826,7 +826,7 @@ void BedrockJobsCommand::process(SQLite& db) {
 
         if (!retriableJobs.empty()) {
             for (auto job : retriableJobs) {
-                SINFO("Updating job with retryAfter " << job["jobID"]);
+                SDEBUG("Updating job with retryAfter " << job["jobID"]);
                 STable jobData = SParseJSONObject(job["data"]);
                 if (SToInt(jobData["retryAfterCount"]) >= 10) {
                     SINFO("Job " << job["jobID"] << " has retried 10 times, marking it as FAILED.");

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -676,7 +676,7 @@ int SQLite::commit(const string& description) {
         int framesCheckpointed = 0;
         uint64_t start = STimeNow();
         int result = sqlite3_wal_checkpoint_v2(_db, 0, SQLITE_CHECKPOINT_PASSIVE, &walSizeFrames, &framesCheckpointed);
-        SINFO("[checkpoint] Checkpoint complete. Result: " << result << ". Total frames checkpointed: "
+        SDEBUG("[checkpoint] Checkpoint complete. Result: " << result << ". Total frames checkpointed: "
               << framesCheckpointed << " of " << walSizeFrames << " in " << ((STimeNow() - start) / 1000) << "ms.");
         SINFO(description << " COMMIT complete in " << time << ". Wrote " << (endPages - startPages)
               << " pages. WAL file size is " << sz << " bytes. " << _queryCount << " queries attempted, " << _cacheHits
@@ -745,7 +745,7 @@ void SQLite::rollback() {
         SINFO("Rolling back but not inside transaction, ignoring.");
     }
     _queryCache.clear();
-    SINFO("Transaction rollback with " << _queryCount << " queries attempted, " << _cacheHits << " served from cache.");
+    DEBUG("Transaction rollback with " << _queryCount << " queries attempted, " << _cacheHits << " served from cache.");
     _queryCount = 0;
     _cacheHits = 0;
     _dbCountAtStart = 0;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -745,7 +745,7 @@ void SQLite::rollback() {
         SINFO("Rolling back but not inside transaction, ignoring.");
     }
     _queryCache.clear();
-    DEBUG("Transaction rollback with " << _queryCount << " queries attempted, " << _cacheHits << " served from cache.");
+    SDEBUG("Transaction rollback with " << _queryCount << " queries attempted, " << _cacheHits << " served from cache.");
     _queryCount = 0;
     _cacheHits = 0;
     _dbCountAtStart = 0;

--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -44,7 +44,7 @@ size_t SQLitePool::getIndex(bool createHandle) {
             size_t index = *frontIt;
             _inUseHandles.insert(index);
             _availableHandles.erase(frontIt);
-            SINFO("Returning existing DB handle");
+            SDEBUG("Returning existing DB handle");
             return index;
         } else if (_availableHandles.size() + _inUseHandles.size() < (_maxDBs - 1)) {
             size_t index = _availableHandles.size() + _inUseHandles.size();
@@ -82,7 +82,7 @@ void SQLitePool::returnToPool(size_t index) {
         lock_guard<mutex> lock(_sync);
         _availableHandles.insert(index);
         _inUseHandles.erase(index);
-        SINFO("DB handle returned to pool.");
+        SDEBUG("DB handle returned to pool.");
     }
     _wait.notify_one();
 }


### PR DESCRIPTION
### Details

I sampled an hour of logs *during harvesting*

The total number of lines were:
```
Total bedrock lines: 1,154,102,507
Total php lines: 504,600,579
Total other lines: 19,274,897
```

The loglines removed/demoted in this PR are:
```
libstuff.cpp:1976: 69414414 +
libstuff.cpp:2031: 83397217 +
SQLitePool.cpp:47: 41765910 +
SQLitePool.cpp:85: 41766112 +
SQLiteNode.cpp:1644: 41766138 +
SQLiteNode.cpp:1647: 41766138 +
SQLiteNode.cpp:156: 41766161 +
SQLite.cpp:748: 42421887 +
BedrockServer.cpp:2164: 39999116 +
BedrockServer.cpp:1623: 39493163 +
BedrockServer.cpp:1617: 39493142 +
SQLite.cpp:679: 24568083 +
SQLiteNode.cpp:166: 20883069 +
SQLiteNode.cpp:206: 20981227 +
SQLiteNode.cpp:190: 20981592 +
BedrockCore.cpp:101: 10424501 +
SQLiteNode.cpp:2532: 16605352 +
Jobs.cpp:829: 10013868 =
```

647,507,090

That cuts lines logged by bedrock by 56%.

It cuts all lines logged by 39%.

You could make a case to save some of these log lines but most of them are pretty redundant and rarely useful. We can see if we miss any of them as they're `DEBUG` except for a couple super-high-volume and completely obsolete performance log lines.

### Fixed Issues
Fixes logs falling behind by miles constantly.

### Tests
Not much to test.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
