### PR TITLE
Faster HTTP parsing.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2093,8 +2093,11 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
                 }
             } else {
                 // Otherwise, handle any default request.
-                int requestSize = request.deserialize(socket.recvBuffer);
-                socket.recvBuffer.consumeFront(requestSize);
+                int requestSize = 0;
+                if (socket.recvBuffer.startsWithHTTPRequest()) {
+                    requestSize = request.deserialize(socket.recvBuffer);
+                    socket.recvBuffer.consumeFront(requestSize);
+                }
 
                 // If this socket was accepted from the public command port, and that's supposed to be closed now, set
                 // `Connection: close` so that we don't keep doing a bunch of activity on it.

--- a/libstuff/SFastBuffer.cpp
+++ b/libstuff/SFastBuffer.cpp
@@ -102,6 +102,9 @@ void SFastBuffer::append(const char* buffer, size_t bytes) {
         memmove(&data[0], data.data() + front, size());
         data.resize(size());
         front = 0;
+        nextToCheck = 0;
+        headerLength = 0;
+        contentLength = 0;
 
         // If the capacity is more than 4x the size we need, let's give some memory back.
         if (data.capacity() > (data.size() + bytes) * 4) {

--- a/libstuff/SFastBuffer.cpp
+++ b/libstuff/SFastBuffer.cpp
@@ -19,19 +19,22 @@ bool SFastBuffer::startsWithHTTPRequest() {
     // aren't any".
     if (!headerLength) {
         size_t bodySeparator = data.find("\r\n\r\n", nextToCheck);
+        if (bodySeparator == string::npos) {
+            // This is dumb.
+            bodySeparator = data.find("\n\n", nextToCheck);
+        }
         if (bodySeparator != string::npos) {
             headerLength = bodySeparator - front;
-            return true;
         } else {
             // We subtract 4 so that we can't accidentally end up in the middle of the 4-char sequence that we're searching for and end up missing it on two sequential calls because each
             // contained only a single newline.
-            nextToCheck = data.length() - 4;
+            nextToCheck = data.size() - 4;
         }
     }
 
     // This is good enough for what we need right now, but it suffers the same exact problem that this was meant to fix, except for the body. This may be deferred as a future improvement to
     // deal with long bodies in addition to long headers.
-    return false;
+    return headerLength;
 }
 
 bool SFastBuffer::empty() const {

--- a/libstuff/SFastBuffer.cpp
+++ b/libstuff/SFastBuffer.cpp
@@ -18,7 +18,7 @@ bool SFastBuffer::startsWithHTTPRequest() {
     // aren't any".
     if (!headerLength) {
         size_t next = nextToCheck;
-        while (next != string::npos && !headerLength) {
+        while (!headerLength) {
             next = data.find('\n', next);
 
             if (next == string::npos) {

--- a/libstuff/SFastBuffer.h
+++ b/libstuff/SFastBuffer.h
@@ -10,6 +10,7 @@ class SFastBuffer {
     SFastBuffer();
     SFastBuffer(const string& str);
     bool empty() const;
+    bool startsWithHTTPRequest();
     size_t size() const;
     const char* c_str() const;
     void clear();
@@ -21,5 +22,10 @@ class SFastBuffer {
   private:
     size_t front;
     string data;
+
+    // State for managing checking if this contains an HTTP request.
+    size_t nextToCheck = 0;
+    size_t headerLength = 0;
+    size_t contentLength = 0;
 };
 ostream& operator<<(ostream& os, const SFastBuffer& buf);

--- a/test/tests/FastHTTPParsing.cpp
+++ b/test/tests/FastHTTPParsing.cpp
@@ -1,0 +1,102 @@
+#include <libstuff/SFastBuffer.h>
+#include <libstuff/SData.h>
+#include <test/lib/BedrockTester.h>
+
+struct FastHTTPParsing : tpunit::TestFixture {
+    FastHTTPParsing() : tpunit::TestFixture(true, "FastHTTPParsing",
+                                    TEST(FastHTTPParsing::simpleSuccess),
+                                    TEST(FastHTTPParsing::simpleFail),
+                                    TEST(FastHTTPParsing::blank),
+                                    TEST(FastHTTPParsing::noHeaders),
+                                    TEST(FastHTTPParsing::splitSeparators),
+                                    TEST(FastHTTPParsing::reset),
+                                    TEST(FastHTTPParsing::noop))
+    { }
+
+    // We test both supported line ends everywhere.
+    list<string> lineEnds = {"\r\n", "\n"};
+
+    void simpleSuccess() {
+        for (const auto& end : lineEnds) {
+            SFastBuffer fb("GET / HTTP/1.1" + end +
+                           "Content-Length: 0" + end +
+                           end);
+            ASSERT_TRUE(fb.startsWithHTTPRequest());
+        }
+    }
+
+    void simpleFail() {
+        for (const auto& end : lineEnds) {
+            SFastBuffer fb("GET / HTTP/1.1" + end +
+                           "Content-Length: 0" + end);
+            ASSERT_FALSE(fb.startsWithHTTPRequest());
+        }
+    }
+
+    void blank() {
+        SFastBuffer fb;
+        ASSERT_FALSE(fb.startsWithHTTPRequest());
+    }
+
+    void noHeaders() {
+        for (const auto& end : lineEnds) {
+            SFastBuffer fb("GET / HTTP/1.1" + end +
+                           end);
+            ASSERT_TRUE(fb.startsWithHTTPRequest());
+        }
+    }
+
+    void splitSeparators() {
+        SFastBuffer fb;
+        string start = "GET / HTTP/1.1\r\nContent-Length: 0";
+        fb.append(start.c_str(), start.size());
+        ASSERT_FALSE(fb.startsWithHTTPRequest());
+        fb.append("\r", 1);
+        ASSERT_FALSE(fb.startsWithHTTPRequest());
+        fb.append("\n", 1);
+        ASSERT_FALSE(fb.startsWithHTTPRequest());
+        fb.append("\r", 1);
+        ASSERT_FALSE(fb.startsWithHTTPRequest());
+        fb.append("\n", 1);
+        ASSERT_TRUE(fb.startsWithHTTPRequest());
+
+        fb.clear();
+        string start2 = "GET / HTTP/1.1\nContent-Length: 0";
+        fb.append(start2.c_str(), start.size());
+        fb.append("\n", 1);
+        ASSERT_FALSE(fb.startsWithHTTPRequest());
+        fb.append("\n", 1);
+        ASSERT_TRUE(fb.startsWithHTTPRequest());
+    }
+
+    void reset() {
+        for (const auto& end : lineEnds) {
+            SFastBuffer fb("GET / HTTP/1.1" + end +
+                           "Content-Length: 0" + end +
+                           end + "GET");
+            ASSERT_TRUE(fb.startsWithHTTPRequest());
+
+            SData request;
+            int requestSize = request.deserialize(fb);
+            fb.consumeFront(requestSize); 
+
+            ASSERT_EQUAL(string(fb.c_str()), string("GET"));
+
+            string restOf2ndRequest = " / HTTP/1.1" + end +
+                                      "Content-Length: 1" + end +
+                                      end +
+                                      "A";
+            fb.append(restOf2ndRequest.c_str(), restOf2ndRequest.size());
+            requestSize = request.deserialize(fb);
+            fb.consumeFront(requestSize); 
+            ASSERT_TRUE(fb.empty());
+
+            ASSERT_EQUAL(request.content, "A");
+            ASSERT_EQUAL(request["Content-length"], "1");
+        }
+    }
+
+    void noop() {
+    }
+
+} __FastHTTPParsing;

--- a/test/tests/FastHTTPParsing.cpp
+++ b/test/tests/FastHTTPParsing.cpp
@@ -80,12 +80,14 @@ struct FastHTTPParsing : tpunit::TestFixture {
             fb.consumeFront(requestSize); 
 
             ASSERT_EQUAL(string(fb.c_str()), string("GET"));
+            ASSERT_FALSE(fb.startsWithHTTPRequest());
 
             string restOf2ndRequest = " / HTTP/1.1" + end +
                                       "Content-Length: 1" + end +
                                       end +
                                       "A";
             fb.append(restOf2ndRequest.c_str(), restOf2ndRequest.size());
+            ASSERT_TRUE(fb.startsWithHTTPRequest());
             requestSize = request.deserialize(fb);
             fb.consumeFront(requestSize); 
             ASSERT_TRUE(fb.empty());

--- a/test/tests/FastHTTPParsing.cpp
+++ b/test/tests/FastHTTPParsing.cpp
@@ -9,8 +9,7 @@ struct FastHTTPParsing : tpunit::TestFixture {
                                     TEST(FastHTTPParsing::blank),
                                     TEST(FastHTTPParsing::noHeaders),
                                     TEST(FastHTTPParsing::splitSeparators),
-                                    TEST(FastHTTPParsing::reset),
-                                    TEST(FastHTTPParsing::noop))
+                                    TEST(FastHTTPParsing::reset))
     { }
 
     // We test both supported line ends everywhere.
@@ -95,8 +94,4 @@ struct FastHTTPParsing : tpunit::TestFixture {
             ASSERT_EQUAL(request["Content-length"], "1");
         }
     }
-
-    void noop() {
-    }
-
 } __FastHTTPParsing;


### PR DESCRIPTION
### Details
Don't re-parse the same thing a million times.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/249240

### Tests
I tested this manually with both `\r\n\r\n` and `\n\n` versions of the `flocommand.txt` file included in the issue. I also added some (not quite exhaustive) unit tests.

Before:
```
vagrant@expensidev2004:/vagrant/Bedrock$ time nc auth 4444 < flocommand.txt
430 Unrecognized command
commitCount: 35219
nodeName: auth
peekTime: 77
totalTime: 194
unaccountedTime: 117
Content-Length: 0

^C

real	0m17.229s
user	0m0.006s
sys	0m0.015s
```

After:
```
vagrant@expensidev2004:/vagrant/Bedrock$ time nc auth 4444 < flocommand.txt
430 Unrecognized command
commitCount: 35239
nodeName: auth
peekTime: 101
totalTime: 266
unaccountedTime: 165
Content-Length: 0

^C

real	0m0.437s
user	0m0.000s
sys	0m0.023s
vagrant@expensidev2004:/vagrant/Bedrock$
```
