### PR TITLE
Improve handling of escalations during leader changeover

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -856,7 +856,7 @@ void BedrockServer::worker(int threadId)
                         // command->complete is now true for this command. It will get handled a few lines below.
                         SINFO("Immediately escalated " << command->request.methodLine << " to leader.");
                     } else {
-                        SWARN("Couldn't immediately escalate command " << command->request.methodLine << " to leader, queuing normally.");
+                        SINFO("Couldn't immediately escalate command " << command->request.methodLine << " to leader, queuing normally.");
                         _commandQueue.push(move(command));
                         continue;
                     }
@@ -1042,7 +1042,7 @@ void BedrockServer::worker(int threadId)
                             } else {
                                 // TODO: Something less naive that considers how these failures happen rather than a simple
                                 // endless loop of requeue and retry.
-                                SWARN("Couldn't escalate command " << command->request.methodLine << " to leader. We are in state: " << STCPNode::stateName(state));
+                                SINFO("Couldn't escalate command " << command->request.methodLine << " to leader. We are in state: " << STCPNode::stateName(state));
                                 _commandQueue.push(move(command));
                             }
                         } else {

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -52,7 +52,7 @@ SQLiteClusterMessenger::WaitForReadyResult SQLiteClusterMessenger::waitForReady(
                 SINFO("[HTTPESC] Socket disconnected while waiting to be ready (" << type << ").");
                 // This case in particular happens if we try and escalate to a leader with a closed command port. Maybe
                 // we should wait and retry?
-                return fdspec.events == POLLIN ? WaitForReadyResult::DISCONNECTED_IN : WaitForReadyResult::DISCONNETED_OUT;
+                return fdspec.events == POLLIN ? WaitForReadyResult::DISCONNECTED_IN : WaitForReadyResult::DISCONNECTED_OUT;
             } else if ((fdspec.events & POLLIN && fdspec.revents & POLLIN) || (fdspec.events & POLLOUT && fdspec.revents & POLLOUT)) {
                 // Expected case.
                 return WaitForReadyResult::OK;
@@ -122,7 +122,7 @@ bool SQLiteClusterMessenger::runOnLeader(BedrockCommand& command) {
         pollfd fdspec = {s->s, POLLOUT, 0};
         while (true) {
             WaitForReadyResult result = waitForReady(fdspec, command.timeout());
-            if (result == WaitForReadyResult::DISCONNECTED_IN) {
+            if (result == WaitForReadyResult::DISCONNECTED_OUT) {
                 // This is the case we're likely to get if the leader's port is closed.
                 // We break this loop and let the top loop (with the timer) start over.
                 // But first we sleep 1/2 second to make this not spam a million times.

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -160,7 +160,8 @@ bool SQLiteClusterMessenger::runOnLeader(BedrockCommand& command) {
         return false;
     }
     if (sleepsDueToFailures) {
-        SINFO("[HTTPESC] Escalation to leader blocked. Slept " << sleepsDueToFailures << " times, but succeeded.");
+        auto msElapsed = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - start).count();
+        SINFO("[HTTPESC] Problems connecting for escalation but succeeded in " << msElapsed << "ms.");
     }
 
     // If we fail before here, we can try again. If we fail after here, we should return an error.

--- a/sqlitecluster/SQLiteClusterMessenger.h
+++ b/sqlitecluster/SQLiteClusterMessenger.h
@@ -11,7 +11,7 @@ class SQLiteClusterMessenger {
         SHUTTING_DOWN,
         TIMEOUT,
         DISCONNECTED_IN,
-        DISCONNETED_OUT,
+        DISCONNECTED_OUT,
         UNSPECIFIED,
         POLL_ERROR,
     };

--- a/sqlitecluster/SQLiteClusterMessenger.h
+++ b/sqlitecluster/SQLiteClusterMessenger.h
@@ -5,6 +5,17 @@ class BedrockCommand;
 
 class SQLiteClusterMessenger {
   public:
+
+    enum class WaitForReadyResult {
+        OK,
+        SHUTTING_DOWN,
+        TIMEOUT,
+        DISCONNECTED_IN,
+        DISCONNETED_OUT,
+        UNSPECIFIED,
+        POLL_ERROR,
+    };
+
     SQLiteClusterMessenger(shared_ptr<SQLiteNode>& node);
 
     // Attempts to make a TCP connection to the leader, and run the given command there, setting the appropriate
@@ -24,7 +35,7 @@ class SQLiteClusterMessenger {
     // This takes a pollfd with either POLLIN or POLLOUT set, and waits for the socket to be ready to read or write,
     // respectively. It returns true if ready, or false if error or timeout. The timeout is specified as a timestamp in
     // microseconds.
-    bool waitForReady(pollfd& fdspec, uint64_t timeoutTimestamp);
+    WaitForReadyResult waitForReady(pollfd& fdspec, uint64_t timeoutTimestamp);
 
     // This sets a command as a 500 and marks it as complete.
     void setErrorResponse(BedrockCommand& command);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -434,7 +434,7 @@ void SQLiteNode::_sendOutstandingTransactions(const set<uint64_t>& commitOnlyIDs
 
 void SQLiteNode::escalateCommand(unique_ptr<SQLiteCommand>&& command, bool forget) {
     AutoTimerTime time(_escalateTimer);
-    lock_guard<mutex> leadPeerLock(_leadPeerMutex);
+    unique_lock<shared_mutex> leadPeerLock(_leadPeerMutex);
     // Send this to the leader
     SASSERT(_leadPeer);
 
@@ -758,7 +758,7 @@ bool SQLiteNode::update() {
         if (currentLeader && _priority < highestPriorityPeer->priority && currentLeader->state == LEADING) {
             // Subscribe to the leader
             SINFO("Subscribing to leader '" << currentLeader->name << "'");
-            lock_guard<mutex> leadPeerLock(_leadPeerMutex);
+            unique_lock<shared_mutex> leadPeerLock(_leadPeerMutex);
             _leadPeer = currentLeader;
             _leaderVersion = _leadPeer.load()->version;
             _sendToPeer(currentLeader, SData("SUBSCRIBE"));
@@ -1172,7 +1172,7 @@ bool SQLiteNode::update() {
         if (STimeNow() > _stateTimeout) {
             // Give up
             SHMMM("Timed out waiting for SUBSCRIPTION_APPROVED, reconnecting to leader and re-SEARCHING.");
-            lock_guard<mutex> leadPeerLock(_leadPeerMutex);
+            unique_lock<shared_mutex> leadPeerLock(_leadPeerMutex);
             _reconnectPeer(_leadPeer);
             _leadPeer = nullptr;
             _changeState(SEARCHING);
@@ -1881,7 +1881,7 @@ void SQLiteNode::_onDisconnect(Peer* peer) {
         PHMMM("Lost our LEADER, re-SEARCHING.");
         SASSERTWARN(_state == SUBSCRIBING || _state == FOLLOWING);
         {
-            lock_guard<mutex> leadPeerLock(_leadPeerMutex);
+            unique_lock<shared_mutex> leadPeerLock(_leadPeerMutex);
             _leadPeer = nullptr;
         }
         if (!_db.getUncommittedHash().empty()) {
@@ -2078,7 +2078,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
         // Clear some state if we can
         if (newState < SUBSCRIBING) {
             // We're no longer SUBSCRIBING or FOLLOWING, so we have no leader
-            lock_guard<mutex> leadPeerLock(_leadPeerMutex);
+            unique_lock<shared_mutex> leadPeerLock(_leadPeerMutex);
             _leadPeer = nullptr;
         }
 
@@ -2519,7 +2519,7 @@ void SQLiteNode::handlePrepareTransaction(SQLite& db, Peer* peer, const SData& m
             response["NewCount"] = SToStr(db.getCommitCount() + 1);
             response["NewHash"] = success ? db.getUncommittedHash() : message["NewHash"];
             response["ID"] = message["ID"];
-            lock_guard<mutex> leadPeerLock(_leadPeerMutex);
+            unique_lock<shared_mutex> leadPeerLock(_leadPeerMutex);
             if (!_leadPeer) {
                 STHROW("no leader?");
             }
@@ -2605,7 +2605,7 @@ void SQLiteNode::handleRollbackTransaction(SQLite& db, Peer* peer, const SData& 
 }
 
 SQLiteNode::State SQLiteNode::leaderState() const {
-    lock_guard<mutex> leadPeerLock(_leadPeerMutex);
+    shared_lock<shared_mutex> leadPeerLock(_leadPeerMutex);
     if (_leadPeer) {
         return _leadPeer.load()->state;
     }
@@ -2613,8 +2613,7 @@ SQLiteNode::State SQLiteNode::leaderState() const {
 }
 
 string SQLiteNode::leaderCommandAddress() const {
-    // TODO: Make shared mutex.
-    lock_guard<mutex> leadPeerLock(_leadPeerMutex);
+    shared_lock<shared_mutex> leadPeerLock(_leadPeerMutex);
     if (_leadPeer && _leadPeer.load()->state == State::LEADING) {
         if (_leadPeer.load()->state == State::LEADING) {
             return _leadPeer.load()->commandAddress;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2615,9 +2615,7 @@ SQLiteNode::State SQLiteNode::leaderState() const {
 string SQLiteNode::leaderCommandAddress() const {
     shared_lock<shared_mutex> leadPeerLock(_leadPeerMutex);
     if (_leadPeer && _leadPeer.load()->state == State::LEADING) {
-        if (_leadPeer.load()->state == State::LEADING) {
-            return _leadPeer.load()->commandAddress;
-        }
+        return _leadPeer.load()->commandAddress;
     }
     return "";
 }

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -161,7 +161,7 @@ class SQLiteNode : public STCPNode {
     // There's a mutex here to lock around changes to this, or any complex operations that expect leader to remain
     // unchanged throughout, notably, _sendToPeer. This is sort of a mess, but replication threads need to send
     // acknowledgments to the lead peer, but the main sync loop can update that at any time.
-    mutable mutex _leadPeerMutex;
+    mutable shared_mutex _leadPeerMutex;
 
     // Timestamp that, if we pass with no activity, we'll give up on our current state, and start over from SEARCHING.
     uint64_t _stateTimeout;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -117,6 +117,9 @@ class SQLiteNode : public STCPNode {
     // for data, and send the new commit.
     void notifyCommit();
 
+    // Return the command address of the current leader, if there is one (empty string otherwise).
+    string leaderCommandAddress() const;
+
   private:
     // STCPNode API: Peer handling framework functions
     void _onConnect(Peer* peer);


### PR DESCRIPTION
### Details

Note: hide whitespace

Because of this line:
https://github.com/Expensify/Bedrock/blob/75c0c389d2884f60f9c9ea48c5c3a05c987b5d5a/BedrockServer.cpp#L1039

We get a lot of noise during leader changeover during deploys. If `runOnLeader` fails, the command is requeued to run again, but that happens immediately, and it's requeued to run again immediately, etc. This puts followers in a spinning state until leader stabliizes.

The reason for this is a couple of things.
1. Leader closes its command port to escalations before it starts standing down.
2. Once leader stands down, there is no leader for a moment.

If we think we still have a leader, but it has just closed it's command port, we don't actually know that until we try to open a socket and then see if we can send to it, which fails. We've added special case handling for this to retry.

On the other hand, we can have a leader that's actually `STANDINGDOWN` but isn't useful to us. We've created a `leaderCommandAddress` method that will return an address if we have a leader that's actually *leading* and has an address.

In either case, with no address or a failure to be able to send on our new socket, we will retry the connection for up to 5 seconds before giving up and letting `runOnLeader` return false.

This greatly reduces the log volume, attempted connections, and CPU load during the few seconds of leader changeover.

Note that because of the 0.5s loop timing, we may not send an escalation for up to 0.5 second after leader is able to receive it, which will add an average of 0.25s latency to commands that are waiting on the leader changeover. As this can take 2+ seconds anyway, I don't think this is particularly significant. We could mitigate this some by having `SQLiteNode` notify listeners of changes to `leaderCommandAddress` but it's significantly more complicated to implement for minimal gain, and it still doesn't get us around handling the "port is closed" case, though that generally will happen before the "no address" case and so would likely have elapsed anyway by the time the new address is available.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/193926

### Tests
testing with `./clustertest -only GracefulFailover` and verifying relevant logs. For example:
```
2022-04-22T03:40:30.059239+00:00 expensidev2004 bedrock10007: axyoIX (SQLiteClusterMessenger.cpp:164) runOnLeader [worker1] [info] [HTTPESC] Problems connecting for escalation but succeeded in 4034ms.
```
and:
```
2022-04-22T03:40:31.276314+00:00 expensidev2004 bedrock10004: CwfYmb (BedrockServer.cpp:1045) worker [worker4] [warn] Couldn't escalate command idcollision r_11291_r to leader. We are in state: FOLLOWING
```

There was a  bit more analysis in the logs, for example the entire block from the above line is:
```
2022-04-22T03:40:26.190544+00:00 expensidev2004 bedrock10004: CwfYmb (BedrockServer.cpp:770) worker [worker4] [info] Dequeued command idcollision r_11291_r (cluster_node_1#67) in worker, 16 commands in  queue.
2022-04-22T03:40:26.190574+00:00 expensidev2004 bedrock10004: CwfYmb (BedrockCore.cpp:81) peekCommand [worker4] [dbug] Peeking at 'idcollision r_11291_r' with priority: 500
2022-04-22T03:40:26.190598+00:00 expensidev2004 bedrock10004: CwfYmb (SQLite.cpp:316) beginTransaction [worker4] [dbug] [concurrent] Beginning transaction
2022-04-22T03:40:26.190626+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:2527) SQuery [worker4] [dbug] BEGIN CONCURRENT
2022-04-22T03:40:26.190652+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:2527) SQuery [worker4] [dbug] PRAGMA query_only = true;
2022-04-22T03:40:26.197276+00:00 expensidev2004 bedrock10004: CwfYmb (BedrockCore.cpp:98) peekCommand [worker4] [dbug] Plugin 'TestPlugin' peeked command 'idcollision r_11291_r'
2022-04-22T03:40:26.197353+00:00 expensidev2004 bedrock10004: CwfYmb (BedrockCore.cpp:101) peekCommand [worker4] [dbug] Command 'idcollision r_11291_r' not finished in peek, re-queuing.
2022-04-22T03:40:26.197400+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:2527) SQuery [worker4] [dbug] PRAGMA query_only = false;
2022-04-22T03:40:26.197430+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:2527) SQuery [worker4] [dbug] ROLLBACK
2022-04-22T03:40:26.197469+00:00 expensidev2004 bedrock10004: CwfYmb (SQLite.cpp:748) rollback [worker4] [dbug] Transaction rollback with 0 queries attempted, 0 served from cache.
2022-04-22T03:40:26.197502+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:1729) S_socket [worker4] [info] DNS lookup took 0ms for '0.0.0.0'.
2022-04-22T03:40:26.197557+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:1741) S_socket [worker4] [info] Resolved 0.0.0.0 to ip: 0.0.0.0.
2022-04-22T03:40:26.197605+00:00 expensidev2004 bedrock10004: CwfYmb (SQLiteClusterMessenger.cpp:52) waitForReady [worker4] [info] [HTTPESC] Socket disconnected while waiting to be ready (send).
2022-04-22T03:40:26.698452+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:1729) S_socket [worker4] [info] DNS lookup took 0ms for '0.0.0.0'.
2022-04-22T03:40:26.698626+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:1741) S_socket [worker4] [info] Resolved 0.0.0.0 to ip: 0.0.0.0.
2022-04-22T03:40:26.698702+00:00 expensidev2004 bedrock10004: CwfYmb (SQLiteClusterMessenger.cpp:52) waitForReady [worker4] [info] [HTTPESC] Socket disconnected while waiting to be ready (send).
2022-04-22T03:40:27.199297+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:1729) S_socket [worker4] [info] DNS lookup took 0ms for '0.0.0.0'.
2022-04-22T03:40:27.199449+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:1741) S_socket [worker4] [info] Resolved 0.0.0.0 to ip: 0.0.0.0.
2022-04-22T03:40:27.199507+00:00 expensidev2004 bedrock10004: CwfYmb (SQLiteClusterMessenger.cpp:52) waitForReady [worker4] [info] [HTTPESC] Socket disconnected while waiting to be ready (send).
2022-04-22T03:40:27.758722+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:1729) S_socket [worker4] [info] DNS lookup took 0ms for '0.0.0.0'.
2022-04-22T03:40:27.758795+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:1741) S_socket [worker4] [info] Resolved 0.0.0.0 to ip: 0.0.0.0.
2022-04-22T03:40:27.759431+00:00 expensidev2004 bedrock10004: CwfYmb (SQLiteClusterMessenger.cpp:52) waitForReady [worker4] [info] [HTTPESC] Socket disconnected while waiting to be ready (send).
2022-04-22T03:40:28.271219+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:1729) S_socket [worker4] [info] DNS lookup took 0ms for '0.0.0.0'.
2022-04-22T03:40:28.271450+00:00 expensidev2004 bedrock10004: CwfYmb (libstuff.cpp:1741) S_socket [worker4] [info] Resolved 0.0.0.0 to ip: 0.0.0.0.
2022-04-22T03:40:28.271673+00:00 expensidev2004 bedrock10004: CwfYmb (SQLiteClusterMessenger.cpp:52) waitForReady [worker4] [info] [HTTPESC] Socket disconnected while waiting to be ready (send).
2022-04-22T03:40:28.771286+00:00 expensidev2004 bedrock10004: CwfYmb (SQLiteClusterMessenger.cpp:89) runOnLeader [worker4] [info] [HTTPESC] No leader address.
2022-04-22T03:40:29.272392+00:00 expensidev2004 bedrock10004: CwfYmb (SQLiteClusterMessenger.cpp:89) runOnLeader [worker4] [info] [HTTPESC] No leader address.
2022-04-22T03:40:29.774422+00:00 expensidev2004 bedrock10004: CwfYmb (SQLiteClusterMessenger.cpp:89) runOnLeader [worker4] [info] [HTTPESC] No leader address.
2022-04-22T03:40:30.275090+00:00 expensidev2004 bedrock10004: CwfYmb (SQLiteClusterMessenger.cpp:89) runOnLeader [worker4] [info] [HTTPESC] No leader address.
2022-04-22T03:40:30.775719+00:00 expensidev2004 bedrock10004: CwfYmb (SQLiteClusterMessenger.cpp:89) runOnLeader [worker4] [info] [HTTPESC] No leader address.
2022-04-22T03:40:31.276119+00:00 expensidev2004 bedrock10004: CwfYmb (SQLiteClusterMessenger.cpp:159) runOnLeader [worker4] [info] [HTTPESC] Failed to send to leader after timeout establishing connnection.
2022-04-22T03:40:31.276314+00:00 expensidev2004 bedrock10004: CwfYmb (BedrockServer.cpp:1045) worker [worker4] [warn] Couldn't escalate command idcollision r_11291_r to leader. We are in state: FOLLOWING
```
Which seems to be working correctly.
