### PR TITLE
Revert exclusive checkpoint change and update checkpoint logline.

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -666,10 +666,11 @@ int SQLite::commit(const string& description, function<void()>* preCheckpointCal
         if (!_sharedData.checkpointInProgress.test_and_set()) {
             if (_sharedData.outstandingFramesToCheckpoint) {
                 auto start = STimeNow();
+                int totalFrames = 0;
                 int framesCheckpointed = 0;
-                sqlite3_wal_checkpoint_v2(_db, 0, SQLITE_CHECKPOINT_PASSIVE, NULL, &framesCheckpointed);
+                sqlite3_wal_checkpoint_v2(_db, 0, SQLITE_CHECKPOINT_PASSIVE, &totalFrames, &framesCheckpointed);
                 auto end = STimeNow();
-                SINFO("Checkpointed " << framesCheckpointed << " (total) frames of " << _sharedData.outstandingFramesToCheckpoint << " in " << (end - start) << "us.");
+                SINFO("Checkpoint finished with " << (totalFrames - framesCheckpointed) << " frames remaining to checkpoint in " << (end - start) << "us.");
 
                 // It might not actually be 0, but we'll just let sqlite tell us what it is next time _walHookCallback runs.
                 _sharedData.outstandingFramesToCheckpoint = 0;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -343,9 +343,6 @@ class SQLite {
     // True when we have a transaction in progress.
     bool _insideTransaction = false;
 
-    // Keep track of what type of transaction we've started, we want to do complete checkpoints at the end of exclusive transactions.
-    TRANSACTION_TYPE _currentTransactionType;
-
     // The new query and new hash to add to the journal for a transaction that's nearing completion, before we commit
     // it.
     string _uncommittedQuery;


### PR DESCRIPTION
Reverts Expensify/Bedrock#1403

Also edits a logline to make it clear how much of the remaining WAL files is uncheckpointed.