### PR TITLE
Don't let forked peers approve standup

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -752,13 +752,15 @@ bool SQLiteNode::update() {
         SASSERTWARN(_db.getUncommittedHash().empty());
         // Wait for everyone to respond
         bool allResponded = true;
-        int numFullPeers = 0;
-        int numLoggedInFullPeers = 0;
+        size_t numFullPeers = 0;
+        size_t numLoggedInFullPeers = 0;
+        size_t approveCount = 0;
         if (_isShuttingDown) {
             SINFO("Shutting down while standing up, setting state to SEARCHING");
             _changeState(SQLiteNodeState::SEARCHING);
             return true; // Re-update
         }
+
         for (auto peer : _peerList) {
             // Check this peer; if not logged in, tacit approval
             if (!peer->permaFollower) {
@@ -771,11 +773,16 @@ bool SQLiteNode::update() {
                     if (peer->standupResponse == SQLitePeer::Response::NONE) {
                         // At least one logged in full peer hasn't responded
                         allResponded = false;
-                    } else if (peer->standupResponse != SQLitePeer::Response::APPROVE) {
+                        break;
+                    } else if (peer->standupResponse == SQLitePeer::Response::ABSTAIN) {
+                        PHMMM("Peer abstained from participation in quorum");
+                    } else if (peer->standupResponse == SQLitePeer::Response::DENY) {
                         // It responeded, but didn't approve -- abort
-                        PHMMM("Refused our STANDUP, cancel and RESEARCH");
+                        PHMMM("Refused our STANDUP, cancel and RE-SEARCH");
                         _changeState(SQLiteNodeState::SEARCHING);
                         return true; // Re-update
+                    } else if (peer->standupResponse == SQLitePeer::Response::APPROVE) {
+                        approveCount++;
                     }
                 }
             }
@@ -783,9 +790,10 @@ bool SQLiteNode::update() {
 
         // If everyone's responded with approval and we form a majority, then finish standup.
         bool majorityConnected = numLoggedInFullPeers * 2 >= numFullPeers;
-        if (allResponded && majorityConnected) {
+        bool quorumApproved = approveCount * 2 >= numFullPeers;
+        if (allResponded && majorityConnected && quorumApproved) {
             // Complete standup
-            SINFO("All peers approved standup, going LEADING.");
+            SINFO("All peers responded, going LEADING.");
             _changeState(SQLiteNodeState::LEADING);
             return true; // Re-update
         }
@@ -1300,12 +1308,17 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     response["StateChangeCount"] = message["StateChangeCount"];
 
                     // Reason we would deny, if we do.
-                    string reason;
                     if (peer->permaFollower) {
                         // We think it's a permafollower, deny
                         PHMMM("Permafollower trying to stand up, denying.");
                         response["Response"] = "deny";
-                        reason = "You're a permafollower";
+                        response["Reason"] = "You're a permafollower";
+                    }
+
+                    if (_forkedFrom.count(peer->name)) {
+                        PHMMM("Forked from peer, can't approve standup.");
+                        response["Response"] = "abstain";
+                        response["Reason"] = "We are forked";
                     }
 
                     // What's our state
@@ -1327,7 +1340,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                         } else {
                             // Deny because we're currently in the process of leading and we're higher priority.
                             response["Response"] = "deny";
-                            reason = "I am leading";
+                            response["Reason"] = "I am leading";
 
                             // Hmm, why is a lower priority peer trying to stand up? Is it possible we're no longer in
                             // control of the cluster? Let's see how many nodes are subscribed.
@@ -1359,7 +1372,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                                 if (otherPeer->state == SQLiteNodeState::STANDINGUP || otherPeer->state == SQLiteNodeState::LEADING || otherPeer->state == SQLiteNodeState::STANDINGDOWN) {
                                     // We need to contest this standup
                                     response["Response"] = "deny";
-                                    reason = "peer '" + otherPeer->name + "' is '" + stateName(otherPeer->state) + "'";
+                                    response["Reason"] = "peer '" + otherPeer->name + "' is '" + stateName(otherPeer->state) + "'";
                                     break;
                                 }
                             }
@@ -1370,7 +1383,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     if (SIEquals(response["Response"], "approve")) {
                         PINFO("Approving standup request");
                     } else {
-                        PHMMM("Denying standup request because " << reason);
+                        PHMMM("Not approving standup request because " << response["Reason"]);
                     }
                     _sendToPeer(peer, response);
                 } else if (from == SQLiteNodeState::STANDINGDOWN) {
@@ -1411,6 +1424,9 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                 if (SIEquals(message["Response"], "approve")) {
                     PINFO("Received standup approval");
                     peer->standupResponse = SQLitePeer::Response::APPROVE;
+                } else if (SIEquals(message["Response"], "abstain")) {
+                    PINFO("Received standup abstain");
+                    peer->standupResponse = SQLitePeer::Response::ABSTAIN;
                 } else {
                     PHMMM("Received standup denial: reason='" << message["Reason"] << "'");
                     peer->standupResponse = SQLitePeer::Response::DENY;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1301,9 +1301,8 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     // STANDINGUP: When a peer announces it intends to stand up, we immediately respond with approval or
                     // denial. We determine this by checking to see if there is any  other peer who is already leader or
                     // also trying to stand up.
-                    //
-                    // **FIXME**: Should it also deny if it knows of a higher priority peer?
                     SData response("STANDUP_RESPONSE");
+
                     // Parrot back the node's attempt count so that it can differentiate stale responses.
                     response["StateChangeCount"] = message["StateChangeCount"];
 
@@ -1313,12 +1312,16 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                         PHMMM("Permafollower trying to stand up, denying.");
                         response["Response"] = "deny";
                         response["Reason"] = "You're a permafollower";
+                        _sendToPeer(peer, response);
+                        return;
                     }
 
                     if (_forkedFrom.count(peer->name)) {
                         PHMMM("Forked from peer, can't approve standup.");
                         response["Response"] = "abstain";
                         response["Reason"] = "We are forked";
+                        _sendToPeer(peer, response);
+                        return;
                     }
 
                     // What's our state

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -173,6 +173,9 @@ string SQLitePeer::responseName(Response response) {
         case Response::DENY:
             return "DENY";
             break;
+        case Response::ABSTAIN:
+            return "ABSTAIN";
+            break;
         default:
             return "";
     }

--- a/sqlitecluster/SQLitePeer.h
+++ b/sqlitecluster/SQLitePeer.h
@@ -8,7 +8,8 @@ class SQLitePeer {
     enum class Response {
         NONE,
         APPROVE,
-        DENY
+        DENY,
+        ABSTAIN
     };
 
     enum class PeerPostPollStatus {

--- a/test/clustertest/tests/ForkedNodeApprovalTest.cpp
+++ b/test/clustertest/tests/ForkedNodeApprovalTest.cpp
@@ -1,0 +1,133 @@
+
+#include <sys/wait.h>
+
+#include <libstuff/SData.h>
+#include <libstuff/SQResult.h>
+#include <sqlitecluster/SQLite.h>
+#include <test/clustertest/BedrockClusterTester.h>
+
+struct ForkedNodeApprovalTest : tpunit::TestFixture {
+    ForkedNodeApprovalTest()
+        : tpunit::TestFixture("ForkCheck", TEST(ForkedNodeApprovalTest::test)) {}
+
+    pair<uint64_t, string> getMaxJournalCommit(BedrockTester& tester, bool online = true) {
+        SQResult journals;
+        tester.readDB("SELECT name FROM sqlite_schema WHERE type ='table' AND name LIKE 'journal%';", journals, online);
+        uint64_t maxJournalCommit = 0;
+        string maxJournalTable;
+        for (auto& row : journals.rows) {
+            string maxID = tester.readDB("SELECT MAX(id) FROM " + row[0] + ";", online);
+            try {
+                uint64_t maxCommitNum = stoull(maxID);
+                if (maxCommitNum > maxJournalCommit) {
+                    maxJournalCommit = maxCommitNum;
+                    maxJournalTable = row[0];
+                }
+            } catch (const invalid_argument& e) {
+                // do nothing, skip this journal with no entries.
+                continue;
+            }
+        }
+        return make_pair(maxJournalCommit, maxJournalTable);
+    }
+
+    void test() {
+        // Create a cluster, wait for it to come up.
+        BedrockClusterTester tester(ClusterSize::THREE_NODE_CLUSTER);
+
+        // We'll tell the threads to stop when they're done.
+        atomic<bool> stop(false);
+
+        // We want to not spam a stopped leader.
+        atomic<bool> leaderIsUp(true);
+
+        // Just use a bunch of copies of the same command.
+        SData spamCommand("idcollision");
+
+        // In a vector.
+        const vector<SData> commands(100, spamCommand);
+
+        // Now create 9 threads spamming 100 commands at a time, each. 9 cause we have three nodes.
+        vector<thread> threads;
+        for (size_t i = 0; i < 9; i++) {
+            threads.emplace_back([&tester, i, &commands, &stop, &leaderIsUp](){
+                while (!stop) {
+                    // Pick a tester, send, don't care about the result.
+                    size_t testerNum = i % 3;
+                    if (testerNum == 0 && !leaderIsUp) {
+                        // If we're looking for leader and it's down, wait a second to avoid pegging the CPU.
+                        sleep(1);
+                    } else {
+                        // If we're not leader or leader is up, spam away!
+                        tester.getTester(testerNum).executeWaitMultipleData(commands);
+                    }
+                }
+            });
+        }
+
+        // Let them spam for a second.
+        sleep(1);
+
+        // We can try and stop the leader.
+        leaderIsUp = false;
+        tester.getTester(0).stopServer();
+
+        // Spam a few more commands and then we can stop.
+        sleep(1);
+        stop = true;
+        for (auto& t : threads) {
+            t.join();
+        }
+
+        // Break the journal on leader intentionally to fake a fork.
+        auto result = getMaxJournalCommit(tester.getTester(0), false);
+
+        uint64_t leaderMaxCommit = result.first;
+        string leaderMaxCommitJournal = result.second;
+        result = getMaxJournalCommit(tester.getTester(1));
+        uint64_t followerMaxCommit = result.first;
+
+        // Make sure the follower got farther than the leader.
+        ASSERT_GREATER_THAN(followerMaxCommit, leaderMaxCommit);
+
+        // We need to release any DB that the tester is holding.
+        tester.getTester(0).freeDB();
+
+        // Break leader.
+        {
+            string filename = tester.getTester(0).getArg("-db");
+            string query = "UPDATE " + leaderMaxCommitJournal + " SET hash = 'abcdef123456' WHERE id = " + to_string(leaderMaxCommit) + ";";
+
+            sqlite3* db = nullptr;
+            sqlite3_open_v2(filename.c_str(), &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX, NULL);
+            char* errMsg = nullptr;
+            sqlite3_exec(db, query.c_str(), 0, 0, &errMsg);
+            if (errMsg) {
+                cout << "Error updating db: " << errMsg << endl;
+            }
+            sqlite3_close_v2(db);
+        }
+
+        // Stop the second follower.
+        tester.getTester(2).stopServer();
+
+        // Start the broken leader back up.
+        tester.getTester(0).startServer(false);
+
+        // We should not get a leader, the primary leader needs to synchronize, but can't because it's forked.
+        // The secondary leader should go leading, but can't, because it only receives `abstain` responses to standup requests.
+
+        threads.clear();
+        for (auto i: {0, 1} ) {
+            threads.emplace_back([i, &tester](){
+                SData command("Status");
+                auto response = tester.getTester(i).executeWaitMultipleData({command});
+                cout << response.front().serialize() << endl;
+            });
+        }
+
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+} __ForkedNodeApprovalTest;

--- a/test/clustertest/tests/ForkedNodeApprovalTest.cpp
+++ b/test/clustertest/tests/ForkedNodeApprovalTest.cpp
@@ -79,7 +79,7 @@ struct ForkedNodeApprovalTest : tpunit::TestFixture {
             t.join();
         }
 
-        // Break the journal on leader intentionally to fake a fork.
+        // Fetch the latest journal commits on leader and follower
         auto result = getMaxJournalCommit(tester.getTester(0), false);
 
         uint64_t leaderMaxCommit = result.first;

--- a/test/clustertest/tests/ForkedNodeApprovalTest.cpp
+++ b/test/clustertest/tests/ForkedNodeApprovalTest.cpp
@@ -105,6 +105,7 @@ struct ForkedNodeApprovalTest : tpunit::TestFixture {
             sqlite3_exec(db, query.c_str(), 0, 0, &errMsg);
             if (errMsg) {
                 cout << "Error updating db: " << errMsg << endl;
+                ASSERT_TRUE(false);
             }
             sqlite3_close_v2(db);
         }


### PR DESCRIPTION
### Details
This has an edge case where it's still possible for a node to miss that it's forked from another on first starting up. It is possible for the standup message to come in to a node that hasn't attempted to synchronize, but nodes that are behind need to be able to approve leaders. Once they know they're forked though, this prevents them getting in a loop where they could continually approve a leader that disagrees with them on the state of the database.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/273462

### Tests
Added a new test.

