### PR TITLE
Cancel all outstanding commits when stopping following

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1994,8 +1994,8 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
         // If we were following, and now we're not, we give up an any replications.
         if (_state == FOLLOWING) {
             _replicationThreadsShouldExit = true;
-            uint64_t cancelAfter = _leaderCommitNotifier.getValue();
-            SINFO("Replication threads should exit, canceling commits after current leader commit " << cancelAfter);
+            uint64_t cancelAfter = _localCommitNotifier.getValue();
+            SINFO("Replication threads should exit, canceling commits after current commit " << cancelAfter);
             _localCommitNotifier.cancel(cancelAfter);
             _leaderCommitNotifier.cancel(cancelAfter);
 


### PR DESCRIPTION
### Details
I think this fixes the linked hangup. This issue is a weird edge case where we are attempting to approve a quorum transaction, but lose connection to leader. We (correctly) attempt to stop replicating and start over here, as we can't expect to receive the `commit` for the transaction we're approving if leader is disconnected.

However, what we attempt to do when stopping following is cancel all commits ahead of the current leader commit. But the current leader commit can be ahead of our quorum commit (if we are handling it late and it has already been approved by enough other nodes), and so as we roll back the quorum commit, any other replication threads that are waiting on commits ahead of it never complete.

This change is to cancel all outstanding commits ahead of our own current highest commit, rather than leader's, as we drop out of `following`.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/209740

### Tests
I haven't tested this except that it doesn't break the existing tests.