### PR TITLE
Fix 'escalated' flag

### DIFF
--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -190,6 +190,7 @@ bool SQLiteClusterMessenger::runOnLeader(BedrockCommand& command) {
 
     // If we got here, the command is complete.
     command.complete = true;
+    command.escalated = true;
 
     // Finish our escalation timing.
     command.escalationTimeUS = STimeNow() - command.escalationTimeUS;

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -121,7 +121,7 @@ TestPluginCommand::~TestPluginCommand()
         // check simply that we're not leading, because this should also fail if we end up in some weird state (we
         // don't want the test to pass if our follower is actually `WAITING` or something strange).
         if (serverState != SQLiteNode::stateName(SQLiteNode::LEADING)) {
-            // SASSERT(escalated); TODO: Remove this flag.
+            SASSERT(escalated);
             string fileContents = fileLockAndLoad(request["tempFile"]);
             SFileDelete(request["tempFile"]);
 


### PR DESCRIPTION
### Details
This fixes the `escalated` flag that Auth uses to make sure that it can't accidentally forward commands both from a follower and the leader. This can only happen anyway if http esclations are enabled (which is not the case currently but should be the default eventually) and we change something else, as we have a warning that would catch if we tried this anyway, but the warning wont work with this flag broken.


### Fixed Issues
https://github.com/Expensify/Expensify/issues/193926

### Tests
None.
