### PR TITLE
Attempt to avoid forking when a quorum command is slow.

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -253,3 +253,9 @@ void BedrockCommand::postPoll(fd_map& fdm, uint64_t nextActivity, uint64_t maxWa
         transaction->manager.postPoll(fdm, *transaction, nextActivity, maxWaitMS);
     }
 }
+
+void BedrockCommand::setTimeout(uint64_t timeout) {
+    timeout *= 1'000;
+    timeout += STimeNow();
+    _timeout = timeout;
+}

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -254,8 +254,9 @@ void BedrockCommand::postPoll(fd_map& fdm, uint64_t nextActivity, uint64_t maxWa
     }
 }
 
-void BedrockCommand::setTimeout(uint64_t timeout) {
-    timeout *= 1'000;
-    timeout += STimeNow();
-    _timeout = timeout;
+void BedrockCommand::setTimeout(uint64_t timeoutDurationMS) {
+    // Because _timeout is in microseconds.
+    timeoutDurationMS *= 1'000;
+    timeoutDurationMS += STimeNow();
+    _timeout = timeoutDurationMS;
 }

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -151,8 +151,8 @@ class BedrockCommand : public SQLiteCommand {
     // Return the timestamp by which this command must finish executing.
     uint64_t timeout() const { return _timeout; }
 
-    // In milliseconds from the current time.
-    void setTimeout(uint64_t timeout);
+    // This updates the timeout for this command to the specified number of milliseconds from the current time.
+    void setTimeout(uint64_t timeoutDurationMS);
 
     // Return the number of commands in existence.
     static size_t getCommandCount() { return _commandCount.load(); }

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -151,6 +151,9 @@ class BedrockCommand : public SQLiteCommand {
     // Return the timestamp by which this command must finish executing.
     uint64_t timeout() const { return _timeout; }
 
+    // In milliseconds from the current time.
+    void setTimeout(uint64_t timeout);
+
     // Return the number of commands in existence.
     static size_t getCommandCount() { return _commandCount.load(); }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -900,7 +900,8 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                 core.rollback();
                 auto _clusterMessengerCopy = _clusterMessenger;
                 if (state == SQLiteNode::LEADING) {
-                    // Limit the command timeout to 20s.
+                    // Limit the command timeout to 20s to avoid blocking the sync thread long enough to cause the cluster to give up and elect a new leader (causing a fork), which happens
+                    // after 30s.
                     command->setTimeout(20'000);
                     SINFO("Sending non-parallel command " << command->request.methodLine
                           << " to sync thread. Sync thread has " << _syncNodeQueuedCommands.size() << " queued commands.");

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -488,7 +488,6 @@ void BedrockServer::sync()
                     // risk duplicating that request. If your command creates an HTTPS request, it needs to explicitly
                     // re-verify that any checks made in peek are still valid in process.
                     if (!command->httpsRequests.size()) {
-                        // runs
                         BedrockCore::RESULT result = core.peekCommand(command, true);
                         if (result == BedrockCore::RESULT::COMPLETE) {
                             // This command completed in peek, respond to it appropriately, either directly or by sending it
@@ -521,7 +520,6 @@ void BedrockServer::sync()
                         }
                     }
 
-                    // runs
                     BedrockCore::RESULT result = core.processCommand(command, true);
                     if (result == BedrockCore::RESULT::NEEDS_COMMIT) {
                         // The processor says we need to commit this, so let's start that process.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -61,6 +61,7 @@ void BedrockServer::syncWrapper()
 {
     // Initialize the thread.
     SInitialize(_syncThreadName);
+    isSyncThread = true;
 
     while(true) {
         // If the server's set to be detached, we wait until that flag is unset, and then start the sync thread.
@@ -487,6 +488,7 @@ void BedrockServer::sync()
                     // risk duplicating that request. If your command creates an HTTPS request, it needs to explicitly
                     // re-verify that any checks made in peek are still valid in process.
                     if (!command->httpsRequests.size()) {
+                        // runs
                         BedrockCore::RESULT result = core.peekCommand(command, true);
                         if (result == BedrockCore::RESULT::COMPLETE) {
                             // This command completed in peek, respond to it appropriately, either directly or by sending it
@@ -519,6 +521,7 @@ void BedrockServer::sync()
                         }
                     }
 
+                    // runs
                     BedrockCore::RESULT result = core.processCommand(command, true);
                     if (result == BedrockCore::RESULT::NEEDS_COMMIT) {
                         // The processor says we need to commit this, so let's start that process.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -899,6 +899,8 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                 core.rollback();
                 auto _clusterMessengerCopy = _clusterMessenger;
                 if (state == SQLiteNode::LEADING) {
+                    // Limit the command timeout to 20s.
+                    command->setTimeout(20'000);
                     SINFO("Sending non-parallel command " << command->request.methodLine
                           << " to sync thread. Sync thread has " << _syncNodeQueuedCommands.size() << " queued commands.");
                     _syncNodeQueuedCommands.push(move(command));

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -80,6 +80,7 @@
 
 thread_local string SThreadLogPrefix;
 thread_local string SThreadLogName;
+thread_local bool isSyncThread;
 
 // We store the process name passed in `SInitialize` to use in logging.
 thread_local string SProcessName;
@@ -97,6 +98,7 @@ atomic_flag SLogSocketsInitialized = ATOMIC_FLAG_INIT;
 atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc = &syslog;
 
 void SInitialize(string threadName, const char* processName) {
+    isSyncThread = false;
     // This is not really thread safe. It's guaranteed to run only once, because of the atomic flag, but it's not
     // guaranteed that a second caller to `SInitialize` will wait until this block has completed before attempting to
     // use the socket logging variables. This is handled by the fact that we call `SInitialize` in main() which waits

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2528,9 +2528,11 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
             if (isSyncThread) {
                 prepareTimeUS += STimeNow() - beforePrepare;
             }
-             if (error) {
-                // This will just drop through to the general error handling below.
+            if (error) {
+                // Delete our statement.
                 sqlite3_finalize(preparedStatement);
+
+                // This will just drop through to the general error handling below.
                 break;
             } else if (!preparedStatement) {
                 // If we get a null statement (from parsing a blank string) we can skip, this isn't an error.

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2535,8 +2535,11 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
         do {
             sqlite3_stmt *preparedStatement = nullptr;
             error = sqlite3_prepare_v2(db, statementRemainder, strlen(statementRemainder), &preparedStatement, &statementRemainder);
-            if (!preparedStatement) {
-                // If we get a null statement (from parsing a blank string) we can skip.
+             if (error) {
+                // This will just drop through to the general error handling below.
+                continue;
+            } else if (!preparedStatement) {
+                // If we get a null statement (from parsing a blank string) we can skip, this isn't an error.
                 error = SQLITE_OK;
                 continue;
             }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 // --------------------------------------------------------------------------
 // libstuff.cpp
 // --------------------------------------------------------------------------
@@ -2597,8 +2596,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
         if (error != SQLITE_BUSY || extErr == SQLITE_BUSY_SNAPSHOT) {
             break;
         }
-
-        SWARN("sqlite3_exec returned SQLITE_BUSY on try #"
+        SWARN("sqlite3 returned SQLITE_BUSY on try #"
               << (tries + 1) << " of " << MAX_TRIES << ". "
               << "Extended error code: " << sqlite3_extended_errcode(db) << ". "
               << (((tries + 1) < MAX_TRIES) ? "Sleeping 1 second and re-trying." : "No more retries."));
@@ -2612,7 +2610,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
 
     // Warn if it took longer than the specified threshold
     string sqlToLog = sql;
-    if ((int64_t)elapsed > 1000) {
+    if ((int64_t)elapsed > warnThreshold) {
         // This code removing authTokens is a quick fix and should be removed once https://github.com/Expensify/Expensify/issues/144185 is done.
         pcrecpp::RE("\"authToken\":\"[0-9A-F]{400,1024}\"").GlobalReplace("\"authToken\":<REDACTED>", &sqlToLog);
         if (isSyncThread) {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2536,9 +2536,14 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
             sqlite3_stmt *preparedStatement = nullptr;
             error = sqlite3_prepare_v2(db, statementRemainder, strlen(statementRemainder), &preparedStatement, &statementRemainder);
             int numColumns = sqlite3_column_count(preparedStatement);
+            result.headers.resize(numColumns);
 
             while (true) {
                 error = sqlite3_step(preparedStatement);
+                for (int i = 0; i < numColumns; i++) {
+                    result.headers[i] = sqlite3_column_name(preparedStatement, i);
+                }
+
                 if (error == SQLITE_DONE) {
                     error = SQLITE_OK;
                     break;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2535,6 +2535,11 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
         do {
             sqlite3_stmt *preparedStatement = nullptr;
             error = sqlite3_prepare_v2(db, statementRemainder, strlen(statementRemainder), &preparedStatement, &statementRemainder);
+            if (!preparedStatement) {
+                // If we get a null statement (from parsing a blank string) we can break.
+                error = SQLITE_OK;
+                break;
+            }
             int numColumns = sqlite3_column_count(preparedStatement);
             result.headers.resize(numColumns);
 

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2537,11 +2537,12 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
             error = sqlite3_prepare_v2(db, statementRemainder, strlen(statementRemainder), &preparedStatement, &statementRemainder);
              if (error) {
                 // This will just drop through to the general error handling below.
-                continue;
+                sqlite3_finalize(preparedStatement);
+                break;
             } else if (!preparedStatement) {
                 // If we get a null statement (from parsing a blank string) we can skip, this isn't an error.
                 error = SQLITE_OK;
-                continue;
+                break;
             }
             int numColumns = sqlite3_column_count(preparedStatement);
             result.headers.resize(numColumns);
@@ -2583,7 +2584,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
                 }
             }
             sqlite3_finalize(preparedStatement);
-        } while (*statementRemainder != 0);
+        } while (*statementRemainder != 0 && error == SQLITE_OK);
 
         //error = sqlite3_exec(db, sql.c_str(), _SQueryCallback, &result, 0);
         extErr = sqlite3_extended_errcode(db);

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2538,7 +2538,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
             if (!preparedStatement) {
                 // If we get a null statement (from parsing a blank string) we can break.
                 error = SQLITE_OK;
-                break;
+                continue;
             }
             int numColumns = sqlite3_column_count(preparedStatement);
             result.headers.resize(numColumns);

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -264,6 +264,8 @@ extern atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc;
 extern thread_local string SThreadLogPrefix;
 extern thread_local string SThreadLogName;
 
+extern thread_local bool isSyncThread;
+
 // Thread-local log prefix
 void SLogSetThreadPrefix(const string& logPrefix);
 void SLogSetThreadName(const string& name);

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -286,7 +286,7 @@ class SQLite {
         // Mutex to serialize commits to this DB. This should be locked anytime a thread needs to commit to the DB, or
         // needs to prevent other threads from committing to the DB (such as to guarantee there are no commit conflicts
         // during a transaction).
-        recursive_mutex commitLock;
+        recursive_timed_mutex commitLock;
 
         // If set to false, this prevents any thread from being able to commit to the DB.
         atomic<bool> _commitEnabled;


### PR DESCRIPTION
### Details
I think these changes are correct but I don't actually think this will solve our problem. They are largely diagnostic, but *may* solve the problem in certain cases. I will comment inline in the PR with what each thing does.

Example of the new query timing logline from dev (note: I needed to decrease the time limits to trigger these in dev):
```
2022-11-18T17:41:10.407845+00:00 expensidev2004 bedrock10063: xxxxxx (libstuff.cpp:2642) SQuery [sync] [warn] Slow query sync (loops: 1, prepare US: 6543, steps: 2, step US: 6, longest step US: 3): SELECT * FROM sqlite_master WHERE tbl_name='journal'
```

Example of the new lock timeout error from dev:
```
vagrant@expensidev2004:/vagrant/Bedrock$ tail -F /var/log/syslog | grep '\(Failed to acquire commit lock\)\|\(Stack\)'
2022-11-18T21:09:56.937862+00:00 expensidev2004 bedrock10001: iHJG0w (SQLite.cpp:302) beginTransaction [sync] [warn] Failed to acquire commit lock in sync thread exclusive transaction!
2022-11-18T21:10:56.938027+00:00 expensidev2004 bedrock10001: kQAgrj (SQLite.cpp:302) beginTransaction [sync] [warn] Failed to acquire commit lock in sync thread exclusive transaction!
2022-11-18T21:11:56.939004+00:00 expensidev2004 bedrock10001: RxzMre (SQLite.cpp:302) beginTransaction [sync] [warn] Failed to acquire commit lock in sync thread exclusive transaction!
```

And:
```
✅ ConflictSpamTest::slow
[ConflictSpamTest] Node 2 Expected 200, got: 512
[ConflictSpamTest]
[ConflictSpamTest] Node 1 Expected 200, got: 512
[ConflictSpamTest]
[ConflictSpamTest] Node 1 Expected 200, got: 512
[ConflictSpamTest]
(Integral): 60015 != 60012
   assertion #1 at test/clustertest/tests/ConflictSpamTest.cpp:287
❌ !FAILED! ❌ ConflictSpamTest::spam

[ TEST RESULTS ] Passed: 1, Failed: 1
```

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/240223 https://github.com/Expensify/Expensify/issues/242390

### Tests
No new tests have been added, existing tests have been run extensively.
