### PR TITLE
Fix ForkCheck HCTree test

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -104,7 +104,10 @@ sqlite3* SQLite::initializeDB(const string& filename, int64_t mmapSizeGB, bool h
         // We only need to specify the full URL when creating new DBs. Existing DBs will be auto-detected as HC-Tree or not.
         completeFilename = "file://" + completeFilename + "?hctree=1";
     }
-    SASSERT(!sqlite3_open_v2(completeFilename.c_str(), &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX | SQLITE_OPEN_URI, NULL));
+    int result = sqlite3_open_v2(completeFilename.c_str(), &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX | SQLITE_OPEN_URI, NULL);
+    if (result) {
+        SERROR("sqlite3_open_v2 returned " << result << ", Extended error code: " << sqlite3_extended_errcode(db));
+    }
 
     // PRAGMA legacy_file_format=OFF sets the default for creating new databases, so it must be called before creating
     // any tables to be effective.

--- a/test/clustertest/tests/ForkCheckTest.cpp
+++ b/test/clustertest/tests/ForkCheckTest.cpp
@@ -80,6 +80,7 @@ struct ForkCheckTest : tpunit::TestFixture {
 
         // Break the journal on leader intentionally to fake a fork.
         auto result = getMaxJournalCommit(tester.getTester(0), false);
+
         uint64_t leaderMaxCommit = result.first;
         string leaderMaxCommitJournal = result.second;
         result = getMaxJournalCommit(tester.getTester(1));
@@ -87,6 +88,9 @@ struct ForkCheckTest : tpunit::TestFixture {
 
         // Make sure the follower got farther than the leader.
         ASSERT_GREATER_THAN(followerMaxCommit, leaderMaxCommit);
+
+        // We need to release any DB that the tester is holding.
+        tester.getTester(0).freeDB();
 
         // Break leader.
         {

--- a/test/clustertest/tests/ForkCheckTest.cpp
+++ b/test/clustertest/tests/ForkCheckTest.cpp
@@ -15,7 +15,9 @@ struct ForkCheckTest : tpunit::TestFixture {
         uint64_t maxJournalCommit = 0;
         string maxJournalTable;
         for (auto& row : journals.rows) {
+            cout << "Got journal row: " << row[0] << endl;
             string maxID = tester.readDB("SELECT MAX(id) FROM " + row[0] + ";");
+            cout << "maxID: " << maxID << endl;
             try {
                 uint64_t maxCommitNum = stoull(maxID);
                 if (maxCommitNum > maxJournalCommit) {
@@ -28,6 +30,57 @@ struct ForkCheckTest : tpunit::TestFixture {
             }
         }
         return make_pair(maxJournalCommit, maxJournalTable);
+    }
+
+
+    static int offlineLookupCallback(void* ref, int numcol, char** colvals, char** colnames) {
+        list<string>& res = *(static_cast<list<string>*>(ref));
+        if (numcol) {
+            res.push_back(colvals[0]);
+        }
+        return SQLITE_OK;
+    }
+
+    pair<uint64_t, string> getMaxJournalCommitOffline(BedrockTester& tester) {
+        string filename = tester.getArg("-db");
+        list<string> results;
+        sqlite3* db = nullptr;
+        sqlite3_open_v2(filename.c_str(), &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX, NULL);
+        char* errMsg = nullptr;
+        sqlite3_exec(db, "SELECT name FROM sqlite_schema WHERE type ='table' AND name LIKE 'journal%';", &offlineLookupCallback, 0, &errMsg);
+        if (errMsg) {
+            cout << "Error updating db: " << errMsg << endl;
+        }
+
+        for (auto& str : results) {
+            cout << "Result table: " << str << endl;
+        }
+        sqlite3_close_v2(db);
+
+
+        /*
+        SQResult journals;
+        tester.readDB("SELECT name FROM sqlite_schema WHERE type ='table' AND name LIKE 'journal%';", journals);
+        uint64_t maxJournalCommit = 0;
+        string maxJournalTable;
+        for (auto& row : journals.rows) {
+            cout << "Got journal row: " << row[0] << endl;
+            string maxID = tester.readDB("SELECT MAX(id) FROM " + row[0] + ";");
+            cout << "maxID: " << maxID << endl;
+            try {
+                uint64_t maxCommitNum = stoull(maxID);
+                if (maxCommitNum > maxJournalCommit) {
+                    maxJournalCommit = maxCommitNum;
+                    maxJournalTable = row[0];
+                }
+            } catch (const invalid_argument& e) {
+                // do nothing, skip this journal with no entries.
+                continue;
+            }
+        }
+        return make_pair(maxJournalCommit, maxJournalTable);
+        */
+        return make_pair(0, "");
     }
 
     void test() {
@@ -79,9 +132,11 @@ struct ForkCheckTest : tpunit::TestFixture {
         }
 
         // Break the journal on leader intentionally to fake a fork.
-        auto result = getMaxJournalCommit(tester.getTester(0));
+        cout << "tester 0" << endl;
+        auto result = getMaxJournalCommitOffline(tester.getTester(0));
         uint64_t leaderMaxCommit = result.first;
         string leaderMaxCommitJournal = result.second;
+        cout << "tester 1" << endl;
         result = getMaxJournalCommit(tester.getTester(1));
         uint64_t followerMaxCommit = result.first;
 
@@ -92,6 +147,11 @@ struct ForkCheckTest : tpunit::TestFixture {
         {
             string filename = tester.getTester(0).getArg("-db");
             string query = "UPDATE " + leaderMaxCommitJournal + " SET hash = 'abcdef123456' WHERE id = " + to_string(leaderMaxCommit) + ";";
+            cout << query << endl;
+            cout << "filename: " << filename << endl;
+            string temp;
+            cout << "Type something to open." << endl;
+            cin >> temp;
 
             sqlite3* db = nullptr;
             sqlite3_open_v2(filename.c_str(), &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX, NULL);
@@ -107,7 +167,7 @@ struct ForkCheckTest : tpunit::TestFixture {
         tester.getTester(0).startServer(false);
 
         // We expect it to die shortly.
-        int status;
+        int status = 0;
         waitpid(tester.getTester(0).getPID(), &status, 0);
 
         // Should have gotten a signal when it died.

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -367,7 +367,7 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
                                 *errorCode = 2;
                             }
                             if (timeout) {
-                                cout << "executeWaitMultiple(): ran out of time waiting for socket" << endl;
+                                cout << "executeWaitMultipleData(): ran out of time waiting for socket" << endl;
                             }
                             return;
                         }
@@ -528,6 +528,11 @@ SQLite& BedrockTester::getSQLiteDB()
         _db = new SQLite(_args["-db"], 1000000, 3000000, -1, "", 0, ENABLE_HCTREE);
     }
     return *_db;
+}
+
+void BedrockTester::freeDB() {
+    delete _db;
+    _db = nullptr;
 }
 
 string BedrockTester::readDB(const string& query, bool online)

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -525,18 +525,22 @@ SQLite& BedrockTester::getSQLiteDB()
 {
     if (!_db) {
         // Assumes wal2 mode.
-        _db = new SQLite(_args["-db"], 1000000, 3000000, -1, "", 0);
+        _db = new SQLite(_args["-db"], 1000000, 3000000, -1, "", 0, ENABLE_HCTREE);
     }
     return *_db;
 }
 
-string BedrockTester::readDB(const string& query)
+string BedrockTester::readDB(const string& query, bool online)
 {
-    if (ENABLE_HCTREE) {
+    if (ENABLE_HCTREE && online) {
         SData command("Query");
         command["Query"] = query;
         command["Format"] = "JSON";
         auto row0 = SParseJSONObject(executeWaitMultipleData({command})[0].content)["rows"];
+        if (row0 == "") {
+            return "";
+        }
+
         return SParseJSONArray(SParseJSONArray(row0).front()).front();
     } else {
         SQLite& db = getSQLiteDB();
@@ -547,9 +551,9 @@ string BedrockTester::readDB(const string& query)
     }
 }
 
-bool BedrockTester::readDB(const string& query, SQResult& result)
+bool BedrockTester::readDB(const string& query, SQResult& result, bool online)
 {
-    if (ENABLE_HCTREE) {
+    if (ENABLE_HCTREE && online) {
         result.clear();
         SData command("Query");
         command["Query"] = query;

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -77,6 +77,9 @@ class BedrockTester {
     string readDB(const string& query, bool online = true);
     bool readDB(const string& query, SQResult& result, bool online = true);
 
+    // Closes and releases any existing DB file.
+    void freeDB();
+
     // Wait for a particular key in a `Status` message to equal a particular value, for up to `timeoutUS` us. Returns
     // true if a match was found, or times out otherwose.
     bool waitForStatusTerm(const string& term, const string& testValue, uint64_t timeoutUS = 60'000'000);

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -74,8 +74,8 @@ class BedrockTester {
 
     // Read from the DB file, without going through the bedrock server. Two interfaces are provided to maintain
     // compatibility with the `SQLite` class.
-    string readDB(const string& query);
-    bool readDB(const string& query, SQResult& result);
+    string readDB(const string& query, bool online = true);
+    bool readDB(const string& query, SQResult& result, bool online = true);
 
     // Wait for a particular key in a `Status` message to equal a particular value, for up to `timeoutUS` us. Returns
     // true if a match was found, or times out otherwose.


### PR DESCRIPTION
### Details
This fixes the `ForkCheck` test in HC-Tree mode. We needed to add an "online" mode for HC-Tree that causes `readDB` to go through the running server to query the DB. However, in this test, the server is explicitly not running, so we add back an option to run `readDB` in an offline mode.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/268224

### Tests
Is a test