### PR TITLE
Remove old state names

### DIFF
--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -59,11 +59,6 @@ class SQLiteNode : public STCPManager {
     friend class SQLiteNodeTester;
 
   public:
-    // Compatibility with Auth. Remove once auth is changed to use SQLiteNodeState;
-    static const SQLiteNodeState LEADING = SQLiteNodeState::LEADING;
-    static const SQLiteNodeState FOLLOWING = SQLiteNodeState::FOLLOWING;
-    static const SQLiteNodeState STANDINGDOWN = SQLiteNodeState::STANDINGDOWN;
-
     // These are the possible states a transaction can be in.
     enum class CommitState {
         UNINITIALIZED,


### PR DESCRIPTION
### Details
Removes the old names we're no longer using.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/265868

### Tests
Tested with auth, FuzzyBot, ExpensifyBackupManager, and ExpensifyTableManager.
