### PR TITLE
Close connections when command port is closed

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1632,7 +1632,10 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
         }
 
         // If `Connection: close` was set, shut down the socket, in case the caller ignores us.
-        if (SIEquals(command->request["Connection"], "close") || _shutdownState.load() != RUNNING) {
+        if (SIEquals(command->request["Connection"], "close") || _shutdownState.load() != RUNNING || _suppressCommandPort) {
+            // TODO: If we're doing this because of the command port being suppressed, we should really only close the
+            // socket if it came in on the public command port. This doesn't matter much though until escalations reuse
+            // sockets.
             command->socket->shutdown();
         }
     } else {
@@ -2240,7 +2243,7 @@ void BedrockServer::handleSocket(Socket&& socket, bool isControlPort) {
                 SINFO("Socket thread exiting because no data and shutting down.");
                 socket.shutdown(Socket::CLOSED);
                 break;
-            } 
+            }
         }
 
         // If the above loop didn't close the socket due to inactivity at shutdown, let's handle the activity.


### PR DESCRIPTION
### Details
When we close the command port, it has no effect on already connected clients. Because PHP reuses sockets to bedrock, we can end up receiving many commands well after the command port is closed.

Example:
```
2022-04-05T01:01:38.421783+00:00 db2.rno bedrock: xxxxxx (BedrockServer.cpp:2213) handleSocket [socket13723320] [info] Socket thread starting
2022-04-05T01:01:38.421838+00:00 db2.rno bedrock: xxxxxx (BedrockServer.cpp:2337) handleSocket [socket13723320] [info] Queuing new 'GetNotifications' command from local client, with 0 commands already queued.
...
2022-04-05T01:01:52.226515+00:00 db2.rno bedrock: WDvOv5 (BedrockServer.cpp:1647) suppressCommandPort [worker62] [info] Suppressing command port due to: BeginAutomatedBilling
...
2022-04-05T01:02:59.500147+00:00 db2.rno bedrock: xxxxxx (BedrockServer.cpp:2337) handleSocket [socket13723320] [info] Queuing new 'SetNameValuePair' command from local client, with 0 commands already queued.
```

That socket queues a total of 163 commands, 92 of which come in *after* the command port is closed.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/199047

### Tests
No additional tests.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
