### PR TITLE
Detect loss of quorum more quickly after slow query.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2415,6 +2415,7 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                             // error, and start over. So, once a connection is established, we should just use that one
                             // for all communication until it breaks.
                             peer->reset();
+                            _onDisconnect(peer);
                             STHROW("Peer " + peer->name + " seems already connected."); 
                         }
                     } else {


### PR DESCRIPTION
### Details
We aren't noticing that we've lost quorum when we get disconnected from peers here: https://github.com/Expensify/Bedrock/blob/e12ca062ef57e08876f49a8bfd997b21a7ec86bb/sqlitecluster/SQLiteNode.cpp#L2417

So we disconnect all these sockets, but then we get to here: https://github.com/Expensify/Bedrock/blob/e12ca062ef57e08876f49a8bfd997b21a7ec86bb/sqlitecluster/SQLiteNode.cpp#L2444

And that reconnects them again, and we don't notice in the meantime that we had less than half the cluster connected.

This change will move us into `SEARCHING` as soon as we lose enough connected nodes.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/246929

### Tests
None, good luck.