### PR TITLE
Fix Auth iTunes Billing tests

### DIFF
--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -100,6 +100,11 @@ BedrockTester::BedrockTester(const map<string, string>& args,
     for (auto& row : args) {
         _args[row.first] = row.second;
     }
+
+    // If the DB file doesn't exist, create it.
+    if (!SFileExists(_args["-db"])) {
+        SFileSave(_args["-db"], "");
+    }
     
     // Run any supplied queries on the DB.
     // We don't use SQLite here, because we specifically want to avoid dealing with journal tables.


### PR DESCRIPTION
### Details
This was removed here:
https://github.com/Expensify/Bedrock/pull/1467/files#diff-b2617abd2d61733520af1c93bb1781c366247c780d6bfdf05c215a3ed41ce2c2L97-L101

Because we had removed the check for file existence in that PR, but then we added that check back, but forgot to readd this.

### Fixed Issues
Fixes iTunes Billing tests not working.

### Tests
Build auth, run billing tests:
```
[ TEST RESULTS ] Passed: 1995, Failed: 0
```
