### PR TITLE
Fixing 2.rno hanging during billing

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2706,6 +2706,8 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                         _onMESSAGE(peer, message);
                         messagesDeqeued++;
                         if (messagesDeqeued >= 100) {
+                            // We should run again immediately, we have more to do.
+                            nextActivity = STimeNow();
                             break;
                         }
                     }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2505,9 +2505,20 @@ SQLiteNode::State SQLiteNode::leaderState() const {
 }
 
 string SQLiteNode::leaderCommandAddress() const {
-    shared_lock<decltype(_stateMutex)> sharedLock(_stateMutex);
-    if (_leadPeer && _leadPeer.load()->state == State::LEADING) {
-        return _leadPeer.load()->commandAddress;
+    // Note: this can skip locking because it only accesses atomic variables in a predicatable order.
+    // If there's a _leadPeer, we atomically get a copy of it. Because these can only point to our const list of peers,
+    // once we have this value, we know that `_leadPeerCopy` is safe. It's either pointing at null, or a valid Peer
+    // object.
+    // Once we have this pointer, we can check if it's leading, which is an atomic operation, and if so, we can get
+    // it's command address, which is also atomic.
+    // These are not mutually atomic, but it doesn't matter, as this address can only be used for non-atomic network
+    // operations anyway. The command address for peers doesn't actually change under normal circumstances anyway. The
+    // riskiest thing here is getting a peer in the moment it's being unassigned as leader, in which case you could
+    // return an address that had just turned invalid, but as mentioned above, you can only use this to make network
+    // requests, which are inherently non-atomic.
+    auto _leadPeerCopy = _leadPeer;
+    if (_leadPeerCopy && _leadPeerCopy->state == State::LEADING) {
+        return _leadPeer->commandAddress;
     }
     return "";
 }
@@ -2644,9 +2655,12 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     for (SQLitePeer* peer : _peerList) {
         start = STimeNow();
         auto result = peer->postPoll(fdm, nextActivity);
+        string resultString;
+        auto first = STimeNow();
         switch (result) {
             case SQLitePeer::PeerPostPollStatus::JUST_CONNECTED:
             {
+                resultString = "JUST_CONNECTED";
                 SData login("NODE_LOGIN");
                 login["Name"] = _name;
                 peer->sendMessage(login.serialize());
@@ -2656,6 +2670,7 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
             break;
             case SQLitePeer::PeerPostPollStatus::SOCKET_ERROR:
             {
+                resultString = "SOCKET_ERROR";
                 SData reconnect("RECONNECT");
                 reconnect["Reason"] = "socket error";
                 peer->sendMessage(reconnect.serialize());
@@ -2664,21 +2679,29 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
             break;
             case SQLitePeer::PeerPostPollStatus::SOCKET_CLOSED:
             {
+                resultString = "SOCKET_CLOSED";
                 _onDisconnect(peer);
             }
             break;
             case SQLitePeer::PeerPostPollStatus::OK:
             {
+                resultString = "OK";
                 auto lastSendTime = peer->lastSendTime();
                 if (lastSendTime && STimeNow() - lastSendTime > SQLiteNode::RECV_TIMEOUT - 5 * STIME_US_PER_S) {
                     SINFO("Close to timeout, sending PING to peer '" << peer->name << "'");
                     _sendPING(peer);
                 }
                 try {
+                    auto messageStart = STimeNow();
                     while (true) {
                         SData message = peer->popMessage();
                         _onMESSAGE(peer, message);
+                        messagesDeqeued++;
+                        if (messagesDeqeued >= 50) {
+                            break;
+                        }
                     }
+
                 } catch (const out_of_range& e) {
                     // Ok, just no messages.
                 }
@@ -2687,7 +2710,7 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
         }
         end = STimeNow();
         if ((end - start) > 5'000) {
-            SINFO("[diag][performance] Took " << (end - start) << "us to check peer " << peer->name);
+            SINFO("[diag][performance] Took " << (end - start) << "us to check peer " << peer->name << ", peer->postPoll:" << (first - start) << "us, connection state: " << resultString << );
         }
     }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2633,6 +2633,8 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 } else {
                     STHROW("expecting NODE_LOGIN");
                 }
+            } else if (STimeNow() > socket->lastRecvTime + 5'000'000) {
+                STHROW("Incoming socket didn't send a message for over 5s, closing.");
             }
         } catch (const SException& e) {
             SWARN("Incoming connection failed from '" << socket->addr << "' (" << e.what() << ")");
@@ -2647,7 +2649,7 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     }
 
     end = STimeNow();
-    if ((end - start) > 5'000) {
+    if ((end - start) > 5'000 || _unauthenticatedIncomingSockets.size() > 5) {
         SINFO("[diag][performance] Took " << (end - start) << "us to check _unauthenticatedIncomingSockets, " << _unauthenticatedIncomingSockets.size() << " unauthenticated sockets remaining.");
     }
 

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -101,6 +101,7 @@ SQLitePeer::PeerPostPollStatus SQLitePeer::postPoll(fd_map& fdm, uint64_t& nextA
             default:
                 // Connecting or shutting down, wait
                 // **FIXME: Add timeout here?
+                SINFO("Peer connection to " << name << " in state " << socket->state.load() << ", waiting for it to stabilize.");
                 break;
         }
     } else {


### PR DESCRIPTION
### Details

Where we are getting stuck is in checking a peer in _syncNode->postPoll(), see:
```
2022-05-15T01:07:37.982894+00:00 db2.rno bedrock: xxxxxx (SQLiteNode.cpp:2690) postPoll [sync] [info] {auth.db2.rno/FOLLOWING} [diag][performance] Took 36555029us to check peer auth.db1.sjc
```

The code that does this is here:
https://github.com/Expensify/Bedrock/blob/d15a3df20f327a34fa4405c63dbb44186fe6ad57/sqlitecluster/SQLiteNode.cpp#L2645-L2691

Now, there are a couple candidates here as to what this can be:

1. We added timing in `SQLitePeer::postPoll` for getting the mutex lock, but not for the whole method, so this is possible (I think it's unlikely though, see below).

We should not hit the `JUST_CONNECTED` block, as we've been following the whole time. If we hit the `SOCKET_ERROR` block, we should have logged sending the `RECONNECT` message, but we didn't. If we had hit the `SOCKET_CLOSED` case, we should have logged as well, because the peer we'd have lost connection to was the leader, so that shouldn't have happened, either.

So that leaves:

2. The `SQLitePeer::PeerPostPollStatus::OK` block.

The first part of this (checking for timeouts) didn't occur, so we've got the loop dequeuing messages. I think this is taking forever. Let me explain why.

There was a 36.555 second gap between these log lines:
```
2022-05-15T01:07:01.427662+00:00 db2.rno bedrock: xxxxxx (SQLiteNode.cpp:2690) postPoll [sync] [info] {auth.db2.rno/FOLLOWING} [diag][performance] Took 715386us to check peer auth.db1.sjc
...
2022-05-15T01:07:37.982894+00:00 db2.rno bedrock: xxxxxx (SQLiteNode.cpp:2690) postPoll [sync] [info] {auth.db2.rno/FOLLOWING} [diag][performance] Took 36555029us to check peer auth.db1.sjc
```

And coincidentally, that's the exact same amount of time we spent checking `peer auth.db1.sjc` in the second log line. Nothing was logged by the sync thread there, but I think what's happening here is the sync thread is just plain falling behind on replication. Let me include some evidence.

Here's a transaction sent from leader to db2.rno:
```
2022-05-15T01:06:35.563413+00:00 db1.sjc bedrock: xxxxxx (SQLiteNode.cpp:441) _sendOutstandingTransactions [sync] [info] {auth.db1.sjc/LEADING} Sending COMMIT for ASYNC transaction 15677024921 to followers
```

Here is the first place that `db2.rno` mentions this:
```
2022-05-15T01:07:01.519006+00:00 db2.rno bedrock: xxxxxx (SQLiteNode.cpp:2432) _handlePrepareTransaction [replicate15670695] [info] {auth.db2.rno/FOLLOWING} ->{auth.db1.sjc} Would approve/deny transaction #15677024921 (697AC291C7321DFC1D9940A9A1C3C8CDF955901B), but a permafollower -- keeping quiet.
```

It's already running behind at this point. By the time it gets around to attempting to commit:
```
2022-05-15T01:07:01.519471+00:00 db2.rno bedrock: xxxxxx (SQLiteNode.cpp:2439) _handlePrepareTransaction [replicate15670695] [info] {auth.db2.rno/FOLLOWING} ->{auth.db1.sjc} Replicated transaction 15677024921, sent by leader at 1652576795563403, transit/dequeue time: 25956ms, applied in: 0.08ms, should COMMIT next.
```
 
 You can see we're running behind by ~26 seconds. Then this happens:
 ```
 2022-05-15T01:07:27.028539+00:00 db2.rno bedrock: xxxxxx (SQLiteNode.cpp:2475) _handleCommitTransaction [replicate15670695] [info] {auth.db2.rno/FOLLOWING} Committed follower transaction #15677024921 (697AC291C7321DFC1D9940A9A1C3C8CDF955901B) in 25509 ms (0+0+0+0+25508+0ms)
```
 It takes 25 seconds to commit.
 
 So now it's twice as behind. What's the sync thread doing all this time? It's probably spinning up replicate threads that are all blocked on this one, but not as quickly as leader is sending them over the wire. So it takes 37 seconds before it empties that queue and we finish this loop:
 https://github.com/Expensify/Bedrock/blob/d15a3df20f327a34fa4405c63dbb44186fe6ad57/sqlitecluster/SQLiteNode.cpp#L2678-L2681
 
 The next few commits after the 25 second one take 14.75ms, 0.88ms, 9.19ms, 0.86ms, and 12.93ms. It looks like it's catching up. I think it does finally catch up at the 37 second mark (the total time it took to check the peer), at which point it finally exits.
 
However, at this point, it hasn't sent/received a PING/PONG message with leader for over 30 seconds and so it disconnects. It then has a hard time cleaning up after the disconnect from leader.
 
This PR means to fix the timeout from the long loop when behind on syncing. It doesn't try to fix the difficulty cleaning up after it, nor why it falls behind or a single commit blocks for 25 seconds. All I have for those issues so far is speculation. More to come, but separate PR.

### How I picked the number of iteration to break after:

from the above log line:

```
2022-05-15T01:06:35.563413+00:00 db1.sjc bedrock: xxxxxx (SQLiteNode.cpp:441) _sendOutstandingTransactions [sync] [info] {auth.db1.sjc/LEADING} Sending COMMIT for ASYNC transaction 15677024921 to followers
```

I skipped forward 37 seconds to see about how many commits leader is sending during this time:
```
2022-05-15T01:07:12.065740+00:00 db1.sjc bedrock: xxxxxx (SQLiteNode.cpp:441) _sendOutstandingTransactions [sync] [info] {auth.db1.sjc/LEADING} Sending COMMIT for ASYNC transaction 15677026172 to followers
```

15677026172 - 15677024921 = 1251

At 1251 commits in 30 seconds, that's only ~30 commits/second. There are two messages per commit, so 60 messages should be roughly "one second's worth" of replication at this level. We might get a few more messages in there as well. We try to run the sync thread every second, even if there's no activity, so I aimed for breaking roughly every second, and picked a round number in that ballpark.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/210528

### Tests
Gonna have to do it in prod.