### PR TITLE
Fix hang when waiting for replication threads.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1990,7 +1990,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
             // in, and so I've left it out for the time being.
             size_t infoCount = 1;
             while (_replicationThreadCount) {
-                if (!(infoCount % 100)) {
+                if (infoCount % 100 == 0) {
                     SINFO("Waiting for " << _replicationThreadCount << " remaining replication threads.");
                 }
                 infoCount++;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1988,7 +1988,12 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
             // Polling wait for threads to quit. This could use a notification model such as with a condition_variable,
             // which would probably be "better" but introduces yet more state variables for a state that we're rarely
             // in, and so I've left it out for the time being.
+            size_t infoCount = 1;
             while (_replicationThreadCount) {
+                if (!(infoCount % 100)) {
+                    SINFO("Waiting for " << _replicationThreadCount << "remaining replication threads.");
+                }
+                infoCount++;
                 usleep(10'000);
             }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1980,8 +1980,8 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
         // If we were following, and now we're not, we give up an any replications.
         if (_state == FOLLOWING) {
             _replicationThreadsShouldExit = true;
-            uint64_t cancelAfter = _localCommitNotifier.getValue();
-            SINFO("Replication threads should exit, canceling commits after current commit " << cancelAfter);
+            uint64_t cancelAfter = _leaderCommitNotifier.getValue();
+            SINFO("Replication threads should exit, canceling commits after current leader commit " << cancelAfter);
             _localCommitNotifier.cancel(cancelAfter);
             _leaderCommitNotifier.cancel(cancelAfter);
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2426,10 +2426,11 @@ void SQLiteNode::_handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const S
             response["NewCount"] = SToStr(db.getCommitCount() + 1);
             response["NewHash"] = success ? db.getUncommittedHash() : message["NewHash"];
             response["ID"] = message["ID"];
-            if (!_leadPeer) {
-                STHROW("no leader?");
+            if (_leadPeer) {
+                _sendToPeer(_leadPeer, response);
+            } else {
+                SWARN("no leader? Still handling transaction, it may have been approved elsewhere.");
             }
-            _sendToPeer(_leadPeer, response);
         } else {
             SDEBUG("Skipping " << verb << " for ASYNC command.");
         }

--- a/sqlitecluster/SQLiteSequentialNotifier.cpp
+++ b/sqlitecluster/SQLiteSequentialNotifier.cpp
@@ -37,7 +37,19 @@ SQLiteSequentialNotifier::RESULT SQLiteSequentialNotifier::waitFor(uint64_t valu
         } else if (state->result != RESULT::UNKNOWN) {
             return state->result;
         }
-        state->waitingThreadConditionVariable.wait(lock);
+        cv_status result = state->waitingThreadConditionVariable.wait_for(lock, 1s);
+        if (result == cv_status::timeout) {
+            // So, normally, we should only get woken up if something has happened. If we get woken up because of a
+            // timeout, that's fundamentally fine, we could just still be waiting for that thing to happen.
+            // But if one of the things we're tracking has changed, and we got woken up from a timeout, not from that
+            // change, that's worrisome, and indicates that maybe there's a condition in which we can get stuck. Note
+            // that this isn't 100%, we could get woken up here by chance and one of these conditions could change
+            // immediately following that wakeup, so there's a small but nonzero chance of this log line firing in a
+            // valid case.
+            if (_globalResult == RESULT::CANCELED || state->result != RESULT::UNKNOWN) {
+                SWARN("Got timeout in wait_for but state has changed!");
+            }
+        }
     }
 }
 

--- a/sqlitecluster/SQLiteSequentialNotifier.cpp
+++ b/sqlitecluster/SQLiteSequentialNotifier.cpp
@@ -47,7 +47,7 @@ SQLiteSequentialNotifier::RESULT SQLiteSequentialNotifier::waitFor(uint64_t valu
             // immediately following that wakeup, so there's a small but nonzero chance of this log line firing in a
             // valid case.
             if (_globalResult == RESULT::CANCELED || state->result != RESULT::UNKNOWN) {
-                SWARN("Got timeout in wait_for but state has changed!");
+                SWARN("Got timeout in wait_for but state has changed! Was waiting for " << value);
             }
         }
     }

--- a/sqlitecluster/SQLiteSequentialNotifier.h
+++ b/sqlitecluster/SQLiteSequentialNotifier.h
@@ -53,7 +53,7 @@ class SQLiteSequentialNotifier {
     uint64_t _value;
 
     // If there is a global result for all pending operations (i.e., they've been canceled), that is stored here.
-    RESULT _globalResult;
+    atomic<RESULT> _globalResult;
 
     // For saving the value after which new or existing waiters will be returned a CANCELED result.
     atomic<uint64_t> _cancelAfter;


### PR DESCRIPTION
### Details
This change is not big, but it's super nuanced. Let me try and explain as much as I can. From the top down in the diff:

1. We undo this change: https://github.com/Expensify/Bedrock/pull/1265

Why do that? Because in researching how this works, I came across this change: https://github.com/Expensify/Bedrock/pull/919

That's where we added the above behavior, and I think we actually want to keep it. Read the issue there to see what it does, but basically I think the change in #1265 was the wrong way to do that. More on this below.

2. The second block just adds some logging to a while loop so we can see if we get stuck in it. This seems to be what's happening in issue 209479 that this PR fixes, so it'll be nice to know if we actually get stuck there.

3. Ok, this is the second part of undoing 1265, and handling it better. Now, if we get to where we'd approve a quorum transaction but we've lost the connection to leader, we just warn and continue along. The case that we're trying to handle is that we are late approving a quorum transaction, and leader has already sent us a bunch more commits (because quorum was handled by other nodes). In this case, we want to commit this transaction, even if leader has since disconnected. So long as leader sent us the COMMIT message for this transaction, it will still get committed. This unblocks all other replication threads, so that the change above, where we only cancel commits that leader hasn't said are complete can complete.

This leaves the possibility that leader sends us a quorum transaction, we approve, and we get disconnected before leader sends us the COMMIT for this transaction, in which case, we should still fall out of FOLLOWING and cancel all outstanding commit threads, including this one that's still waiting on this commit from leader.

4. This gets to the meat of fixing the actual linked issue. It seems that sometimes replication threads can get stuck. This adds a timeout so every second they re-check their conditions, and thus shouldn't be "stuck" for more than a second. It doesn't actually address why they get stuck in the first place, which I'm not sure about. It warns if we hit  a timeout in suspicious circumstances, which is where we likely would have gotten stuck before.

5. Setting `_globalResult` to be `atomic` *might* fix the above issue of getting stuck. I'm not actually sure. It seems possible that this value could get cached in the CPU, and then when it was updated by one thread, the other thread that was waiting for it would be interrupted (where we added the check for the timeout above). Whenthis thread was interrupted, it might hit the top of the loop, and check for `_globalResult == RESULT::CANCELED` by looking at a value of `_globalResult` that was in the CPU cache, not yet updated, even though the other thread set this value before interrupting this thread.

If that were to happen, this thread would jump back into it's `wait()` but, being that the cancel had already happened, it could just sit there forever.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/209479

### Tests
Only existing tests.