### PR TITLE
Don't stop writes during checkpoints

### DIFF
--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -150,7 +150,9 @@ class SQLite {
     void setRewriteHandler(bool (*handler)(int, const char*, string&));
 
     // Commits the current transaction to disk. Returns an sqlite3 result code.
-    int commit(const string& description = "UNSPECIFIED");
+    // preCheckpointCallback is an optional callback that will be called before the checkpoint code runs, after the commit has completed. Note that if the commit fails, this is not called.
+    // The main purpose of this is to allow replications in SQLiteNode to notify other waiting threads that the commit has finished even before the checkpoint is done.
+    int commit(const string& description = "UNSPECIFIED", function<void()>* preCheckpointCallback = nullptr);
 
     // Cancels the current transaction and rolls it back.
     void rollback();

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -249,7 +249,6 @@ void SQLiteNode::_replicate(SQLitePeer* peer, SData command, size_t sqlitePoolIn
 
                     // Leader says it has committed this transaction, so we can too.
                     ++commitAttemptCount;
-
                     result = _handleCommitTransaction(db, peer, command.calcU64("NewCount"), command["NewHash"]);
                     if (result != SQLITE_OK) {
                         db.rollback();


### PR DESCRIPTION
### Details
This change attempts to unblock writes from checkpoints. When investigating slowdowns with Dan from SQLite, we noticed that writes seem to block on checkpoints, which is not the intended behavior.

On further investigation, it's  not that writes are explicitly blocked on checkpoints, but that replication threads on followers will not notify other waiting threads that the current commit is complete until any pending checkpoint is complete. This means the other threads won't attempt their writes/commits until the checkpoint finishes, which adds unnecessary delay to replication. 

### Fixed Issues
Fixes N/A

### Tests
Only the existing tests.
