### PR TITLE
Add accessor for recent error message

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -18,6 +18,12 @@ sqlite3* SQLite::getDBHandle() {
     return _db;
 }
 
+thread_local string SQLite::_mostRecentSQLiteErrorLog;
+
+const string SQLite::getMostRecentSQLiteErrorLog() const {
+    return _mostRecentSQLiteErrorLog;
+}
+
 string SQLite::initializeFilename(const string& filename) {
     // Canonicalize our filename and save that version.
     if (filename == ":memory:") {
@@ -259,7 +265,8 @@ int SQLite::_walHookCallback(void* sqliteObject, sqlite3* db, const char* name, 
 }
 
 void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg) {
-    SSYSLOG(LOG_INFO, "[info] " << "{SQLITE} Code: " << iErrCode << ", Message: " << zMsg);
+    _mostRecentSQLiteErrorLog = "{SQLITE} Code: "s + to_string(iErrCode) + ", Message: "s + zMsg;
+    SSYSLOG(LOG_INFO, "[info] " << _mostRecentSQLiteErrorLog);
 }
 
 int SQLite::_sqliteTraceCallback(unsigned int traceCode, void* c, void* p, void* x) {

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -187,6 +187,9 @@ class SQLite {
     // Gets any error message associated with the previous query
     string getLastError() { return sqlite3_errmsg(_db); }
 
+    // Returns the most recent error string from sqlite.
+    const string getMostRecentSQLiteErrorLog() const;
+
     // Returns true if we're inside an uncommitted transaction.
     bool insideTransaction() { return _insideTransaction; }
 
@@ -465,4 +468,7 @@ class SQLite {
     int _cacheSize;
     const string _synchronous;
     int64_t _mmapSizeGB;
+
+    // This is a string (which may be empty) containing the most recent logged error by SQLite in this thread.
+    static thread_local string _mostRecentSQLiteErrorLog;
 };


### PR DESCRIPTION
### Details
This adds a simple way to query for a recent error message from code, without having to find it in the logs.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/232598

### Tests
This will be tested in the auth change.
