### PR TITLE
Escape DEL with \u escape sequence.

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -452,12 +452,13 @@ string SEscape(const char* lhs, const string& unsafe, char escaper) {
                 working += 'r';
             else if (c == '\t')
                 working += 't';
-            else if (c > 0x00 && c < 0x20) {
+            else if ((c > 0x00 && c < 0x20) || c == 0x7f) {
                 char utfCode[6] = {0};
                 sprintf(utfCode, "u%04x", c);
                 working += utfCode;
-            } else
+            } else {
                 working += c;
+            }
         } else {
             // Insert as normal
             working += *lhs;
@@ -1318,10 +1319,9 @@ string SToJSON(const string& value, const bool forceString) {
     }
 
     // Otherwise, it's a string -- escape and return
-    // We need to escape all control characters in the string, not just the
-    // white-space control characters.
-    return "\"" + SEscape(value, "\x01\x02\x03\x04\x05\x06\x07\b\t\n\x0b\f\r\x0e\x0f\x10\x11"
-                                 "\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f\"\\/",
+    // We need to escape all control characters in the string, not just the white-space control characters.
+    return "\"" + SEscape(value, "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
+                                 "\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f\"\\/",
                           '\\') +
            "\"";
 }


### PR DESCRIPTION
### Details

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/266806

### Tests
Tested by manually changing the BR test suqite and adding: 
```
    string str = "nt Add-Ons:";
    str += '\x7f';
    str += "Dance Floor not";
    str = SToJSON(str);
    cout << str << endl;

    return 0;
    ```
    
at the top of `main()`

Which outputs:
```
"nt Add-Ons:\u007fDance Floor not"
```

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
