### PR TITLE
Try and always checkpoint in exclusive mode

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -295,6 +295,7 @@ SQLite::~SQLite() {
 }
 
 bool SQLite::beginTransaction(TRANSACTION_TYPE type) {
+    _currentTransactionType = type;
     if (type == TRANSACTION_TYPE::EXCLUSIVE) {
         if (isSyncThread) {
             // Blocking the sync thread has catastrophic results (forking) and so we either get this quickly, or we fail the transaction.
@@ -655,6 +656,21 @@ int SQLite::commit(const string& description, function<void()>* preCheckpointCal
         _uncommittedQuery.clear();
         _sharedData._commitLockTimer.stop();
         _sharedData.commitLock.unlock();
+        if (_currentTransactionType == TRANSACTION_TYPE::EXCLUSIVE) {
+            // This is is basically duplicate code from below, but this is a quick fix tosee if this helps, we can de-dupe later if this works. It's only 6 lines.
+            _sharedData.checkpointInProgress.test_and_set();
+            auto start = STimeNow();
+            int framesCheckpointed = 0;
+
+            // SQLITE_CHECKPOINT_TRUNCATE is the "most aggressive" checkpoint setting. It clears the entire file and resets its size to 0.
+            sqlite3_wal_checkpoint_v2(_db, 0, SQLITE_CHECKPOINT_TRUNCATE, NULL, &framesCheckpointed);
+            auto end = STimeNow();
+            SINFO("Checkpointed " << framesCheckpointed << " (total) frames of " << _sharedData.outstandingFramesToCheckpoint << " in " << (end - start) << "us. EXCLUSIVE mode.");
+
+            // It might not actually be 0, but we'll just let sqlite tell us what it is next time _walHookCallback runs.
+            _sharedData.outstandingFramesToCheckpoint = 0;
+            _sharedData.checkpointInProgress.clear();
+        }
         _mutexLocked = false;
         _queryCache.clear();
 
@@ -663,7 +679,7 @@ int SQLite::commit(const string& description, function<void()>* preCheckpointCal
         }
 
         // If we are the first to set it (i.e., test_and_set returned `false` as the previous value), we'll start a checkpoint.
-        if (!_sharedData.checkpointInProgress.test_and_set()) {
+        if ((_currentTransactionType != TRANSACTION_TYPE::EXCLUSIVE) && (!_sharedData.checkpointInProgress.test_and_set())) {
             if (_sharedData.outstandingFramesToCheckpoint) {
                 auto start = STimeNow();
                 int framesCheckpointed = 0;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -343,6 +343,9 @@ class SQLite {
     // True when we have a transaction in progress.
     bool _insideTransaction = false;
 
+    // Keep track of what type of transaction we've started, we want to do complete checkpoints at the end of exclusive transactions.
+    TRANSACTION_TYPE _currentTransactionType;
+
     // The new query and new hash to add to the journal for a transaction that's nearing completion, before we commit
     // it.
     string _uncommittedQuery;


### PR DESCRIPTION
### Details
Always do a TRUNCATE checkpoint in the sync or blocking commit thread.

### Fixed Issues
Fixes site being down

### Tests
Just verified the code gets called:

```
2022-12-05T20:50:15.172549+00:00 expensidev2004 bedrock10037: zr2npy (SQLite.cpp:668) commit [blockingCommit] [info] Checkpointed 1000 (total) frames of 0 in 3us. EXCLUSIVE mode.
2022-12-05T20:50:15.186597+00:00 expensidev2004 bedrock10037: ySk4eE (SQLite.cpp:668) commit [blockingCommit] [info] Checkpointed 1000 (total) frames of 0 in 4us. EXCLUSIVE mode.
2022-12-05T20:50:15.200636+00:00 expensidev2004 bedrock10037: oOQlTv (SQLite.cpp:668) commit [blockingCommit] [info] Checkpointed 1000 (total) frames of 0 in 3us. EXCLUSIVE mode.
2022-12-05T20:50:15.214504+00:00 expensidev2004 bedrock10037: feRz3n (SQLite.cpp:668) commit [blockingCommit] [info] Checkpointed 1000 (total) frames of 0 in 3us. EXCLUSIVE mode.
2022-12-05T20:50:15.228390+00:00 expensidev2004 bedrock10037: CNrz79 (SQLite.cpp:668) commit [blockingCommit] [info] Checkpointed 1000 (total) frames of 0 in 3us. EXCLUSIVE mode.
2022-12-05T20:50:15.242719+00:00 expensidev2004 bedrock10037: HF65Mb (SQLite.cpp:668) commit [blockingCommit] [info] Checkpointed 1000 (total) frames of 0 in 7us. EXCLUSIVE mode.
2022-12-05T20:50:15.257294+00:00 expensidev2004 bedrock10037: Kn94Bj (SQLite.cpp:668) commit [blockingCommit] [info] Checkpointed 1000 (total) frames of 0 in 3us. EXCLUSIVE mode.
2022-12-05T20:50:15.270984+00:00 expensidev2004 bedrock10037: l3zgNS (SQLite.cpp:668) commit [blockingCommit] [info] Checkpointed 1000 (total) frames of 0 in 3us. EXCLUSIVE mode.
2022-12-05T20:50:15.285370+00:00 expensidev2004 bedrock10037: XDAqc5 (SQLite.cpp:668) commit [blockingCommit] [info] Checkpointed 1000 (total) frames of 0 in 3us. EXCLUSIVE mode.
2022-12-05T20:50:15.299698+00:00 expensidev2004 bedrock10037: nUQ0nz (SQLite.cpp:668) commit [blockingCommit] [info] Checkpointed 1000 (total) frames of 0 in 3us. EXCLUSIVE mode.
2022-12-05T20:50:15.328026+00:00 expensidev2004 bedrock10037: k8xp4I (SQLite.cpp:668) commit [blockingCommit] [info] Checkpointed 1000 (total) frames of 0 in 3us. EXCLUSIVE mode.
```
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
