### PR TITLE
Remove encrypted values in logged queries

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2621,6 +2621,9 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
         // We should always avoid logging authTokens because they give access to accounts
         pcrecpp::RE("\"authToken\":\"[0-9A-F]{400,1024}\"").GlobalReplace("\"authToken\":<REDACTED>", &sqlToLog);
 
+        // Let's remove queries that contain encrypted fields since there's no value in displaying them
+        pcrecpp::RE("v[0-9]+:[0-9A-F]{10,}").GlobalReplace("<REDACTED>", &sqlToLog);
+
         // We remove anything inside "html" because we intentionally don't log chats
         pcrecpp::RE("\"html\":\".*\"").GlobalReplace("\"html\":\"<REDACTED>\"", &sqlToLog);
         if ((int64_t)elapsed > warnThreshold) {


### PR DESCRIPTION
### Details

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/264733

### Tests

- On a new account follow this SO to add a corporate card: https://stackoverflowteams.com/c/expensify/questions/67?noredirect=1&lq=1

- Make sure that the logs like this (before changes):

```
2023-02-28T09:24:33.493937+00:00 expensidev2004 bedrock: 495nJD maxence@companycards.com (libstuff.cpp:2649) SQuery [sync] [info] Query completed (0ms): UPDATE cards SET password = 'v1:F996E6540869DCCA750F3B871E052486',lastScrapeResult = 200 WHERE (accountID = 241 OR fundID = 241 OR (fundID = 0 AND fundID > 0))AND bank = 'discover.com' AND +login = 'expensidemo' AND lastScrapeResult IS NOT 434 AND state = 3;
```

Are redacted like this (after changes):

```
2023-02-28T10:16:58.413741+00:00 expensidev2004 bedrock: bxW0Yc maxence@companycards.com (libstuff.cpp:2649) SQuery [sync] [info] Query completed (0ms): UPDATE cards SET password = '<REDACTED>',lastScrapeResult = 200 WHERE (accountID = 241 OR fundID = 241 OR (fundID = 0 AND fundID > 0))AND bank = 'discover.com' AND +login = 'expensidemo' AND lastScrapeResult IS NOT 434 AND state = 3;
```

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
