### PR TITLE
Remove buffer from logs to stop logging authTokens

### DIFF
--- a/libstuff/STCPNode.cpp
+++ b/libstuff/STCPNode.cpp
@@ -203,8 +203,7 @@ void STCPNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
             if (socket->recvBuffer.empty() && socket->sendBufferEmpty()) {
                 SDEBUG("Incoming connection failed from '" << socket->addr << "' (" << e.what() << "), empty buffers");
             } else {
-                SWARN("Incoming connection failed from '" << socket->addr << "' (" << e.what() << "), recv='"
-                      << socket->recvBuffer << "', send='" << socket->sendBufferCopy() << "'");
+                SWARN("Incoming connection failed from '" << socket->addr << "' (" << e.what() << "), send='" << socket->sendBufferCopy() << "'");
             }
             socketList.remove(socket);
             acceptedSocketList.erase(socketIt);


### PR DESCRIPTION
### Details

Pretty self-explanatory.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/203370

### Tests

Too hard to test locally. I tried a few different ways like forcing a throw and running the tests, but nothing.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
