### PR TITLE
Add logging to see if old feature is still used

### DIFF
--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -7,6 +7,14 @@ SData SQLiteCommand::preprocessRequest(SData&& request) {
     // If the request doesn't specify an execution time, default to right now.
     if (!request.isSet("commandExecuteTime")) {
         request["commandExecuteTime"] = to_string(STimeNow());
+    } else {
+        // We are deprecating `commandExecuteTime` so need to figure out where it's used.
+        auto now = STimeNow();
+        auto executeTime = request.calcU64("commandExecuteTime");
+        if (executeTime > now + 5'000'000) {
+            auto difference = executeTime - now;
+            SINFO("Command '" << request.methodLine << "' requested execution time " << difference << "us in the future.");
+        }
     }
 
     // Add a request ID if one was missing.


### PR DESCRIPTION
### Details
For Bedrock 3.0 we want to drop holding commands for the future as it leaves them in a weird state where they can be lost if the node shuts down. These are seldom used I think, but this PR adds logging to check if any commands are scheduled more that 5s in advance.

If we find anything using this, it needs to be converted to some other mechanism.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/165277

### Tests
N/A
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
