### PR TITLE
Default _isCommandPortLikelyBlocked to false on init for broken tests

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1121,6 +1121,7 @@ BedrockServer::BedrockServer(const SData& args_)
     _lastQuorumCommandTime(STimeNow()), _pluginsDetached(false), _socketThreadNumber(0),
     _outstandingSocketThreads(0), _shouldBlockNewSocketThreads(false)
 {
+    _isCommandPortLikelyBlocked = false;
     _version = VERSION;
 
     // Enable the requested plugins, and update our version string if required.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1115,13 +1115,13 @@ BedrockServer::BedrockServer(SQLiteNode::State state, const SData& args_)
 BedrockServer::BedrockServer(const SData& args_)
   : SQLiteServer(), shutdownWhileDetached(false), args(args_), _requestCount(0), _replicationState(SQLiteNode::SEARCHING),
     _upgradeInProgress(false),
+    _isCommandPortLikelyBlocked(false),
     _syncThreadComplete(false), _syncNode(nullptr), _clusterMessenger(nullptr), _shutdownState(RUNNING),
     _multiWriteEnabled(args.test("-enableMultiWrite")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),
     _controlPort(nullptr), _commandPortPublic(nullptr), _commandPortPrivate(nullptr), _maxConflictRetries(3),
     _lastQuorumCommandTime(STimeNow()), _pluginsDetached(false), _socketThreadNumber(0),
     _outstandingSocketThreads(0), _shouldBlockNewSocketThreads(false)
 {
-    _isCommandPortLikelyBlocked = false;
     _version = VERSION;
 
     // Enable the requested plugins, and update our version string if required.


### PR DESCRIPTION
### Details
This was never initiated to a default value and bools are set to garbage by default. See 
https://app.travis-ci.com/github/Expensify/Auth/jobs/583377405 for proof 

This caused flakey parts of tests which became very apparent today
See this giant thread for context: https://expensify.slack.com/archives/C094TGUTZ/p1663671773822939

### Fixed Issues
Fixes auth tests not working on the 20.04.5 ubuntu version

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
