### PR TITLE
Remove obsolete/unused var.

### DIFF
--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -20,7 +20,6 @@ class SStandaloneHTTPSManager : public STCPManager {
         SData fullRequest;
         SData fullResponse;
         int response;
-        STable values;
         SStandaloneHTTPSManager& manager;
         uint64_t sentTime;
         const string requestID;


### PR DESCRIPTION
### Details
Hold for https://github.com/Expensify/Auth/pull/7684, which removes Auth's usage of this.

### Fixed Issues
Fixes GH_LINK

### Tests
Auth tests pass with this change.