### PR TITLE
Don't give up until we actually hit the shutdown timeout

### DIFF
--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -40,7 +40,7 @@ SQLiteClusterMessenger::WaitForReadyResult SQLiteClusterMessenger::waitForReady(
     while (true) {
         int result = poll(&fdspec, 1, 100); // 100 is timeout in ms.
         if (!result) {
-            if (_shutDownBy) {
+            if (_shutDownBy && STimeNow() > _shutDownBy) {
                 SINFO("[HTTPESC] Giving up because shutting down.");
                 return WaitForReadyResult::SHUTTING_DOWN;
             } else if (timeoutTimestamp && timeoutTimestamp < STimeNow()) {


### PR DESCRIPTION
### Details
We are currently giving up on escalations as soon as a timeout is set. We need to wait for them to finish.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/197479

### Tests
None.