### PR TITLE
Add milliseconds to all timestamps

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2905,7 +2905,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold,
 }
 
 string SUNQUOTED_TIMESTAMP(uint64_t when) {
-    return SComposeTime("%Y-%m-%d %H:%M:%S", when);
+    return SComposeTime("%Y-%m-%d %H:%M:%f", when);
 }
 
 string STIMESTAMP(uint64_t when) {


### PR DESCRIPTION
### Details
This adds milliseconds to almost all timestamps.

### Fixed Issues
This is necessary because we are adding a reportActionID column to the reportActions table as the primary key. However, there are many places where we do `ORDER BY ROWID`, where `ROWID` will no longer be sequential. Instead, we need to `ORDER BY created`. In order to make that more predictable/precise, we will add ms to the `created` timestamp.

While we _could_ do that in only one place, I opted for the slightly more drastic option of just adding ms everywhere ... because it _should_ be pretty safe to do?

### Tests
1. Recompile Bedrock and Auth
1. Run Auth tests
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
