### PR TITLE
Handle the case of a timeout getting leaderAddress

### DIFF
--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -300,7 +300,7 @@ bool SQLiteClusterMessenger::runOnLeader(BedrockCommand& command) {
         return false;
     }
 
-    // If we succeeded but were delayed, log that but cintinue.
+    // If we succeeded but were delayed, log that and continue.
     if (sleepsDueToFailures) {
         auto msElapsed = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - start).count();
         SINFO("[HTTPESC] Problems connecting for escalation but succeeded in " << msElapsed << "ms.");

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -293,6 +293,14 @@ bool SQLiteClusterMessenger::runOnLeader(BedrockCommand& command) {
             return false;
         }
     }
+
+    // If we fell out of the loop simply because we did not get a leader address in time, we can return false and retry later.
+    if (leaderAddress.empty()) {
+        SINFO("[HTTPESC] Could not get leader address in 5s, will retry later.");
+        return false;
+    }
+
+    // If we succeeded but were delayed, log that but cintinue.
     if (sleepsDueToFailures) {
         auto msElapsed = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - start).count();
         SINFO("[HTTPESC] Problems connecting for escalation but succeeded in " << msElapsed << "ms.");


### PR DESCRIPTION
### Details
This is pretty straightforward. If we simply hit the time limit trying to get an address, we would fall into the success case. This changes that to return false and retry the command later.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/217723

### Tests
No tests added.