### PR TITLE
Add a Travis check to ensure we remember to reset SQLITE_MAX_PAGE_COUNT

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -57,6 +57,23 @@ travis_fold() {
   echo -en "travis_fold:${action}:${name}\r${ANSI_CLEAR}"
 }
 
+enforce_max_page_count() {
+    local fold_name="enforce_max_page_count"
+    travis_fold start $fold_name
+    travis_time_start
+    local intended_max_page_count="4294967295"
+    local max_page_count="$(grep -E 'define SQLITE_MAX_PAGE_COUNT [0-9]+' libstuff/sqlite3.c | awk '{print $4}')"
+    if [[ "$max_page_count" != "$intended_max_page_count" ]] ; then
+        echo "SQLITE_MAX_PAGE_COUNT should be set to ${intended_max_page_count}, set to ${max_page_count} instead." >&2
+        exit 1
+    fi
+    travis_time_finish
+    travis_fold end $fold_name
+}
+
+# Check that we remembered to reset the value for SQLITE_MAX_PAGE_COUNT in case we updated sqlite3.c
+enforce_max_page_count
+
 travis_fold start install_packages
 travis_time_start
 


### PR DESCRIPTION
cc @bondydaa @tylerkaraszewski 

### Details
If we update sqlite3.c, this value won't be updated in the mainline, so we need to ensure it gets updated or else we will run into problems.

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/219373

### Tests
Added a check to the Travis tests, they should pass.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
