### PR TITLE
Code changes for g++12 support

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -265,7 +265,7 @@ void BedrockServer::sync()
         // auto-revert when we're finished.
         {
             // Set the default log prefix.
-            SAUTOPREFIX(SData());
+            SAUTOPREFIX(SData{});
 
             // Process any activity in our plugins.
             AutoTimerTime postPollTime(postPollTimer);

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,11 @@
 # to be set, but for the time being we need to override the defaults so that our existing dev environment works. This
 # can be removed when that is resolved.
 ifeq ($(CC),cc)
-CC = /usr/local/bin/gcc
+CC = gcc-9
 endif
 ifeq ($(CXX),g++)
-CXX = /usr/local/bin/g++
+CXX = g++-9
 endif
-CC = /usr/local/bin/gcc
-CXX = /usr/local/bin/g++
 
 # Set the optimization level from the environment, or default to -O2.
 ifndef BEDROCK_OPTIM_COMPILE_FLAG

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,13 @@
 # to be set, but for the time being we need to override the defaults so that our existing dev environment works. This
 # can be removed when that is resolved.
 ifeq ($(CC),cc)
-CC = gcc-9
+CC = /usr/local/bin/gcc
 endif
 ifeq ($(CXX),g++)
-CXX = g++-9
+CXX = /usr/local/bin/g++
 endif
+CC = /usr/local/bin/gcc
+CXX = /usr/local/bin/g++
 
 # Set the optimization level from the environment, or default to -O2.
 ifndef BEDROCK_OPTIM_COMPILE_FLAG

--- a/libstuff/SMultiHostSocketPool.h
+++ b/libstuff/SMultiHostSocketPool.h
@@ -2,6 +2,8 @@
 #include <libstuff/STCPManager.h>
 #include <libstuff/SSocketPool.h>
 
+#include <condition_variable>
+
 class SMultiHostSocketPool {
   public:
     SMultiHostSocketPool();

--- a/libstuff/SMultiHostSocketPool.h
+++ b/libstuff/SMultiHostSocketPool.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <libstuff/STCPManager.h>
 #include <libstuff/SSocketPool.h>
-
 #include <condition_variable>
 
 class SMultiHostSocketPool {

--- a/libstuff/SScheduledPriorityQueue.h
+++ b/libstuff/SScheduledPriorityQueue.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <libstuff/libstuff.h>
 
+#include <condition_variable>
+
 // A scheduled priority queue does the following:
 // Enqueues items with a scheduled time, a priority, and a timeout.
 // Both the scheduled time and timeout are epoch times in microseconds.

--- a/libstuff/SScheduledPriorityQueue.h
+++ b/libstuff/SScheduledPriorityQueue.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <libstuff/libstuff.h>
-
 #include <condition_variable>
 
 // A scheduled priority queue does the following:

--- a/libstuff/SSocketPool.h
+++ b/libstuff/SSocketPool.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <libstuff/STCPManager.h>
 #include <chrono>
-
 #include <condition_variable>
 
 class SSocketPool {

--- a/libstuff/SSocketPool.h
+++ b/libstuff/SSocketPool.h
@@ -2,6 +2,8 @@
 #include <libstuff/STCPManager.h>
 #include <chrono>
 
+#include <condition_variable>
+
 class SSocketPool {
   public:
     SSocketPool(const string& host);

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -43,7 +43,7 @@
 
 // Common error definitions
 #define S_errno errno
-#define S_NOTINITIALISED 0xFEFEFEFE // Doesn't exist for Linux
+#define S_NOTINITIALISED ((int)0xFEFEFEFE) // Doesn't exist for Linux
 #ifdef __APPLE__
 // The above doesn't even build on OS X with C++11 turned on. I don't know why
 // we even have that check, but I'm leaving it and just setting this to INT_MAX

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -68,15 +68,12 @@ void SSetSignalHandlerDieFunc(function<void()>&& func);
 // A very simple name/value pair table with case-insensitive name matching
 // --------------------------------------------------------------------------
 // See: http://stackoverflow.com/questions/1801892/making-mapfind-operation-case-insensitive
-class STableComp : binary_function<string, string, bool> {
+class STableComp {
   public:
-    bool operator()(const string& s1, const string& s2) const;
-
-  private:
-    class nocase_compare : public binary_function<unsigned char, unsigned char, bool> {
-      public:
-        bool operator()(const unsigned char& c1, const unsigned char& c2) const;
+    struct nocase_compare {
+      bool operator() (const unsigned char& c1, const unsigned char& c2) const;
     };
+    bool operator() (const string& s1, const string& s2) const;
 };
 
 // An SString is just a string with special assignment operators so that we get automatic conversion from arithmetic

--- a/sqlitecluster/SQLitePool.h
+++ b/sqlitecluster/SQLitePool.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <libstuff/libstuff.h>
 #include <sqlitecluster/SQLite.h>
-
 #include <condition_variable>
 
 class SQLitePool {

--- a/sqlitecluster/SQLitePool.h
+++ b/sqlitecluster/SQLitePool.h
@@ -2,6 +2,8 @@
 #include <libstuff/libstuff.h>
 #include <sqlitecluster/SQLite.h>
 
+#include <condition_variable>
+
 class SQLitePool {
   public:
     // Create a pool of DB handles.

--- a/sqlitecluster/SQLiteSequentialNotifier.h
+++ b/sqlitecluster/SQLiteSequentialNotifier.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <libstuff/libstuff.h>
 #include "SQLite.h"
-
 #include <condition_variable>
 
 class SQLiteSequentialNotifier {

--- a/sqlitecluster/SQLiteSequentialNotifier.h
+++ b/sqlitecluster/SQLiteSequentialNotifier.h
@@ -2,6 +2,8 @@
 #include <libstuff/libstuff.h>
 #include "SQLite.h"
 
+#include <condition_variable>
+
 class SQLiteSequentialNotifier {
   public:
 


### PR DESCRIPTION
### Details
I was experimenting with g++12, and made these changes requires to compile bedrock in the newer compiler. We might as well just merge them since there's no harm in being stricter in our existing compiler until we actual upgrade.

### Fixed Issues
For, but doesn't fix: https://github.com/Expensify/Expensify/issues/264459

### Tests
Existing tests. Nothing functional is changed here.