### PR TITLE
Improve HTTP Escalation

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2187,14 +2187,14 @@ unique_ptr<BedrockCommand> BedrockServer::buildCommandFromRequest(SData&& reques
     // This is important! All commands passed through the entire cluster must have unique IDs, or they
     // won't get routed properly from follower to leader and back.
     // If the command specifies an ID header (for HTTP escalations) use that, otherwise generate one.
-    auto existingID = request.nameValueMap.find("ID");
-    if (existingID != request.nameValueMap.end()) {
+    auto existingID = command->request.nameValueMap.find("ID");
+    if (existingID != command->request.nameValueMap.end()) {
         command->id = existingID->second;
     } else {
         command->id = args["-nodeName"] + "#" + to_string(_requestCount++);
     }
 
-    SINFO("Waiting for '" << request.methodLine << "' to complete.");
+    SINFO("Waiting for '" << command->request.methodLine << "' to complete.");
 
     // And we and keep track of the client that initiated this command, so we can respond later, except
     // if we received connection:forget in which case we don't respond later

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -412,6 +412,11 @@ class BedrockServer : public SQLiteServer {
     // requests are complete.
     void waitForHTTPS(unique_ptr<BedrockCommand>&& command);
 
+    // This doesn't really do anything in itself, but when we need to add new sockets to a poll loop (like when we
+    // create an outgoing http request) we queue something here, so that the poll loop in `sync` gets interrupted. This
+    // allows it to start again and pick up the new socket we just created.
+    SSynchronizedQueue<bool> _newCommandsWaiting;
+
     // Send a reply to a command that was escalated to us from a peer, rather than a locally-connected client.
     void _finishPeerCommand(unique_ptr<BedrockCommand>& command);
 

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -54,8 +54,11 @@ bool SQLiteClusterMessenger::sendToLeader(BedrockCommand& command) {
         return false;
     }
 
+    SData request = command.request;
+    request.nameValueMap["ID"] = command.id;
+
     transaction->s = s;
-    transaction->fullRequest = command.request.serialize();
+    transaction->fullRequest = request.serialize();
 
     command.httpsRequests.push_back(transaction);
 

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -56,14 +56,12 @@ bool SQLiteClusterMessenger::sendToLeader(BedrockCommand& command) {
 
     SData request = command.request;
     request.nameValueMap["ID"] = command.id;
-
     transaction->s = s;
     transaction->fullRequest = request.serialize();
-
     command.httpsRequests.push_back(transaction);
 
     // Ship it.
-    transaction->s->send(command.request.serialize());
+    transaction->s->send(transaction->fullRequest);
 
     return true;
 }

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -61,7 +61,7 @@ bool SQLiteClusterMessenger::sendToLeader(BedrockCommand& command) {
     command.httpsRequests.push_back(transaction);
 
     // Ship it.
-    transaction->s->send(transaction->fullRequest);
+    transaction->s->send(transaction->fullRequest.serialize());
 
     return true;
 }


### PR DESCRIPTION
### Details
This fixes two problems:

1. We aren't preserving command IDs across escalation, so they appear as a different command on leader than follower. This is minor, it only affects logging, but it makes logs for a particular command difficult to follow.

2. It improves throughput by fixing an unknown and longstanding bug where we don't get the response from a HTTP request until the current poll loop finishes.

Here's the explanation. For all HTTPS requests (for now, this will change once we get further through this bedrock 3 refactor) are polled by the `sync` thread. In the sync thread poll loop, we poll the sockets to the rest of the cluster, and also https sockets. This includes the newly "Escalated via http" commands.

So on followers, the sync thread doesn't do a lot typically, because followers don't make https requests and followers don't talk much except with leader, waiting for new transactions.

So, on followers `poll` just sits around waiting for a new transaction to come in from leader, and then it commits that transaction, and starts over.

Here's the issue.

When we create a new HTTP connection to leader, for the newly escalated command, we want to insert it into that `poll` loop so that the sync thread will wait for some data on that socket. But that poll loop is currently sitting, *not* waiting on that socket, because it wasn't one of the sockets that poll was told to watch when it started (of course it wasn't, it didn't exist yet). So, `poll` waits for something to happen (like leader to broadcast a new transaction, or a previous HTTP request to finish) and then when `poll` returns, it does it's thing, and when it starts next, it will pick up the new socket. Only then will it try and notice data that needs to be read or written, and then when poll returns a second time, we can have data for this new socket.

The change here is to add a queue that's part of the poll loop that we deliberately interrupt whenever we start watching a new HTTP connection. This prevents `poll` from waiting for something to happen before adding the new connection, it will return early and add it immediately.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/193926

### Tests
Lots of watching logs to verify we don't end up waiting a second between sending data and poll noticing that our socket has connected.