### PR TITLE
setting currentTestName in the test method thread

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -395,6 +395,7 @@ void tpunit::TestFixture::tpunit_detail_do_tests(TestFixture* f) {
     while(t) {
         testThreads.push_back(thread([t, f]() {
             recursive_mutex& m = *(f->_mutex);
+            currentTestName = f->_name;
             f->_stats._assertions = 0;
             f->_stats._exceptions = 0;
             f->testOutputBuffer = "";


### PR DESCRIPTION
### Details
Setting this thread_local variable in the start of the actual test method runner thread to fix tests where it's missing.

### Fixed Issues
none

### Tests
ran clustertest with debugging output and saw that tests all had currentTestName set in the BedrockTester constructor.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
