### PR TITLE
Fix atomicity in SQLiteClusterMessenger when SQLiteNode doesn't exist

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -192,7 +192,7 @@ void BedrockServer::sync()
                                                             args["-peerList"], args.calc("-priority"), firstTimeout,
                                                             _version, args["-commandPortPrivate"]));
 
-    _clusterMessenger = make_shared<SQLiteClusterMessenger>(*_syncNode);
+    _clusterMessenger = make_shared<SQLiteClusterMessenger>(_syncNode);
 
     // The node is now coming up, and should eventually end up in a `LEADING` or `FOLLOWING` state. We can start adding
     // our worker threads now. We don't wait until the node is `LEADING` or `FOLLOWING`, as it's state can change while

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -192,6 +192,8 @@ void BedrockServer::sync()
                                                             args["-peerList"], args.calc("-priority"), firstTimeout,
                                                             _version, args["-commandPortPrivate"]));
 
+    atomic_store(&_clusterMessenger, make_shared<SQLiteClusterMessenger>(*_syncNode));
+
     // The node is now coming up, and should eventually end up in a `LEADING` or `FOLLOWING` state. We can start adding
     // our worker threads now. We don't wait until the node is `LEADING` or `FOLLOWING`, as it's state can change while
     // it's running, and our workers will have to maintain awareness of that state anyway.
@@ -704,6 +706,9 @@ void BedrockServer::sync()
         _blockingCommandQueue.clear();
     }
 
+    // We clear this before the _syncNode that it references.
+    _clusterMessenger.reset();
+
     // Release our handle to this pointer. Any other functions that are still using it will keep the object alive
     // until they return.
     atomic_store(&_syncNode, shared_ptr<SQLiteNode>(nullptr));
@@ -841,7 +846,8 @@ void BedrockServer::worker(int threadId)
             // the `_futureCommitCommands` queue.
             if (state == SQLiteNode::FOLLOWING && command->escalateImmediately && !command->complete) {
                 if (_escalateOverHTTP) {
-                    if (_clusterMessenger.runOnLeader(*command)) {
+                    auto _clusterMessengerCopy = atomic_load(&_clusterMessenger);
+                    if (_clusterMessengerCopy && _clusterMessengerCopy->runOnLeader(*command)) {
                         // command->complete is now true for this command. It will get handled a few lines below.
                         SINFO("Immediately escalated " << command->request.methodLine << " to leader.");
                     } else {
@@ -1012,6 +1018,7 @@ void BedrockServer::worker(int threadId)
                         // TODO: When escalation over HTTP is totally vetted, remove this "else" block and just always
                         // use the "if" case.
                         if (_escalateOverHTTP) {
+                            auto _clusterMessengerCopy = atomic_load(&_clusterMessenger);
                             if (state == SQLiteNode::LEADING) {
                                 SINFO("Sending non-parallel command " << command->request.methodLine
                                       << " to sync thread. Sync thread has " << _syncNodeQueuedCommands.size() << " queued commands.");
@@ -1019,7 +1026,7 @@ void BedrockServer::worker(int threadId)
                             } else if (state == SQLiteNode::STANDINGDOWN) {
                                 SINFO("Need to process command " << command->request.methodLine << " but STANDINGDOWN, moving to _standDownQueue.");
                                 _standDownQueue.push(move(command));
-                            } else if (_clusterMessenger.runOnLeader(*command)) {
+                            } else if (_clusterMessengerCopy && _clusterMessengerCopy->runOnLeader(*command)) {
                                 SINFO("Escalated " << command->request.methodLine << " to leader and complete, responding.");
                                 _reply(command);
                             } else {
@@ -1240,7 +1247,6 @@ void BedrockServer::_resetServer() {
     _gracefulShutdownTimeout.alarmDuration = 0;
     _pluginsDetached = false;
     _lastChance = 0;
-    _clusterMessenger.reset();
 
     // Tell any plugins that they can attach now
     for (auto plugin : plugins) {
@@ -1250,13 +1256,13 @@ void BedrockServer::_resetServer() {
 
 BedrockServer::BedrockServer(SQLiteNode::State state, const SData& args_)
   : SQLiteServer(), args(args_), _replicationState(SQLiteNode::LEADING),
-    _syncNode(nullptr), _clusterMessenger(_syncNode)
+    _syncNode(nullptr), _clusterMessenger(nullptr)
 {}
 
 BedrockServer::BedrockServer(const SData& args_)
   : SQLiteServer(), shutdownWhileDetached(false), args(args_), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false),
-    _syncThreadComplete(false), _syncNode(nullptr), _clusterMessenger(_syncNode), _shutdownState(RUNNING),
+    _syncThreadComplete(false), _syncNode(nullptr), _clusterMessenger(nullptr), _shutdownState(RUNNING),
     _multiWriteEnabled(args.test("-enableMultiWrite")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),
     _controlPort(nullptr), _commandPortPublic(nullptr), _commandPortPrivate(nullptr), _maxConflictRetries(3),
     _lastQuorumCommandTime(STimeNow()), _pluginsDetached(false), _lastChance(0), _socketThreadNumber(0),
@@ -1517,7 +1523,10 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     if (_shutdownState.load() == START_SHUTDOWN) {
         if (!_lastChance) {
             _lastChance = STimeNow() + 5 * 1'000'000; // 5 seconds from now.
-            _clusterMessenger.shutdownBy(_lastChance);
+            auto _clusterMessengerCopy = atomic_load(&_clusterMessenger);
+            if (_clusterMessengerCopy) {
+                _clusterMessengerCopy->shutdownBy(_lastChance);
+            }
         }
 
         // Locking here means that no commands can be running when we do these checks and then switch to
@@ -2354,7 +2363,8 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
                         } else {
                             if (_version != _leaderVersion.load()) {
                                 SINFO("Immediately escalating " << command->request.methodLine << " to leader due to version mismatch.");
-                                if (_clusterMessenger.runOnLeader(*command)) {
+                                auto _clusterMessengerCopy = atomic_load(&_clusterMessenger);
+                                if (_clusterMessengerCopy && _clusterMessenger->runOnLeader(*command)) {
                                     _reply(command);
                                 } else {
                                     SINFO("Re-queueing command that couldn't run on leader.");

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -348,7 +348,7 @@ class BedrockServer : public SQLiteServer {
 
     // SStandaloneHTTPSManager for communication between SQLiteNodes for anything other than cluster state and
     // synchronization.
-    SQLiteClusterMessenger _clusterMessenger;
+    shared_ptr<SQLiteClusterMessenger> _clusterMessenger;
 
     // Functions for checking for and responding to status and control commands.
     bool _isStatusCommand(const unique_ptr<BedrockCommand>& command);

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-SQLiteClusterMessenger::SQLiteClusterMessenger(shared_ptr<SQLiteNode>& node)
+SQLiteClusterMessenger::SQLiteClusterMessenger(SQLiteNode& node)
  : _node(node)
 {
 }
@@ -19,11 +19,11 @@ void SQLiteClusterMessenger::setErrorResponse(BedrockCommand& command) {
 }
 
 void SQLiteClusterMessenger::shutdownBy(uint64_t shutdownTimestamp) {
-    _shutDownBy = shutdownTimestamp;
-}
-
-void SQLiteClusterMessenger::reset() {
-    _shutDownBy = 0;
+    // If we hadn't set a shutdown flag before, set one now.
+    // If it was already set, we don't do anything.
+    if(!_shutdownSet.test_and_set()) {
+        _shutDownBy = shutdownTimestamp;
+    }
 }
 
 // Returns true on ready or false on error or timeout.
@@ -40,6 +40,8 @@ SQLiteClusterMessenger::WaitForReadyResult SQLiteClusterMessenger::waitForReady(
     while (true) {
         int result = poll(&fdspec, 1, 100); // 100 is timeout in ms.
         if (!result) {
+            // Because _shutDownBy can only change form 0 to non-zero once, there's no race condition here. If it's
+            // true in the non-zero check, it will always be true after that.
             if (_shutDownBy && STimeNow() > _shutDownBy) {
                 SINFO("[HTTPESC] Giving up because shutting down.");
                 return WaitForReadyResult::SHUTTING_DOWN;
@@ -74,20 +76,16 @@ SQLiteClusterMessenger::WaitForReadyResult SQLiteClusterMessenger::waitForReady(
 }
 
 bool SQLiteClusterMessenger::runOnLeader(BedrockCommand& command) {
-    if (!_node) {
-        return false;
-    }
-
     auto start = chrono::steady_clock::now();
     bool sent = false;
     size_t sleepsDueToFailures = 0;
 
     unique_ptr<SHTTPSManager::Socket> s;
     while (chrono::steady_clock::now() < (start + 5s) && !sent) {
-        string leaderAddress = _node->leaderCommandAddress();
+        string leaderAddress = _node.leaderCommandAddress();
         if (leaderAddress.empty()) {
             // If there's no leader, it's possible we're supposed to be the leader. In this case, we can exit early.
-            auto myState = _node->getState();
+            auto myState = _node.getState();
             if (myState == SQLiteNode::LEADING || myState == SQLiteNode::STANDINGUP) {
                 SINFO("[HTTPESC] I'm the leader now! Exiting early.");
                 return false;

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-SQLiteClusterMessenger::SQLiteClusterMessenger(SQLiteNode& node)
+SQLiteClusterMessenger::SQLiteClusterMessenger(const SQLiteNode& node)
  : _node(node)
 {
 }

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-SQLiteClusterMessenger::SQLiteClusterMessenger(const SQLiteNode& node)
+SQLiteClusterMessenger::SQLiteClusterMessenger(const shared_ptr<const SQLiteNode> node)
  : _node(node)
 {
 }
@@ -82,10 +82,10 @@ bool SQLiteClusterMessenger::runOnLeader(BedrockCommand& command) {
 
     unique_ptr<SHTTPSManager::Socket> s;
     while (chrono::steady_clock::now() < (start + 5s) && !sent) {
-        string leaderAddress = _node.leaderCommandAddress();
+        string leaderAddress = _node->leaderCommandAddress();
         if (leaderAddress.empty()) {
             // If there's no leader, it's possible we're supposed to be the leader. In this case, we can exit early.
-            auto myState = _node.getState();
+            auto myState = _node->getState();
             if (myState == SQLiteNode::LEADING || myState == SQLiteNode::STANDINGUP) {
                 SINFO("[HTTPESC] I'm the leader now! Exiting early.");
                 return false;

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -19,7 +19,7 @@ void SQLiteClusterMessenger::setErrorResponse(BedrockCommand& command) {
 }
 
 void SQLiteClusterMessenger::shutdownBy(uint64_t shutdownTimestamp) {
-    // If we hadn't set a shutdown flag before, set one now.
+    // If we haven't set a shutdown flag before, set one now.
     // If it was already set, we don't do anything.
     if(!_shutdownSet.test_and_set()) {
         _shutDownBy = shutdownTimestamp;

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -40,7 +40,7 @@ SQLiteClusterMessenger::WaitForReadyResult SQLiteClusterMessenger::waitForReady(
     while (true) {
         int result = poll(&fdspec, 1, 100); // 100 is timeout in ms.
         if (!result) {
-            // Because _shutDownBy can only change form 0 to non-zero once, there's no race condition here. If it's
+            // Because _shutDownBy can only change from 0 to non-zero once, there's no race condition here. If it's
             // true in the non-zero check, it will always be true after that.
             if (_shutDownBy && STimeNow() > _shutDownBy) {
                 SINFO("[HTTPESC] Giving up because shutting down.");

--- a/sqlitecluster/SQLiteClusterMessenger.h
+++ b/sqlitecluster/SQLiteClusterMessenger.h
@@ -16,7 +16,7 @@ class SQLiteClusterMessenger {
         POLL_ERROR,
     };
 
-    SQLiteClusterMessenger(SQLiteNode& node);
+    SQLiteClusterMessenger(const SQLiteNode& node);
 
     // Attempts to make a TCP connection to the leader, and run the given command there, setting the appropriate
     // response from leader in the command, and marking it as complete if possible.

--- a/sqlitecluster/SQLiteClusterMessenger.h
+++ b/sqlitecluster/SQLiteClusterMessenger.h
@@ -16,7 +16,7 @@ class SQLiteClusterMessenger {
         POLL_ERROR,
     };
 
-    SQLiteClusterMessenger(shared_ptr<SQLiteNode>& node);
+    SQLiteClusterMessenger(SQLiteNode& node);
 
     // Attempts to make a TCP connection to the leader, and run the given command there, setting the appropriate
     // response from leader in the command, and marking it as complete if possible.
@@ -25,11 +25,9 @@ class SQLiteClusterMessenger {
     // no connection to leader could be made).
     bool runOnLeader(BedrockCommand& command);
 
-    // Set a timestamp by which we should give up on any pending commands.
+    // Set a timestamp by which we should give up on any pending commands. Once set, this is permanent. You will need a
+    // new SQLiteClusterMessenger if you want to shutdown again.
     void shutdownBy(uint64_t shutdownTimestamp);
-
-    // Reset to not be shutting down.
-    void reset();
 
   private:
     // This takes a pollfd with either POLLIN or POLLOUT set, and waits for the socket to be ready to read or write,
@@ -40,9 +38,10 @@ class SQLiteClusterMessenger {
     // This sets a command as a 500 and marks it as complete.
     void setErrorResponse(BedrockCommand& command);
 
-    shared_ptr<SQLiteNode>& _node;
+    const SQLiteNode& _node;
 
     // This is set to a timestamp when the server is shutting down so that we can abandon any commands that would
     // block that.
     atomic<uint64_t> _shutDownBy = 0;
+    atomic_flag _shutdownSet = ATOMIC_FLAG_INIT;
 };

--- a/sqlitecluster/SQLiteClusterMessenger.h
+++ b/sqlitecluster/SQLiteClusterMessenger.h
@@ -16,7 +16,7 @@ class SQLiteClusterMessenger {
         POLL_ERROR,
     };
 
-    SQLiteClusterMessenger(const SQLiteNode& node);
+    SQLiteClusterMessenger(const shared_ptr<const SQLiteNode> node);
 
     // Attempts to make a TCP connection to the leader, and run the given command there, setting the appropriate
     // response from leader in the command, and marking it as complete if possible.
@@ -38,7 +38,7 @@ class SQLiteClusterMessenger {
     // This sets a command as a 500 and marks it as complete.
     void setErrorResponse(BedrockCommand& command);
 
-    const SQLiteNode& _node;
+    const shared_ptr<const SQLiteNode> _node;
 
     // This is set to a timestamp when the server is shutting down so that we can abandon any commands that would
     // block that.


### PR DESCRIPTION
### Details
This cleans up atomicity in `SQLiteClusterManager`. Rather than taking a *reference* to a `shared_ptr` to a `SQLiteNode`, we now take a `shared_ptr` directly (and it is `const` as well). Because it is not a reference, and made clear by being `const`, once this `SQLiteClusterManager` is created, the `SQLiteNode` it's pointer refers to will not change. This means that we do not need to check for the validity of this pointer. If it was ever valid, it is still valid (and we only ever create it with a valid object).

However, this `const shared_ptr` necessitates changing the lifetime of the `SQLiteClusterManager`, which now can't be created before our sync node is created, as we need a `shared_ptr` to it. We now create an `SQLiteClusterManager` immediately after creating the sync node, and release it immediately before destroying the sync node.

This in turn, necessitates changes to our threads that access `SQLiteClusterManager`. Because the object is now created and destroyed with the sync thread, we make a `shared_ptr` to it in `BedrockServer` so that the other threads besides the sync thread (where it is created and destroyed) can access it through the pointer (which is null when the sync thread is not running).

The sync thread sets and clears this `shared_ptr`. Every thread that wants to access the `SQLiteClusterManager` now does so by copying the `shared_ptr` to it. Once the copy is made, if it contains a value, that `SQLiteClusterManager` is guaranteed to stay in scope until the copy is destroyed. Because the `SQLiteClusterManager` in turn contains a `shared_ptr` to the sync node, that object is also guaranteed to stay in scope until all copies of the `SQLiteClusterManager` have been destroyed.

Additionally, this change `_shutDownBy` in `SQLiteClusterManager` to have lock-free atomicity by using an `atomic_flag` to indicate if a shutdown time has been set. A shutdown flag can only be set once, and to be re-used, you need to re-create a new `SQLiteClusterManager`, but this is how `BedrockServer` manages this object's lifetime now anyway.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/210104

### Tests
All FuzzyBot tests pass ([256a3da](https://github.com/Expensify/Bedrock/pull/1270/commits/256a3da4b92ad5d8bd80d079a59afff0a4c4c988))
All EBM Tests pass ([256a3da](https://github.com/Expensify/Bedrock/pull/1270/commits/256a3da4b92ad5d8bd80d079a59afff0a4c4c988))
All Auth tests pass ([256a3da](https://github.com/Expensify/Bedrock/pull/1270/commits/256a3da4b92ad5d8bd80d079a59afff0a4c4c988))

Note: Travis is only failing for internal Travis BS. Will re-run tomorrow.

