### PR TITLE
Set umask to 0077 after forking

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -183,9 +183,7 @@ int main(int argc, char* argv[]) {
             return 0;
         }
 
-        // Daemonize
-        // **NOTE: See http://www-theorie.physik.unizh.ch/~dpotter/howto/daemonize
-        umask(0);
+        // Code below here is run by the child process; the parent exited above
         SASSERT(setsid() >= 0);
         SASSERT(chdir("/") >= 0);
         if (!freopen("/dev/null", "r", stdin) ||

--- a/main.cpp
+++ b/main.cpp
@@ -184,6 +184,7 @@ int main(int argc, char* argv[]) {
         }
 
         // Code below here is run by the child process; the parent exited above
+        umask(0077);
         SASSERT(setsid() >= 0);
         SASSERT(chdir("/") >= 0);
         if (!freopen("/dev/null", "r", stdin) ||


### PR DESCRIPTION
### Details

When `umask()` is set to 0 upon forking, all files and directories are created with excessive permissions: `666` for files, and `777` for directories. This appears to have been included by reference to the removed URL when the forking code was first written, however that link is now dead. Upon researching, many tutorials for forking/daemonizing C++ code include this umask function, however they all appear to have been blindly copied from one to another, all with a comment saying something like "make sure the process can read/write log files" which doesn't make a whole lot of sense, especially since umask only controls the permissions of newly created files/directories by the process; even if those permissions are wrong, the process will still be able to read/write what it creates itself.

This means after restoring a backup (using EBM), the main Auth database file has world read-write permissions, giving ANYONE on the box access to read **and write** the database:

```
phs@db1.sjc ~  $ sudo ls -lh /var/lib/authdb/
total 3.9T
-r--r----- 1 root root 1.2K Oct  4  2021 credentials.txt
-rw-rw-rw- 1 root root 3.9T Jul  8 00:30 main.db
-rw-rw-rw- 1 root root 3.2M Jul  8 00:30 main.db-shm
-rw-rw-rw- 1 root root 810M Jul  8 00:30 main.db-wal
-rw-rw-rw- 1 root root 515M Jul  8 00:30 main.db-wal2
phs@db1.sjc ~  $
```

By not changing this value, we inherit the parents umask (default to 022) which results in permissions of `644` for files, and `755` for directories. We could/should arguably make this umask `077` to restrict the perms even tighter, but this is a reasonable start to at least prevent writing by unauthorized processes.

### Fixed Issues
[Slack thread](https://expensify.slack.com/archives/C094TGUTZ/p1657240253381299)

### Tests

![image](https://user-images.githubusercontent.com/139959/177916887-a8ebc5a6-96a3-4868-abb0-d6a0674ff2ca.png)

![image](https://user-images.githubusercontent.com/139959/177917159-1ad5c0e4-8189-4001-9077-c44bff78d356.png)

Auth was recompiled and runs against this PR:

![image](https://user-images.githubusercontent.com/139959/177916986-febc0bc7-37e5-4a95-a44d-1d7cc35d9485.png)