### PR TITLE
Remove initiatingPeerID

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1125,7 +1125,7 @@ BedrockServer::BedrockServer(SQLiteNode::State state, const SData& args_)
 
 BedrockServer::BedrockServer(const SData& args_)
   : SQLiteServer(), shutdownWhileDetached(false), args(args_), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
-    _upgradeInProgress(false),
+    _upgradeInProgress(false), _isCommandPortLikelyBlocked(false),
     _syncThreadComplete(false), _syncNode(nullptr), _clusterMessenger(nullptr), _shutdownState(RUNNING),
     _multiWriteEnabled(args.test("-enableMultiWrite")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),
     _controlPort(nullptr), _commandPortPublic(nullptr), _commandPortPrivate(nullptr), _maxConflictRetries(3),

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1125,7 +1125,7 @@ BedrockServer::BedrockServer(SQLiteNode::State state, const SData& args_)
 
 BedrockServer::BedrockServer(const SData& args_)
   : SQLiteServer(), shutdownWhileDetached(false), args(args_), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
-    _upgradeInProgress(false), _isCommandPortLikelyBlocked(false),
+    _upgradeInProgress(false),
     _syncThreadComplete(false), _syncNode(nullptr), _clusterMessenger(nullptr), _shutdownState(RUNNING),
     _multiWriteEnabled(args.test("-enableMultiWrite")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),
     _controlPort(nullptr), _commandPortPublic(nullptr), _commandPortPrivate(nullptr), _maxConflictRetries(3),

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1968,7 +1968,7 @@ bool S_recvappend(int s, SFastBuffer& recvBuffer) {
     char buffer[4096];
     int totalRecv = 0;
     ssize_t numRecv = 0;
-    sockaddr_in fromAddr;
+    sockaddr_in fromAddr = {0};
     socklen_t fromAddrLen = sizeof(fromAddr);
     while ((numRecv = recvfrom(s, buffer, sizeof(buffer), 0, (sockaddr*)&fromAddr, &fromAddrLen)) > 0) {
         // Got some more data

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1968,7 +1968,7 @@ bool S_recvappend(int s, SFastBuffer& recvBuffer) {
     char buffer[4096];
     int totalRecv = 0;
     ssize_t numRecv = 0;
-    sockaddr_in fromAddr = {0};
+    sockaddr_in fromAddr;
     socklen_t fromAddrLen = sizeof(fromAddr);
     while ((numRecv = recvfrom(s, buffer, sizeof(buffer), 0, (sockaddr*)&fromAddr, &fromAddrLen)) > 0) {
         // Got some more data

--- a/sqlitecluster/SQLiteCommand.cpp
+++ b/sqlitecluster/SQLiteCommand.cpp
@@ -30,7 +30,6 @@ SData SQLiteCommand::preprocessRequest(SData&& request) {
 SQLiteCommand::SQLiteCommand(SData&& _request) :
     privateRequest(move(preprocessRequest(move(_request)))),
     request(privateRequest),
-    initiatingPeerID(0),
     initiatingClientID(0),
     writeConsistency(SQLiteNode::ASYNC),
     complete(false),
@@ -60,7 +59,6 @@ SQLiteCommand::SQLiteCommand(SData&& _request) :
 SQLiteCommand::SQLiteCommand(SQLiteCommand&& from) :
     privateRequest(move(from.privateRequest)),
     request(privateRequest),
-    initiatingPeerID(from.initiatingPeerID),
     initiatingClientID(from.initiatingClientID),
     id(move(from.id)),
     jsonContent(move(from.jsonContent)),
@@ -76,7 +74,6 @@ SQLiteCommand::SQLiteCommand(SQLiteCommand&& from) :
 SQLiteCommand::SQLiteCommand() :
     privateRequest(),
     request(privateRequest),
-    initiatingPeerID(0),
     initiatingClientID(0),
     writeConsistency(SQLiteNode::ASYNC),
     complete(false),

--- a/sqlitecluster/SQLiteCommand.h
+++ b/sqlitecluster/SQLiteCommand.h
@@ -35,9 +35,6 @@ class SQLiteCommand {
     // Accumulated response content
     STable jsonContent;
 
-    // Makes it not crash.
-    char empty;
-
     // Final response
     SData response;
 

--- a/sqlitecluster/SQLiteCommand.h
+++ b/sqlitecluster/SQLiteCommand.h
@@ -35,6 +35,9 @@ class SQLiteCommand {
     // Accumulated response content
     STable jsonContent;
 
+    // Makes it not crash.
+    char empty;
+
     // Final response
     SData response;
 

--- a/sqlitecluster/SQLiteCommand.h
+++ b/sqlitecluster/SQLiteCommand.h
@@ -22,17 +22,6 @@ class SQLiteCommand {
     // This allows for modifying a request passed into the constructor such that we can store it as `const`.
     static SData preprocessRequest(SData&& request);
 
-    // If this command was created via an escalation from a peer, this value will point to that peer object. As such,
-    // this should only ever be set on leader nodes, though it does not *need* to be set on leader nodes, as they can
-    // also accept connections directly from clients.
-    // A value of zero is an invalid ID, and is interpreted to mean "not set".
-    // A negative value indicates a valid ID of an invalid peer (a psuedo-peer, or a disconnected peer), that we can't
-    // respond to.
-    int64_t initiatingPeerID;
-
-    // If this command was created via a direct client connection, this value should be set. This can be set on both
-    // leader and followers, but should not be set simultaneously with `initiatingPeerID`. A command was initiated either
-    // by a client, or by a peer.
     // A value of zero is an invalid ID, and is interpreted to mean "not set".
     // A negative value indicates a valid ID of an invalid client (a psuedo-client, or a disconnected client), that we
     // can't respond to.

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -78,13 +78,13 @@ ClusterTester<T>::ClusterTester(ClusterSize size,
         ports[i][2] = controlPort;
     }
 
-    // If the test plugin exists, load it. Otherwise, skip it. This keeps this from failing for derived tests that
+    // If the test plugin exists, and isn't already specified, load it. Otherwise, skip it. This keeps this from failing for derived tests that
     // don't use this plugin. This should get moved somewhere else, really. Probably inside TestPlugin.
     char cwd[1024];
     if (!getcwd(cwd, sizeof(cwd))) {
         STHROW("Couldn't get CWD");
     }
-    if (SFileExists(string(cwd) + "/testplugin/testplugin.so")) {
+    if (SFileExists(string(cwd) + "/testplugin/testplugin.so") && !SContains(pluginsToLoad, "testplugin")) {
         pluginsToLoad += pluginsToLoad.size() ? "," : "";
         pluginsToLoad += string(cwd) + "/testplugin/testplugin.so";
     }

--- a/test/clustertest/tests/ClusterUpgradeTest.cpp
+++ b/test/clustertest/tests/ClusterUpgradeTest.cpp
@@ -172,9 +172,6 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
         ASSERT_EQUAL(versions[2], devVersion);
 
         // Now we need to send a command to node 1 to verify we can escalate old->new.
-        cout << "Sleeping for 10 seconds, see if this is where you need to look." << endl;
-        sleep(10);
-        cout << "Done." << endl;
         cmdResult = tester->getTester(1).executeWaitMultipleData({cmd});
         ASSERT_EQUAL(cmdResult[0].methodLine, "200 OK");
 

--- a/test/clustertest/tests/ClusterUpgradeTest.cpp
+++ b/test/clustertest/tests/ClusterUpgradeTest.cpp
@@ -11,6 +11,8 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
 
     BedrockClusterTester* tester;
     string prodBedrockName;
+    string prodBedrockPluginName;
+    string newTestPlugin;
 
     void setup() {
         // Get the most recent releases.
@@ -61,7 +63,9 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
 
         // If we've already built this, don't bother doing it again. This makes running this test multiple times in a
         // row much faster.
-        prodBedrockName = "/tmp/bedrock-" + bedrockTagName; 
+        string prodBedrockDirName = "/tmp/bedrock-" + bedrockTagName;
+        prodBedrockName = prodBedrockDirName + "/bedrock";
+        prodBedrockPluginName = prodBedrockDirName + "/testplugin.so";
         if (!SFileExists(prodBedrockName)) {
             // Get a directory we can work in.
             char brReleaseDirArr[] = "/tmp/br-prod-test-XXXXXX";
@@ -75,13 +79,26 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
             ASSERT_FALSE(system(("cd " + brReleaseDir + " && cd Bedrock && git checkout " + bedrockTagName + "  > /dev/null").c_str()));
 
             // Build the release.
-            ASSERT_FALSE(system(("cd " + brReleaseDir + " && cd Bedrock && make -j8 bedrock  > /dev/null").c_str()));
+            ASSERT_FALSE(system(("cd " + brReleaseDir + " && cd Bedrock && make -j8 > /dev/null").c_str()));
 
             // Save the final product.
+            mkdir(prodBedrockDirName.c_str(), 0755);
             ASSERT_FALSE(system(("mv " + brReleaseDir + "/Bedrock/bedrock " + prodBedrockName).c_str()));
+            ASSERT_FALSE(system(("mv " + brReleaseDir + "/Bedrock/test/clustertest/testplugin/testplugin.so " + prodBedrockPluginName).c_str()));
+
+            // Remove the intermediate dir.
+            rmdir(brReleaseDir.c_str());
         }
 
-        tester = new BedrockClusterTester("db,cache,jobs", prodBedrockName);
+        // Figure out where the new test plugin is.
+        char cwd[1024];
+        if (!getcwd(cwd, sizeof(cwd))) {
+            STHROW("Couldn't get CWD");
+        }
+        newTestPlugin = string(cwd) + "/testplugin/testplugin.so";
+
+        // Load the whole prod cluster with the prod test plugin.
+        tester = new BedrockClusterTester("db,cache,jobs," + prodBedrockPluginName, prodBedrockName);
     }
 
     void teardown() {
@@ -117,6 +134,7 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
         // Restart 2 on the new version.
         tester->getTester(2).stopServer();
         tester->getTester(2).serverName = "bedrock";
+        tester->getTester(2).updateArgs({{"-plugins","db,cache,jobs," + newTestPlugin}});
         tester->getTester(2).startServer();
         ASSERT_TRUE(tester->getTester(2).waitForState("FOLLOWING"));
 
@@ -139,6 +157,7 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
 
         // Start up the old leader on the new version.
         tester->getTester(0).serverName = "bedrock";
+        tester->getTester(1).updateArgs({{"-plugins","db,cache,jobs," + newTestPlugin}});
         tester->getTester(0).startServer();
 
         // We should get the expected cluster state.
@@ -159,6 +178,7 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
         // And finally, upgrade the last node.
         tester->getTester(1).stopServer();
         tester->getTester(1).serverName = "bedrock";
+        tester->getTester(1).updateArgs({{"-plugins","db,cache,jobs," + newTestPlugin}});
         tester->getTester(1).startServer();
         ASSERT_TRUE(tester->getTester(1).waitForState("FOLLOWING"));
 

--- a/test/clustertest/tests/ClusterUpgradeTest.cpp
+++ b/test/clustertest/tests/ClusterUpgradeTest.cpp
@@ -98,7 +98,7 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
         newTestPlugin = string(cwd) + "/testplugin/testplugin.so";
 
         // Load the whole prod cluster with the prod test plugin.
-        tester = new BedrockClusterTester("db,cache,jobs," + prodBedrockPluginName, prodBedrockName);
+        tester = new BedrockClusterTester(prodBedrockPluginName, prodBedrockName);
     }
 
     void teardown() {
@@ -134,7 +134,7 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
         // Restart 2 on the new version.
         tester->getTester(2).stopServer();
         tester->getTester(2).serverName = "bedrock";
-        tester->getTester(2).updateArgs({{"-plugins","db,cache,jobs," + newTestPlugin}});
+        tester->getTester(2).updateArgs({{"-plugins", newTestPlugin}});
         tester->getTester(2).startServer();
         ASSERT_TRUE(tester->getTester(2).waitForState("FOLLOWING"));
 
@@ -157,7 +157,7 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
 
         // Start up the old leader on the new version.
         tester->getTester(0).serverName = "bedrock";
-        tester->getTester(1).updateArgs({{"-plugins","db,cache,jobs," + newTestPlugin}});
+        tester->getTester(0).updateArgs({{"-plugins", newTestPlugin}});
         tester->getTester(0).startServer();
 
         // We should get the expected cluster state.
@@ -172,13 +172,16 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
         ASSERT_EQUAL(versions[2], devVersion);
 
         // Now we need to send a command to node 1 to verify we can escalate old->new.
+        cout << "Sleeping for 10 seconds, see if this is where you need to look." << endl;
+        sleep(10);
+        cout << "Done." << endl;
         cmdResult = tester->getTester(1).executeWaitMultipleData({cmd});
         ASSERT_EQUAL(cmdResult[0].methodLine, "200 OK");
 
         // And finally, upgrade the last node.
         tester->getTester(1).stopServer();
         tester->getTester(1).serverName = "bedrock";
-        tester->getTester(1).updateArgs({{"-plugins","db,cache,jobs," + newTestPlugin}});
+        tester->getTester(1).updateArgs({{"-plugins", newTestPlugin}});
         tester->getTester(1).startServer();
         ASSERT_TRUE(tester->getTester(1).waitForState("FOLLOWING"));
 


### PR DESCRIPTION
### Details
Cleanup PR, removes obsolete `initiatingPeerID`.

This had a super confusing bug causing it to crash in the *old* bedrock during `ClusterUpgradeTest` that was perplexing.

It turned out that we were building the old version of the cluster to upgrade from, but loading the new `TestPlugin` that the tests build with it, which could cause it to crash from some misalignment issue between the old and new code.

This change incorporates

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/224506

### Tests
This is predominantly a test change.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
