### PR TITLE
Revert PR 1427

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2503,7 +2503,7 @@ void SQueryLogClose() {
 
 // --------------------------------------------------------------------------
 // Executes a SQLite query
-int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold, bool skipWarn, bool* wasSlow) {
+int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold, bool skipWarn) {
 #define MAX_TRIES 3
     // Execute the query and get the results
     uint64_t startTime = STimeNow();
@@ -2634,11 +2634,6 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
                       << sqlToLog);
             } else {
                 SWARN("Slow query '" << e << "' (" << elapsed / 1000 << "ms): " << sqlToLog);
-            }
-
-            // Notify the caller that this was a slow query.
-            if (wasSlow != nullptr) {
-                *wasSlow = true;
             }
         } else {
             // We log the time the queries took, as long as they are over 10ms (to reduce noise of many queries that are
@@ -2998,9 +2993,9 @@ string SQ(double val) {
     return SToStr(val);
 }
 
-int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold, bool skipWarn, bool* wasSlow) {
+int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold, bool skipWarn) {
     SQResult ignore;
-    return SQuery(db, e, sql, ignore, warnThreshold, skipWarn, wasSlow);
+    return SQuery(db, e, sql, ignore, warnThreshold, skipWarn);
 }
 
 string SUNQUOTED_TIMESTAMP(uint64_t when) {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2625,7 +2625,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
         pcrecpp::RE("\"html\":\".*\"").GlobalReplace("\"html\":\"<REDACTED>\"", &sqlToLog);
         if ((int64_t)elapsed > warnThreshold) {
             if (isSyncThread) {
-                SWARN("Slow query sync '" << e << "' ("
+                SWARN("Slow query sync ("
                       << "loops: " << numLoops << ", "
                       << "prepare US: " << prepareTimeUS << ", "
                       << "steps: " << numSteps << ", "
@@ -2633,7 +2633,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
                       << "longest step US: " << longestStepTimeUS << "): "
                       << sqlToLog);
             } else {
-                SWARN("Slow query '" << e << "' (" << elapsed / 1000 << "ms): " << sqlToLog);
+                SWARN("Slow query (" << elapsed / 1000 << "ms): " << sqlToLog);
             }
         } else {
             // We log the time the queries took, as long as they are over 10ms (to reduce noise of many queries that are

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -584,8 +584,8 @@ void SQueryLogOpen(const string& logFilename);
 void SQueryLogClose();
 
 // Returns an SQLite result code.
-int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false, bool* wasSlow = nullptr);
-int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false, bool* wasSlow = nullptr);
+int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
+int SQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipWarn = false);
 bool SQVerifyTable(sqlite3* db, const string& tableName, const string& sql);
 bool SQVerifyTableExists(sqlite3* db, const string& tableName);
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -499,7 +499,6 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
     // First, check our current state
     SQResult results;
     SASSERT(!SQuery(_db, "looking up schema version", "PRAGMA schema_version;", results));
-
     SASSERT(!results.empty() && !results[0].empty());
     uint64_t schemaBefore = SToUInt64(results[0][0]);
     uint64_t changesBefore = sqlite3_total_changes(_db);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -237,6 +237,7 @@ SQLite::SQLite(const SQLite& from) :
 int SQLite::_progressHandlerCallback(void* arg) {
     SQLite* sqlite = static_cast<SQLite*>(arg);
     uint64_t now = STimeNow();
+    sqlite->_progressHandlerInvocationTimestamps.push_back(now);
     if (sqlite->_timeoutLimit && now > sqlite->_timeoutLimit) {
         // Timeout! We don't throw here, we let `read` and `write` do it so we don't throw out of the middle of a
         // sqlite3 operation.
@@ -428,7 +429,12 @@ bool SQLite::read(const string& query, SQResult& result) {
         queryResult = true;
     } else {
         _isDeterministicQuery = true;
-        queryResult = !SQuery(_db, "read only query", query, result);
+        string label = "read only query";
+        if (_queryCount == 1) {
+            label += " [first query of transaction]";
+        }
+        _progressHandlerInvocationTimestamps.clear();
+        queryResult = !SQuery(_db, label.c_str(), query, result, 2'000'000, false);
         if (_isDeterministicQuery && queryResult) {
             _queryCache.emplace(make_pair(query, result));
         }
@@ -498,7 +504,13 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
 
     // First, check our current state
     SQResult results;
-    SASSERT(!SQuery(_db, "looking up schema version", "PRAGMA schema_version;", results));
+    string label = "looking up schema version";
+    if (_queryCount == 1) {
+        label += " [first query of transaction]";
+    }
+    _progressHandlerInvocationTimestamps.clear();
+    SASSERT(!SQuery(_db, label.c_str(), "PRAGMA schema_version;", results, 2'000'000, false));
+
     SASSERT(!results.empty() && !results[0].empty());
     uint64_t schemaBefore = SToUInt64(results[0][0]);
     uint64_t changesBefore = sqlite3_total_changes(_db);
@@ -507,18 +519,21 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
     uint64_t before = STimeNow();
     bool usedRewrittenQuery = false;
     int resultCode = 0;
+    _progressHandlerInvocationTimestamps.clear();
     if (_enableRewrite) {
-        resultCode = SQuery(_db, "read/write transaction", query, 2000 * STIME_US_PER_MS, true);
+        resultCode = SQuery(_db, "read/write transaction", query, 2'000'000, true);
         if (resultCode == SQLITE_AUTH) {
+            _progressHandlerInvocationTimestamps.clear();
+
             // Run re-written query.
             _currentlyRunningRewritten = true;
             SASSERT(SEndsWith(_rewrittenQuery, ";"));
-            resultCode = SQuery(_db, "read/write transaction", _rewrittenQuery);
+            resultCode = SQuery(_db, "read/write transaction", _rewrittenQuery, 2'000'000, false);
             usedRewrittenQuery = true;
             _currentlyRunningRewritten = false;
         }
     } else {
-        resultCode = SQuery(_db, "read/write transaction", query);
+        resultCode = SQuery(_db, "read/write transaction", query, 2'000'000, false);
     }
 
     // If we got a constraints error, throw that.
@@ -785,7 +800,10 @@ bool SQLite::getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result) 
     string query = _getJournalQuery({"SELECT id, hash, query FROM", "WHERE id >= " + SQ(fromIndex) +
                                     (toIndex ? " AND id <= " + SQ(toIndex) : "")});
     SDEBUG("Getting commits #" << fromIndex << "-" << toIndex);
-    return !SQuery(_db, "getting commits", query, result);
+    query = "SELECT hash, query FROM (" + query  + ") ORDER BY id";
+
+    // These queries run with no transaction wrapping them. This makes them effectively the "first" query.
+    return !SQuery(_db, "getting commits [first query of transaction]", query, result);
 }
 
 int64_t SQLite::getLastInsertRowID() {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -786,9 +786,7 @@ bool SQLite::getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result) 
                                     (toIndex ? " AND id <= " + SQ(toIndex) : "")});
     SDEBUG("Getting commits #" << fromIndex << "-" << toIndex);
     query = "SELECT hash, query FROM (" + query  + ") ORDER BY id";
-
-    // These queries run with no transaction wrapping them. This makes them effectively the "first" query.
-    return !SQuery(_db, "getting commits [first query of transaction]", query, result);
+    return !SQuery(_db, "getting commits", query, result);
 }
 
 int64_t SQLite::getLastInsertRowID() {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -428,11 +428,7 @@ bool SQLite::read(const string& query, SQResult& result) {
         queryResult = true;
     } else {
         _isDeterministicQuery = true;
-        string label = "read only query";
-        if (_queryCount == 1) {
-            label += " [first query of transaction]";
-        }
-        queryResult = !SQuery(_db, label.c_str(), query, result);
+        queryResult = !SQuery(_db, "read only query", query, result);
         if (_isDeterministicQuery && queryResult) {
             _queryCache.emplace(make_pair(query, result));
         }
@@ -502,11 +498,7 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
 
     // First, check our current state
     SQResult results;
-    string label = "looking up schema version";
-    if (_queryCount == 1) {
-        label += " [first query of transaction]";
-    }
-    SASSERT(!SQuery(_db, label.c_str(), "PRAGMA schema_version;", results));
+    SASSERT(!SQuery(_db, "looking up schema version", "PRAGMA schema_version;", results));
 
     SASSERT(!results.empty() && !results[0].empty());
     uint64_t schemaBefore = SToUInt64(results[0][0]);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -510,7 +510,6 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
     if (_enableRewrite) {
         resultCode = SQuery(_db, "read/write transaction", query, 2'000'000, true);
         if (resultCode == SQLITE_AUTH) {
-
             // Run re-written query.
             _currentlyRunningRewritten = true;
             SASSERT(SEndsWith(_rewrittenQuery, ";"));

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -237,7 +237,6 @@ SQLite::SQLite(const SQLite& from) :
 int SQLite::_progressHandlerCallback(void* arg) {
     SQLite* sqlite = static_cast<SQLite*>(arg);
     uint64_t now = STimeNow();
-    sqlite->_progressHandlerInvocationTimestamps.push_back(now);
     if (sqlite->_timeoutLimit && now > sqlite->_timeoutLimit) {
         // Timeout! We don't throw here, we let `read` and `write` do it so we don't throw out of the middle of a
         // sqlite3 operation.
@@ -429,16 +428,7 @@ bool SQLite::read(const string& query, SQResult& result) {
         queryResult = true;
     } else {
         _isDeterministicQuery = true;
-        string label = "read only query";
-        if (_queryCount == 1) {
-            label += " [first query of transaction]";
-        }
-        bool wasSlow = false;
-        _progressHandlerInvocationTimestamps.clear();
-        queryResult = !SQuery(_db, label.c_str(), query, result, 2'000'000, false, &wasSlow);
-        if (wasSlow) {
-            SWARN("Slow query progress timings (count: " << _progressHandlerInvocationTimestamps.size() << "): " << SComposeList(_progressHandlerInvocationTimestamps));
-        }
+        queryResult = !SQuery(_db, "read only query", query, result);
         if (_isDeterministicQuery && queryResult) {
             _queryCache.emplace(make_pair(query, result));
         }
@@ -508,17 +498,7 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
 
     // First, check our current state
     SQResult results;
-    string label = "looking up schema version";
-    if (_queryCount == 1) {
-        label += " [first query of transaction]";
-    }
-    bool wasSlow = false;
-    _progressHandlerInvocationTimestamps.clear();
-    SASSERT(!SQuery(_db, label.c_str(), "PRAGMA schema_version;", results, 2'000'000, false, &wasSlow));
-    if (wasSlow) {
-        SWARN("Slow query progress timings (count: " << _progressHandlerInvocationTimestamps.size() << "): " << SComposeList(_progressHandlerInvocationTimestamps));
-    }
-
+    SASSERT(!SQuery(_db, "looking up schema version", "PRAGMA schema_version;", results));
     SASSERT(!results.empty() && !results[0].empty());
     uint64_t schemaBefore = SToUInt64(results[0][0]);
     uint64_t changesBefore = sqlite3_total_changes(_db);
@@ -527,32 +507,18 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
     uint64_t before = STimeNow();
     bool usedRewrittenQuery = false;
     int resultCode = 0;
-    wasSlow = false;
-    _progressHandlerInvocationTimestamps.clear();
     if (_enableRewrite) {
-        resultCode = SQuery(_db, "read/write transaction", query, 2'000'000, true, &wasSlow);
-        if (wasSlow) {
-            SWARN("Slow query progress timings (count: " << _progressHandlerInvocationTimestamps.size() << "): " << SComposeList(_progressHandlerInvocationTimestamps));
-        }
+        resultCode = SQuery(_db, "read/write transaction", query, 2000 * STIME_US_PER_MS, true);
         if (resultCode == SQLITE_AUTH) {
-            wasSlow = false;
-            _progressHandlerInvocationTimestamps.clear();
-
             // Run re-written query.
             _currentlyRunningRewritten = true;
             SASSERT(SEndsWith(_rewrittenQuery, ";"));
-            resultCode = SQuery(_db, "read/write transaction", _rewrittenQuery, 2'000'000, false, &wasSlow);
-            if (wasSlow) {
-                SWARN("Slow query progress timings (count: " << _progressHandlerInvocationTimestamps.size() << "): " << SComposeList(_progressHandlerInvocationTimestamps));
-            }
+            resultCode = SQuery(_db, "read/write transaction", _rewrittenQuery);
             usedRewrittenQuery = true;
             _currentlyRunningRewritten = false;
         }
     } else {
-        resultCode = SQuery(_db, "read/write transaction", query, 2'000'000, false, &wasSlow);
-        if (wasSlow) {
-            SWARN("Slow query progress timings (count: " << _progressHandlerInvocationTimestamps.size() << "): " << SComposeList(_progressHandlerInvocationTimestamps));
-        }
+        resultCode = SQuery(_db, "read/write transaction", query);
     }
 
     // If we got a constraints error, throw that.
@@ -819,10 +785,7 @@ bool SQLite::getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result) 
     string query = _getJournalQuery({"SELECT id, hash, query FROM", "WHERE id >= " + SQ(fromIndex) +
                                     (toIndex ? " AND id <= " + SQ(toIndex) : "")});
     SDEBUG("Getting commits #" << fromIndex << "-" << toIndex);
-    query = "SELECT hash, query FROM (" + query  + ") ORDER BY id";
-
-    // These queries run with no transaction wrapping them. This makes them effectively the "first" query.
-    return !SQuery(_db, "getting commits [first query of transaction]", query, result);
+    return !SQuery(_db, "getting commits", query, result);
 }
 
 int64_t SQLite::getLastInsertRowID() {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -432,7 +432,7 @@ bool SQLite::read(const string& query, SQResult& result) {
         if (_queryCount == 1) {
             label += " [first query of transaction]";
         }
-        queryResult = !SQuery(_db, label.c_str(), query, result, 2'000'000, false);
+        queryResult = !SQuery(_db, label.c_str(), query, result);
         if (_isDeterministicQuery && queryResult) {
             _queryCache.emplace(make_pair(query, result));
         }
@@ -506,7 +506,7 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
     if (_queryCount == 1) {
         label += " [first query of transaction]";
     }
-    SASSERT(!SQuery(_db, label.c_str(), "PRAGMA schema_version;", results, 2'000'000, false));
+    SASSERT(!SQuery(_db, label.c_str(), "PRAGMA schema_version;", results));
 
     SASSERT(!results.empty() && !results[0].empty());
     uint64_t schemaBefore = SToUInt64(results[0][0]);
@@ -523,12 +523,12 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
             // Run re-written query.
             _currentlyRunningRewritten = true;
             SASSERT(SEndsWith(_rewrittenQuery, ";"));
-            resultCode = SQuery(_db, "read/write transaction", _rewrittenQuery, 2'000'000, false);
+            resultCode = SQuery(_db, "read/write transaction", _rewrittenQuery);
             usedRewrittenQuery = true;
             _currentlyRunningRewritten = false;
         }
     } else {
-        resultCode = SQuery(_db, "read/write transaction", query, 2'000'000, false);
+        resultCode = SQuery(_db, "read/write transaction", query);
     }
 
     // If we got a constraints error, throw that.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -450,9 +450,6 @@ class SQLite {
     // Number of queries that have been attempted in this transaction (for metrics only).
     int64_t _queryCount = 0;
 
-    // Whenever we hit the progress handler for a query, we log the timestamp here. This list is reset before each query, and is only used for diagnostic purposes.
-    list<uint64_t> _progressHandlerInvocationTimestamps;
-
     // Number of queries found in cache in this transaction (for metrics only).
     int64_t _cacheHits = 0;
 


### PR DESCRIPTION
### Details
Manual revert of: https://github.com/Expensify/Bedrock/pull/1427
Code is no longer necessary. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/263814

### Tests
Existing tests pass, plus auth tests pass.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
