### PR TITLE
Don't save sockets that the server says it's closing

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1586,7 +1586,8 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
     command->response["nodeName"] = args["-nodeName"];
 
     // If we're shutting down, tell the caller to close the connection.
-    if (_shutdownState.load() != RUNNING) {
+    // Also, if the caller wanted us to close the connection, we'll parrot that back.
+    if (_shutdownState.load() != RUNNING || command->request["Connection"] == "close") {
         command->response["Connection"] = "close";
     }
 

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -240,9 +240,9 @@ bool SQLiteClusterMessenger::commandWillCloseSocket(BedrockCommand& command) {
     for (const auto& message : {command.request.nameValueMap, command.response.nameValueMap}) {
         auto connectionHeader = message.find("Connection");
         if (connectionHeader != message.end() && connectionHeader->second == "close") {
-            return false;
+            return true;
         }
     }
 
-    return true;
+    return false;
 }

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -222,8 +222,20 @@ bool SQLiteClusterMessenger::runOnLeader(BedrockCommand& command) {
     // Finish our escalation timing.
     command.escalationTimeUS = STimeNow() - command.escalationTimeUS;
 
-    // Since everything went fine with this command, we can save its socket.
-    {
+    // See if either the client or the leader specified `Connection: close`.
+    // Technically, we shouldn't need to care if the client wants to close the connection, we could still re-use the connection from this server to leader, except that we've already sent
+    // it a command with `Connection: close` on this socket so we should expect that it will honor that and close this socket.
+    bool keepOpen = true;
+    for (const auto& message : {command.request.nameValueMap, command.response.nameValueMap}) {
+        auto connectionHeader = message.find("Connection");
+        if (connectionHeader != message.end() && connectionHeader->second == "close") {
+            keepOpen = false;
+            break;
+        }
+    }
+
+    // Since everything went fine with this command, we can save its socket, unless it's being closed.
+    if (keepOpen) {
         lock_guard<mutex> lock(_socketPoolMutex);
         if (_socketPool && _socketPool->host == host) {
             _socketPool->returnSocket(move(s));

--- a/sqlitecluster/SQLiteClusterMessenger.h
+++ b/sqlitecluster/SQLiteClusterMessenger.h
@@ -37,7 +37,10 @@ class SQLiteClusterMessenger {
     WaitForReadyResult waitForReady(pollfd& fdspec, uint64_t timeoutTimestamp);
 
     // This sets a command as a 500 and marks it as complete.
-    void setErrorResponse(BedrockCommand& command);
+    static void setErrorResponse(BedrockCommand& command);
+
+    // Checks if a command will cause the server to close this socket, indicating we can't reuse it.
+    static bool commandWillCloseSocket(BedrockCommand& command);
 
     const shared_ptr<const SQLiteNode> _node;
 

--- a/test/clustertest/tests/EscalateTest.cpp
+++ b/test/clustertest/tests/EscalateTest.cpp
@@ -2,7 +2,22 @@
 #include <test/clustertest/BedrockClusterTester.h>
 
 struct EscalateTest : tpunit::TestFixture {
-    EscalateTest() : tpunit::TestFixture("Escalate", TEST(EscalateTest::test)) { }
+    EscalateTest() : tpunit::TestFixture("Escalate", BEFORE_CLASS(EscalateTest::setup),
+                                                     AFTER_CLASS(EscalateTest::teardown),
+                                                     TEST(EscalateTest::test),
+                                                     TEST(EscalateTest::socketReuse)) { }
+
+    BedrockClusterTester* tester = nullptr;
+
+    void setup()
+    {
+        tester = new BedrockClusterTester;
+    }
+
+    void teardown()
+    {
+        delete tester;
+    }
 
     // NOTE: This test relies on two processes (the leader and follower Bedrock nodes) both writing to the same temp
     // file at potentially the same time. It's not impossible that these two writes step on each other and this test
@@ -10,10 +25,9 @@ struct EscalateTest : tpunit::TestFixture {
     // add some sort of file locking to the reading/writing from this file.
     void test()
     {
-        BedrockClusterTester tester;
 
         // We're going to send a command to a follower.
-        BedrockTester& brtester = tester.getTester(1);
+        BedrockTester& brtester = tester->getTester(1);
         SData cmd("testescalate");
         cmd["writeConsistency"] = "ASYNC";
         cmd["tempFile"] = BedrockTester::getTempFileName("escalate_test");
@@ -30,5 +44,31 @@ struct EscalateTest : tpunit::TestFixture {
         ASSERT_EQUAL(results.size(), 1);
         ASSERT_EQUAL(results[0].methodLine, "200 OK");
         SFileDelete(cmd["tempFile"]);
+    }
+
+    // Note: see this PR: https://github.com/Expensify/Bedrock/pull/1308 for the reasoning behind this test.
+    void socketReuse()
+    {
+        // We're going to escalate from follower 1.
+        BedrockTester& brtester = tester->getTester(1);
+
+        // Build a command.
+        SData cmd("testescalate");
+        cmd["writeConsistency"] = "ASYNC";
+        cmd["tempFile"] = BedrockTester::getTempFileName("escalate_test");
+
+        // Set this so the follower's socket to leader won't get reused.
+        cmd["Connection"] = "close";
+
+        // Ok, send the command.
+        auto results = brtester.executeWaitMultipleData({cmd});
+        ASSERT_EQUAL(results[0].methodLine, "200 OK");
+
+        // Let the follower put the escalation socket back in the pool for reuse, or not (the intended case).
+        usleep(100'000);
+
+        // Send the command again. It shouldn't fail with a broken socket.
+        results = brtester.executeWaitMultipleData({cmd});
+        ASSERT_EQUAL(results[0].methodLine, "200 OK");
     }
 } __EscalateTest;


### PR DESCRIPTION
### Details

So, based on this set of logs, I had an idea:
<img width="976" alt="Screen Shot 2022-06-07 at 10 45 08 AM" src="https://user-images.githubusercontent.com/705000/172448567-a4c67962-14b0-4771-82f0-83e4c2720750.png">

Firing and forgetting a command is actually a perfectly valid reason to keep a socket open, however the server does close sockets, though typically only when it's shutting down. Specifically though, if the client sends `Close:` the server will also close the connection: https://github.com/Expensify/Bedrock/blob/a33869ca3dfef3abeae2f0593e49f01746437a38/BedrockServer.cpp#L1620-L1621

This change prevents us from saving a socket for later that it is going to be closed by the server.

There's another issue that this doesn't fix though, and that seems to be that we can not notice a socket is closed until after we do a `send` on it. I am also going to try and address that but it's going to take more digging. This is a quick and easy fix that may handle 95% of our failures, though it hasn't actually been tested at all except to see that it doesn't break the existing tests.

### Fixed Issues
Fixes:
[SOMEONE ADD THESE]

### Tests
Existing