### PR TITLE
Redact authTokens when logging an SQLite error

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2761,6 +2761,18 @@ bool SREMatch(const string& regExp, const string& s, string& match) {
     return pcrecpp::RE(regExp).FullMatch(s, &match);
 }
 
+void redactredactSensitiveValues(string& s) {
+    // The message may be truncated midway through the authToken, so there may not be a closing quote (") at the end of
+    // the authToken, so we need to optionally match the closing quote with a question mark (?).
+    pcrecpp::RE("\"authToken\":\".*\"?").GlobalReplace("\"authToken\":<REDACTED>", s);
+
+    // Redact queries that contain encrypted fields since there's no value in logging them.
+    pcrecpp::RE("v[0-9]+:[0-9A-F]{10,}").GlobalReplace("<REDACTED>", s);
+
+    // Remove anything inside "html" because we intentionally don't log chats.
+    pcrecpp::RE("\"html\":\".*\"").GlobalReplace("\"html\":\"<REDACTED>\"", s);
+}
+
 SStopwatch::SStopwatch() {
     start();
     alarmDuration.store(0);

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2659,7 +2659,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
     if (error != SQLITE_OK && extErr != SQLITE_BUSY_SNAPSHOT && !skipWarn) {
         // We remove anything inside "html" because we intentionally don't log chats
         pcrecpp::RE("\"html\":\".*\"").GlobalReplace("\"html\":\"<REDACTED>\"", &sqlToLog);
-        pcrecpp::RE("\"authToken\":\".*\"").GlobalReplace("\"authToken\":\"<REDACTED>\"", &sqlToLog);
+        pcrecpp::RE("\"authToken\":\"[0-9A-F]{400,1024}\"").GlobalReplace("\"authToken\":<REDACTED>", &sqlToLog);
 
         SWARN("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
     }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2756,13 +2756,13 @@ bool SREMatch(const string& regExp, const string& s, string& match) {
 void redactredactSensitiveValues(string& s) {
     // The message may be truncated midway through the authToken, so there may not be a closing quote (") at the end of
     // the authToken, so we need to optionally match the closing quote with a question mark (?).
-    pcrecpp::RE("\"authToken\":\".*\"?").GlobalReplace("\"authToken\":<REDACTED>", s);
+    pcrecpp::RE("\"authToken\":\".*\"?").GlobalReplace("\"authToken\":<REDACTED>", &s);
 
     // Redact queries that contain encrypted fields since there's no value in logging them.
-    pcrecpp::RE("v[0-9]+:[0-9A-F]{10,}").GlobalReplace("<REDACTED>", s);
+    pcrecpp::RE("v[0-9]+:[0-9A-F]{10,}").GlobalReplace("<REDACTED>", &s);
 
     // Remove anything inside "html" because we intentionally don't log chats.
-    pcrecpp::RE("\"html\":\".*\"").GlobalReplace("\"html\":\"<REDACTED>\"", s);
+    pcrecpp::RE("\"html\":\".*\"").GlobalReplace("\"html\":\"<REDACTED>\"", &s);
 }
 
 SStopwatch::SStopwatch() {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2659,6 +2659,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
     if (error != SQLITE_OK && extErr != SQLITE_BUSY_SNAPSHOT && !skipWarn) {
         // We remove anything inside "html" because we intentionally don't log chats
         pcrecpp::RE("\"html\":\".*\"").GlobalReplace("\"html\":\"<REDACTED>\"", &sqlToLog);
+        pcrecpp::RE("\"authToken\":\".*\"").GlobalReplace("\"authToken\":\"<REDACTED>\"", &sqlToLog);
 
         SWARN("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
     }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2618,7 +2618,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
     string sqlToLog = sql;
 
     if ((int64_t)elapsed > warnThreshold || (int64_t)elapsed > 10000) {
-        redactSensitiveValues(sqlToLog);
+        SRedactSensitiveValues(sqlToLog);
 
         if ((int64_t)elapsed > warnThreshold) {
             if (isSyncThread) {
@@ -2651,7 +2651,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
     // Only OK and commit conflicts are allowed without warning because they're the only "successful" results that we expect here.
     // OK means it succeeds, conflicts will get retried further up the call stack.
     if (error != SQLITE_OK && extErr != SQLITE_BUSY_SNAPSHOT && !skipWarn) {
-        redactSensitiveValues(sqlToLog);
+        SRedactSensitiveValues(sqlToLog);
 
         SWARN("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
     }
@@ -2753,7 +2753,7 @@ bool SREMatch(const string& regExp, const string& s, string& match) {
     return pcrecpp::RE(regExp).FullMatch(s, &match);
 }
 
-void redactredactSensitiveValues(string& s) {
+void SRedactSensitiveValues(string& s) {
     // The message may be truncated midway through the authToken, so there may not be a closing quote (") at the end of
     // the authToken, so we need to optionally match the closing quote with a question mark (?).
     pcrecpp::RE("\"authToken\":\".*\"?").GlobalReplace("\"authToken\":<REDACTED>", &s);

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -387,7 +387,7 @@ bool SREMatch(const string& regExp, const string& s);
 bool SREMatch(const string& regExp, const string& s, string& match);
 
 // Redact values that should not be logged.
-void redactSensitiveValues(string& s);
+void SRedactSensitiveValues(string& s);
 
 // Case testing and conversion
 string SToLower(string value);

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -386,6 +386,9 @@ bool SConstantTimeIEquals(const string& secret, const string& userInput);
 bool SREMatch(const string& regExp, const string& s);
 bool SREMatch(const string& regExp, const string& s, string& match);
 
+// Redact values that should not be logged.
+void redactSensitiveValues(string& s);
+
 // Case testing and conversion
 string SToLower(string value);
 string SToUpper(string value);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -256,7 +256,8 @@ int SQLite::_walHookCallback(void* sqliteObject, sqlite3* db, const char* name, 
 
 void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg) {
     _mostRecentSQLiteErrorLog = "{SQLITE} Code: "s + to_string(iErrCode) + ", Message: "s + zMsg;
-    SSYSLOG(LOG_INFO, "[info] " << _mostRecentSQLiteErrorLog);
+    pcrecpp::RE("\"authToken\":\".*\"?").GlobalReplace("\"authToken\":\"<REDACTED>\"", &_mostRecentSQLiteErrorLog);
+    SINFO(_mostRecentSQLiteErrorLog);
 }
 
 int SQLite::_sqliteTraceCallback(unsigned int traceCode, void* c, void* p, void* x) {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -257,6 +257,9 @@ int SQLite::_walHookCallback(void* sqliteObject, sqlite3* db, const char* name, 
 
 void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg) {
     _mostRecentSQLiteErrorLog = "{SQLITE} Code: "s + to_string(iErrCode) + ", Message: "s + zMsg;
+
+    // The message may be truncated midway through the authToken, so there may not be a closing quote (") at the end of
+    // the authToken, so we need to optionally match the closing quote with a question mark (?).
     pcrecpp::RE("\"authToken\":\".*\"?").GlobalReplace("\"authToken\":\"<REDACTED>\"", &_mostRecentSQLiteErrorLog);
     SINFO(_mostRecentSQLiteErrorLog);
 }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -256,7 +256,7 @@ int SQLite::_walHookCallback(void* sqliteObject, sqlite3* db, const char* name, 
 
 void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg) {
     _mostRecentSQLiteErrorLog = "{SQLITE} Code: "s + to_string(iErrCode) + ", Message: "s + zMsg;
-    redactSensitiveValues(_mostRecentSQLiteErrorLog);
+    SRedactSensitiveValues(_mostRecentSQLiteErrorLog);
     SINFO(_mostRecentSQLiteErrorLog);
 }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -5,6 +5,7 @@
 
 #include <libstuff/libstuff.h>
 #include <libstuff/SQResult.h>
+#include <pcrecpp.h> // sudo apt-get install libpcre++-dev
 
 #define DBINFO(_MSG_) SINFO("{" << _filename << "} " << _MSG_)
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -257,10 +257,7 @@ int SQLite::_walHookCallback(void* sqliteObject, sqlite3* db, const char* name, 
 
 void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg) {
     _mostRecentSQLiteErrorLog = "{SQLITE} Code: "s + to_string(iErrCode) + ", Message: "s + zMsg;
-
-    // The message may be truncated midway through the authToken, so there may not be a closing quote (") at the end of
-    // the authToken, so we need to optionally match the closing quote with a question mark (?).
-    pcrecpp::RE("\"authToken\":\".*\"?").GlobalReplace("\"authToken\":\"<REDACTED>\"", &_mostRecentSQLiteErrorLog);
+    redactSensitiveValues(_mostRecentSQLiteErrorLog);
     SINFO(_mostRecentSQLiteErrorLog);
 }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -5,7 +5,6 @@
 
 #include <libstuff/libstuff.h>
 #include <libstuff/SQResult.h>
-#include <pcrecpp.h> // sudo apt-get install libpcre++-dev
 
 #define DBINFO(_MSG_) SINFO("{" << _filename << "} " << _MSG_)
 


### PR DESCRIPTION
### Details
This PR make sure we do not log an auth token when logging an SQLite error.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/266804

### Tests
1. Set up the `Notifications::add` method in Auth to create a JSON that was malformed.
2. Called `CreateNotification` with netcat that had a JSON with an authToken in it (don't worry, this authToken is from a fake account run locally):
```
vagrant@expensidev2004:/vagrant/Auth$ nc localhost 4444
CreateNotification
authToken: 5A59AC4730E31662263FEC022A3097076E2D0EAE9494BF56410B4EFEA9E1109FB8B2E79CBE198E08282F01290CEB0C1157251771A6B34AB4027312C6E30ED2429BDE0A2E2F8D13788C3D3A86576E9D77CE83959AA6197BF3C18A926CFD33188553530C55DA51ECD770DA835C3AA6E3CE32047082EAFE5CB0F7A83CAD98916D2E1215FDDFE8257DDD36BD1C328B8A9C96ACA0C08503CC11697FAD81CDB40B793EC167EEA27C8AE35C3C29337FB9F416F98A2DB75DEB3B569BB668B364F0BEEA94AB1266A6DFB9289CAC123B9CA65E4599DAF248C6A77BF31F213450F5B70311098E243FB97E21DE8A066AB45B9E5A85432A9DF969DD7EEA313B87E5F1462628C02E919146A46EF16D0E317615A907930EA91800A382264FB5EF143A0D1AF7587FD2C53D16F0C41185FFB33D289E01B297C76450746D246CB09B1A85A13E5A58206360B1BFFAA0314C6FDD89FF9D06F3EF823153B15AE842AB9D349E69E0A6B13E
From: Expensify Concierge <concierge@expensify.com>
reply-to: concierge@expensify.com
to: jbexpensifytest+2@gmail.com
title: Expensify Integrations to QuickBooks Online Warning (Report ID: 80805898)
message: 2023-03-07 22:53:46::752652: Request ID jnLS67#0122023-03-07 22:53:46::752705: User chelsea@cinespia.org attempted to export report [80805898] - 2021-09-23 - 2021-09-23#0122023-03-07 22:53:46::752722: Export is to QuickBooks Online#0122023-03-07 22:53:46::752738: <span style="color:red;">Oops! Expensify encountered an error when auto-exporting to QuickBooks Online, and this requires your attention.</span>#0122023-03-07 22:53:46::752753: <span style="color:red;">Account Event Add-Ons:Dance Floor not found on policy E5ABEAC9AD1F1762, make sure the QBO connection is synced.</span>#012
integrationName: QuickBooks Online
template: Integrations_Warning

502 Query failed
commitCount: 68016
nodeName: auth
peekTime: 1552
processTime: 10881
requestID: 6MUVdo
totalTime: 13036
unaccountedTime: 603
Content-Length: 0
```
3. Confirmed that the auth command was redacted from the SQLite error:
![image](https://user-images.githubusercontent.com/13264774/223892885-98f3ce7a-ff87-404f-bc5e-53368691d08f.png)
```
2023-03-09T01:32:54.410940+00:00 expensidev2004 bedrock: 4SyFz6 (SQLite.cpp:262) _sqliteLogCallback [socket0] [info] {SQLITE} Code: 1, Message: statement aborts at 5: [INSERT INTO notifications (json, priority, created) VALUES ( JSON('{"accountID":15,"authToken":"<REDACTED>"
2023-03-09T01:32:54.410988+00:00 expensidev2004 bedrock: 4SyFz6 (libstuff.cpp:2664) SQuery [socket0] [warn] 'read/write transaction', query failed with error #1 (malformed JSON): INSERT INTO notifications (json, priority, created) VALUES ( JSON('{"accountID":15,"authToken":<REDACTED>,"From":"Expensify Concierge <concierge@expensify.com>","integrationName":"QuickBooks Online","message":"2023-03-07 22:53:46::752652: Request ID jnLS67#0122023-03-07 22:53:46::752705: User chelsea@cinespia.org attempted to export report [80805898] - 2021-09-23 - 2021-09-23#0122023-03-07 22:53:46::752722: Export is to QuickBooks Online#0122023-03-07 22:53:46::752738: <span style=\"color:red;\">Oops! Expensify encountered an error when auto-exporting to QuickBooks Online, and this requires your attention.<\/span>#0122023-03-07 22:53:46::752753: <span style=\"color:red;\">Account Event Add-Ons:Dance Floor not found on policy E5ABEAC9AD1F1762, make sure the QBO connection is synced.<\/span>#012","reply-to":"concierge@expensify.com","template":"Integrations_Warning","title":"Expensify Integrations to QuickBooks Online Warning (Report ID: 80805898)","to":"jbexpensifytest+2@gmail.com"}}'), 100, '2023-03-09 01:32:54');
```
