### PR TITLE
Interrupt sync thread poll loop to send commits.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1972,12 +1972,7 @@ void BedrockServer::_postPollCommands(fd_map& fdm, uint64_t nextActivity) {
 
     // Just clear this, it doesn't matter what the contents are.
     _newCommandsWaiting.postPoll(fdm);
-    try {
-        while (true) {
-            _newCommandsWaiting.pop();
-        }
-    } catch (const out_of_range& e) {
-    }
+    _newCommandsWaiting.clear();
 
     // Because we modify this list as we walk across it, we use an iterator to our current position.
     auto it = _outstandingHTTPSCommands.begin();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -917,22 +917,18 @@ void BedrockServer::worker(int threadId)
             uint64_t commitCount = db.getCommitCount();
             uint64_t commandCommitCount = command->request.calcU64("commitCount");
             if (commandCommitCount > commitCount) {
-                auto _syncNodeCopy = atomic_load(&_syncNode);
-                if (_syncNodeCopy) {
-                    uint64_t start = STimeNow();
-                    SQLiteSequentialNotifier::RESULT result = _syncNodeCopy->waitForCommit(commandCommitCount);
-                    if (result == SQLiteSequentialNotifier::RESULT::CANCELED) {
-                        SINFO("_localCommitNotifier.waitFor canceled early, returning.");
-                        _commandQueue.push(move(command));
-                        continue;
-                    }
-                    SASSERT(result == SQLiteSequentialNotifier::RESULT::COMPLETED);
-                    uint64_t elapsed = (STimeNow() - start)/1000;
-                    SINFO("Command (" << command->request.methodLine << ") waited " << elapsed << "ms for commit " << commandCommitCount << ".");
-                } else {
-                    SWARN("Attempted to load sync node with none. Re-queueing command.");
-                    _commandQueue.push(move(command));
+                SAUTOLOCK(_futureCommitCommandMutex);
+                auto newQueueSize = _futureCommitCommands.size() + 1;
+                SINFO("Command (" << command->request.methodLine << ") depends on future commit (" << commandCommitCount
+                      << "), Currently at: " << commitCount << ", storing for later. Queue size: " << newQueueSize);
+                _futureCommitCommandTimeouts.insert(make_pair(command->timeout(), commandCommitCount));
+                _futureCommitCommands.insert(make_pair(commandCommitCount, move(command)));
+
+                // Don't count this as `in progress`, it's just sitting there.
+                if (newQueueSize > 100) {
+                    SHMMM("_futureCommitCommands.size() == " << newQueueSize);
                 }
+                continue;
             }
 
             if (command->request.isSet("mockRequest")) {
@@ -2099,14 +2095,6 @@ void BedrockServer::_finishPeerCommand(unique_ptr<BedrockCommand>& command) {
 }
 
 void BedrockServer::_acceptSockets() {
-
-    // We've been experimenting with _escalateOverHTTP and it seems to slow down when a lot of sockets are being
-    // escalated. We're adding timing here to see if we can narrow down if the `accept` call takes a while.
-    uint64_t start = 0;
-    if (_escalateOverHTTP) {
-        start = STimeNow();
-    }
-
     // Make a list of ports to accept on.
     // We'll check the control port, command port, and any plugin ports for new connections.
     list<reference_wrapper<const unique_ptr<Port>>> portList = {_commandPortPublic, _commandPortPrivate, _controlPort};
@@ -2118,9 +2106,6 @@ void BedrockServer::_acceptSockets() {
     for (auto& p : _portPluginMap) {
         portList.push_back(reference_wrapper<const unique_ptr<Port>>(p.first));
     }
-
-    // Keep track of how many sockets we accept for performance testing.
-    size_t acceptedSockets = 0;
 
     // Try each port.
     for (auto portWrapper : portList) {
@@ -2141,9 +2126,6 @@ void BedrockServer::_acceptSockets() {
                 break;
             }
 
-            // Count how many sockets we accepted.
-            acceptedSockets++;
-
             // Otherwise create the object for this new socket.
             SDEBUG("Accepting socket from '" << addr << "' on port '" << port->host << "'");
             Socket socket(s, Socket::CONNECTED);
@@ -2159,12 +2141,6 @@ void BedrockServer::_acceptSockets() {
             _outstandingSocketThreads++;
             thread(&BedrockServer::handleSocket, this, move(socket), port == _controlPort).detach();
         }
-    }
-
-    // Log how quickly we accepted sockets if that's a thing we're doing.
-    if (_escalateOverHTTP && acceptedSockets) {
-        uint64_t elapsed = STimeNow() - start;
-        SINFO("Accepted " << acceptedSockets << " sockets in " << elapsed << "us.");
     }
 }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1095,6 +1095,10 @@ void BedrockServer::worker(int threadId)
                             }
                         }
                         if (commitSuccess) {
+                            // Tell the sync node that there's been a commit so that it can jump out of it's "poll"
+                            // loop and send it to followers. NOTE: we don't check for null here, that should be
+                            // impossible inside a worker thread.
+                            _syncNode->notifyCommit();
                             SINFO("Successfully committed " << command->request.methodLine << " on worker thread. blocking: "
                                   << (threadId ? "false" : "true"));
                             // So we must still be leading, and at this point our commit has succeeded, let's

--- a/libstuff/SSynchronizedQueue.h
+++ b/libstuff/SSynchronizedQueue.h
@@ -18,6 +18,9 @@ class SSynchronizedQueue {
     void prePoll(fd_map& fdm);
     void postPoll(fd_map& fdm);
 
+    // Erases all elements from the container.
+    void clear() noexcept;
+
     // Returns true if the queue is empty.
     bool empty() const;
 
@@ -98,6 +101,12 @@ void SSynchronizedQueue<T>::postPoll(fd_map& fdm) {
             }
         }
     }
+}
+
+template<typename T>
+void SSynchronizedQueue<T>::clear() noexcept {
+    lock_guard<decltype(_queueMutex)> lock(_queueMutex);
+    _queue.clear();
 }
 
 template<typename T>

--- a/libstuff/STCPNode.h
+++ b/libstuff/STCPNode.h
@@ -60,8 +60,8 @@ struct STCPNode : public STCPManager {
     static State stateFromName(const string& name);
 
     // Updates all peers
-    void prePoll(fd_map& fdm);
-    void postPoll(fd_map& fdm, uint64_t& nextActivity);
+    virtual void prePoll(fd_map& fdm);
+    virtual void postPoll(fd_map& fdm, uint64_t& nextActivity);
     Socket* acceptSocket();
 
     // Represents a single peer in the database cluster

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -900,7 +900,6 @@ bool SQLiteNode::update() {
         // should never be any commits in here while a commit is in progress anyway, since all commits except the one
         // running are blocked until that one finishes.
         if (!commitInProgress()) {
-            // This only gets called when the sync thread isn't polling.
             _sendOutstandingTransactions();
         }
 
@@ -2824,11 +2823,6 @@ string SQLiteNode::replaceAddressPort(const string& hostPart, const string& port
     string result = hostToUse + ":" + to_string(portToUse);
     SINFO("Combined " << hostPart << " and " << portPart << " to get " << result);
     return result;
-}
-
-SQLiteSequentialNotifier::RESULT SQLiteNode::waitForCommit(uint64_t commitNum) {
-    // Needs to support a timeout.
-    return _localCommitNotifier.waitFor(commitNum, false);
 }
 
 void SQLiteNode::prePoll(fd_map& fdm) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2837,3 +2837,7 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     _commitsToSend.postPoll(fdm);
     _commitsToSend.clear();
 }
+
+void SQLiteNode::notifyCommit() {
+    _commitsToSend.push(true);
+}

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2824,3 +2824,8 @@ string SQLiteNode::replaceAddressPort(const string& hostPart, const string& port
     SINFO("Combined " << hostPart << " and " << portPart << " to get " << result);
     return result;
 }
+
+SQLiteSequentialNotifier::RESULT SQLiteNode::waitForCommit(uint64_t commitNum) {
+    return _localCommitNotifier.waitFor(commitNum, false);
+}
+

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -117,8 +117,6 @@ class SQLiteNode : public STCPNode {
     // similar string with the host from hostPart and the port from portPart .
     string replaceAddressPort(const string& hostPart, const string& portPart);
 
-    SQLiteSequentialNotifier::RESULT waitForCommit(uint64_t commitNum);
-
   private:
     // STCPNode API: Peer handling framework functions
     void _onConnect(Peer* peer);
@@ -293,8 +291,7 @@ class SQLiteNode : public STCPNode {
     // port".
     const string _commandAddress;
 
-    // This doesn't really do anything in itself, but when we need to add new sockets to a poll loop (like when we
-    // create an outgoing http request) we queue something here, so that the poll loop in `sync` gets interrupted. This
-    // allows it to start again and pick up the new socket we just created.
+    // This is just here to allow `poll` to get interrupted when there are new commits to send. We don't want followers
+    // to wait up to a full second for them.
     SSynchronizedQueue<bool> _commitsToSend;
 };

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -117,6 +117,10 @@ class SQLiteNode : public STCPNode {
     // similar string with the host from hostPart and the port from portPart .
     string replaceAddressPort(const string& hostPart, const string& portPart);
 
+    // Tell the node a commit has been made by another thread, so that we can interrupt our poll loop if we're waiting
+    // for data, and send the new commit.
+    void notifyCommit();
+
   private:
     // STCPNode API: Peer handling framework functions
     void _onConnect(Peer* peer);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -111,6 +111,8 @@ class SQLiteNode : public STCPNode {
     // similar string with the host from hostPart and the port from portPart .
     string replaceAddressPort(const string& hostPart, const string& portPart);
 
+    SQLiteSequentialNotifier::RESULT waitForCommit(uint64_t commitNum);
+
   private:
     // STCPNode API: Peer handling framework functions
     void _onConnect(Peer* peer);


### PR DESCRIPTION
### Details
So this is a fun one. We've been testing HTTP escalations on webrock, and whenever we do, we see something like this:
<img width="693" alt="Screen Shot 2022-04-06 at 2 32 02 PM" src="https://user-images.githubusercontent.com/705000/162312073-afe01bba-b2aa-4259-a407-7b52c82ecfa4.png">

Note the increase in times for *some* commands right after 20:20. It was a mystery why some commands were drastically affected:
<img width="684" alt="Screen Shot 2022-04-06 at 2 37 33 PM" src="https://user-images.githubusercontent.com/705000/162312642-1109c61e-6a3d-406f-bd6d-338151b4900d.png">

And others weren't at all:
<img width="691" alt="Screen Shot 2022-04-06 at 2 36 58 PM" src="https://user-images.githubusercontent.com/705000/162312935-4acd0388-24a6-40f9-b1f9-cea015cf800c.png">

To spare all of the investigation that went into it, there are three commands that "skip the queue" and are escalated directly to leader:
`CreateJob`, `CreateJobs`, and `FinishJob`.

These get escalated as soon as they're received, and the others don't. What's the difference? So the Bedrock PHP client sends `commitCount` by default: https://github.com/Expensify/Bedrock-PHP/blob/20140b2d9cf14d081f53e680b1ce02cae1c840b5/src/Client.php#L321

The purpose of this feature is that if you send two sequential commands, the first a write and the second a read, the read command waits until the commit from the write command is available on the current server (likely a follower) before executing, in order to guarantee it has the data from the previous write.

So, if we get a command that "skips the queue" we don't wait around for this commit, we're gonna send the command to leader anyway, we just do it immediately here:
https://github.com/Expensify/Bedrock/blob/44b264cb7b27c5345093c00bf6ae0f4ef1d2752d/BedrockServer.cpp#L853

For other commands, we set it aside to wait until the sync thread has replicated this commit locally:
https://github.com/Expensify/Bedrock/blob/44b264cb7b27c5345093c00bf6ae0f4ef1d2752d/BedrockServer.cpp#L925

So, ok, it makes sense then maybe that commands that skip the queue are a bit faster in general than commands that don't, we don't have to wait for the DB to catch up before we handle them, but why does this change drastically when we turn on escalation over HTTP?

Well, normally the sync thread on *leader* sits in a poll loop waiting for any data from followers, and when it gets some, it handles it, then it checks it's own state, sees if it has any quorum commands to deal with, and then jumps into the poll loop again until it gets some data from followers.

Well, the data that it gets from followers is basically entirely `ESCALATE` commands, and when we turn on HTTP escalation, these stop coming on the sync thread, but come to the command port instead.

So incoming traffic on the `sync` thread drops to 0, and with nothing to read, the `poll` loop just sits idle until it hits it's 1 second timeout and checks for other stuff to do.

One of the things that counts as "other stuff to do" is send any new commits to followers. Because worker threads have been committing enitely separately from the sync thread, it doesn't know if there are any new commits to send until `poll` returns, at which point it will send all of them.

This results in a sort of "pulse" every second where leader sends a block of new commits to followers. This in itself isn't that big of a problem, but the issue is that followers have been sitting there with the commands that depend on a future commit to run, and they don't get any commits delivered for a second at a time.

With new commits coming in every second, the average length of time any command should wait to run is 500ms, as it can start anywhere in that 1s window. So, no surprise then:
<img width="1370" alt="Screen Shot 2022-04-06 at 2 46 16 PM" src="https://user-images.githubusercontent.com/705000/162322339-a4daa12a-cc3b-4742-8cb5-748facd4123f.png">

Average command times sit right around 500ms.

The fix is to let the sync thread `poll` get interrupted whenever a worker thread commits.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/193926

### Tests
I haven't made any new tests just for this. It's a performance optimization, so it's tough to test outside of production. I think we can safely deploy it with just the existing test suite.