### PR TITLE
Remove acceptCommand

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1420,7 +1420,9 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
         }
         size_t count = BedrockCommand::getCommandCount();
         if (count) {
-            // This is possible to have these commands with no clients for commands with initiatingClientID = -1.
+            // For commands not initiated by a client (those with initiatingClientID = -1), we can have commands
+            // remaining here even with `CLIENTS_RESPONDED` being true. We may want to address this in the future so
+            // that we can't orphan these commands at shutdown.
             SINFO("Have " << count << " remaining commands to delete.");
         }
     }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -177,15 +177,6 @@ class BedrockServer : public SQLiteServer {
         const BedrockServer& _owner;
     };
 
-    // Accept an incoming command from an SQLiteNode.
-    // `isNew` will be set to true if this command has never been seen before, and false if this is an existing command
-    // being returned to the command queue (such as one that was previously escalated).
-    // SQLiteNode API.
-    void acceptCommand(unique_ptr<SQLiteCommand>&& command, bool isNew = true);
-
-    // Backwards-compatible version of the above method for plugins that already used it.
-    void acceptCommand(SQLiteCommand&& command, bool isNew = true);
-
     // Flush the send buffers
     // STCPNode API.
     void prePoll(fd_map& fdm);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1965,7 +1965,7 @@ void SQLiteNode::_queueSynchronize(const SQLiteNode* const node, SQLitePeer* pee
 }
 
 void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message) {
-    if (!message.isSet("ShuttingDown")) {
+    if (message.isSet("ShuttingDown")) {
         STHROW("Sync peer is shutting down");
     }
     if (!message.isSet("NumCommits")) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -310,6 +310,10 @@ bool SQLiteNode::_isNothingBlockingShutdown() const {
         return false;
     }
 
+    if (_pendingSynchronizeResponses) {
+        return false;
+    }
+
     return true;
 }
 
@@ -1433,25 +1437,22 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
             // there's a backlog of commands, these can get stale, and by the time they reach the follower, it's already
             // behind, thus never catching up.
             if (_state == FOLLOWING) {
-                // Attach all of the state required to populate a SYNCHRONIZE_RESPONSE to this message. All of this is
-                // processed asynchronously, but that is fine, the final `SUBSCRIBE` message and its response will be
-                // processed synchronously.
-                SData request = message;
-                uint64_t count = 0;
-                string hash;
-                peer->getCommit(count, hash);
-                request["peerCommitCount"] = to_string(count);
-                request["peerHash"] = hash;
-                request["peerID"] = to_string(_getIDByPeer(peer));
+                // There's an obvious race condition here and nothing actually prevents us from shutting down while these are running, or about to be running.
+                _pendingSynchronizeResponses++;
+                static atomic<size_t> synchronizeCount(0);
+                thread([message, peer, currentSynchronizeCount = synchronizeCount++, this] () {
+                    SInitialize("synchronize" + to_string(currentSynchronizeCount));
+                    SData response("SYNCHRONIZE_RESPONSE");
+                    SQLiteScopedHandle dbScope(*_dbPool, _dbPool->getIndex());
+                    SQLite& db = dbScope.db();
+                    _queueSynchronize(this, peer, db, response, false);
 
-                // The following properties are only used to expand out our log macros.
-                request["name"] = _name;
-                request["peerName"] = peer->name;
-
-                // Create a command from this request and pass it on to the server to handle.
-                auto command = make_unique<SQLiteCommand>(move(request));
-                command->initiatingPeerID = peer->id;
-                _server.acceptCommand(move(command), true);
+                    // The following two lines are copied from `_sendToPeer`.
+                    response["CommitCount"] = to_string(db.getCommitCount());
+                    response["Hash"] = db.getCommittedHash();
+                    peer->sendMessage(response);
+                    _pendingSynchronizeResponses--;
+                }).detach();
             } else {
                 // Otherwise we handle them immediately, as the server doesn't deliver commands to workers until we've
                 // stood up.
@@ -1635,11 +1636,6 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                       << message.calc("NewCount") << " (" << message["NewHash"] << ", " << message["ID"] << ") but '"
                       << e.what() << "', ignoring.");
             }
-        } else if (SIEquals(message.methodLine, "CRASH_COMMAND") || SIEquals(message.methodLine, "BROADCAST_COMMAND")) {
-            // Create a new Command and send to the server.
-            SData messageCopy = message;
-            PINFO("Received " << message.methodLine << " command, forwarding to server.");
-            _server.acceptCommand(make_unique<SQLiteCommand>(move(messageCopy)), true);
         } else {
             STHROW("unrecognized message");
         }
@@ -2120,40 +2116,6 @@ bool SQLiteNode::_majoritySubscribed() const {
     return (numFullFollowers * 2 >= numFullPeers);
 }
 
-bool SQLiteNode::peekPeerCommand(SQLite& db, SQLiteCommand& command) const
-{
-    shared_lock<decltype(_stateMutex)> sharedLock(_stateMutex);
-    SQLitePeer* peer = nullptr;
-    try {
-        if (SIEquals(command.request.methodLine, "SYNCHRONIZE")) {
-            peer = _getPeerByID(SToUInt64(command.request["peerID"]));
-            if (!peer) {
-                // There's nobody to send to, but this was a valid command that's been handled.
-                return true;
-            }
-            command.response.methodLine = "SYNCHRONIZE_RESPONSE";
-            _queueSynchronize(this, peer, db, command.response, false);
-
-            // The following two lines are copied from `_sendToPeer`.
-            command.response["CommitCount"] = to_string(db.getCommitCount());
-            command.response["Hash"] = db.getCommittedHash();
-            peer->sendMessage(command.response);
-            return true;
-        }
-    } catch (const SException& e) {
-        if (peer) {
-            // Any failure causes the response to in initiate a reconnect, if we got a peer.
-            command.response.methodLine = "RECONNECT";
-            command.response["Reason"] = e.what();
-            peer->sendMessage(command.response);
-        }
-
-        // If we even got here, then it must have been a peer command, so we'll call it complete.
-        return true;
-    }
-    return false;
-}
-
 void SQLiteNode::_handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SData& message, bool wasConflict) {
     // BEGIN_TRANSACTION: Sent by the LEADER to all subscribed followers to begin a new distributed transaction. Each
     // follower begins a local transaction with this query and responds APPROVE_TRANSACTION. If the follower cannot start
@@ -2521,28 +2483,6 @@ void SQLiteNode::_sendPING(SQLitePeer* peer) {
     SData ping("PING");
     ping["Timestamp"] = SToStr(STimeNow());
     peer->sendMessage(ping.serialize());
-}
-
-uint64_t SQLiteNode::_getIDByPeer(SQLitePeer* peer) const {
-    uint64_t id = 1;
-    for (auto p : _peerList) {
-        if (p == peer) {
-            return id;
-        }
-        id++;
-    }
-    return 0;
-}
-
-SQLitePeer* SQLiteNode::_getPeerByID(uint64_t id) const {
-    if (id <= 0) {
-        return nullptr;
-    }
-    try {
-        return _peerList[id - 1];
-    } catch (const out_of_range& e) {
-        return nullptr;
-    }
 }
 
 SQLitePeer* SQLiteNode::getPeerByName(const string& name) const {

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -132,9 +132,6 @@ class SQLiteNode : public STCPManager {
     // Does not block.
     void notifyCommit() const;
 
-    [[deprecated("Use HTTP escalation")]]
-    bool peekPeerCommand(SQLite& db, SQLiteCommand& command) const;
-
     // Prepare a set of sockets to wait for read/write.
     // Can block.
     void prePoll(fd_map& fdm) const;
@@ -194,14 +191,6 @@ class SQLiteNode : public STCPManager {
     // *correct* DB for the thread that's making the call (i.e., you can't use the node's internal DB from a worker
     // thread with a different DB object) - which is why this is static.
     static void _queueSynchronize(const SQLiteNode* const node, SQLitePeer* peer, SQLite& db, SData& response, bool sendAll);
-
-    // Returns the ID of SQLitePeer. If the peer is not found, returns 0.
-    [[deprecated("Only required as long as synchronize uses peekPeerCommand")]]
-    uint64_t _getIDByPeer(SQLitePeer* peer) const;
-
-    // Returns a peer by it's ID. If the ID is invalid, returns nullptr.
-    [[deprecated("Only required as long as synchronize uses peekPeerCommand")]]
-    SQLitePeer* _getPeerByID(uint64_t id) const;
 
     // Returns whether we're in the process of gracefully shutting down.
     bool _gracefulShutdown() const;
@@ -310,6 +299,10 @@ class SQLiteNode : public STCPManager {
     // These are used in _replicate, _changeState, and _recvSynchronize to coordinate the replication threads.
     SQLiteSequentialNotifier _leaderCommitNotifier;
     SQLiteSequentialNotifier _localCommitNotifier;
+
+    // We can spin up threads to handle responding to `SYNCHRONIZE` messages out of band. We want to make sure we don't
+    // shut down in the middle of running these, so we keep a count of them.
+    atomic<size_t> _pendingSynchronizeResponses = 0;
 
     // Our priority, with respect to other nodes in the cluster. This is passed in to our constructor. The node with
     // the highest priority in the cluster will attempt to become the leader.

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -300,7 +300,7 @@ class SQLiteNode : public STCPManager {
     SQLiteSequentialNotifier _leaderCommitNotifier;
     SQLiteSequentialNotifier _localCommitNotifier;
 
-    // We can spin up threads to handle responding to `SYNCHRONIZE` messages out of band. We want to make sure we don't
+    // We can spin up threads to handle responding to `SYNCHRONIZE` messages out-of-band. We want to make sure we don't
     // shut down in the middle of running these, so we keep a count of them.
     atomic<size_t> _pendingSynchronizeResponses = 0;
 

--- a/sqlitecluster/SQLiteServer.h
+++ b/sqlitecluster/SQLiteServer.h
@@ -8,12 +8,6 @@ class SQLitePeer;
 // commands it receives.
 class SQLiteServer : public STCPManager {
   public:
-    // An SQLiteNode will call this to pass a command to a server for processing. The isNew flag is set if this is the
-    // first time this command has been sent to this server, as opposed to being an existing command, such as one that
-    // was previously escalated.
-    [[deprecated("Use HTTP escalation")]]
-    virtual void acceptCommand(unique_ptr<SQLiteCommand>&& command, bool isNew) = 0;
-
     // This will return true if there's no outstanding writable activity that we're waiting on. It's called by an
     // SQLiteNode in a STANDINGDOWN state to know that it can switch to searching.
     virtual bool canStandDown() = 0;

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -23,7 +23,6 @@ class TestServer : public SQLiteServer {
   public:
     TestServer() : SQLiteServer() { }
 
-    virtual void acceptCommand(unique_ptr<SQLiteCommand>&& command, bool isNew) { }
     virtual bool canStandDown() { return true; }
     virtual void onNodeLogin(SQLitePeer* peer) { }
 };


### PR DESCRIPTION
### Details

This finishes cleanup of all the deprecated stuff from the HTTP escalation refactor.

This handles `SYNCHRONIZE` commands very much like how auth is now handling `forwardCommand`.

~HOLD for https://github.com/Expensify/Auth/pull/6952~

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/221469

### Tests
Existing tests pass. Auth tested and passing against [4ff2af6](https://github.com/Expensify/Auth/pull/6952/commits/4ff2af6ab01fdd93a2c0c47b7e0540655741d22a)
