### PR TITLE
Broadcast correct command port address

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -112,7 +112,7 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, cons
       _legacyReplication("legacy-replication"),
       _onMessageTimer("_onMESSAGE"),
       _escalateTimer("escalateCommand"),
-      _commandAddress(replaceAddressPort(port->host, commandPort))
+      _commandAddress(commandPort)
     {
 
     SASSERT(priority >= 0);
@@ -2810,19 +2810,6 @@ bool SQLiteNode::hasQuorum() {
         }
     }
     return (numFullFollowers * 2 >= numFullPeers);
-}
-
-string SQLiteNode::replaceAddressPort(const string& hostPart, const string& portPart) {
-    string hostToUse;
-    string hostToDiscard;
-    uint16_t portToUse = 0;
-    uint16_t portToDiscard = 0;
-    if (!SParseHost(hostPart, hostToUse, portToDiscard) || !SParseHost(portPart, hostToDiscard, portToUse)) {
-        STHROW("Couldn't combine " + hostPart + " with " + portPart);
-    }
-    string result = hostToUse + ":" + to_string(portToUse);
-    SINFO("Combined " << hostPart << " and " << portPart << " to get " << result);
-    return result;
 }
 
 void SQLiteNode::prePoll(fd_map& fdm) {

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -113,10 +113,6 @@ class SQLiteNode : public STCPNode {
     // This will broadcast a message to all peers, or a specific peer.
     void broadcast(const SData& message, Peer* peer = nullptr);
 
-    // Takes two string in the form of `host:port` (i.e., `www.expensify.com:80` or `127.0.0.1:443`) and creates a
-    // similar string with the host from hostPart and the port from portPart .
-    string replaceAddressPort(const string& hostPart, const string& portPart);
-
     // Tell the node a commit has been made by another thread, so that we can interrupt our poll loop if we're waiting
     // for data, and send the new commit.
     void notifyCommit();


### PR DESCRIPTION
### Details
Testing http escalation on `db1.rno` yesterday, we would immediately build up a backlog of commands.

Looking at the logs, we were getting thousands of these:
```
2022-04-20T00:27:01.866474+00:00 db1.rno bedrock: IcqQYS we@dont.know (SQLiteClusterMessenger.cpp:103) runOnLeader [worker95] [info] [HTTPESC] Socket opening.
2022-04-20T00:27:01.868500+00:00 db1.rno bedrock: IcqQYS we@dont.know (libstuff.cpp:1729) S_socket [worker95] [info] DNS lookup took 0ms for '0.0.0.0'.
2022-04-20T00:27:01.876981+00:00 db1.rno bedrock: IcqQYS we@dont.know (libstuff.cpp:1741) S_socket [worker95] [info] Resolved 0.0.0.0 to ip: 0.0.0.0.
2022-04-20T00:27:01.881382+00:00 db1.rno bedrock: IcqQYS we@dont.know (SQLiteClusterMessenger.cpp:115) runOnLeader [worker95] [info] [HTTPESC] Socket opened.
2022-04-20T00:27:01.883702+00:00 db1.rno bedrock: IcqQYS we@dont.know (SQLiteClusterMessenger.cpp:53) waitForReady [worker95] [info] [HTTPESC] Socket disconnected while waiting to be ready (send).
2022-04-20T00:27:01.883721+00:00 db1.rno bedrock: IcqQYS we@dont.know (BedrockServer.cpp:1046) worker [worker95] [warn] Couldn't escalate command PingLeader to leader. We are in state: FOLLOWING
2022-04-20T00:27:01.887618+00:00 db1.rno bedrock: IcqQYS we@dont.know (BedrockServer.cpp:770) worker [worker95] [info] Dequeued command PingLeader (auth.db1.rno#2246142) in worker, 2961 commands in  queue.
```

The server is attempting to connect to `0.0.0.0` as leader. Why is it doing that? I did a little more digging and looked up these logs:
<img width="901" alt="Screen Shot 2022-04-20 at 2 10 38 PM" src="https://user-images.githubusercontent.com/705000/164325518-6097450f-282b-4526-b735-fb6bc9b36073.png">

You can see that webrock works ok because the IP is the same in both addresses, but auth combines the address from the node port with the port from the command port, which is incorrect. Actually, in both cases, we don't need to do a combination anyway, we only need to use the command port.

So, this PR removes the combination logic and just uses commandPort

### Fixed Issues
https://github.com/Expensify/Expensify/issues/193926

### Tests
Existing Bedrock tests, existing auth tests, verified auth and bedrock start and run correctly in VM.
