### PR TITLE
Add logging to see if query is first in transaction and progress handler info

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2499,7 +2499,7 @@ void SQueryLogClose() {
 
 // --------------------------------------------------------------------------
 // Executes a SQLite query
-int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold, bool skipWarn) {
+int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold, bool skipWarn, bool* wasSlow) {
 #define MAX_TRIES 3
     // Execute the query and get the results
     uint64_t startTime = STimeNow();
@@ -2625,6 +2625,11 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
                   << sqlToLog);
         } else {
             SWARN("Slow query '" << e << "' (" << elapsed / 1000 << "ms): " << sqlToLog);
+        }
+
+        // Notify the caller that this was a slow query.
+        if (wasSlow != nullptr) {
+            *wasSlow = true;
         }
     }
 
@@ -2977,9 +2982,9 @@ string SQ(double val) {
     return SToStr(val);
 }
 
-int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold, bool skipWarn) {
+int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold, bool skipWarn, bool* wasSlow) {
     SQResult ignore;
-    return SQuery(db, e, sql, ignore, warnThreshold, skipWarn);
+    return SQuery(db, e, sql, ignore, warnThreshold, skipWarn, wasSlow);
 }
 
 string SUNQUOTED_TIMESTAMP(uint64_t when) {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2616,7 +2616,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
         // This code removing authTokens is a quick fix and should be removed once https://github.com/Expensify/Expensify/issues/144185 is done.
         pcrecpp::RE("\"authToken\":\"[0-9A-F]{400,1024}\"").GlobalReplace("\"authToken\":<REDACTED>", &sqlToLog);
         if (isSyncThread) {
-            SWARN("Slow query sync ("
+            SWARN("Slow query sync '" << e << "' ("
                   << "loops: " << numLoops << ", "
                   << "prepare US: " << prepareTimeUS << ", "
                   << "steps: " << numSteps << ", "
@@ -2624,7 +2624,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
                   << "longest step US: " << longestStepTimeUS << "): "
                   << sqlToLog);
         } else {
-            SWARN("Slow query (" << elapsed / 1000 << "ms): " << sqlToLog);
+            SWARN("Slow query '" << e << "' (" << elapsed / 1000 << "ms): " << sqlToLog);
         }
     }
 

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -583,8 +583,8 @@ void SQueryLogOpen(const string& logFilename);
 void SQueryLogClose();
 
 // Returns an SQLite result code.
-int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
-int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
+int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false, bool* wasSlow = nullptr);
+int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false, bool* wasSlow = nullptr);
 bool SQVerifyTable(sqlite3* db, const string& tableName, const string& sql);
 bool SQVerifyTableExists(sqlite3* db, const string& tableName);
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -954,12 +954,7 @@ void SQLite::setUpdateNoopMode(bool enabled) {
 
     // Enable or disable this query.
     string query = "PRAGMA noop_update="s + (enabled ? "ON" : "OFF") + ";";
-    _queryCount++;
-    string label = "setting noop-update mode";
-    if (_queryCount == 1) {
-        label += " [first query of transaction]";
-    }
-    SQuery(_db, label.c_str(), query);
+    SQuery(_db, "setting noop-update mode", query);
     _noopUpdateMode = enabled;
 
     // If we're inside a transaction, make sure this gets saved so it can be replicated.
@@ -1012,12 +1007,7 @@ int SQLite::getPreparedStatements(const string& query, list<sqlite3_stmt*>& stat
 void SQLite::setQueryOnly(bool enabled) {
     SQResult result;
     string query = "PRAGMA query_only = "s + (enabled ? "true" : "false") + ";";
-    _queryCount++;
-    string label = "set query_only";
-    if (_queryCount == 1) {
-        label += " [first query of transaction]";
-    }
-    SQuery(_db, label.c_str(), query, result);
+    SQuery(_db, "set query_only", query, result);
 }
 
 SQLite::SharedData::SharedData() :

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -450,6 +450,9 @@ class SQLite {
     // Number of queries that have been attempted in this transaction (for metrics only).
     int64_t _queryCount = 0;
 
+    // Whenever we hit the progress handler for a query, we log the timestamp here. This list is reset before each query, and is only used for diagnostic purposes.
+    list<uint64_t> _progressHandlerInvocationTimestamps;
+
     // Number of queries found in cache in this transaction (for metrics only).
     int64_t _cacheHits = 0;
 


### PR DESCRIPTION
### Details
This adds more logging around what happens when queries are slow. Particularly, if they're the first query in a transaction, and also timing of how often the progress handler has been called.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/237689

### Tests
No tests, just logging.

Auth still works:
```
[ TEST RESULTS ] Passed: 1886, Failed: 0
```
