### PR TITLE
Handle jobs with improperly formatted times

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1427,7 +1427,7 @@ void BedrockJobsCommand::_validatePriority(const int64_t priority) {
 }
 
 void BedrockJobsCommand::_handleFailedRetryAfterQuery(SQLite& db, const string& jobID) {
-    SALERT("ENSURE_BUGBOT Query error when updating job with retryAfter");
+    SALERT("ENSURE_BUGBOT Query error when updating job with retryAfter. JobID: " << jobID);
     if (!db.writeIdempotent("UPDATE jobs "
                             "SET state = 'FAILED' "
                             "WHERE jobID = " + SQ(jobID) + ";")) {

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1427,13 +1427,12 @@ void BedrockJobsCommand::_validatePriority(const int64_t priority) {
 }
 
 void BedrockJobsCommand::_handleFailedRetryAfterQuery(SQLite& db, const string& jobID) {
-    SDEBUG("Setting retryAfter for job " << jobID << " has errored, marking it as FAILED.");
+    SALERT("ENSURE_BUGBOT Query error when updating job with retryAfter");
     if (!db.writeIdempotent("UPDATE jobs "
-                            "SET state='FAILED' "
+                            "SET state = 'FAILED' "
                             "WHERE jobID = " + SQ(jobID) + ";")) {
         STHROW("502 Update failed");
     }
-    SALERT("ENSURE_BUGBOT Query error when updating job with retryAfter");
 }
 
 void BedrockJobsCommand::handleFailedReply() {

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -38,6 +38,11 @@ class BedrockJobsCommand : public BedrockCommand {
     bool _hasPendingChildJobs(SQLite& db, int64_t jobID);
     void _validatePriority(const int64_t priority);
 
+    // Do not throw an exception when something goes wrong with the query to update a job's retryAfter.
+    // Update the job to the failed state and log a Bugbot instead.
+    // This is to avoid causing GetJob(s) to error which will render BWM unable to fetch any jobs that need to be run.
+    void _handleFailedRetryAfterQuery(SQLite& db, const string& jobID);
+
     bool mockRequest;
 
     // Returns true if this command can skip straight to leader for process.

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -819,10 +819,10 @@ struct GetJobTest : tpunit::TestFixture {
         string jobID = response["jobID"];
 
         // Set an invalid nextRun date time
-        string date = SUNQUOTED_CURRENT_TIMESTAMP(); // 2020-11-02 00:00:00
+        string date = SUNQUOTED_CURRENT_TIMESTAMP();
         command.clear();
         command.methodLine = "Query";
-        command["query"] = "UPDATE jobs SET nextRun = '2022-01-01 00' WHERE jobID = " + jobID + ";";
+        command["query"] = "UPDATE jobs SET nextRun = '" + date.substr(0, 13) + "' WHERE jobID = " + jobID + ";";
         tester->executeWaitVerifyContent(command);
 
         // Get the job

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -41,6 +41,7 @@ struct GetJobTest : tpunit::TestFixture {
                               TEST(GetJobTest::testPriorityParameter),
                               TEST(GetJobTest::testInvalidJobPriority),
                               TEST(GetJobTest::testRetryableParentJobs),
+                              TEST(GetJobTest::testInvalidNextRun),
                               AFTER(GetJobTest::tearDown),
                               AFTER_CLASS(GetJobTest::tearDownClass)) { }
 


### PR DESCRIPTION
### Details
When retrieving a job, if the retryAfter update query fails for whatever reason, mark that job as failed and log a BugBot

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/199535

### Tests
New test case in GetJobTest.cpp
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
