### PR TITLE
re-write 'SEARCHING' section for clarity and to fix forkedFrom selection

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -506,7 +506,7 @@ bool SQLiteNode::update() {
             SHMMM("No peers configured, jumping to LEADING");
             _changeState(LEADING);
 
-            // re-run `update` immediately.
+            // Run `update` again immediately.
             return true;
         }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -495,6 +495,7 @@ bool SQLiteNode::update() {
         SASSERTWARN(!_syncPeer);
         SASSERTWARN(!_leadPeer);
         SASSERTWARN(_db.getUncommittedHash().empty());
+
         // If we're trying to shut down, just do nothing, especially don't jump directly to leading and get stuck in an endless loop.
         if (_isShuttingDown) {
             return false; // Don't re-update
@@ -502,86 +503,82 @@ bool SQLiteNode::update() {
 
         // If no peers, we're the leader, unless we're shutting down.
         if (_peerList.empty()) {
-            // There are no peers, jump straight to leading
             SHMMM("No peers configured, jumping to LEADING");
             _changeState(LEADING);
-            return true; // Re-update immediately
+
+            // re-run `update` immediately.
+            return true;
         }
 
         // How many peers have we logged in to?
-        int numFullPeers = 0;
-        int numLoggedInFullPeers = 0;
+        size_t numFullPeers = 0;
+        size_t numLoggedInFullPeers = 0;
         SQLitePeer* freshestPeer = nullptr;
-        for (auto peer : _peerList) {
-            // Wait until all connected (or failed) and logged in
-            bool permaFollower = peer->permaFollower;
-            bool loggedIn = peer->loggedIn;
+        for (const auto peer : _peerList) {
+            // Count how many full peers (non-permafollowers) we have, and how many are logged in.
+            // Note that the `permaFollower` property is const and this value will always be the same for a given peer.
+            if (!peer->permaFollower) {
+                numFullPeers++;
+                if (peer->loggedIn) {
+                    numLoggedInFullPeers++;
+                }
+            }
 
-            // Count how many full peers (non-permafollowers) we have
-            numFullPeers += !permaFollower;
+            // Find the freshest non-broken peer (including permafollowers).
+            if (peer->loggedIn) {
+                if (_forkedFrom.count(peer->name)) {
+                    SWARN("Hash mismatch. Forked from peer " << peer->name << " so not considering it.");
+                    continue;
+                }
 
-            // Count how many full peers are logged in
-            numLoggedInFullPeers += (!permaFollower) && loggedIn;
-
-            // Find the freshest peer
-            if (loggedIn) {
-                // The freshest peer is the one that has the most commits.
+                // The freshest peer is the one that has the most commits. There can be ties here, they don't matter.
                 if (!freshestPeer || peer->commitCount > freshestPeer->commitCount) {
                     freshestPeer = peer;
                 }
             }
         }
 
-        // Keep searching until we connect to at least half our non-permafollowers peers OR timeout
-        SINFO("Signed in to " << numLoggedInFullPeers << " of " << numFullPeers << " full peers (" << _peerList.size()
-                              << " with permafollowers), timeout in " << (_stateTimeout - STimeNow()) / 1000
-                              << "ms");
-        if (((float)numLoggedInFullPeers < numFullPeers / 2.0) && (STimeNow() < _stateTimeout))
+        SINFO("Signed in to " << numLoggedInFullPeers << " of " << numFullPeers << " full peers (" << _peerList.size() << " with permafollowers).");
+
+        // We just keep searching until we are connected to at least half the full peers.
+        // Note that `numLoggedInFullPeers == numFullPeers` is adequate to satisfy the cluster size, because we do not include ourselves in the cluster size.
+        // For example, for a cluster of size 5, we have 4 peers. If we are logged into two of them, that means we are a group of three connected peers,
+        // which is sufficient for quorum. In this case `if (2 * 2 < 4)` will return `false` and we will skip the `return false`.
+        if (numLoggedInFullPeers * 2 < numFullPeers) {
             return false;
-
-        // We've given up searching; did we time out?
-        if (STimeNow() >= _stateTimeout)
-            SHMMM("Timeout SEARCHING for peers, continuing.");
-
-        // If no freshest (not connected to anyone), wait
-        if (!freshestPeer) {
-            // Unable to connect to anyone
-            SHMMM("Unable to connect to any peer, WAITING.");
-            _changeState(WAITING);
-            return true; // Re-update
         }
 
-        // How does our state compare with the freshest peer?
-        SASSERT(freshestPeer);
-        uint64_t freshestPeerCommitCount = freshestPeer->commitCount;
-        if (freshestPeerCommitCount == _db.getCommitCount()) {
-            // We're up to date
+        // The only way to not have a freshest peer, given that we've already checked that there should be peers, and that we're connected to at least half of
+        // them, is if all of the peers that we're connected to have forked from us. In this case, the best course of action is to wait for a non-forked peer
+        // to connect. If we have forked from too many peers, we can't get here, we'll have crashed.
+        if (!freshestPeer) {
+            SHMMM("Not connected to any non-forked peer. Retrying.");
+            return false;
+        }
+
+        // If we're at or ahead of the freshest peer, we can move forward towards LEADING or FOLLOWING.
+        if (_db.getCommitCount() >= freshestPeer->commitCount) {
             SINFO("Synchronized with the freshest peer '" << freshestPeer->name << "', WAITING.");
             _changeState(WAITING);
-            return true; // Re-update
+
+            // Run `update` again immediately.
+            return true;
         }
 
-        // Are we fresher than the freshest peer?
-        if (freshestPeerCommitCount < _db.getCommitCount()) {
-            // Looks like we're the freshest peer overall
-            SINFO("We're the freshest peer, WAITING.");
-            _changeState(WAITING);
-            return true; // Re-update
-        }
-
-        // It has a higher commit count than us, synchronize.
-        SASSERT(freshestPeerCommitCount > _db.getCommitCount());
+        // Otherwise, the peer has a higher commit count than us, synchronize from it.
         SASSERTWARN(!_syncPeer);
         _updateSyncPeer();
         if (_syncPeer) {
             _sendToPeer(_syncPeer, SData("SYNCHRONIZE"));
-        } else {
-            SWARN("Updated to NULL _syncPeer when about to send SYNCHRONIZE. Going to WAITING.");
-            _changeState(WAITING);
-            return true; // Re-update
+            _changeState(SYNCHRONIZING);
+
+            // Run `update` again immediately.
+            return true;
         }
-        _changeState(SYNCHRONIZING);
-        return true; // Re-update
+
+        // Wait on some network activity to see if we can fix this with a new peer login.
+        SWARN("We have a fresher peer but couldn't get a sync peer, SEARCHING again.");
+        return false;
     }
 
     /// - SYNCHRONIZING: We only stay in this state while waiting for
@@ -1873,7 +1870,7 @@ void SQLiteNode::_changeState(SQLiteNode::State newState) {
         } 
 
         if (newState >= STANDINGUP) {
-            // Not forked from anyone.
+            // Not forked from anyone. Note that this includes both LEADING and FOLLOWING.
             _forkedFrom.clear();
         }
 


### PR DESCRIPTION
### Details

This largely re-writes the SEARCHING section of `SQLiteNode::update` for clarity. It changed the way we select `freshestPeer` to ignore forked peers, and changes behavior to wait for more network activity in this case.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/230531
Fixes https://github.com/Expensify/Expensify/issues/230533

### Tests
Existing tests.