### PR TITLE
Don't alter request object

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -61,13 +61,10 @@ int64_t BedrockCommand::_getTimeout(const SData& request) {
     // Convert to microseconds.
     timeout *= 1000;
 
-    int64_t start;
-    if (request.isSet("commandExecuteTime")) {
-        start = request.calc64("commandExecuteTime");
-    } else {
-        SWARN("BedrockCommand '" + request.methodLine + "' created with no commandExecuteTime, should be done in base constructor!");
-        start = STimeNow();
-    }
+    // If the command has specified an execute time, that's the time we'll start counting from or our timeout,
+    // otherwise it's right now.
+    int64_t commandExecuteTime = request.calc64("commandExecuteTime");
+    int64_t start = commandExecuteTime ? commandExecuteTime : STimeNow();
     return timeout + start;
 }
 

--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -67,6 +67,9 @@ void BedrockCommandQueue::abandonFutureCommands(int msInFuture) {
 void BedrockCommandQueue::push(unique_ptr<BedrockCommand>&& command) {
     BedrockCommand::Priority priority = command->priority;
     uint64_t executionTime = command->request.calcU64("commandExecuteTime");
+    if (!executionTime) {
+        executionTime = STimeNow();
+    }
     uint64_t timeout = command->timeout();
     SScheduledPriorityQueue<unique_ptr<BedrockCommand>>::push(move(command), priority, executionTime, timeout);
 }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -44,8 +44,7 @@ uint64_t BedrockCore::_getRemainingTime(const unique_ptr<BedrockCommand>& comman
 
     // Already expired.
     if (adjustedTimeout <= 0 || (isProcessing && processTimeout <= 0)) {
-        SALERT("Command " << command->request.methodLine << " timed out after "
-               << ((now - command->request.calc64("commandExecuteTime")) / 1000) << "ms.");
+        SALERT("Command " << command->request.methodLine << " timed out.");
         STHROW("555 Timeout");
     }
 

--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -5,9 +5,7 @@
 
 SData SQLiteCommand::preprocessRequest(SData&& request) {
     // If the request doesn't specify an execution time, default to right now.
-    if (!request.isSet("commandExecuteTime")) {
-        request["commandExecuteTime"] = to_string(STimeNow());
-    } else {
+    if (request.isSet("commandExecuteTime")) {
         // We are deprecating `commandExecuteTime` so need to figure out where it's used.
         auto now = STimeNow();
         auto executeTime = request.calcU64("commandExecuteTime");

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -474,9 +474,6 @@ void SQLiteNode::escalateCommand(unique_ptr<SQLiteCommand>&& command, bool forge
     }
 
     SASSERTEQUALS(_leadPeer.load()->state, LEADING);
-    uint64_t elapsed = STimeNow() - command->request.calcU64("commandExecuteTime");
-    SINFO("Escalating '" << command->request.methodLine << "' (" << command->id << ") to leader '" << _leadPeer.load()->name
-          << "' after " << elapsed / 1000 << " ms");
 
     // Create a command to send to our leader.
     SData escalate("ESCALATE");


### PR DESCRIPTION
### Details
This changes the behavior of creating a command to not alter the request object with `commadnExecuteTime` if it is not specified by the caller. This lets these commands escalate without creating a race condition where slightly out-of-sync clocks can cause these commands to be treated as "future execution" with no response required.

### Fixed Issues
Second part of https://github.com/Expensify/Expensify/issues/211978

### Tests
Just the existing tests.