### PR TITLE
Improve command port closing behavior and attempt to fix crash.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1648,7 +1648,7 @@ void BedrockServer::blockCommandPort(const string& reason) {
         _commandPortPublic = nullptr;
         _portPluginMap.clear();
     }
-    SINFO("Blocking command port due to: " <<  reason << (_commandPortBlockReasons.size() > 1 ? " (but is was already blocked)" : "") << ".");
+    SINFO("Blocking command port due to: " <<  reason << (_commandPortBlockReasons.size() > 1 ? " (but it was already blocked)" : "") << ".");
 }
 
 void BedrockServer::unblockCommandPort(const string& reason) {
@@ -1659,6 +1659,7 @@ void BedrockServer::unblockCommandPort(const string& reason) {
         SWARN("Tried to unblock command port because: " << reason << ", but it wasn't blocked for that reason!");
     } else {
         _commandPortBlockReasons.erase(it);
+        SINFO("Unblocking command port due to: " <<  reason << ".");
     }
     if (_commandPortBlockReasons.empty()) {
         _commandPortLikelyBlocked = false;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1644,7 +1644,7 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
 void BedrockServer::blockCommandPort(const string& reason) {
     lock_guard<mutex> lock(_portMutex);
     _commandPortBlockReasons.insert(reason);
-    if (reason.size() == 1) {
+    if (_commandPortBlockReasons.size() == 1) {
         _commandPortPublic = nullptr;
         _portPluginMap.clear();
     }
@@ -2317,7 +2317,7 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
 
                 // If this socket was accepted from the public command port, and that's supposed to be closed now, set
                 // `Connection: close` so that we don't keep doing a bunch of activity on it.
-                if (fromPublicCommandPort && _commandPortLikelyBlocked) {
+                if (requestSize && fromPublicCommandPort && _commandPortLikelyBlocked) {
                     request["Connection"] = "close";
                 }
             }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1649,7 +1649,7 @@ void BedrockServer::blockCommandPort(const string& reason) {
         _commandPortPublic = nullptr;
         _portPluginMap.clear();
     }
-    SINFO("Blocking command port due to: " <<  reason << (_commandPortBlockReasons.size() > 1 ? " (already blocked)" : "") << ".");
+    SINFO("Blocking command port due to: " << reason << (_commandPortBlockReasons.size() > 1 ? " (already blocked)" : "") << ".");
 }
 
 void BedrockServer::unblockCommandPort(const string& reason) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1792,7 +1792,7 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
 
         {
             lock_guard<mutex> lock(_portMutex);
-            content["commandPortBlockReasons"] = SComposeList(_commandPortBlockReasons);
+            content["commandPortBlockReasons"] = SComposeJSONArray(_commandPortBlockReasons);
         }
 
         // We can use the `each` functionality to pass a lambda that will grab each method line in

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1656,10 +1656,10 @@ void BedrockServer::unblockCommandPort(const string& reason) {
     lock_guard<mutex> lock(_portMutex);
     auto it = _commandPortBlockReasons.find(reason);
     if (it == _commandPortBlockReasons.end()) {
-        SWARN("Tried to unblock command port because: " << reason << ", but it wasn't blocked for that reason!");
+        SWARN("Tried to remove command port block because: " << reason << ", but it wasn't blocked for that reason!");
     } else {
         _commandPortBlockReasons.erase(it);
-        SINFO("Unblocking command port due to: " <<  reason << (_commandPortBlockReasons.size() > 0 ? " (blocks remaining)" : "") << ".");
+        SINFO("Removing command port block due to: " <<  reason << (_commandPortBlockReasons.size() > 0 ? " (blocks remaining)" : "") << ".");
     }
     if (_commandPortBlockReasons.empty()) {
         _isCommandPortLikelyBlocked = false;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1644,11 +1644,11 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
 void BedrockServer::blockCommandPort(const string& reason) {
     lock_guard<mutex> lock(_portMutex);
     _commandPortBlockReasons.insert(reason);
-    if (_commandPortBlockReasons.size() == 1) {
+    if (reason.size() == 1) {
         _commandPortPublic = nullptr;
         _portPluginMap.clear();
     }
-    SINFO("Blocking command port due to: " <<  reason << (_commandPortBlockReasons.size() > 1 ? " (but it was already blocked)" : "") << ".");
+    SINFO("Blocking command port due to: " <<  reason << (_commandPortBlockReasons.size() > 1 ? " (already blocked)" : "") << ".");
 }
 
 void BedrockServer::unblockCommandPort(const string& reason) {
@@ -1659,7 +1659,7 @@ void BedrockServer::unblockCommandPort(const string& reason) {
         SWARN("Tried to unblock command port because: " << reason << ", but it wasn't blocked for that reason!");
     } else {
         _commandPortBlockReasons.erase(it);
-        SINFO("Unblocking command port due to: " <<  reason << ".");
+        SINFO("Unblocking command port due to: " <<  reason << (_commandPortBlockReasons.size() > 0 ? " (blocks remaining)" : "") << ".");
     }
     if (_commandPortBlockReasons.empty()) {
         _commandPortLikelyBlocked = false;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2166,6 +2166,11 @@ void BedrockServer::_acceptSockets() {
                             // we were to block new threads with less than 50 threads already running, we'd never
                             // unblock new threads. Instead, if that happens, we throw this error and crash (which was
                             // the behavior we saw here before handling `system_error`).
+                            // We check for 100 threads here instead of the 50 we check for in `handleSocket` to
+                            // minimize the risk of race conditions pushing this number through `50` (either up or
+                            // down) as we're checking this. For such a race condition to happen here, we'd need to
+                            // increment/decrement all the way from 50-100 (or vice versa) to hit such a race condition,
+                            // which is theoretically possible but exceedingly unlikely.
                             SERROR("Got system_error creating thread with only " << _outstandingSocketThreads << " threads!");
                         }
                         if (!_shouldBlockNewSocketThreads) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1644,7 +1644,7 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
 void BedrockServer::blockCommandPort(const string& reason) {
     lock_guard<mutex> lock(_portMutex);
     _commandPortBlockReasons.insert(reason);
-    if (reason.size() == 1) {
+    if (_commandPortBlockReasons.size() == 1) {
         _commandPortPublic = nullptr;
         _portPluginMap.clear();
     }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -8,6 +8,13 @@
 #include "BedrockTimeoutCommandQueue.h"
 
 class BedrockServer : public SQLiteServer {
+
+    enum struct CommandPortSuppressionType {
+        NONE,
+        UNSPECIFIED,
+        THREAD_LIMIT,
+    };
+
   public:
 
     // Shutting Down and Standing Down a BedrockServer.
@@ -208,7 +215,7 @@ class BedrockServer : public SQLiteServer {
 
     // Control the command port. The server will toggle this as necessary, unless manualOverride is set,
     // in which case the `suppress` setting will be forced.
-    void suppressCommandPort(const string& reason, bool suppress, bool manualOverride = false);
+    void suppressCommandPort(const string& reason, bool suppress, bool manualOverride = false, const CommandPortSuppressionType type = CommandPortSuppressionType::UNSPECIFIED);
 
     // This will return true if there's no outstanding writable activity that we're waiting on. It's called by an
     // SQLiteNode in a STANDINGDOWN state to know that it can switch to searching.
@@ -279,6 +286,7 @@ class BedrockServer : public SQLiteServer {
     // These control whether or not the command port is currently opened.
     bool _suppressCommandPort;
     bool _suppressCommandPortManualOverride;
+    CommandPortSuppressionType _suppressCommandPortType = CommandPortSuppressionType::NONE;
 
     // This is a map of open listening ports to the plugin objects that created them.
     map<unique_ptr<Port>, BedrockPlugin*> _portPluginMap;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -213,7 +213,7 @@ class BedrockServer : public SQLiteServer {
     // Legacy version of above.
     void suppressCommandPort(const string& reason, bool suppress, bool manualOverride = false);
 
-    // Reasons for each request so close the command port mapped to the instance of commandPortSuppressionCount that
+    // Reasons for each request to close the command port mapped to the instance of commandPortSuppressionCount that
     // created them.
     // Not atomic because it's only accessed with a lock on _portMutex.
     list<string> commandPortSuppressionReasons;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -253,6 +253,8 @@ class BedrockServer : public SQLiteServer {
     const SData args;
 
     // This is the thread that handles a new socket, parses a command, and queues it for work.
+    // One of the three 'Port' parameters will be true and the other two false, indicating whether the socket was
+    // accepted on _controlPort, _commandPortPublic, or _commandPortPrivate.
     void handleSocket(Socket&& socket, bool fromControlPort, bool fromPublicCommandPort, bool fromPrivateCommandPort);
 
   private:
@@ -293,7 +295,7 @@ class BedrockServer : public SQLiteServer {
     // close connections after commands complete if this is true, and not if it is false, so the worst-case scenario of
     // this being wrong is we accept an extra command as the port is blocked, or cause a client to reconnect after a
     // command is it's unblocked.
-    atomic<bool> _commandPortLikelyBlocked;
+    atomic<bool> _isCommandPortLikelyBlocked;
 
     // This is a map of open listening ports to the plugin objects that created them.
     map<unique_ptr<Port>, BedrockPlugin*> _portPluginMap;
@@ -496,7 +498,7 @@ class BedrockServer : public SQLiteServer {
     atomic<uint64_t> _outstandingSocketThreads;
 
     // If we hit the point where we're unable to create new socket threads, we block doing so.
-    bool _newSocketThreadsBlocked; 
+    bool _shouldBlockNewSocketThreads; 
     mutex _newSocketThreadBlockedMutex;
 
     // This mutex prevents the check for whether there are outstanding commands preventing shutdown from running at the

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -487,6 +487,10 @@ class BedrockServer : public SQLiteServer {
     // This records how many outstanding socket threads there are so we can wait for them to complete before exiting.
     atomic<uint64_t> _outstandingSocketThreads;
 
+    // If we hit the point where we're unable to create new socket threads, we block doing so.
+    bool _newSocketThreadsBlocked; 
+    mutex _newSocketThreadBlockedMutex;
+
     // This mutex prevents the check for whether there are outstanding commands preventing shutdown from running at the
     // same time a control port command is running (which would indicate that there is a command blocking shutdown -
     // the current control command).


### PR DESCRIPTION
### Details

Note: easier review with whitespace changes hidden.

This change combines a couple of related fixes under a single PR because they're all intertwined. Let me give an overview of what we're doing.

First, we're trying to fix a crash in https://github.com/Expensify/Expensify/issues/205707. The crash is caused by an unhandled `system_error` that I'm 99% sure happens when we run out of threads. So, we've instrumented `_acceptSockets` to better log what's happening so hopefully we can get better info on what's going on when we catch this error.

But, since I'm 99% sure of what this is anyway, I've gone ahead and attempted to fix it. When we fail to open a thread, we close the command port and retry starting the thread. The command port remains closed until we drop below 50 socket threads. 50 is an entirely arbitrary number here, but the idea is that we've "caught up" more-or-less.

To implement opening and closing the command port because of the number of sockets, I wanted to improve the way we handle the command port in general. I didn't want to open the command port when the number of sockets dropped if it was supposed to be closed for some other reason (billing, readdb, etc). So, I went through the existing code and cleaned it up. We had code to handle opening/closing the command port on signals that was obsolete, and it was removed. We had a `manualOverride` flag that was never *not* used, so I removed that.

I changed the way that command port closures are done so that we have a set of closure reasons. Each time you close the port, you add a reason. Each time you open the port, you remove a reason. When the number of reasons changes from 0 to 1, the port is closed, and when it changes from 1 to 0, it is opened. This means that if you have multiple closures, the port doesn't open until they're all cleared.

There are three `reason` strings in use in this PR. One is `MANUAL` which is what happens when you close (or open) the port with an external command (`SuppressCommandPort` or `ClearCommandPort`). The second is `LEGACY_`... which is what will end up being used by auth until it gets changed to use the new code. In practice, this is just `LEGACY_BeginAutomatedBilling`. The final reason is `NOT_ENOUGH_THREADS` which is what started this in the first place.

Also, to handle race conditions correctly, I went ahead and added the parameters required to `handleSocket` so that we could know which socket a command came from and close connections after responding to commands if the socket that the command came from was closed.

This also adds the list of closure reasons to `Status` out (see the tests below) which prepares us well for fixing https://github.com/Expensify/Expensify/issues/206510

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/205707

### Tests
Existing automated tests pass, including auth:
```
[ TEST RESULTS ] Passed: 1790, Failed: 0
```

#### Manual tests in the VM:

First, build `bedrock` and then `auth` and `expensifyBackupmanager`.

Once all three are built, restart auth with `sudo service restart auth`.

For the remainder of this, you will need to send commands to auth on either the command port (4444) or the control port (9999) in your VM.

An example of sending a `Status` command to the command port looks like:
```
vagrant@expensidev2004:~$ nc localhost 4444
Status

```

Note the blank line at the bottom is important.

In a separate window, tail the logs and watch for `command port`:
```
sudo tail -F /var/log/syslog | grep 'command port'
```

Now, in your main window, issue a `Status` command on the command port, you should see a response like:
```
{"commandPortBlockReasons":[],"CommitCount":5378,"crashCommands":0,"escalatedCommandList":[],"escalateOverHTTP":false,"host":"0.0.0.0:4445","isLeader":true,"multiWriteEnabled":true,"multiWriteManualBlacklist":[],"peerList":[],"plugins":[{"name":"Auth","version":1},{"name":"DB"},{"name":"expensifyBackupManager","version":"2e9b163272"}],"priority":-1,"queuedCommandList":[],"state":"LEADING","syncNodeAvailable":true,"syncThreadQueuedCommandList":[],"version":"461ea8cb3e:Auth_1:expensifyBackupManager_2e9b163272"}^C
```

Note that `commandPortBlockReasons` is present and is an empty array.

Send a `SuppressCommandPort` on the control port, and then follow it with another `Status` command (still on the control port)

In the status response, you should see:
```
"commandPortBlockReasons":["MANUAL"]
```

Now attempt to connect to the control port again (`nc localhost 4444`). 
```
vagrant@expensidev2004:~$ nc localhost 4444
localhost [127.0.0.1] 4444 (?) : Connection refused
```

Send a second pair of `SuppressCommandPort` and `Status` commands to the control port. You should now see *two* entries for `MANUAL` in the response:
```
"commandPortBlockReasons":["MANUAL","MANUAL"]
```

Now clear one of the command port closures by sending `ClearCommandPort` and another `Status` to the control port. Check the response which should show one closure:
```
"commandPortBlockReasons":["MANUAL"]
```

And attempt to connect to the command port again, it should still fail:
```
vagrant@expensidev2004:~$ nc localhost 4444
localhost [127.0.0.1] 4444 (?) : Connection refused
```

Now, clear the last remaining closure by sending `ClearCommandPort` and another `Status` to the control port again.

Attempt to connect on the command port and send a `Status`. Verify it connects. It should report a blank list of closures:
```
"commandPortBlockReasons":[]
```

The logs should have output like this:
```
2022-04-14T22:23:17.738508+00:00 expensidev2004 bedrock: xxxxxx (BedrockServer.cpp:1651) blockCommandPort [socket1] [info] Blocking command port due to: MANUAL.
2022-04-14T22:23:38.838000+00:00 expensidev2004 bedrock: xxxxxx (BedrockServer.cpp:1651) blockCommandPort [socket2] [info] Blocking command port due to: MANUAL (already blocked).
2022-04-14T22:23:57.043451+00:00 expensidev2004 bedrock: xxxxxx (BedrockServer.cpp:1662) unblockCommandPort [socket3] [info] Unblocking command port due to: MANUAL (blocks remaining).
2022-04-14T22:24:19.393438+00:00 expensidev2004 bedrock: xxxxxx (BedrockServer.cpp:1662) unblockCommandPort [socket4] [info] Unblocking command port due to: MANUAL.
2022-04-14T22:24:20.189351+00:00 expensidev2004 bedrock: xxxxxx (BedrockServer.cpp:1480) postPoll [main] [info] Ready to process commands, opening public command port on '0.0.0.0:4444'
```