### PR TITLE
Add SToJSON for ints

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1281,6 +1281,10 @@ string SDecodeURIComponent(const char* buffer, int length) {
 // --------------------------------------------------------------------------
 extern const char* _SParseJSONValue(const char* ptr, const char* end, string& value, bool populateValue);
 
+string SToJSON(const int64_t value, const bool forceString) {
+    return SToJSON(to_string(value), forceString);
+}
+
 string SToJSON(const string& value, const bool forceString) {
     // Is it an integer?
     if (SToStr(SToInt64(value.c_str())) == value) {

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -464,6 +464,7 @@ template <typename T> string SComposeList(const T& valueList, const string& sepa
 // --------------------------------------------------------------------------
 // JSON message management
 string SToJSON(const string& value, const bool forceString = false);
+string SToJSON(const int64_t value, const bool forceString = false);
 
 template <typename T>
 string SComposeJSONArray(const T& valueList) {


### PR DESCRIPTION
### Details

Discussed here: https://expensify.slack.com/archives/C03TQ48KC/p1676413799000809

### Fixed Issues
Allows to call `SComposeJSONArray` on a `set<int64_t>`

### Tests
TBD
