### PR TITLE
Don't lock for commands that aren't being destroyed

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2357,7 +2357,7 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
                             lock.lock();
                         }
 
-                        // Now we'll queue this command in one of three queues.
+                        // Now we'll queue this command in one of two queues.
                         auto _syncNodeCopy = atomic_load(&_syncNode);
                         if (_syncNodeCopy && _syncNodeCopy->getState() == SQLiteNode::STANDINGDOWN) {
                             _standDownQueue.push(move(command));

--- a/test/clustertest/tests/UpgradeTest.cpp
+++ b/test/clustertest/tests/UpgradeTest.cpp
@@ -1,0 +1,49 @@
+
+#include <libstuff/SData.h>
+#include <libstuff/SRandom.h>
+#include <test/clustertest/BedrockClusterTester.h>
+
+struct UpgradeTest : tpunit::TestFixture {
+    UpgradeTest()
+    : tpunit::TestFixture("Upgrade",
+                          TEST(UpgradeTest::mismatchedFollowerSendMultipleCommands)
+                         ) { }
+
+    void mismatchedFollowerSendMultipleCommands() {
+        BedrockClusterTester tester;
+
+        // Cluster is up, shut down follower 2.
+        tester.stopNode(2);
+
+        // Change it's version.
+        tester.getTester(2).updateArgs({{"-versionOverride", "FAKE_VERSION"}});
+
+        // Start it back up and let it go following.
+        tester.startNode(2);
+        ASSERT_TRUE(tester.getTester(2).waitForState("FOLLOWING"));
+
+        // Get status info from leader and follower.
+        SData status("Status");
+        auto results = tester.getTester(0).executeWaitMultipleData({status}, 1, false, true);
+        string leaderVersion = SParseJSONObject(results[0].content)["version"];
+        string leaderState = SParseJSONObject(results[0].content)["state"];
+        results = tester.getTester(2).executeWaitMultipleData({status}, 1, false, true);
+        string followerVersion = SParseJSONObject(results[0].content)["version"];
+        string followerState = SParseJSONObject(results[0].content)["state"];
+
+        // Verify it's what we expect.
+        ASSERT_EQUAL(leaderState, "LEADING");
+        ASSERT_EQUAL(followerState, "FOLLOWING");
+        ASSERT_EQUAL(followerVersion, "FAKE_VERSION");
+        ASSERT_NOT_EQUAL(leaderVersion, followerVersion);
+
+        // Send two commands *on the same socket* (the `1` param to executeWaitMultipleData is number of sockets to
+        // open) and verify we get results for both of them.
+        SData idcollision1("idcollision");
+        SData idcollision2("idcollision");
+        results = tester.getTester(2).executeWaitMultipleData({idcollision1, idcollision2}, 1, false, true);
+        ASSERT_EQUAL(results[0].methodLine, "200 OK");
+        ASSERT_EQUAL(results[1].methodLine, "200 OK");
+    }
+
+} __UpgradeTest;


### PR DESCRIPTION
### Details
So, the way that we complete commands from socket threads, because the commands are actually run by worker threads asynchronously, is that we attach a callback to the destructor of a command, and then hand that command off to a queue somewhere to be run by a worker thread.

The socket threads then waits on a condition_variable for that destructor to run, and when it does, it stops waiting, and continues on to handle the next command on the socket (or close it, or whatever).

The problem is that for commands that are escalated to leader on version mismatch, we never move the command to a different queue for a worker. We handle it locally in the socket thread, and so the command stays in scope while we wait on the condition_variable. The destructor is never called, and so the socket gets "stuck", waiting forever.

Meanwhile, the client has received the response from this first command and thinks everything is fine, and sends a second command on the same socket, but that command never gets handled because the socket is "stuck" and then it takes 5 minutes to time out.

Consider this graph, and particularly db1.rno.
<img width="1368" alt="Screen Shot 2022-05-19 at 3 16 53 PM" src="https://user-images.githubusercontent.com/705000/169413672-f1e4eb0b-55a4-48ae-925c-c947b7fc82d3.png">

db1.rno had been on the same version as leader, so everything was going smoothly. Then we upgraded it:
```
2022-05-19T15:06:25.871719+00:00 db1.rno bedrock: xxxxxx (BedrockServer.cpp:2002) _beginShutdown [main] [info] Beginning graceful shutdown due to 'Terminated, Continued',
2022-05-19T15:11:30.449911+00:00 db1.rno bedrock: xxxxxx (main.cpp:338) main [main] [info] Starting bedrock server
2022-05-19T15:12:15.731864+00:00 db1.rno bedrock: xxxxxx (SQLiteNode.cpp:2012) _changeState [sync] [info] {auth.db1.rno/SUBSCRIBING} Switching from 'SUBSCRIBING' to 'FOLLOWING'
```

When it goes FOLLOWING at 15:12, it is now version-mismatched from leader, and starts escalating commands to leader using the broken codepath. You see the increasing number of broken socket connections.

Eventually, db1.sjc is upgraded and starts leading, db1.rno is no longer version-mismatched, so new connections made after this time do not hit the broken code path.

```
2022-05-19T15:24:01.687554+00:00 db1.sjc bedrock: xxxxxx (SQLiteNode.cpp:2012) _changeState [sync] [info] {auth.db1.sjc/STANDINGUP} Switching from 'STANDINGUP' to 'LEADING'
```

These socket threads are still stuck, but after [5 minutes](https://github.com/Expensify/Bedrock-PHP/blob/0d734d5338abec32cd9a0b389d9e001af39a0d24/src/Client.php#L243-L244), all of the PHP clients have hit their timeouts and given up at 15:29.

You can see the same thing happens with db1.lax. It starts following at 15:18:
```
2022-05-19T15:18:27.318325+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2012) _changeState [sync] [info] {auth.db1.lax/SUBSCRIBING} Switching from 'SUBSCRIBING' to 'FOLLOWING'
```

But it also resolves at 15:29, five minutes after it matches leader's version.

The fix is to not have special case handling for this here, but just use the standard handling here:
https://github.com/Expensify/Bedrock/blob/c3535e26dde5f2ce7e4813ee9dd483000776212a/BedrockServer.cpp#L851-L858

Because this uses a regular command queue, the command destructor will be called.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/211091
Probably fixes https://github.com/Expensify/Expensify/issues/211135

### Tests
Added a very basic `UpgradeTest` that only tests this particular case. Verified it failed with the old code:
```
expensidev2004:/vagrant/Bedrock/test/clustertest: ./clustertest -only Upgrade
--------------
Cluster is up. Shutting down follower 2.
Follower 2 is stopped. Let's change it's version.
Changed, start it up.
Follower 2 is following, see that it's version mismatched.
Leader and follower in correct state on different versions. Sending two write commands to follower on same socket.
(string): "000 Timeout" != "200 OK"
   assertion #1 at test/clustertest/tests/UpgradeTest.cpp:46
❌ !FAILED! ❌ UpgradeTest::mismatchedFollowerSendMultipleCommands

[ TEST RESULTS ] Passed: 0, Failed: 1

Failures:
UpgradeTest::mismatchedFollowerSendMultipleCommands
```

Verified it passed with the new code.

### Deployment Plan
We should not see the backlog developing on the first two nodes upgraded like we have seen, because they will be on the new version with the old leader, and they will have fixed this problem. However, when db1.sjc comes up as leader on the new version, the remain (2db.*) nodes will be on the old version, with a mismatched leader, and so we should still close the command port on these nodes as db1.sjc stands up.