### PR TITLE
Hand out journals at use time instead of object creation time

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -214,7 +214,6 @@ SQLite::SQLite(const string& filename, int cacheSize, int maxJournalSize,
     _db(initializeDB(_filename, mmapSizeGB)),
     _journalNames(initializeJournal(_db, minJournalTables)),
     _sharedData(initializeSharedData(_db, _filename, _journalNames)),
-    _journalName(_journalNames[0]),
     _journalSize(initializeJournalSize(_db, _journalNames)),
     _pageLoggingEnabled(pageLoggingEnabled),
     _cacheSize(cacheSize),
@@ -230,7 +229,6 @@ SQLite::SQLite(const SQLite& from) :
     _db(initializeDB(_filename, from._mmapSizeGB)), // Create a *new* DB handle from the same filename, don't copy the existing handle.
     _journalNames(from._journalNames),
     _sharedData(from._sharedData),
-    _journalName(_journalNames[(_sharedData.nextJournalCount++ % _journalNames.size() - 1) + 1]),
     _journalSize(from._journalSize),
     _pageLoggingEnabled(from._pageLoggingEnabled),
     _cacheSize(from._cacheSize),
@@ -564,6 +562,7 @@ bool SQLite::prepare() {
     uint64_t before = STimeNow();
 
     // Crete our query.
+    _journalName = _journalNames[_sharedData.nextJournalCount++ % _journalNames.size()];
     string query = "INSERT INTO " + _journalName + " VALUES (" + SQ(commitCount + 1) + ", " + SQ(_uncommittedQuery) + ", " + SQ(_uncommittedHash) + " )";
 
     // These are the values we're currently operating on, until we either commit or rollback.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -332,7 +332,7 @@ class SQLite {
     SharedData& _sharedData;
 
     // The name of the journal table that this particular DB handle with write to.
-    const string _journalName;
+    string _journalName;
 
     // The current size of the journal, in rows. TODO: Why isn't this in SharedData?
     uint64_t _journalSize;


### PR DESCRIPTION
### Details
The idea behind this change is to reduce conflicts on the journal tables. We don't actually see a ton of conflicts on the journal tables currently, but we've made two deploys to remove the blocking queue (see: https://github.com/Expensify/Bedrock/pull/1353) and each time, we've had to revert them because of a high number of conflicts in journals causing a performance problem.

All of the following numbers are taken from `virt1.lax` which somehow seems to perform particularly badly here.

Here's a sample of a single weekday harvesting run, from 2022-09-23T02:00 until 2022-09-23T07:00. We had 8,868 total conflicts in journal tables. We hope to see this drop significantly after deploying this change.

```
❯ grep -o 'part of db table journal[^ ]\+' conflicts_harvesting_journal.log.virt1.lax | sort | uniq -c | sort -r
 344 part of db table journal;
 208 part of db table journal0000;
 201 part of db table journal0001;
 178 part of db table journal0003;
 169 part of db table journal0002;
 148 part of db table journal0006;
 145 part of db table journal0011;
 137 part of db table journal0004;
 127 part of db table journal0005;
 125 part of db table journal0009;
 120 part of db table journal0010;
 116 part of db table journal0008;
 114 part of db table journal0013;
 113 part of db table journal0016;
 110 part of db table journal0015;
 109 part of db table journal0014;
 102 part of db table journal0022;
 102 part of db table journal0018;
 102 part of db table journal0012;
  98 part of db table journal0007;
  96 part of db table journal0020;
  95 part of db table journal0021;
  95 part of db table journal0019;
  94 part of db table journal0023;
  91 part of db table journal0029;
  91 part of db table journal0024;
  89 part of db table journal0039;
  89 part of db table journal0031;
  87 part of db table journal0026;
  83 part of db table journal0038;
  83 part of db table journal0025;
  81 part of db table journal0017;
  80 part of db table journal0037;
  80 part of db table journal0035;
  79 part of db table journal0027;
  76 part of db table journal0045;
  74 part of db table journal0034;
  74 part of db table journal0028;
  70 part of db table journal0051;
  69 part of db table journal0043;
  69 part of db table journal0036;
  66 part of db table journal0042;
  65 part of db table journal0047;
  63 part of db table journal0044;
  63 part of db table journal0030;
  62 part of db table journal0032;
  61 part of db table journal0052;
  59 part of db table journal0055;
  59 part of db table journal0046;
  59 part of db table journal0033;
  58 part of db table journal0060;
  58 part of db table journal0048;
  57 part of db table journal0066;
  57 part of db table journal0054;
  56 part of db table journal0050;
  55 part of db table journal0040;
  53 part of db table journal0073;
  53 part of db table journal0057;
  53 part of db table journal0049;
  53 part of db table journal0041;
  51 part of db table journal0071;
  50 part of db table journal0053;
  49 part of db table journal0072;
  49 part of db table journal0065;
  49 part of db table journal0064;
  47 part of db table journal0069;
  47 part of db table journal0061;
  47 part of db table journal0059;
  47 part of db table journal0058;
  45 part of db table journal0062;
  44 part of db table journal0074;
  43 part of db table journal0068;
  43 part of db table journal0056;
  42 part of db table journal0079;
  41 part of db table journal0070;
  40 part of db table journal0077;
  40 part of db table journal0063;
  38 part of db table journal0081;
  38 part of db table journal0076;
  37 part of db table journal0088;
  37 part of db table journal0083;
  37 part of db table journal0080;
  36 part of db table journal0109;
  36 part of db table journal0101;
  36 part of db table journal0087;
  36 part of db table journal0075;
  36 part of db table journal0067;
  35 part of db table journal0084;
  35 part of db table journal0082;
  34 part of db table journal0095;
  34 part of db table journal0092;
  34 part of db table journal0085;
  33 part of db table journal0106;
  33 part of db table journal0097;
  32 part of db table journal0105;
  31 part of db table journal0108;
  30 part of db table journal0094;
  29 part of db table journal0123;
  29 part of db table journal0086;
  28 part of db table journal0114;
  28 part of db table journal0096;
  28 part of db table journal0090;
  28 part of db table journal0078;
  27 part of db table journal0122;
  27 part of db table journal0104;
  27 part of db table journal0102;
  27 part of db table journal0098;
  27 part of db table journal0093;
  26 part of db table journal0129;
  26 part of db table journal0127;
  26 part of db table journal0112;
  26 part of db table journal0103;
  25 part of db table journal0130;
  25 part of db table journal0118;
  25 part of db table journal0110;
  24 part of db table journal0150;
  24 part of db table journal0139;
  24 part of db table journal0124;
  24 part of db table journal0116;
  24 part of db table journal0107;
  24 part of db table journal0100;
  23 part of db table journal0147;
  23 part of db table journal0120;
  23 part of db table journal0119;
  23 part of db table journal0113;
  23 part of db table journal0099;
  23 part of db table journal0089;
  22 part of db table journal0140;
  22 part of db table journal0121;
  21 part of db table journal0128;
  21 part of db table journal0115;
  21 part of db table journal0091;
  19 part of db table journal0155;
  19 part of db table journal0143;
  19 part of db table journal0111;
  18 part of db table journal0153;
  18 part of db table journal0145;
  18 part of db table journal0144;
  18 part of db table journal0138;
  18 part of db table journal0136;
  18 part of db table journal0126;
  18 part of db table journal0117;
  17 part of db table journal0142;
  17 part of db table journal0137;
  17 part of db table journal0133;
  16 part of db table journal0169;
  16 part of db table journal0152;
  16 part of db table journal0151;
  16 part of db table journal0149;
  16 part of db table journal0135;
  16 part of db table journal0132;
  16 part of db table journal0131;
  15 part of db table journal0175;
  15 part of db table journal0160;
  15 part of db table journal0157;
  15 part of db table journal0154;
  15 part of db table journal0148;
  15 part of db table journal0141;
  14 part of db table journal0173;
  14 part of db table journal0167;
  14 part of db table journal0125;
  13 part of db table journal0179;
  13 part of db table journal0161;
  12 part of db table journal0182;
  12 part of db table journal0180;
  12 part of db table journal0172;
  12 part of db table journal0170;
  12 part of db table journal0168;
  12 part of db table journal0166;
  12 part of db table journal0146;
  11 part of db table journal0185;
  11 part of db table journal0159;
  11 part of db table journal0158;
  11 part of db table journal0156;
  10 part of db table journal0190;
  10 part of db table journal0187;
  10 part of db table journal0183;
  10 part of db table journal0177;
  10 part of db table journal0174;
  10 part of db table journal0164;
  10 part of db table journal0134;
   8 part of db table journal0189;
   8 part of db table journal0178;
   8 part of db table journal0171;
   8 part of db table journal0165;
   8 part of db table journal0163;
   7 part of db table journal0192;
   7 part of db table journal0188;
   7 part of db table journal0181;
   7 part of db table journal0176;
   7 part of db table journal0162;
   6 part of db table journal0191;
   6 part of db table journal0184;
   5 part of db table journal0186;
   ```
   
As a comparison, we saw 401,559 conflicts in journal tables ob virt1.lax in *a single hour* with the change to remove the blocking queue. If this change reduces conflicts during harvesting in general, we can retry removing the blocking queue and see if we have better luck.

Note that the distribution of which journal tables conflict is significantly more even when we removed the blocking queue, but that may just be due to higher volume.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/221908

### Tests
This needs to be tested in prod.