### PR TITLE
Clean up SQLiteNode

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1689,9 +1689,7 @@ list<STable> BedrockServer::getPeerInfo() {
     list<STable> peerData;
     auto _syncNodeCopy = atomic_load(&_syncNode);
     if (_syncNodeCopy) {
-        for (SQLiteNode::Peer* peer : _syncNodeCopy->peerList) {
-            peerData.emplace_back(peer->getData());
-        }
+        peerData =  _syncNodeCopy->getPeerInfo();
     }
     return peerData;
 }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -192,7 +192,7 @@ void BedrockServer::sync()
     // Initialize the shared pointer to our sync node object.
     atomic_store(&_syncNode, make_shared<SQLiteNode>(*this, _dbPool, args["-nodeName"], args["-nodeHost"],
                                                             args["-peerList"], args.calc("-priority"), firstTimeout,
-                                                            _version, args.test("-parallelReplication"), args["-commandPortPrivate"]));
+                                                            _version, args["-commandPortPrivate"]));
 
     // The node is now coming up, and should eventually end up in a `LEADING` or `FOLLOWING` state. We can start adding
     // our worker threads now. We don't wait until the node is `LEADING` or `FOLLOWING`, as it's state can change while

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -13,6 +13,7 @@
 #include <BedrockPlugin.h>
 #include <libstuff/libstuff.h>
 #include <libstuff/SRandom.h>
+#include <libstuff/AutoTimer.h>
 
 set<string>BedrockServer::_blacklistedParallelCommands;
 shared_timed_mutex BedrockServer::_blacklistedParallelCommandMutex;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -14,6 +14,7 @@
 #include <libstuff/libstuff.h>
 #include <libstuff/SRandom.h>
 #include <libstuff/AutoTimer.h>
+#include <sqlitecluster/SQLitePeer.h>
 
 set<string>BedrockServer::_blacklistedParallelCommands;
 shared_timed_mutex BedrockServer::_blacklistedParallelCommandMutex;
@@ -2061,7 +2062,7 @@ void BedrockServer::broadcastCommand(const SData& cmd) {
     }
 }
 
-void BedrockServer::onNodeLogin(SQLiteNode::Peer* peer)
+void BedrockServer::onNodeLogin(SQLitePeer* peer)
 {
     shared_lock<decltype(_crashCommandMutex)> lock(_crashCommandMutex);
     for (const auto& p : _crashCommands) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1810,9 +1810,6 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
             // Set some information about this node.
             content["CommitCount"] = to_string(_syncNodeCopy->getCommitCount());
             content["priority"] = to_string(_syncNodeCopy->getPriority());
-
-            // Get any escalated commands that are waiting to be processed.
-            content["escalatedCommandList"] = SComposeJSONArray(_syncNodeCopy->getEscalatedCommandRequestMethodLines());
             _syncNodeCopy = nullptr;
         } else {
             content["syncNodeAvailable"] = "false";

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -7,6 +7,8 @@
 #include "BedrockCommandQueue.h"
 #include "BedrockTimeoutCommandQueue.h"
 
+class SQLitePeer;
+
 class BedrockServer : public SQLiteServer {
   public:
 
@@ -204,7 +206,7 @@ class BedrockServer : public SQLiteServer {
     const atomic<SQLiteNode::State>& getState() const;
 
     // When a peer node logs in, we'll send it our crash command list.
-    void onNodeLogin(SQLiteNode::Peer* peer);
+    void onNodeLogin(SQLitePeer* peer);
 
     // You must block and unblock the command port with *identical strings*.
     void blockCommandPort(const string& reason);

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ INTERMEDIATEDIR = .build
 
 # We use the same library paths and required libraries for all binaries.
 LIBPATHS =-L$(PROJECT) -Lmbedtls/library
-LIBRARIES =-lbedrock -lstuff -lbedrock -ldl -lpcrecpp -lpthread -lmbedtls -lmbedx509 -lmbedcrypto -lz -lm
+LIBRARIES =-Wl,--start-group -lbedrock -lstuff -Wl,--end-group -ldl -lpcrecpp -lpthread -lmbedtls -lmbedx509 -lmbedcrypto -lz -lm
 
 # These targets aren't actual files.
 .PHONY: all test clustertest clean testplugin

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PROJECT = $(shell git rev-parse --show-toplevel)
 INCLUDE = -I$(PROJECT) -I$(PROJECT)/mbedtls/include
 
 # Set our standard C++ compiler flags
-CXXFLAGS = -g -std=c++17 -fpic -DSQLITE_ENABLE_NORMALIZE $(BEDROCK_OPTIM_COMPILE_FLAG) -Wall -Werror -Wformat-security $(INCLUDE)
+CXXFLAGS = -g -std=c++17 -fpic -DSQLITE_ENABLE_NORMALIZE $(BEDROCK_OPTIM_COMPILE_FLAG) -Wall -Werror -Wformat-security  -Wno-error=deprecated-declarations $(INCLUDE)
 
 # All our intermediate, dependency, object, etc files get hidden in here.
 INTERMEDIATEDIR = .build

--- a/SynchronizedMap.h
+++ b/SynchronizedMap.h
@@ -55,7 +55,7 @@ class SynchronizedMap {
         lock_guard <decltype(_m)> lock(_m);
         return _data.find(item);
     }
-    auto size() {
+    auto size() const {
         lock_guard <decltype(_m)> lock(_m);
         return _data.size();
     }

--- a/SynchronizedMap.h
+++ b/SynchronizedMap.h
@@ -37,7 +37,7 @@ class SynchronizedMap {
         lock_guard <decltype(_m)> lock(_m);
         return _data.emplace(key, move(value));
     }
-    auto empty() {
+    auto empty() const {
         lock_guard <decltype(_m)> lock(_m);
         return _data.empty();
     }
@@ -65,5 +65,5 @@ class SynchronizedMap {
     
   private :
     map<T, U> _data;
-    recursive_mutex _m;
+    mutable recursive_mutex _m;
 };

--- a/libstuff/AutoTimer.cpp
+++ b/libstuff/AutoTimer.cpp
@@ -1,0 +1,34 @@
+#include "AutoTimer.h"
+#include <libstuff/libstuff.h>
+
+#undef SLOGPREFIX
+#define SLOGPREFIX "{} "
+
+AutoTimer::AutoTimer(string name) : _name(name), _intervalStart(chrono::steady_clock::now()), _countedTime(0) {
+}
+
+void AutoTimer::start() {
+    _instanceStart = chrono::steady_clock::now();
+}
+
+void AutoTimer::stop() {
+    auto stopped = chrono::steady_clock::now();
+    _countedTime += stopped - _instanceStart;
+    if (stopped > (_intervalStart + 10s)) {
+        auto counted = chrono::duration_cast<chrono::milliseconds>(_countedTime).count();
+        auto elapsed = chrono::duration_cast<chrono::milliseconds>(stopped - _intervalStart).count();
+        static char percent[10] = {0};
+        snprintf(percent, 10, "%.2f", static_cast<double>(counted) / static_cast<double>(elapsed) * 100.0);
+        SINFO("[performance] AutoTimer (" << _name << "): " << counted << "/" << elapsed << " ms timed, " << percent << "%");
+        _intervalStart = stopped;
+        _countedTime = chrono::microseconds::zero();
+    }
+};
+
+AutoTimerTime::AutoTimerTime(AutoTimer& t) : _t(t) {
+    _t.start();
+}
+
+AutoTimerTime::~AutoTimerTime() {
+    _t.stop();
+}

--- a/libstuff/AutoTimer.h
+++ b/libstuff/AutoTimer.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <chrono>
+#include <string>
+using namespace std;
+
+// There is a *different* AutoTimer in BedrockCore, which is annoying.
+class AutoTimer {
+  public:
+    AutoTimer(string name);
+    void start();
+    void stop();
+
+  private:
+    string _name;
+    chrono::steady_clock::time_point _intervalStart;
+    chrono::steady_clock::time_point _instanceStart;
+    chrono::steady_clock::duration _countedTime;
+};
+
+class AutoTimerTime {
+  public:
+    AutoTimerTime(AutoTimer& t);
+    ~AutoTimerTime();
+
+  private:
+    AutoTimer& _t;
+};

--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -200,14 +200,12 @@ void STCPManager::Socket::shutdown(Socket::State toState) {
 
 STCPManager::Socket::Socket(int sock, STCPManager::Socket::State state_, SX509* x509)
   : s(sock), addr{}, state(state_), connectFailure(false), openTime(STimeNow()), lastSendTime(openTime),
-    lastRecvTime(openTime), ssl(nullptr), data(nullptr), id(STCPManager::Socket::socketCount++), _x509(x509),
-    sentBytes(0), recvBytes(0)
+    lastRecvTime(openTime), ssl(nullptr), data(nullptr), id(STCPManager::Socket::socketCount++), _x509(x509)
 { }
 
 STCPManager::Socket::Socket(const string& host, SX509* x509)
   : s(0), addr{}, state(State::CONNECTING), connectFailure(false), openTime(STimeNow()), lastSendTime(openTime),
-    lastRecvTime(openTime), ssl(nullptr), data(nullptr), id(STCPManager::Socket::socketCount++), _x509(x509),
-    sentBytes(0), recvBytes(0)
+    lastRecvTime(openTime), ssl(nullptr), data(nullptr), id(STCPManager::Socket::socketCount++), _x509(x509)
 {
     SASSERT(SHostIsValid(host));
     s = S_socket(host, true, false, false);
@@ -229,9 +227,7 @@ STCPManager::Socket::Socket(Socket&& from)
     ssl(from.ssl),
     data(from.data),
     id(from.id),
-    _x509(from._x509),
-    sentBytes(from.sentBytes),
-    recvBytes(from.recvBytes)
+    _x509(from._x509)
 {
     from.s = -1;
     from.ssl = nullptr;
@@ -251,22 +247,6 @@ STCPManager::Socket::~Socket() {
     }
 }
 
-void STCPManager::Socket::resetCounters() {
-    lock_guard<decltype(sendRecvMutex)> lock(sendRecvMutex);
-    sentBytes = 0;
-    recvBytes = 0;
-}
-
-uint64_t STCPManager::Socket::getRecvBytes() {
-    lock_guard<decltype(sendRecvMutex)> lock(sendRecvMutex);
-    return recvBytes;
-}
-
-uint64_t STCPManager::Socket::getSentBytes() {
-    lock_guard<decltype(sendRecvMutex)> lock(sendRecvMutex);
-    return sentBytes;
-}
-
 bool STCPManager::Socket::send() {
     lock_guard<decltype(sendRecvMutex)> lock(sendRecvMutex);
     // Send data
@@ -278,7 +258,6 @@ bool STCPManager::Socket::send() {
         result = S_sendconsume(s, sendBuffer);
     }
     if (oldSize - sendBuffer.size()) {
-        sentBytes += oldSize - sendBuffer.size();
         lastSendTime = STimeNow();
     }
     return result;
@@ -327,7 +306,6 @@ bool STCPManager::Socket::recv() {
 
     // We've received new data
     if (oldSize != recvBuffer.size()) {
-        recvBytes += (recvBuffer.size() - oldSize);
         lastRecvTime = STimeNow();
     }
     return result;

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -47,10 +47,6 @@ struct STCPManager {
         string sendBufferCopy();
         void setSendBuffer(const string& buffer);
 
-        void resetCounters();
-        uint64_t getRecvBytes();
-        uint64_t getSentBytes();
-
       private:
         static atomic<uint64_t> socketCount;
         recursive_mutex sendRecvMutex;
@@ -64,9 +60,6 @@ struct STCPManager {
         // the underlying ssl code. Once assigned, the socket owns this object for it's lifetime and will delete it
         // upon destruction.
         SX509* _x509;
-
-        uint64_t sentBytes;
-        uint64_t recvBytes;
     };
 
     class Port {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2673,11 +2673,11 @@ SStopwatch::SStopwatch(uint64_t alarm) {
     alarmDuration.store(alarm);
 }
 
-uint64_t SStopwatch::elapsed() {
+uint64_t SStopwatch::elapsed() const {
     return STimeNow() - startTime.load();
 }
 
-uint64_t SStopwatch::ringing() {
+uint64_t SStopwatch::ringing() const {
     return alarmDuration.load() && (elapsed() > alarmDuration.load());
 }
 

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -176,8 +176,8 @@ struct SStopwatch {
     SStopwatch(uint64_t alarm);
 
     // Accessors
-    uint64_t elapsed();
-    uint64_t ringing();
+    uint64_t elapsed() const;
+    uint64_t ringing() const;
 
     // Mutators
     void start();

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -309,7 +309,7 @@ SQLiteNode::~SQLiteNode() {
     }
 }
 
-void SQLiteNode::replicate(SQLiteNode& node, Peer* peer, SData command, size_t sqlitePoolIndex) {
+void SQLiteNode::_replicate(SQLiteNode& node, Peer* peer, SData command, size_t sqlitePoolIndex) {
     // Initialize each new thread with a new number.
     SInitialize("replicate" + to_string(currentReplicateThreadID.fetch_add(1)));
 
@@ -1839,7 +1839,7 @@ void SQLiteNode::_onMESSAGE(Peer* peer, const SData& message) {
         } else {
             auto threadID = _replicationThreadCount.fetch_add(1);
             SDEBUG("Spawning concurrent replicate thread (blocks until DB handle available): " << threadID);
-            thread(replicate, ref(*this), peer, message, _dbPool->getIndex(false)).detach();
+            thread(_replicate, ref(*this), peer, message, _dbPool->getIndex(false)).detach();
             SDEBUG("Done spawning concurrent replicate thread: " << threadID);
         }
     } else if (SIEquals(message.methodLine, "APPROVE_TRANSACTION") || SIEquals(message.methodLine, "DENY_TRANSACTION")) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -272,7 +272,8 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, cons
       _handledCommitCount(0),
       _replicationThreadsShouldExit(false),
       _replicationThreadCount(0),
-      _commandAddress(commandPort)
+      _commandAddress(commandPort),
+      _version(version)
     {
 
     if (!host.empty()) {
@@ -286,7 +287,6 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, cons
     _syncPeer = nullptr;
     _leadPeer = nullptr;
     _stateTimeout = STimeNow() + firstTimeout;
-    _version = version;
 
     SINFO("[NOTIFY] setting commit count to: " << _db.getCommitCount());
     _localCommitNotifier.notifyThrough(_db.getCommitCount());

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -408,7 +408,7 @@ int SQLiteNode::getPriority() const {
 }
 
 const string SQLiteNode::getLeaderVersion() const {
-    if (_state == STANDINGUP || _state == LEADING || _state == STANDINGDOWN) {
+    if (_state == LEADING || _state == STANDINGDOWN) {
         return _version;
     } else if (_leadPeer) {
         return _leadPeer.load()->version;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -59,38 +59,6 @@
 //                   optimizing replication.
 
 #undef SLOGPREFIX
-#define SLOGPREFIX "{} "
-
-AutoTimer::AutoTimer(string name) : _name(name), _intervalStart(chrono::steady_clock::now()), _countedTime(0) {
-}
-
-void AutoTimer::start() {
-    _instanceStart = chrono::steady_clock::now();
-}
-
-void AutoTimer::stop() {
-    auto stopped = chrono::steady_clock::now();
-    _countedTime += stopped - _instanceStart;
-    if (stopped > (_intervalStart + 10s)) {
-        auto counted = chrono::duration_cast<chrono::milliseconds>(_countedTime).count();
-        auto elapsed = chrono::duration_cast<chrono::milliseconds>(stopped - _intervalStart).count();
-        static char percent[10] = {0};
-        snprintf(percent, 10, "%.2f", static_cast<double>(counted) / static_cast<double>(elapsed) * 100.0);
-        SINFO("[performance] AutoTimer (" << _name << "): " << counted << "/" << elapsed << " ms timed, " << percent << "%");
-        _intervalStart = stopped;
-        _countedTime = chrono::microseconds::zero();
-    }
-};
-
-AutoTimerTime::AutoTimerTime(AutoTimer& t) : _t(t) {
-    _t.start();
-}
-
-AutoTimerTime::~AutoTimerTime() {
-    _t.stop();
-}
-
-#undef SLOGPREFIX
 #define SLOGPREFIX "{" << name << "} "
 
 SQLiteNode::Peer::Peer(const string& name_, const string& host_, const STable& params_, uint64_t id_)

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -266,7 +266,7 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, cons
       _recvTimeout(max(SQL_NODE_DEFAULT_RECV_TIMEOUT, SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT)),
       _version(version),
       _commitState(CommitState::UNINITIALIZED),
-      _db(_dbPool->getBase()),
+      _db(dbPool->getBase()),
       _dbPool(dbPool),
       _lastSentTransactionID(0),
       _leadPeer(nullptr),

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -281,11 +281,8 @@ class SQLiteNode : public STCPManager {
     // Monotonically increasing thread counter, used for thread IDs for logging purposes.
     static atomic<int64_t> currentReplicateThreadID;
 
-    // Receive timeout for 'normal' SQLiteNode messages
-    static const uint64_t SQL_NODE_DEFAULT_RECV_TIMEOUT;
-
-    // Separate timeout for receiving and applying synchronization commits.
-    static const uint64_t SQL_NODE_SYNCHRONIZING_RECV_TIMEOUT;
+    // Receive timeout for cluster messages.
+    static const uint64_t RECV_TIMEOUT;
 
     static const vector<Peer*> _initPeers(const string& peerList);
 
@@ -363,7 +360,6 @@ class SQLiteNode : public STCPManager {
 
     // A string representing an address (i.e., `127.0.0.1:80`) where this server accepts commands. I.e., "the command port".
     const unique_ptr<Port> _port;
-    const uint64_t _recvTimeout;
 
     // Our version string. Supplied by constructor.
     const string _version;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -379,7 +379,7 @@ class SQLiteNode : public STCPManager {
 
     // When the node starts, it is not ready to serve requests without first connecting to the other nodes, and checking
     // to make sure it's up-to-date. Store the configured priority here and use "-1" until we're ready to fully join the cluster.
-    int _originalPriority;
+    const int _originalPriority;
 
     // Our current State.
     atomic<State> _state;
@@ -411,15 +411,9 @@ class SQLiteNode : public STCPManager {
     // leader's version string.
     string _leaderVersion;
 
-    // The maximum number of seconds we'll allow before we force a quorum commit. This can be violated when commits
-    // are performed outside of SQLiteNode, but we'll catch up the next time we do a commit.
-    int _quorumCheckpointSeconds;
-
-    // The timestamp of the (end of) the last quorum commit.
-    uint64_t _lastQuorumTime;
-
     // When we're a follower, we can escalate a command to the leader. When we do so, we store that command in the
     // following map of commandID to Command until the follower responds.
+    [[deprecated("Use HTTP escalation")]]
     SynchronizedMap<string, unique_ptr<SQLiteCommand>> _escalatedCommandMap;
 
     // The server object to which we'll pass incoming escalated commands.
@@ -431,10 +425,8 @@ class SQLiteNode : public STCPManager {
     int _stateChangeCount;
 
     // Last time we recorded network stats.
+    // TODO: Kill this and the stuff related to it.
     chrono::steady_clock::time_point _lastNetStatTime;
-
-    WallClockTimer _syncTimer;
-    atomic<uint64_t> _handledCommitCount;
 
     // State variable that indicates when the above threads should quit.
     atomic<bool> _replicationThreadsShouldExit;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -408,9 +408,6 @@ class SQLiteNode : public STCPManager {
     // Stopwatch to track if we're giving up on the server preventing a standdown.
     SStopwatch _standDownTimeOut;
 
-    // Our version string. Supplied by constructor.
-    string _version;
-
     // leader's version string.
     string _leaderVersion;
 
@@ -456,6 +453,9 @@ class SQLiteNode : public STCPManager {
     // This is just here to allow `poll` to get interrupted when there are new commits to send. We don't want followers
     // to wait up to a full second for them.
     mutable SSynchronizedQueue<bool> _commitsToSend;
+
+    // Our version string. Supplied by constructor.
+    const string _version;
 };
 
 // serialization for Responses.

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -425,6 +425,7 @@ class SQLiteNode : public STCPManager {
     SStopwatch _shutdownTimeout;
 
     // List of sockets connected to peers.
+    // Remove. See: https://github.com/Expensify/Expensify/issues/208459
     list<STCPManager::Socket*> _socketList;
 
     // Stopwatch to track if we're giving up on the server preventing a standdown.

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -10,7 +10,7 @@
 
 // This file is long and complex. For each nested sub-structure (I.e., classes inside classes) we have attempted to
 // arrange things as such:
-// For each puplic private block:
+// For each public private block:
 // 1. classes/structs/type definitions
 // 2. static members
 // 3. static methods

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -61,6 +61,7 @@ class SQLiteServer;
 // Distributed, leader/follower, failover, transactional DB cluster
 class SQLiteNode : public STCPManager {
     // This exists to expose internal state to a test harness. It is not used otherwise.
+    friend class SQLiteNodeTest;
     friend class SQLiteNodeTester;
 
   public:
@@ -197,6 +198,8 @@ class SQLiteNode : public STCPManager {
 
     const string& getLeaderVersion() const;
 
+    list<STable> getPeerInfo() const;
+
     int getPriority() const;
 
     State getState() const;
@@ -259,9 +262,7 @@ class SQLiteNode : public STCPManager {
 
 // DONE ABOVE HERE
     // Attributes
-    string name;
-    uint64_t recvTimeout;
-    const vector<Peer*> peerList;
+    const string name;
 
     // What is this?
     list<Socket*> acceptedSocketList;
@@ -373,6 +374,9 @@ class SQLiteNode : public STCPManager {
 
     // Helper functions
     void _sendPING(Peer* peer);
+
+    const uint64_t _recvTimeout;
+    const vector<Peer*> _peerList;
 
     // A bunch of private properties.
     list<STCPManager::Socket*> _socketList;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -21,6 +21,7 @@
 // 8. In each of these sections, things should be alphabetized.
 
 // Diagnostic class for timing what fraction of time happens in certain blocks.
+// TODO: Move out of SQLiteNode.
 class AutoTimer {
   public:
     AutoTimer(string name);
@@ -364,9 +365,6 @@ class SQLiteNode : public STCPManager {
     // TODO:: These are redundant and probably contain the same thing. Or one is empty? Either way it's confusing.
     list<Socket*> _acceptedSocketList;
 
-    AutoTimer _deserializeTimer;
-    AutoTimer _sConsumeFrontTimer;
-    AutoTimer _sAppendTimer;
     unique_ptr<Port> port;
 
     // This is a pool of DB handles that this node can use for any DB access it needs. Currently, it hands them out to
@@ -458,11 +456,6 @@ class SQLiteNode : public STCPManager {
 
     // Indicates whether this node is configured for parallel replication.
     const bool _useParallelReplication;
-
-    AutoTimer _multiReplicationThreadSpawn;
-    AutoTimer _legacyReplication;
-    AutoTimer _onMessageTimer;
-    AutoTimer _escalateTimer;
 
     // A string representing an address (i.e., `127.0.0.1:80`) where this server accepts commands. I.e., "the command
     // port".

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -25,6 +25,7 @@
  *
  * No non-const members should be publicly exposed.
  * Any public method that is `const` must shared_lock<>(nodeMutex).
+ * Alternatively, a public `const` method that is a simple getter for an atomic property can skip the lock.
  * Any pubic method that is non-const must uniaue_lock<>(nodeMutex).
  * Any private methods must not call public methods.
  * Any private methods must not lock nodeMutex (for recursion reasons).

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -237,7 +237,7 @@ class SQLiteNode : public STCPManager {
 
     // Constructor/Destructor
     SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, const string& name, const string& host,
-               const string& peerList, int priority, uint64_t firstTimeout, const string& version, const bool useParallelReplication = false,
+               const string& peerList, int priority, uint64_t firstTimeout, const string& version,
                const string& commandPort = "localhost:8890");
     ~SQLiteNode();
 
@@ -348,11 +348,6 @@ class SQLiteNode : public STCPManager {
     int handleCommitTransaction(SQLite& db, Peer* peer, const uint64_t commandCommitCount, const string& commandCommitHash);
     void handleRollbackTransaction(SQLite& db, Peer* peer, const SData& message);
     
-    // Legacy versions of the above functions for serial replication.
-    void handleSerialBeginTransaction(Peer* peer, const SData& message);
-    void handleSerialCommitTransaction(Peer* peer, const SData& message);
-    void handleSerialRollbackTransaction(Peer* peer, const SData& message);
-
     // Helper functions
     void _sendPING(Peer* peer);
 
@@ -453,9 +448,6 @@ class SQLiteNode : public STCPManager {
     // Counter of the total number of currently active replication threads. This is used to let us know when all
     // threads have finished.
     atomic<int64_t> _replicationThreadCount;
-
-    // Indicates whether this node is configured for parallel replication.
-    const bool _useParallelReplication;
 
     // A string representing an address (i.e., `127.0.0.1:80`) where this server accepts commands. I.e., "the command
     // port".

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -26,7 +26,7 @@
  * No non-const members should be publicly exposed.
  * Any public method that is `const` must shared_lock<>(nodeMutex).
  * Alternatively, a public `const` method that is a simple getter for an atomic property can skip the lock.
- * Any public method that is non-const must uniaue_lock<>(nodeMutex) before changing any internal state, and must hold
+ * Any public method that is non-const must unique_lock<>(nodeMutex) before changing any internal state, and must hold
  * this lock until it is done changing state to make this method's changes atomic.
  * Any private methods must not call public methods.
  * Any private methods must not lock nodeMutex (for recursion reasons).

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -260,13 +260,6 @@ class SQLiteNode : public STCPManager {
     // would be a good idea for the caller to read any new commands or traffic from the network.
     bool update();
 
-// DONE ABOVE HERE
-    // Attributes
-    const string name;
-
-    // What is this?
-    list<Socket*> acceptedSocketList;
-
   private:
     // Utility class that can decrement _replicationThreadCount when objects go out of scope.
     template <typename CounterType>
@@ -357,7 +350,6 @@ class SQLiteNode : public STCPManager {
     void _reconnectPeer(Peer* peer);
     void _reconnectAll();
 
-
     // Replicates any transactions that have been made on our database by other threads to peers.
     void _sendOutstandingTransactions(const set<uint64_t>& commitOnlyIDs = {});
 
@@ -375,11 +367,14 @@ class SQLiteNode : public STCPManager {
     // Helper functions
     void _sendPING(Peer* peer);
 
-    const uint64_t _recvTimeout;
+    const string _name;
     const vector<Peer*> _peerList;
+    const uint64_t _recvTimeout;
 
     // A bunch of private properties.
     list<STCPManager::Socket*> _socketList;
+    // TODO:: These are redundant and probably contain the same thing. Or one is empty? Either way it's confusing.
+    list<Socket*> _acceptedSocketList;
 
     AutoTimer _deserializeTimer;
     AutoTimer _sConsumeFrontTimer;
@@ -476,7 +471,6 @@ class SQLiteNode : public STCPManager {
     // Indicates whether this node is configured for parallel replication.
     const bool _useParallelReplication;
 
-
     AutoTimer _multiReplicationThreadSpawn;
     AutoTimer _legacyReplication;
     AutoTimer _onMessageTimer;
@@ -489,7 +483,6 @@ class SQLiteNode : public STCPManager {
     // This is just here to allow `poll` to get interrupted when there are new commits to send. We don't want followers
     // to wait up to a full second for them.
     mutable SSynchronizedQueue<bool> _commitsToSend;
-
 };
 
 // serialization for Responses.

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -308,6 +308,9 @@ class SQLiteNode : public STCPManager {
     // which happens when a node stops FOLLOWING.
     static void _replicate(SQLiteNode& node, Peer* peer, SData command, size_t sqlitePoolIndex);
 
+    Socket* _acceptSocket();
+    void _changeState(State newState);
+
     // Returns the ID of Peer. If the peer is not found, returns 0.
     uint64_t _getIDByPeer(Peer* peer) const;
 
@@ -316,17 +319,15 @@ class SQLiteNode : public STCPManager {
 
     // Returns whether we're in the process of gracefully shutting down.
     bool _gracefulShutdown() const;
-    bool _isNothingBlockingShutdown() const;
-    bool _majoritySubscribed() const;
-
-    Socket* _acceptSocket();
-    void _changeState(State newState);
 
     // Handlers for transaction messages.
     void _handleBeginTransaction(SQLite& db, Peer* peer, const SData& message, bool wasConflict);
     void _handlePrepareTransaction(SQLite& db, Peer* peer, const SData& message);
     int _handleCommitTransaction(SQLite& db, Peer* peer, const uint64_t commandCommitCount, const string& commandCommitHash);
     void _handleRollbackTransaction(SQLite& db, Peer* peer, const SData& message);
+
+    bool _isNothingBlockingShutdown() const;
+    bool _majoritySubscribed() const;
 
     // Called when we first establish a connection with a new peer
     void _onConnect(Peer* peer);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -23,21 +23,9 @@
 // Diagnostic class for timing what fraction of time happens in certain blocks.
 class AutoTimer {
   public:
-    AutoTimer(string name) : _name(name), _intervalStart(chrono::steady_clock::now()), _countedTime(0) { }
-    void start() { _instanceStart = chrono::steady_clock::now(); };
-    void stop() {
-        auto stopped = chrono::steady_clock::now();
-        _countedTime += stopped - _instanceStart;
-        if (stopped > (_intervalStart + 10s)) {
-            auto counted = chrono::duration_cast<chrono::milliseconds>(_countedTime).count();
-            auto elapsed = chrono::duration_cast<chrono::milliseconds>(stopped - _intervalStart).count();
-            static char percent[10] = {0};
-            snprintf(percent, 10, "%.2f", static_cast<double>(counted) / static_cast<double>(elapsed) * 100.0);
-            SINFO("[performance] AutoTimer (" << _name << "): " << counted << "/" << elapsed << " ms timed, " << percent << "%");
-            _intervalStart = stopped;
-            _countedTime = chrono::microseconds::zero();
-        }
-    };
+    AutoTimer(string name);
+    void start();
+    void stop();
 
   private:
     string _name;
@@ -48,8 +36,8 @@ class AutoTimer {
 
 class AutoTimerTime {
   public:
-    AutoTimerTime(AutoTimer& t) : _t(t) { _t.start(); }
-    ~AutoTimerTime() { _t.stop(); }
+    AutoTimerTime(AutoTimer& t);
+    ~AutoTimerTime();
 
   private:
     AutoTimer& _t;
@@ -487,4 +475,3 @@ class SQLiteNode : public STCPManager {
 
 // serialization for Responses.
 ostream& operator<<(ostream& os, const atomic<SQLiteNode::Peer::Response>& response);
-

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -37,30 +37,6 @@
  *
  */
 
-// Diagnostic class for timing what fraction of time happens in certain blocks.
-// TODO: Move out of SQLiteNode.
-class AutoTimer {
-  public:
-    AutoTimer(string name);
-    void start();
-    void stop();
-
-  private:
-    string _name;
-    chrono::steady_clock::time_point _intervalStart;
-    chrono::steady_clock::time_point _instanceStart;
-    chrono::steady_clock::duration _countedTime;
-};
-
-class AutoTimerTime {
-  public:
-    AutoTimerTime(AutoTimer& t);
-    ~AutoTimerTime();
-
-  private:
-    AutoTimer& _t;
-};
-
 class SQLiteCommand;
 class SQLiteServer;
 

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -20,6 +20,17 @@
 // 7. non-const instance members.
 // 8. In each of these sections, things should be alphabetized.
 
+/*
+ * Rules for maintaining SQLiteNode methods so that atomicity works as intended.
+ *
+ * No non-const members should be publicly exposed.
+ * Any public method that is `const` must shared_lock<>(nodeMutex).
+ * Any pubic method that is non-const must uniaue_lock<>(nodeMutex).
+ * Any private methods must not call public methods.
+ * Any private methods must not lock nodeMutex (for recursion reasons).
+ * Any public methods must not call other public methods.
+ */
+
 // Diagnostic class for timing what fraction of time happens in certain blocks.
 // TODO: Move out of SQLiteNode.
 class AutoTimer {

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -371,6 +371,8 @@ class SQLiteNode : public STCPManager {
     // A bunch of private properties.
     list<STCPManager::Socket*> _socketList;
     // TODO:: These are redundant and probably contain the same thing. Or one is empty? Either way it's confusing.
+    // Ok, this is annoying because it's a special list of peers that are in the process of connecting right now. I
+    // don't think we need a whole other list for this. Remove this and do something better.
     list<Socket*> _acceptedSocketList;
 
     // Store the ID of the last transaction that we replicated to peers. Whenever we do an update, we will try and send

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -451,10 +451,6 @@ class SQLiteNode : public STCPManager {
     // The peer that we'll synchronize from.
     // Remove. See: https://github.com/Expensify/Expensify/issues/208439
     Peer* _syncPeer;
-
-    // Last time we recorded network stats.
-    // TODO: Kill this and the stuff related to it.
-    chrono::steady_clock::time_point _lastNetStatTime;
 };
 
 // serialization for Responses.

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -10,7 +10,7 @@
 
 // This file is long and complex. For each nested sub-structure (I.e., classes inside classes) we have attempted to
 // arrange things as such:
-// For each public private block:
+// For each public/private block:
 // 1. classes/structs/type definitions
 // 2. static members
 // 3. static methods

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -1,0 +1,131 @@
+#include "SQLitePeer.h"
+
+#include <libstuff/SData.h>
+
+#undef SLOGPREFIX
+#define SLOGPREFIX "{" << name << "} "
+
+SQLitePeer::SQLitePeer(const string& name_, const string& host_, const STable& params_, uint64_t id_)
+  : commitCount(0),
+    host(host_),
+    id(id_),
+    name(name_),
+    params(params_),
+    permaFollower(isPermafollower(params)),
+    failedConnections(0),
+    latency(0),
+    loggedIn(false),
+    nextReconnect(0),
+    priority(0),
+    state(SQLiteNode::SEARCHING),
+    standupResponse(Response::NONE),
+    subscribed(false),
+    transactionResponse(Response::NONE),
+    version(),
+    hash()
+{ }
+
+SQLitePeer::~SQLitePeer() {
+    delete socket;
+}
+
+bool SQLitePeer::connected() const {
+    lock_guard<decltype(peerMutex)> lock(peerMutex);
+    return (socket && socket->state.load() == STCPManager::Socket::CONNECTED);
+}
+
+void SQLitePeer::reset() {
+    lock_guard<decltype(peerMutex)> lock(peerMutex);
+    latency = 0;
+    loggedIn = false;
+    priority = 0;
+    delete socket;
+    socket = nullptr;
+    state = SQLiteNode::SEARCHING;
+    standupResponse = Response::NONE;
+    subscribed = false;
+    transactionResponse = Response::NONE;
+    version = "";
+    setCommit(0, "");
+}
+
+string SQLitePeer::responseName(Response response) {
+    switch (response) {
+        case Response::NONE:
+            return "NONE";
+            break;
+        case Response::APPROVE:
+            return "APPROVE";
+            break;
+        case Response::DENY:
+            return "DENY";
+            break;
+        default:
+            return "";
+    }
+}
+
+void SQLitePeer::setCommit(uint64_t count, const string& hashString) {
+    lock_guard<decltype(peerMutex)> lock(peerMutex);
+    const_cast<atomic<uint64_t>&>(commitCount) = count;
+    hash = hashString;
+}
+
+void SQLitePeer::getCommit(uint64_t& count, string& hashString) const {
+    lock_guard<decltype(peerMutex)> lock(peerMutex);
+    count = commitCount.load();
+    hashString = hash.load();
+}
+
+STable SQLitePeer::getData() const {
+    // Add all of our standard stuff.
+    STable result({
+        {"name", name},
+        {"host", host},
+        {"state", (SQLiteNode::stateName(state) + (connected() ? "" : " (DISCONNECTED)"))},
+        {"latency", to_string(latency)},
+        {"nextReconnect", to_string(nextReconnect)},
+        {"id", to_string(id)},
+        {"failedConnections", to_string(failedConnections)},
+        {"loggedIn", (loggedIn ? "true" : "false")},
+        {"priority", to_string(priority)},
+        {"version", version},
+        {"hash", hash},
+        {"commitCount", to_string(commitCount)},
+        {"standupResponse", responseName(standupResponse)},
+        {"transactionResponse", responseName(transactionResponse)},
+        {"subscribed", (subscribed ? "true" : "false")},
+    });
+
+    // And anything from the params (note: doesn't overwrite our standard stuff).
+    for (auto& p : params) {
+        result.emplace(p);
+    }
+
+    result["commandAddress"] = commandAddress;
+
+    return result;
+}
+
+bool SQLitePeer::isPermafollower(const STable& params) {
+    auto it = params.find("Permafollower");
+    if (it != params.end() && it->second == "true") {
+        return true;
+    }
+    return false;
+}
+
+void SQLitePeer::sendMessage(const SData& message) {
+    lock_guard<decltype(peerMutex)> lock(peerMutex);
+    if (socket) {
+        socket->send(message.serialize());
+    } else {
+        SWARN("Tried to send " << message.methodLine << " to peer, but not available.");
+    }
+}
+
+ostream& operator<<(ostream& os, const atomic<SQLitePeer::Response>& response)
+{
+    os << SQLitePeer::responseName(response.load());
+    return os;
+}

--- a/sqlitecluster/SQLitePeer.h
+++ b/sqlitecluster/SQLitePeer.h
@@ -1,0 +1,83 @@
+#include <libstuff/libstuff.h>
+#include <sqlitecluster/SQLiteNode.h>
+
+// Represents a single peer in the database cluster
+class SQLitePeer {
+    // This allows direct access to the socket from the node object that should actually be managing peer
+    // connections, which should always be handled by a single thread, and thus safe. Ideally, this isn't required,
+    // but for the time being, the amount of refactoring required to fix that is too high.
+    friend class SQLiteNode;
+
+  public:
+    // Possible responses from a peer.
+    enum class Response {
+        NONE,
+        APPROVE,
+        DENY
+    };
+
+    // Get a string name for a Response object.
+    static string responseName(Response response);
+
+    // Atomically get commit and hash.
+    void getCommit(uint64_t& count, string& hashString) const;
+
+    // Gets an STable representation of this peer's current state in order to display status info.
+    STable getData() const;
+
+    // Returns true if there's an active connection to this Peer.
+    bool connected() const;
+
+    SQLitePeer(const string& name_, const string& host_, const STable& params_, uint64_t id_);
+    ~SQLitePeer();
+
+    // Reset a peer, as if disconnected and starting the connection over.
+    void reset();
+
+    // Send a message to this peer. Thread-safe.
+    void sendMessage(const SData& message);
+
+    // Atomically set commit and hash.
+    void setCommit(uint64_t count, const string& hashString);
+
+    // This is const because it's public, and we don't want it to be changed outside of this class, as it needs to
+    // be synchronized with `hash`. However, it's often useful just as it is, so we expose it like this and update
+    // it with `const_cast`. `hash` is only used in few places, so is private, and can only be accessed with
+    // `getCommit`, thus reducing the risk of anyone getting out-of-sync commitCount and hash.
+    const atomic<uint64_t> commitCount;
+
+    const string host;
+    const uint64_t id;
+    const string name;
+    const STable params;
+    const bool permaFollower;
+
+    // An address on which this peer can accept commands.
+    atomic<string> commandAddress;
+    atomic<int> failedConnections;
+    atomic<uint64_t> latency;
+    atomic<bool> loggedIn;
+    atomic<uint64_t> nextReconnect;
+    atomic<int> priority;
+    atomic<SQLiteNode::State> state;
+    atomic<Response> standupResponse;
+    atomic<bool> subscribed;
+    atomic<Response> transactionResponse;
+    atomic<string> version;
+
+  private:
+    // For initializing the permafollower value from the params list.
+    static bool isPermafollower(const STable& params);
+
+    // The hash corresponding to commitCount.
+    atomic<string> hash;
+
+    // Mutex for locking around non-atomic member access (for set/getCommit, accessing socket, etc).
+    mutable recursive_mutex peerMutex;
+
+    // Not named with an underscore because it's only sort-of private (see friend class declaration above).
+    STCPManager::Socket* socket = nullptr;
+};
+
+// serialization for Responses.
+ostream& operator<<(ostream& os, const atomic<SQLitePeer::Response>& response);

--- a/sqlitecluster/SQLiteServer.h
+++ b/sqlitecluster/SQLiteServer.h
@@ -10,10 +10,12 @@ class SQLiteServer : public STCPManager {
     // An SQLiteNode will call this to pass a command to a server for processing. The isNew flag is set if this is the
     // first time this command has been sent to this server, as opposed to being an existing command, such as one that
     // was previously escalated.
+    [[deprecated("Use HTTP escalation")]]
     virtual void acceptCommand(unique_ptr<SQLiteCommand>&& command, bool isNew) = 0;
 
     // An SQLiteNode will call this to cancel a command that a peer has escalated but no longer wants a response to.
     // The command may or may not be canceled, depending on whether it's already been processed.
+    [[deprecated]]
     virtual void cancelCommand(const string& commandID) = 0;
 
     // This will return true if there's no outstanding writable activity that we're waiting on. It's called by an

--- a/sqlitecluster/SQLiteServer.h
+++ b/sqlitecluster/SQLiteServer.h
@@ -1,5 +1,6 @@
 #pragma once
 class SQLiteCommand;
+class SQLitePeer;
 
 #include <libstuff/STCPManager.h>
 
@@ -23,5 +24,5 @@ class SQLiteServer : public STCPManager {
     virtual bool canStandDown() = 0;
 
     // When a node connects to the cluster, this function will be called on the sync thread.
-    virtual void onNodeLogin(SQLiteNode::Peer* peer) = 0;
+    virtual void onNodeLogin(SQLitePeer* peer) = 0;
 };

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -54,7 +54,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
 
         // Do a base test, with one peer with no latency.
         SQLiteNode::Peer* fastest = nullptr;
-        for (auto peer : testNode.peerList) {
+        for (auto peer : testNode._peerList) {
             int peerNum = peer->name[4] - 48;
             peer->loggedIn = true;
             peer->setCommit(10000000 + peerNum, "");
@@ -71,7 +71,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         ASSERT_EQUAL(SQLiteNodeTester::getSyncPeer(testNode), fastest);
 
         // See what happens when another peer becomes faster.
-        for (auto peer : testNode.peerList) {
+        for (auto peer : testNode._peerList) {
             // New fastest is peer 3.
             if (peer->name == "peer3") {
                 peer->latency = 50;
@@ -82,7 +82,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         ASSERT_EQUAL(SQLiteNodeTester::getSyncPeer(testNode), fastest);
 
         // And see what happens if our fastest peer logs out.
-        for (auto peer : testNode.peerList) {
+        for (auto peer : testNode._peerList) {
             if (peer->name == "peer3") {
                 peer->loggedIn = false;
                 peer->latency = 50;
@@ -97,7 +97,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         ASSERT_EQUAL(SQLiteNodeTester::getSyncPeer(testNode), fastest);
 
         // And then if our previously 0 latency peer gets (fast) latency data.
-        for (auto peer : testNode.peerList) {
+        for (auto peer : testNode._peerList) {
             // New fastest is peer 3.
             if (peer->name == "peer1") {
                 peer->latency = 75;
@@ -108,7 +108,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         ASSERT_EQUAL(SQLiteNodeTester::getSyncPeer(testNode), fastest);
 
         // Now none of our peers have latency data, but one has more commits.
-        for (auto peer : testNode.peerList) {
+        for (auto peer : testNode._peerList) {
             peer->latency = 0;
 
             // 4 had highest commit count.

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -1,6 +1,7 @@
 #include <libstuff/libstuff.h>
 #include <sqlitecluster/SQLiteCommand.h>
 #include <sqlitecluster/SQLiteNode.h>
+#include <sqlitecluster/SQLitePeer.h>
 #include <sqlitecluster/SQLiteServer.h>
 #include <test/lib/BedrockTester.h>
 
@@ -9,7 +10,7 @@
 
 class SQLiteNodeTester {
   public:
-    static SQLiteNode::Peer* getSyncPeer(SQLiteNode& node) {
+    static SQLitePeer* getSyncPeer(SQLiteNode& node) {
         return node._syncPeer;
     }
 
@@ -25,7 +26,7 @@ class TestServer : public SQLiteServer {
     virtual void acceptCommand(unique_ptr<SQLiteCommand>&& command, bool isNew) { }
     virtual void cancelCommand(const string& commandID) { }
     virtual bool canStandDown() { return true; }
-    virtual void onNodeLogin(SQLiteNode::Peer* peer) { }
+    virtual void onNodeLogin(SQLitePeer* peer) { }
 };
 
 struct SQLiteNodeTest : tpunit::TestFixture {
@@ -53,7 +54,7 @@ struct SQLiteNodeTest : tpunit::TestFixture {
         SQLiteNode testNode(server, dbPool, "test", "localhost:19998", peerList, 1, 1000000000, "1.0");
 
         // Do a base test, with one peer with no latency.
-        SQLiteNode::Peer* fastest = nullptr;
+        SQLitePeer* fastest = nullptr;
         for (auto peer : testNode._peerList) {
             int peerNum = peer->name[4] - 48;
             peer->loggedIn = true;


### PR DESCRIPTION
### Details
This is all prep work for making `SQLiteNode` changes atomic (see linked issue below). Doing that well without missing anything is tough, so the more organized code we can start with, the better. So, for that reason, this PR does a lot of organization without making *hardly any* functional changes (see definition of "hardly any" in a minute).

This PR:

1. Removes a bunch of stuff that we can get away without. If it's not there, I don't have to reason about how to handle it atomically.
2. Makes a bunch of stuff `const`. Const variables never change, and thus are implicitly thread-safe. Any `const` members I can ignore when thinking about atomic changes, as they don't change. Any `const` methods are guaranteed not to change anything, so I can know for sure I can use a `shared_lock` in these methods and it will be fine -- multiple threads can read with shared locks and so long as no other threads make changes (which requires a `unique_lock`) all of these `const` methods can read at the same time.
3. Makes as much `private` as possible. This shrinks the public API to 0 member variables, 12 `const` methods, and 8 non-`const` methods (not counting the constructor and destructor), with 3 of those 8 being marked deprecated. With a smaller public API, there's less to reason about with how the locking interacts.
4. Makes notes of more stuff we can remove with some additional refactoring. Some of the remaining private members are tagged for removal with associated issues in the comments. I didn't want to do these now because they will have functional effects and this PR is big enough already.
5. Moves some stuff out of `SQLiteNode` for clarity. Mostly `Peer` and `AutoTimer` are moved.
6. Generally organizes stuff. Groups and sorts methods and variables, names stuff consistently, etc.

See the comment at the top of `SQLiteNode.h` for how stuff is organized and rules for who locks what when (that's not yet implemented, it will come in a follow-up PR).

#### Actual functional changes.
Like I said, these are minimal, and are mostly limited to removing things that were straightforward.

1. A bunch of counters are gone. I don't think anyone is using any of these any longer. Worse case, we break a graph someone cared about and we can either add that one back or remove the graph or alert that gets generated. Since we don't currently trust log-based metrics during stress tests, I don't see any problem removing these performance timers.
2. Removed the `-parallelReplication` flag. It's always on now.
3. Removed `getEscalatedCommandRequestMethodLines`. this is only used to generate status messages and is empty now that we're using HTTP escalation.
4. Removed `handleSerial....` functions that only exist for using when `-parallelReplication` is disabled.
5. Collapsed a couple different timeout values into a single one. One was 60s, the other was 30s, one was sometimes one or the other. They're all just 30s now and it should make no difference.

None of these should have any real effect, I'm saving those changes for a followup so that if they have problems they're easy to pull out of a much smaller PR and identify.

### Fixed Issues
This is prep work for: https://github.com/Expensify/Expensify/issues/208302

### Tests
Against `88acdbf`:

Auth:
```
[ TEST RESULTS ] Passed: 1808, Failed: 0
```

ExpensifyBackupManager:
```
[ TEST RESULTS ] Passed: 6, Failed: 0
```

FuzzyBot:
```
[ TEST RESULTS ] Passed: 38, Failed: 0
```