### PR TITLE
Keep original scheduling when re-queueing

### DIFF
--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -169,6 +169,9 @@ class BedrockCommand : public SQLiteCommand {
     // is awaiting a reply.
     STCPManager::Socket* socket;
 
+    // Time at which this command was initially scheduled (typically the time of creation).
+    const uint64_t scheduledTime;
+
   protected:
     // The plugin that owns this command.
     BedrockPlugin* _plugin;
@@ -181,7 +184,7 @@ class BedrockCommand : public SQLiteCommand {
     tuple<TIMING_INFO, uint64_t, uint64_t> _inProgressTiming;
 
     // Get the absolute timeout value for this command based on it's request. This is used to initialize _timeout.
-    static int64_t _getTimeout(const SData& request);
+    static int64_t _getTimeout(const SData& request, const uint64_t scheduledTime);
 
     // This is a timestamp in *microseconds* for when this command should timeout.
     uint64_t _timeout;

--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -65,11 +65,5 @@ void BedrockCommandQueue::abandonFutureCommands(int msInFuture) {
 }
 
 void BedrockCommandQueue::push(unique_ptr<BedrockCommand>&& command) {
-    BedrockCommand::Priority priority = command->priority;
-    uint64_t executionTime = command->request.calcU64("commandExecuteTime");
-    if (!executionTime) {
-        executionTime = STimeNow();
-    }
-    uint64_t timeout = command->timeout();
-    SScheduledPriorityQueue<unique_ptr<BedrockCommand>>::push(move(command), priority, command->scheduledTime, timeout);
+    SScheduledPriorityQueue<unique_ptr<BedrockCommand>>::push(move(command), command->priority, command->scheduledTime, command->timeout());
 }

--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -71,5 +71,5 @@ void BedrockCommandQueue::push(unique_ptr<BedrockCommand>&& command) {
         executionTime = STimeNow();
     }
     uint64_t timeout = command->timeout();
-    SScheduledPriorityQueue<unique_ptr<BedrockCommand>>::push(move(command), priority, executionTime, timeout);
+    SScheduledPriorityQueue<unique_ptr<BedrockCommand>>::push(move(command), priority, command->scheduledTime, timeout);
 }


### PR DESCRIPTION
### Details
When merging this change: https://github.com/Expensify/Bedrock/pull/1299 We made a small behavioral change that I thought would be immaterial -- commands that are dequeued and requeued do not maintain their position at the front of the queue, but are instead moved to the back of the queue.

We saw auth deploy escalation issues during today's deploy and I'm wondering if it was caused by this new behavior. This undoes this behavioral change without undoing the main point of the previous change, which was to not alter the original request object across escalations.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/211978

### Tests
Exisitng tests.