### PR TITLE
Fix crash during dryRunBilling

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -680,25 +680,20 @@ void BedrockServer::worker(int threadId)
 }
 
 void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlocking) {
-
-    // This takes ownership of the passed command. By calling the move constructor, the caller's unique_ptr is now empty, and so when the one here goes out of scope (i.e., this function
-    // returns), the command is destroyed.
-    unique_ptr<BedrockCommand> command(move(_command));
-
     // If there's no sync node (because we're detaching/attaching), we can only queue a command for later.
     // Also,if this command is scheduled in the future, we can't just run it, we need to enqueue it to run at that point.
     // This functionality will go away as we remove the queues from bedrock, and so this can be removed at that time.
     {
         auto _syncNodeCopy = atomic_load(&_syncNode);
-        if (!_syncNodeCopy || command->request.calcU64("commandExecuteTime") > STimeNow()) {
-            if (command->request.calcU64("commandExecuteTime") > STimeNow() && command->socket) {
-                SWARN("TYLER got future command with socket");
-            } else {
-                SINFO("Looks OK");
-            }
+        if (!_syncNodeCopy || _command->request.calcU64("commandExecuteTime") > STimeNow()) {
             _commandQueue.push(move(_command));
+            return;
         }
     }
+
+    // This takes ownership of the passed command. By calling the move constructor, the caller's unique_ptr is now empty, and so when the one here goes out of scope (i.e., this function
+    // returns), the command is destroyed.
+    unique_ptr<BedrockCommand> command(move(_command));
 
     SAUTOPREFIX(command->request);
     // Get a DB handle to work on. This will automatically be returned when dbScope goes out of scope.


### PR DESCRIPTION
### Details
The old `acceptCommand` would just queue commands and return. We replaced this with `runCommand` which, *generally* will run a command immediately instead of putting it in a queue. Most of the time this is fine.

But for billing, we want to run commands in the future, meaning they sort of need to be in the queue. However, we added the check for this in `handleSocket` (which would queue future commands correctly if received on a socket), but when calling `runCommand` directly from auth (here: https://github.com/Expensify/Auth/blob/main/auth/Auth.cpp#L298) we would not hit that check that the command was supposed to run in the future.

Instead, we would try to run the command immediately. This breaks all of the throttling in billing, trying to run all the commands at once, essentially. Since each one now runs in it's own thread, this causes us to run out of available threads.

This change moves the check for `commandExecuteTime` from `handleSocket` to `runCommand` so that future commands get queued correctly in either case.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/223272

### Tests
Existing tests, Auth tests passing on 36647f0809d070900b59ec8a604afa251f8d7eb4
