### PR TITLE
Revert "Remove option to turn off HTTP escalation"

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -47,6 +47,7 @@ void BedrockServer::acceptCommand(unique_ptr<SQLiteCommand>&& command, bool isNe
             newRequest.deserialize(command->request.content);
             newCommand = getCommandFromPlugins(move(newRequest));
             newCommand->initiatingClientID = -1;
+            newCommand->initiatingPeerID = 0;
         } else {
             // If we already have an existing BedrockCommand (as opposed to a base class SQLiteCommand) this is
             // something that we've already constructed (most likely, a response from leader), so no need to ask the
@@ -87,6 +88,7 @@ bool BedrockServer::canStandDown() {
         size_t mainQueueSize = _commandQueue.size();
         size_t blockingQueueSize = _blockingCommandQueue.size();
         size_t syncNodeQueueSize = _syncNodeQueuedCommands.size();
+        size_t completedCommandsSize = _completedCommands.size();
 
         // These two aren't all nicely packaged so we need to lock them ourselves.
         size_t outstandingHTTPSCommandsSize = 0;
@@ -104,6 +106,7 @@ bool BedrockServer::canStandDown() {
               << "mainQueueSize: " << mainQueueSize << ", "
               << "blockingQueueSize: " << blockingQueueSize << ", "
               << "syncNodeQueueSize: " << syncNodeQueueSize << ", "
+              << "completedCommandsSize: " << completedCommandsSize << ", "
               << "outstandingHTTPSCommandsSize: " << outstandingHTTPSCommandsSize << ", "
               << "futureCommitCommandsSize: " << futureCommitCommandsSize << ", "
               << "standDownQueueSize: " << standDownQueueSize << ".");
@@ -308,6 +311,7 @@ void BedrockServer::sync()
 
         // Add our command queues to our fd_map.
         _syncNodeQueuedCommands.prePoll(fdm);
+        _completedCommands.prePoll(fdm);
 
         // Wait for activity on any of those FDs, up to a timeout.
         const uint64_t now = STimeNow();
@@ -330,6 +334,7 @@ void BedrockServer::sync()
             _postPollCommands(fdm, nextActivity);
             _syncNode->postPoll(fdm, nextActivity);
             _syncNodeQueuedCommands.postPoll(fdm);
+            _completedCommands.postPoll(fdm);
         }
 
         // Ok, let the sync node to it's updating for as many iterations as it requires. We'll update the replication
@@ -460,7 +465,13 @@ void BedrockServer::sync()
                     // Otherwise, save the commit count, mark this command as complete, and reply.
                     command->response["commitCount"] = to_string(db.getCommitCount());
                     command->complete = true;
-                    _reply(command);
+                    if (command->initiatingPeerID) {
+                        // This is a command that came from a peer. Have the sync node send the response back to the peer.
+                        _finishPeerCommand(command);
+                    } else {
+                        // The only other option is this came from a client, so respond via the 
+                        _reply(command);
+                    }
                 } else {
                     SINFO("Sync thread finished committing non-command");
                 }
@@ -486,6 +497,20 @@ void BedrockServer::sync()
         // there could also be other finished work to handle while we wait for that to complete. Let's see if we can
         // handle any of that work.
         try {
+            // If there are any completed commands to respond to, we'll do that first.
+            try {
+                while (true) {
+                    unique_ptr<BedrockCommand> completedCommand = _completedCommands.pop();
+                    SAUTOPREFIX(completedCommand->request);
+                    SASSERT(completedCommand->complete);
+                    SASSERT(completedCommand->initiatingPeerID);
+                    SASSERT(!completedCommand->initiatingClientID);
+                    _finishPeerCommand(completedCommand);
+                }
+            } catch (const out_of_range& e) {
+                // when _completedCommands.pop() throws for running out of commands, we fall out of the loop.
+            }
+
             // We don't start processing a new command until we've completed any existing ones.
             if (committingCommand) {
                 continue;
@@ -551,7 +576,11 @@ void BedrockServer::sync()
                             // This command completed in peek, respond to it appropriately, either directly or by sending it
                             // back to the sync thread.
                             SASSERT(command->complete);
-                            _reply(command);
+                            if (command->initiatingPeerID) {
+                                _finishPeerCommand(command);
+                            } else {
+                                _reply(command);
+                            }
                             break;
                         } else if (result == BedrockCore::RESULT::SHOULD_PROCESS) {
                             // This is sort of the "default" case after checking if this command was complete above. If so,
@@ -597,7 +626,11 @@ void BedrockServer::sync()
                     } else if (result == BedrockCore::RESULT::NO_COMMIT_REQUIRED) {
                         // Otherwise, the command doesn't need a commit (maybe it was an error, or it didn't have any work
                         // to do). We'll just respond.
-                        _reply(command);
+                        if (command->initiatingPeerID) {
+                            _finishPeerCommand(command);
+                        } else {
+                            _reply(command);
+                        }
                     } else if (result == BedrockCore::RESULT::SERVER_NOT_LEADING) {
                         SINFO("Server stopped leading, re-queueing commad");
                         _commandQueue.push(move(command));
@@ -746,7 +779,12 @@ void BedrockServer::worker(int threadId)
             // because the commands already had a HTTPS request attached, and then they were immediately re-sent to the
             // sync queue, because of the QUORUM consistency requirement, resulting in an endless loop.
             if (core.isTimedOut(command)) {
-                _reply(command);
+                if (command->initiatingPeerID) {
+                    // Escalated command. Give it back to the sync thread to respond.
+                    _completedCommands.push(move(command));
+                } else {
+                    _reply(command);
+                }
                 continue;
             }
 
@@ -756,7 +794,12 @@ void BedrockServer::worker(int threadId)
                 SALERT("CRASH-INDUCING COMMAND FOUND: " << command->request.methodLine);
                 command->response.methodLine = "500 Refused";
                 command->complete = true;
-                _reply(command);
+                if (command->initiatingPeerID) {
+                    // Escalated command. Give it back to the sync thread to respond.
+                    _completedCommands.push(move(command));
+                } else {
+                    _reply(command);
+                }
                 continue;
             }
 
@@ -798,20 +841,53 @@ void BedrockServer::worker(int threadId)
             // of a `peek` operation, but more importantly, it skips any delays that might be introduced by waiting in
             // the `_futureCommitCommands` queue.
             if (state == SQLiteNode::FOLLOWING && command->escalateImmediately && !command->complete) {
-                if (_clusterMessenger.runOnLeader(*command)) {
-                    // command->complete is now true for this command. It will get handled a few lines below.
-                    SINFO("Immediately escalated " << command->request.methodLine << " to leader.");
+                if (_escalateOverHTTP) {
+                    if (_clusterMessenger.runOnLeader(*command)) {
+                        // command->complete is now true for this command. It will get handled a few lines below.
+                        SINFO("Immediately escalated " << command->request.methodLine << " to leader.");
+                    } else {
+                        SINFO("Couldn't immediately escalate command " << command->request.methodLine << " to leader, queuing normally.");
+                        _commandQueue.push(move(command));
+                        continue;
+                    }
                 } else {
-                    SINFO("Couldn't immediately escalate command " << command->request.methodLine << " to leader, queuing normally.");
-                    _commandQueue.push(move(command));
+                    SINFO("Immediately escalating " << command->request.methodLine << " to leader. Sync thread has " << _syncNodeQueuedCommands.size() << " queued commands.");
+                    _syncNodeQueuedCommands.push(move(command));
                     continue;
                 }
+            }
+
+            // If we find that we've gotten a command with an initiatingPeerID, but we're not in a leading or
+            // standing down state, we'll have no way of returning this command to the caller, so we discard it. The
+            // original caller will need to re-send the request. This can happen if we're leading, and receive a
+            // request from a peer, but then we stand down from leading. The SQLiteNode should have already told its
+            // peers that their outstanding requests were being canceled at this point.
+            if (command->initiatingPeerID && !(state == SQLiteNode::LEADING || state == SQLiteNode::STANDINGDOWN)) {
+                SWARN("Found " << (command->complete ? "" : "in") << "complete " << "command "
+                      << command->request.methodLine << " from peer, but not leading. Too late for it, discarding.");
+
+                // If the command was processed, tell the plugin we couldn't send the response.
+                command->handleFailedReply();
+
+                continue;
             }
 
             // If this command is already complete, then we should be a follower, and the sync node got a response back
             // from a command that had been escalated to leader, and queued it for a worker to respond to. We'll send
             // that response now.
             if (command->complete) {
+                // If this command is already complete, we can return it to the caller.
+                // If it has an initiator, it should have been returned to a peer by a sync node instead, but if we've
+                // just switched states out of leading, we might have an old command in the queue. All we can do here
+                // is note that and discard it, as we have nobody to deliver it to.
+                if (command->initiatingPeerID) {
+                    // Let's note how old this command is.
+                    uint64_t ageSeconds = (STimeNow() - command->creationTime) / STIME_US_PER_S;
+                    SWARN("Found unexpected complete command " << command->request.methodLine
+                          << " from peer in worker thread. Discarding (command was " << ageSeconds << "s old).");
+                    continue;
+                }
+
                 // Make sure we have an initiatingClientID at this point. If we do, but it's negative, it's for a
                 // client that we can't respond to, so we don't bother sending the response.
                 SASSERT(command->initiatingClientID);
@@ -933,21 +1009,32 @@ void BedrockServer::worker(int threadId)
                     if (command->onlyProcessOnSyncThread() || !canWriteParallel) {
                         // Roll back the transaction, it'll get re-run in the sync thread.
                         core.rollback();
-                        if (state == SQLiteNode::LEADING) {
-                            SINFO("Sending non-parallel command " << command->request.methodLine
-                                  << " to sync thread. Sync thread has " << _syncNodeQueuedCommands.size() << " queued commands.");
-                            _syncNodeQueuedCommands.push(move(command));
-                        } else if (state == SQLiteNode::STANDINGDOWN) {
-                            SINFO("Need to process command " << command->request.methodLine << " but STANDINGDOWN, moving to _standDownQueue.");
-                            _standDownQueue.push(move(command));
-                        } else if (_clusterMessenger.runOnLeader(*command)) {
-                            SINFO("Escalated " << command->request.methodLine << " to leader and complete, responding.");
-                            _reply(command);
+
+                        // TODO: When escalation over HTTP is totally vetted, remove this "else" block and just always
+                        // use the "if" case.
+                        if (_escalateOverHTTP) {
+                            if (state == SQLiteNode::LEADING) {
+                                SINFO("Sending non-parallel command " << command->request.methodLine
+                                      << " to sync thread. Sync thread has " << _syncNodeQueuedCommands.size() << " queued commands.");
+                                _syncNodeQueuedCommands.push(move(command));
+                            } else if (state == SQLiteNode::STANDINGDOWN) {
+                                SINFO("Need to process command " << command->request.methodLine << " but STANDINGDOWN, moving to _standDownQueue.");
+                                _standDownQueue.push(move(command));
+                            } else if (_clusterMessenger.runOnLeader(*command)) {
+                                SINFO("Escalated " << command->request.methodLine << " to leader and complete, responding.");
+                                _reply(command);
+                            } else {
+                                // TODO: Something less naive that considers how these failures happen rather than a simple
+                                // endless loop of requeue and retry.
+                                SINFO("Couldn't escalate command " << command->request.methodLine << " to leader. We are in state: " << SQLiteNode::stateName(state));
+                                _commandQueue.push(move(command));
+                            }
                         } else {
-                            // TODO: Something less naive that considers how these failures happen rather than a simple
-                            // endless loop of requeue and retry.
-                            SINFO("Couldn't escalate command " << command->request.methodLine << " to leader. We are in state: " << SQLiteNode::stateName(state));
-                            _commandQueue.push(move(command));
+                            // We're not handling a writable command anymore.
+                            SINFO("Sending non-parallel command " << command->request.methodLine
+                                  << " to sync thread. Sync thread has " << _syncNodeQueuedCommands.size()
+                                  << " queued commands.");
+                            _syncNodeQueuedCommands.push(move(command));
                         }
 
                         // Done with this command, look for the next one.
@@ -1032,7 +1119,12 @@ void BedrockServer::worker(int threadId)
                 // If the command was completed above, then we'll go ahead and respond. Otherwise there must have been
                 // a conflict or the command was abandoned for a checkpoint, and we'll retry.
                 if (command->complete) {
-                    _reply(command);
+                    if (command->initiatingPeerID) {
+                        // Escalated command. Send it back to the peer.
+                        _finishPeerCommand(command);
+                    } else {
+                        _reply(command);
+                    }
 
                     // Don't need to retry.
                     break;
@@ -1169,9 +1261,11 @@ BedrockServer::BedrockServer(const SData& args_)
     _multiWriteEnabled(args.test("-enableMultiWrite")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),
     _controlPort(nullptr), _commandPortPublic(nullptr), _commandPortPrivate(nullptr), _maxConflictRetries(3),
     _lastQuorumCommandTime(STimeNow()), _pluginsDetached(false), _lastChance(0), _socketThreadNumber(0),
-    _outstandingSocketThreads(0), _shouldBlockNewSocketThreads(false)
+    _outstandingSocketThreads(0), _shouldBlockNewSocketThreads(false), _escalateOverHTTP(args.test("-escalateOverHTTP"))
 {
     _version = VERSION;
+
+    SINFO("Escalate over HTTP: " << (_escalateOverHTTP ? "enabled" : "disabled"));
 
     // Enable the requested plugins, and update our version string if required.
     list<string> pluginNameList = SParseList(args["-plugins"]);
@@ -1646,6 +1740,7 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         content["state"]    = SQLiteNode::stateName(state);
         content["version"]  = _version;
         content["host"]     = args["-nodeHost"];
+        content["escalateOverHTTP"] = _escalateOverHTTP ? "true" : "false";
 
         {
             // Make it known if anything is known to cause crashes.
@@ -1741,7 +1836,8 @@ bool BedrockServer::_isControlCommand(const unique_ptr<BedrockCommand>& command)
         SIEquals(command->request.methodLine, "Detach")                 ||
         SIEquals(command->request.methodLine, "Attach")                 ||
         SIEquals(command->request.methodLine, "SetConflictParams")      ||
-        SIEquals(command->request.methodLine, "EnableSQLTracing")
+        SIEquals(command->request.methodLine, "EnableSQLTracing")       ||
+        SIEquals(command->request.methodLine, "EnableEscalateOverHTTP")
         ) {
         return true;
     }
@@ -1791,6 +1887,19 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
         if (command->request.isSet("enable")) {
             SQLite::enableTrace.store(command->request.test("enable"));
             response["newValue"] = SQLite::enableTrace ? "true" : "false";
+        }
+    } else if (SIEquals(command->request.methodLine, "EnableEscalateOverHTTP")) {
+        if (command->request.isSet("enable")) {
+            bool oldValue = _escalateOverHTTP;
+            _escalateOverHTTP = command->request.test("enable");
+            if (_escalateOverHTTP == oldValue) {
+                command->response.methodLine = "200 No Change";
+            } else {
+                SINFO("Escalate over HTTP: " << (_escalateOverHTTP ? "enabled" : "disabled"));
+                command->response.methodLine = "200 "s + (_escalateOverHTTP ? "Enabled" : "Disabled");
+            }
+        } else {
+            command->response.methodLine = "400 Must Specify Enable";
         }
     }
 }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -469,6 +469,10 @@ class BedrockServer : public SQLiteServer {
     // Timestamp for the last time we promoted a command to QUORUM.
     atomic<uint64_t> _lastQuorumCommandTime;
 
+    // We keep a queue of completed commands that workers will insert into when they've successfully finished a command
+    // that just needs to be returned to a peer.
+    BedrockTimeoutCommandQueue _completedCommands;
+
     // Whether or not all plugins are detached
     bool _pluginsDetached;
 
@@ -505,4 +509,7 @@ class BedrockServer : public SQLiteServer {
     // syncNode while the sync thread exists, it's a shared pointer to allow for the last socket thread using it to
     // destroy the pool at shutdown.
     shared_ptr<SQLitePool> _dbPool;
+
+    // TODO: Remove once we've verified this all works.
+    atomic<bool> _escalateOverHTTP = false;
 };

--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -24,6 +24,7 @@ SData SQLiteCommand::preprocessRequest(SData&& request) {
 SQLiteCommand::SQLiteCommand(SData&& _request) : 
     privateRequest(move(preprocessRequest(move(_request)))),
     request(privateRequest),
+    initiatingPeerID(0),
     initiatingClientID(0),
     writeConsistency(SQLiteNode::ASYNC),
     complete(false),
@@ -53,6 +54,7 @@ SQLiteCommand::SQLiteCommand(SData&& _request) :
 SQLiteCommand::SQLiteCommand(SQLiteCommand&& from) : 
     privateRequest(move(from.privateRequest)),
     request(privateRequest),
+    initiatingPeerID(from.initiatingPeerID),
     initiatingClientID(from.initiatingClientID),
     id(move(from.id)),
     jsonContent(move(from.jsonContent)),
@@ -68,6 +70,7 @@ SQLiteCommand::SQLiteCommand(SQLiteCommand&& from) :
 SQLiteCommand::SQLiteCommand() :
     privateRequest(),
     request(privateRequest),
+    initiatingPeerID(0),
     initiatingClientID(0),
     writeConsistency(SQLiteNode::ASYNC),
     complete(false),

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -68,6 +68,7 @@ BedrockTester::BedrockTester(const map<string, string>& args,
         {"-maxJournalSize", "25000"},
         {"-v", ""},
         {"-enableMultiWrite", "true"},
+        {"-escalateOverHTTP", "true"},
         {"-cacheSize", "1000"},
         {"-parallelReplication", "true"},
         // Currently breaks only in Travis and needs debugging, which has been removed, maybe?


### PR DESCRIPTION
Reverts Expensify/Bedrock#1248

We broke upgrades because we still use ESCALATE during version mismatch, but this removed the case where we handle it.