### PR TITLE
Make nodes connect quickly during upgrades

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2575,7 +2575,7 @@ STCPManager::Socket* SQLiteNode::_acceptSocket() {
         socket->addr = addr;
 
         // Try to read immediately
-        S_recvappend(socket->s, socket->recvBuffer);
+        socket->recv();
     }
 
     return socket;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2555,6 +2555,9 @@ void SQLiteNode::prePoll(fd_map& fdm) const {
     for (SQLitePeer* peer : _peerList) {
         peer->prePoll(fdm);
     }
+    for (auto socket : _unauthenticatedIncomingSockets) {
+        STCPManager::prePoll(fdm, &socket);
+    }
     _commitsToSend.prePoll(fdm);
 }
 
@@ -2603,6 +2606,7 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     // Check each new connection for a NODE_LOGIN message.
     start = STimeNow();
     for (auto socket : _unauthenticatedIncomingSockets) {
+        STCPManager::postPoll(fdm, &socket);
         try {
             if (socket->state.load() != Socket::CONNECTED) {
                 STHROW("premature disconnect");

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2556,7 +2556,7 @@ void SQLiteNode::prePoll(fd_map& fdm) const {
         peer->prePoll(fdm);
     }
     for (auto socket : _unauthenticatedIncomingSockets) {
-        STCPManager::prePoll(fdm, &socket);
+        STCPManager::prePoll(fdm, *socket);
     }
     _commitsToSend.prePoll(fdm);
 }
@@ -2606,7 +2606,7 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     // Check each new connection for a NODE_LOGIN message.
     start = STimeNow();
     for (auto socket : _unauthenticatedIncomingSockets) {
-        STCPManager::postPoll(fdm, &socket);
+        STCPManager::postPoll(fdm, *socket);
         try {
             if (socket->state.load() != Socket::CONNECTED) {
                 STHROW("premature disconnect");


### PR DESCRIPTION
### Details
Ok, here's our problem:

When we establish connections between peers, each peer both makes outgoing connections to all other peers, and listens for incoming connections from all other peers. The "outgoing" portion of this works fine, we won't discuss it much except to say that when making an outgoing connection, a peer immediately sends a `NODE_LOGIN` message to tell the other peer who it is:
https://github.com/Expensify/Bedrock/blob/694b039c4d843a5f1f0a8395a56e03915fe46b6f/sqlitecluster/SQLiteNode.cpp#L2672-L2674

So the issue is in handling the incoming peer connections. Each node maintains a list of peers that it's configured to talk to, and each of those peers has a socket associated with it. That socket can be `null` if the peer is not connected. this code all works fine, but there's another code path that happens right at connection.

When we first accept an incoming connection, we're not sure which peer it's coming from. The way we determine that is by waiting for it to send us a `NODE_LOGIN` message to identify itself. See here:
https://github.com/Expensify/Bedrock/blob/694b039c4d843a5f1f0a8395a56e03915fe46b6f/sqlitecluster/SQLiteNode.cpp#L2612-L2616

But, until we receive a `NODE_LOGIN` on a socket, that socket is not associated with a `SQLitePeer` object, and lives in the  `_unauthenticatedIncomingSockets` list. Sockets stay in that list until they have an error, hit a timeout, or send us a message (and any message other than `NODE_LOGIN` is an error). As soon as one of those thing happens, the socket is either moved to the correct `SQLitePeer` object, or closed.

So, what's the problem? It seems super obvious once found: We forgot to call `postPoll` on the sockets in `_unauthenticatedIncomingSockets`. That matters because `postPoll` is where we actually do the `recv()` call that gets data off the socket so that we can check and see if we've got a `NODE_LOGIN` message. So, if we never read any data off the socket, of course we don't get a `NODE_LOGIN` message and we eventually time out. Seems obvious in restrospect.

But then the question is "How does this work at all? Why does it ever login? How do the tests pass?"

Good question.

So, when we call `_acceptSocket` we add the socket to `_unauthenticatedIncomingSockets`:
https://github.com/Expensify/Bedrock/blob/694b039c4d843a5f1f0a8395a56e03915fe46b6f/sqlitecluster/SQLiteNode.cpp#L2592-L2594

And critically, in `_acceptSocket` *we try to read off the socket*:
https://github.com/Expensify/Bedrock/blob/694b039c4d843a5f1f0a8395a56e03915fe46b6f/sqlitecluster/SQLiteNode.cpp#L2574-L2575

So, if the `NODE_LOGIN` message has already arrived by the time we run that line. Then there will be a message for us to handle,and we'll read the `NODE_LOGIN` and associate the socket with the correct peer, after which it works fine.

But it there's no message yet, we would never read again, and eventually we'd hit the 5 second timeout, and close the socket.

Even if we hit the 5 second timeout, the nodes perpetually retry their connections to try and keep the whole cluster connected. So every few seconds (a random time between 0 and 5s) they try to reconnect. Eventually, one of the connections gets the `NODE_LOGIN` message delivered fast enough, and the nodes connect. However, most of the time it doesn't. This is why we see nodes taking random times up to several minutes to connect. If they fail (and they usually do) they retry after a second or two, bu eventually, they do succeed.

Critically, in dev, on localhost, these connections *almost always* succeed on the first try. So the test pass just fine, but over the internet, with longer delivery times for the `NODE_LOGIN` message, these often fail.

### Further elaboration on why this causes major site issues.

What happens here is that when leader flips, every node has to reconnect. The site doesn't have quorum until at least two full nodes are connected to the new leader, and so nothing can happen for this time. This used to take ~1s, but with this bug, could take 30+ seconds. So every node just sits there collecting a backlog of commands until quorum is reached.

Once quorum is reached, leader starts processing commands and the nodes that are connected to leader start processing commands, but any nodes that are slower to log in continue to build a backlog of commands. Eventually, they will connect and start to run through their backlog.

One thing that helps here is that new nodes coming online don't suffer from this problem. Because of this code:
https://github.com/Expensify/Bedrock/blob/694b039c4d843a5f1f0a8395a56e03915fe46b6f/BedrockServer.cpp#L1473-L1482

As a server starts up, it does not open it's port until it's successfully `LEADING` or `FOLLOWING`, meaning it doesn't create any backlog. This is not true for servers that have already been in one of these states, though, they leave their port open and just accumulate a backlog of commands until they're either leading or following again.

So, when leader flips the first time, everyone disconnects, and all of the servers that were previously `FOLLOWING` (all of them) start to accumulate a backlog. Eventually, these servers start to reconnect and work through their backlog.

However, any servers that are not on the same version as leader escalate *all* commands to leader, not just write commands. Leader is already overloaded during this time, because it's running through it's own backlog of commands from the slow standup, plus everyone else's escalated write commands, plus, for every node still on the old version, escalated read commands.

Closing the command port on old-version nodes prevents this flood of read commands on leader, and means that read commands will go to one of the nodes on the same version as leader than can run these commands themselves.

Then when the old version nodes are restarted, they do connect and go following slowly, but it doesn't matter because they're not building a backlog until they finish connecting and open their ports.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/210794

### Tests

Ok, here's the elaborate testing for this. First, here's a diff for the first test. This *disables* the change in this PR, and adds some logging so that we can see how often we hit the timeout, and how many read attempts it takes to make a peer connection:
https://github.com/Expensify/Bedrock/pull/1287/files

Review that diff, and then these logs from:
```
expensidev2004:/vagrant/Bedrock/test/clustertest: ./clustertest -only GracefulFailover
--------------
✅ GracefulFailoverTest::test

[ TEST RESULTS ] Passed: 1, Failed: 0
```

```
expensidev2004:/vagrant/Bedrock: sudo tail -F /var/log/syslog | grep 'TYLER'
2022-05-18T16:49:01.305720+00:00 expensidev2004 bedrock10004: xxxxxx (SQLiteNode.cpp:2630) postPoll [sync] [info] {cluster_node_1/SEARCHING} [TYLER] Connected to peer cluster_node_0 after 1 read attempts.
2022-05-18T16:49:01.447438+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:2630) postPoll [sync] [info] {cluster_node_0/LEADING} [TYLER] Connected to peer cluster_node_2 after 1 read attempts.
2022-05-18T16:49:01.467567+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:2630) postPoll [sync] [info] {cluster_node_2/FOLLOWING} [TYLER] Connected to peer cluster_node_1 after 1 read attempts.
2022-05-18T16:49:12.388642+00:00 expensidev2004 bedrock10004: xxxxxx (SQLiteNode.cpp:2630) postPoll [sync] [info] {cluster_node_1/LEADING} [TYLER] Connected to peer cluster_node_0 after 1 read attempts.
2022-05-18T16:49:12.543818+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:2630) postPoll [sync] [info] {cluster_node_0/SYNCHRONIZING} [TYLER] Connected to peer cluster_node_2 after 1 read attempts.
2022-05-18T16:49:33.470638+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:2630) postPoll [sync] [info] {cluster_node_2/SEARCHING} [TYLER] Connected to peer cluster_node_1 after 1 read attempts.
2022-05-18T16:49:34.032610+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:2630) postPoll [sync] [info] {cluster_node_0/LEADING} [TYLER] Connected to peer cluster_node_2 after 1 read attempts.
2022-05-18T16:49:51.500395+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:2630) postPoll [sync] [info] {cluster_node_0/SEARCHING} [TYLER] Connected to peer cluster_node_2 after 1 read attempts.
2022-05-18T16:49:53.189994+00:00 expensidev2004 bedrock10004: xxxxxx (SQLiteNode.cpp:2630) postPoll [sync] [info] {cluster_node_1/LEADING} [TYLER] Connected to peer cluster_node_0 after 1 read attempts.
2022-05-18T16:49:58.573062+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:2630) postPoll [sync] [info] {cluster_node_2/SEARCHING} [TYLER] Connected to peer cluster_node_0 after 1 read attempts.
2022-05-18T16:50:00.128644+00:00 expensidev2004 bedrock10004: xxxxxx (SQLiteNode.cpp:2630) postPoll [sync] [info] {cluster_node_1/FOLLOWING} [TYLER] Connected to peer cluster_node_2 after 1 read attempts.
```

So you'll note that these *always* connect on the first read attempt. And consequently, we never hit the 5s timeout. So the tests work fine - we get a functioning cluster so long as we connect on the first try.

Let's try the next test. The code is the same as above except we add a delay when sending login messages. Now it takes a node 0.5s to login. Here's the diff (compared to the above):
https://github.com/Expensify/Bedrock/pull/1288/files

With this delay before sending messages, the test fails:
```
expensidev2004:/vagrant/Bedrock/test/clustertest: ./clustertest -only GracefulFailover
--------------
startServer(): ran out of time waiting for server to start
startServer(): ran out of time waiting for server to startstartServer(): ran out of time waiting for server to start

executeWaitMultiple(): ran out of time waiting for socket
executeWaitMultiple(): ran out of time waiting for socket
executeWaitMultiple(): ran out of time waiting for socket
ClusterTester constructor timed out starting cluster
executeWaitMultiple(): ran out of time waiting for socket
executeWaitMultiple(): ran out of time waiting for socket
executeWaitMultiple(): ran out of time waiting for socket
ClusterTester constructor timed out starting cluster
executeWaitMultiple(): ran out of time waiting for socket
executeWaitMultiple(): ran out of time waiting for socket
executeWaitMultiple(): ran out of time waiting for socket
ClusterTester constructor timed out starting cluster
   assertion #1 at test/clustertest/tests/GracefulFailoverTest.cpp:107
    assertion failed: tester->getTester(0).waitForState("LEADING") resolved to FALSE
❌ !FAILED! ❌ GracefulFailoverTest::test

[ TEST RESULTS ] Passed: 0, Failed: 1

Failures:
GracefulFailoverTest::test
```

Here are the logs (you can see it never connects at all and always times out). There were 462 lines of this, I omitted many of them:
```
expensidev2004:/vagrant/Bedrock: sudo tail -F /var/log/syslog | grep 'TYLER'
2022-05-18T16:55:32.650621+00:00 expensidev2004 bedrock10004: xxxxxx (libstuff.cpp:149) SException [sync] [info] Throwing exception with message: '[TYLER] Incoming socket didn't send a message for over 5s, closing.' from sqlitecluster/SQLiteNode.cpp:2650
2022-05-18T16:55:32.650867+00:00 expensidev2004 bedrock10004: xxxxxx (SQLiteNode.cpp:2653) postPoll [sync] [warn] {cluster_node_1/SEARCHING} Incoming connection failed from '127.0.0.1:60760' ([TYLER] Incoming socket didn't send a message for over 5s, closing.)
2022-05-18T16:55:33.690614+00:00 expensidev2004 bedrock10001: xxxxxx (libstuff.cpp:149) SException [sync] [info] Throwing exception with message: '[TYLER] Incoming socket didn't send a message for over 5s, closing.' from sqlitecluster/SQLiteNode.cpp:2650
2022-05-18T16:55:33.690839+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:2653) postPoll [sync] [warn] {cluster_node_0/SEARCHING} Incoming connection failed from '127.0.0.1:33792' ([TYLER] Incoming socket didn't send a message for over 5s, closing.)

...

2022-05-18T17:00:34.733417+00:00 expensidev2004 bedrock10007: xxxxxx (libstuff.cpp:149) SException [sync] [info] Throwing exception with message: '[TYLER] Incoming socket didn't send a message for over 5s, closing.' from sqlitecluster/SQLiteNode.cpp:2650
2022-05-18T17:00:34.733573+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:2653) postPoll [sync] [warn] {cluster_node_2/SEARCHING} Incoming connection failed from '127.0.0.1:40528' ([TYLER] Incoming socket didn't send a message for over 5s, closing.)
2022-05-18T17:00:36.892610+00:00 expensidev2004 bedrock10001: xxxxxx (libstuff.cpp:149) SException [sync] [info] Throwing exception with message: '[TYLER] Incoming socket didn't send a message for over 5s, closing.' from sqlitecluster/SQLiteNode.cpp:2650
2022-05-18T17:00:36.893465+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:2653) postPoll [sync] [warn] {cluster_node_0/SEARCHING} Incoming connection failed from '127.0.0.1:41608' ([TYLER] Incoming socket didn't send a message for over 5s, closing.)
2022-05-18T17:00:38.208507+00:00 expensidev2004 bedrock10004: xxxxxx (libstuff.cpp:149) SException [sync] [info] Throwing exception with message: '[TYLER] Incoming socket didn't send a message for over 5s, closing.' from sqlitecluster/SQLiteNode.cpp:2650
2022-05-18T17:00:38.209309+00:00 expensidev2004 bedrock10004: xxxxxx (SQLiteNode.cpp:2653) postPoll [sync] [warn] {cluster_node_1/SEARCHING} Incoming connection failed from '127.0.0.1:40426' ([TYLER] Incoming socket didn't send a message for over 5s, closing.)
```

Ok, so now that we've verified the old code works if we get a message on the first read, but breaks if we delay that message, let's re-enable the fix from this PR and test that. Here's the diff to re-enable the change in this PR:
https://github.com/Expensify/Bedrock/pull/1289/files

And the test:
```
expensidev2004:/vagrant/Bedrock/test/clustertest: ./clustertest -only GracefulFailover
--------------
✅ GracefulFailoverTest::test

[ TEST RESULTS ] Passed: 1, Failed: 0
```

And the logs:
```
expensidev2004:/vagrant/Bedrock: sudo tail -F /var/log/syslog | grep 'TYLER'
2022-05-18T17:03:52.166034+00:00 expensidev2004 bedrock10004: xxxxxx (SQLiteNode.cpp:2628) postPoll [sync] [info] {cluster_node_1/SEARCHING} [TYLER] Connected to peer cluster_node_2 after 2 read attempts.
2022-05-18T17:03:53.215715+00:00 expensidev2004 bedrock10004: xxxxxx (SQLiteNode.cpp:2628) postPoll [sync] [info] {cluster_node_1/LEADING} [TYLER] Connected to peer cluster_node_0 after 2 read attempts.
2022-05-18T17:03:55.289088+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:2628) postPoll [sync] [info] {cluster_node_2/WAITING} [TYLER] Connected to peer cluster_node_0 after 2 read attempts.
2022-05-18T17:04:07.173891+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:2628) postPoll [sync] [info] {cluster_node_0/SEARCHING} [TYLER] Connected to peer cluster_node_1 after 2 read attempts.
2022-05-18T17:04:07.951861+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:2628) postPoll [sync] [info] {cluster_node_2/FOLLOWING} [TYLER] Connected to peer cluster_node_0 after 2 read attempts.
2022-05-18T17:04:27.911538+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:2628) postPoll [sync] [info] {cluster_node_2/SEARCHING} [TYLER] Connected to peer cluster_node_1 after 2 read attempts.
2022-05-18T17:04:28.872389+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:2628) postPoll [sync] [info] {cluster_node_0/LEADING} [TYLER] Connected to peer cluster_node_2 after 2 read attempts.
2022-05-18T17:04:46.265901+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:2628) postPoll [sync] [info] {cluster_node_0/SEARCHING} [TYLER] Connected to peer cluster_node_2 after 2 read attempts.
2022-05-18T17:04:48.295392+00:00 expensidev2004 bedrock10004: xxxxxx (SQLiteNode.cpp:2628) postPoll [sync] [info] {cluster_node_1/LEADING} [TYLER] Connected to peer cluster_node_0 after 2 read attempts.
2022-05-18T17:04:57.316003+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:2628) postPoll [sync] [info] {cluster_node_2/SEARCHING} [TYLER] Connected to peer cluster_node_1 after 2 read attempts.
2022-05-18T17:04:58.317840+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:2628) postPoll [sync] [info] {cluster_node_0/LEADING} [TYLER] Connected to peer cluster_node_2 after 2 read attempts.
```

It passes again, never hits the timeout, and successfully reads on the second attempt.
