### PR TITLE
Fix mistaken "successful" message about communicating with peer nodes.

### DIFF
--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -230,8 +230,11 @@ bool SQLitePeer::isPermafollower(const STable& params) {
 void SQLitePeer::sendMessage(const SData& message) {
     lock_guard<decltype(peerMutex)> lock(peerMutex);
     if (socket) {
-        socket->send(message.serialize());
-        SINFO("Successfully sent " << message.methodLine << " to peer " << name << ".");
+        if (socket->send(message.serialize())) {
+            SINFO("Successfully sent " << message.methodLine << " to peer " << name << ".");
+        } else {
+            SHMMM("Could not send " << message.methodLine << " to peer " << name << ".");
+        }
     } else {
         SINFO("Tried to send " << message.methodLine << " to peer " << name << ", but not available.");
     }


### PR DESCRIPTION
### Details
Since we never checked the output of `socket->send`, we'd always say it was successful. This fixes that.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/226146

### Tests
N/A
