### PR TITLE
Add explicit checkpoint code to diagnose slow commits with SQLite team.

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -670,10 +670,13 @@ int SQLite::commit(const string& description) {
         _mutexLocked = false;
         _queryCache.clear();
 
-        sqlite3_wal_checkpoint_v2(_db, 0, SQLITE_CHECKPOINT_PASSIVE, NULL, NULL);
+        auto start = STimeNow();
+        int framesCheckpointed = 0;
+        sqlite3_wal_checkpoint_v2(_db, 0, SQLITE_CHECKPOINT_PASSIVE, NULL, &framesCheckpointed);
+        auto end = STimeNow();
         SINFO(description << " COMMIT complete in " << time << ". Wrote " << (endPages - startPages)
               << " pages. WAL file size is " << sz << " bytes. " << _queryCount << " queries attempted, " << _cacheHits
-              << " served from cache.");
+              << " served from cache. Checkpointed " << framesCheckpointed << " (total) frames in " << (end - start) << "us.");
         _queryCount = 0;
         _cacheHits = 0;
         _dbCountAtStart = 0;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -196,6 +196,7 @@ void SQLite::commonConstructorInitialization() {
     // second. This is set to be a bit more granular than that, which is probably adequate.
     sqlite3_progress_handler(_db, 1'000'000, _progressHandlerCallback, this);
 
+    // Setting a wal hook prevents auto-checkpointing.
     sqlite3_wal_hook(_db, _walHookCallback, this);
 
     // Check if synchronous has been set and run query to use a custom synchronous setting

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -405,6 +405,10 @@ class SQLite {
 
     // Callback function for progress tracking.
     static int _progressHandlerCallback(void* arg);
+
+    // Callback when the db checkpoints.
+    static int _walHookCallback(void* sqliteObject, sqlite3* db, const char* name, int walFileSize);
+
     uint64_t _timeoutLimit = 0;
     uint64_t _timeoutStart;
     uint64_t _timeoutError;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -288,6 +288,9 @@ class SQLite {
 
         SPerformanceTimer _commitLockTimer;
 
+        atomic_flag checkpointInProgress = ATOMIC_FLAG_INIT;
+        atomic<size_t> outstandingFramesToCheckpoint = 0;
+
       private:
         // The data required to replicate transactions, in two lists, depending on whether this has only been prepared
         // or if it's been committed.

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -77,7 +77,10 @@ SQLitePeer::PeerPostPollStatus SQLitePeer::postPoll(fd_map& fdm, uint64_t& nextA
         switch (socket->state.load()) {
             case STCPManager::Socket::CONNECTED: {
                 // socket->lastRecvTime is always set, it's initialized to STimeNow() at creation.
-                if (socket->lastRecvTime + SQLiteNode::RECV_TIMEOUT < STimeNow()) {
+                // HACK: we only double RECV_TIMEOUT here because of an issue where the sync thread is blocking long
+                // enough doing replications that it can't respond to pings in the required amount of time, so we are
+                // temporarily making the time longer.
+                if (socket->lastRecvTime + (SQLiteNode::RECV_TIMEOUT * 2) < STimeNow()) {
                     SHMMM("Connection with peer '" << name << "' timed out.");
                     return PeerPostPollStatus::SOCKET_ERROR;
                 }


### PR DESCRIPTION
### Details

This adds a separate `sqlite3_wal_hook` to prevent auto-checkpointing on commit. It then times checkpoints to help us diagnose what gets slow during billing on db2.rno. We'll share the results of this with sqlite.

We also:

1. Added a hack to double timeout times to hopefully not get stuck when this happens.
2. Prevent multiple checkpoints from trying to run simultaneously over one another. it's unclear if this will make a difference but it feels like it could help.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/210528

### Tests
Verified the new lines for uncheckpointed frames and frames checkpointed appear in the dev VM when running the test suite.