### PR TITLE
Use send/recv time, not activity time

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -952,6 +952,10 @@ void BedrockServer::worker(int threadId)
             // We'll retry on conflict up to this many times.
             int retry = _maxConflictRetries.load();
             while (retry) {
+                // If we've changed out of leading, we need to notice that.
+                state = _replicationState.load();
+                canWriteParallel = canWriteParallel && (state == SQLiteNode::LEADING);
+
                 // If the command has any httpsRequests from a previous `peek`, we won't peek it again unless the
                 // command has specifically asked for that.
                 // If peek succeeds, then it's finished, and all we need to do is respond to the command at the bottom.

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2653,8 +2653,8 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
             break;
             case SQLitePeer::PeerPostPollStatus::OK:
             {
-                auto lastRecvTime = peer->lastRecvTime();
-                if (lastRecvTime && STimeNow() - lastRecvTime > SQLiteNode::RECV_TIMEOUT - 5 * STIME_US_PER_S) {
+                auto lastSendTime = peer->lastSendTime();
+                if (lastSendTime && STimeNow() - lastSendTime > SQLiteNode::RECV_TIMEOUT - 5 * STIME_US_PER_S) {
                     SINFO("Close to timeout, sending PING to peer '" << peer->name << "'");
                     _sendPING(peer);
                 }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2653,7 +2653,8 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
             break;
             case SQLitePeer::PeerPostPollStatus::OK:
             {
-                if (peer->lastActivityTime() && STimeNow() - peer->lastActivityTime() > SQLiteNode::RECV_TIMEOUT - 5 * STIME_US_PER_S) {
+                auto lastRecvTime = peer->lastRecvTime();
+                if (lastRecvTime && STimeNow() - lastRecvTime > SQLiteNode::RECV_TIMEOUT - 5 * STIME_US_PER_S) {
                     SINFO("Close to timeout, sending PING to peer '" << peer->name << "'");
                     _sendPING(peer);
                 }

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -120,10 +120,10 @@ SQLitePeer::PeerPostPollStatus SQLitePeer::postPoll(fd_map& fdm, uint64_t& nextA
     return PeerPostPollStatus::OK;
 }
 
-uint64_t SQLitePeer::lastActivityTime() const {
+uint64_t SQLitePeer::lastRecvTime() const {
     lock_guard<decltype(peerMutex)> lock(peerMutex);
     if (socket) {
-        return max(socket->lastSendTime, socket->lastRecvTime);
+        return socket->lastRecvTime;
     }
     return 0;
 }

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -128,6 +128,14 @@ uint64_t SQLitePeer::lastRecvTime() const {
     return 0;
 }
 
+uint64_t SQLitePeer::lastSendTime() const {
+    lock_guard<decltype(peerMutex)> lock(peerMutex);
+    if (socket) {
+        return socket->lastSendTime;
+    }
+    return 0;
+}
+
 SData SQLitePeer::popMessage() {
     lock_guard<decltype(peerMutex)> lock(peerMutex);
     if (socket) {

--- a/sqlitecluster/SQLitePeer.h
+++ b/sqlitecluster/SQLitePeer.h
@@ -30,8 +30,8 @@ class SQLitePeer {
     // Returns true if there's an active connection to this Peer.
     bool connected() const;
 
-    // The most recent send or receive time, in microseconds since the epoch.
-    uint64_t lastActivityTime() const;
+    // The most recent receive time, in microseconds since the epoch.
+    uint64_t lastRecvTime() const;
 
     void prePoll(fd_map& fdm) const;
 

--- a/sqlitecluster/SQLitePeer.h
+++ b/sqlitecluster/SQLitePeer.h
@@ -33,6 +33,9 @@ class SQLitePeer {
     // The most recent receive time, in microseconds since the epoch.
     uint64_t lastRecvTime() const;
 
+    // The most recent send time, in microseconds since the epoch.
+    uint64_t lastSendTime() const;
+
     void prePoll(fd_map& fdm) const;
 
     // Reset a peer, as if disconnected and starting the connection over.


### PR DESCRIPTION
### Details
When refactoring this, I changed from using `lastRecvTime` to `lastActivityTime` for timeouts, but I missed a spot. This means that we'd only send a `ping` to a peer if we had *neither* sent nor received from it for nearly 30 seconds.

But I didn't change the way that we calculated the timeout, which only looks at recv times.
https://github.com/Expensify/Bedrock/blob/bdd967c575b5f71b93729cfa9f6fffcfd9fd29de/sqlitecluster/SQLitePeer.cpp#L75

This meant that if you kept sending other data to a peer, you'd never send it a `ping` which would have triggered it to send you a `pong`. And then eventually you'd see that it hadn't sent you anything for 30 seconds, and you'd time it out.

However, on the other end of the connection, the peer wouldn't pro-actively send you a ping as it got close to the timeout, because it was using the same check - if it had been sending *or receiving* anything, it wouldn't send you a ping. Since it kept receiving data, it didn't need to ping, which would have triggered a pong from the other peer.

This changes back to the old behavior - if you haven't *sent* for close to the timeout, you ping. If you haven't *received* in over the timeout, then you time out.

This also fixes a check in BedrockServer so that if you get a state change while leading you could get stuck in an endless loop, instead you will re-check the state at the top of each loop.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/210202

### Tests
Hard to test.