### PR TITLE
Report number of bytes actually sent

### DIFF
--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -257,8 +257,7 @@ bool STCPManager::Socket::send(size_t* bytesSentCount) {
     } else if (s > 0) {
         result = S_sendconsume(s, sendBuffer);
     }
-    size_t newSize = sendBuffer.size();
-    size_t bytesSent = oldSize - newSize;
+    size_t bytesSent = oldSize - sendBuffer.size();
     if (bytesSent) {
         lastSendTime = STimeNow();
         if (bytesSentCount) {

--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -247,7 +247,7 @@ STCPManager::Socket::~Socket() {
     }
 }
 
-bool STCPManager::Socket::send() {
+bool STCPManager::Socket::send(size_t* bytesSentCount) {
     lock_guard<decltype(sendRecvMutex)> lock(sendRecvMutex);
     // Send data
     bool result = false;
@@ -257,13 +257,18 @@ bool STCPManager::Socket::send() {
     } else if (s > 0) {
         result = S_sendconsume(s, sendBuffer);
     }
-    if (oldSize - sendBuffer.size()) {
+    size_t newSize = sendBuffer.size();
+    size_t bytesSent = oldSize - newSize;
+    if (bytesSent) {
         lastSendTime = STimeNow();
+        if (bytesSentCount) {
+            *bytesSentCount = bytesSent;
+        }
     }
     return result;
 }
 
-bool STCPManager::Socket::send(const string& buffer) {
+bool STCPManager::Socket::send(const string& buffer, size_t* bytesSentCount) {
     lock_guard<decltype(sendRecvMutex)> lock(sendRecvMutex);
 
     // If the socket's in a valid state for sending, append to the sendBuffer, otherwise warn
@@ -274,7 +279,7 @@ bool STCPManager::Socket::send(const string& buffer) {
     }
 
     // Send anything we've got.
-    return send();
+    return send(bytesSentCount);
 }
 
 bool STCPManager::Socket::sendBufferEmpty() {

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -36,8 +36,8 @@ struct STCPManager {
         uint64_t lastRecvTime;
         SSSLState* ssl;
         void* data;
-        bool send();
-        bool send(const string& buffer);
+        bool send(size_t* bytesSentCount = nullptr);
+        bool send(const string& buffer, size_t* bytesSentCount = nullptr);
         bool recv();
         void shutdown(State toState = SHUTTINGDOWN);
         uint64_t id;

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -233,10 +233,11 @@ bool SQLitePeer::isPermafollower(const STable& params) {
 void SQLitePeer::sendMessage(const SData& message) {
     lock_guard<decltype(peerMutex)> lock(peerMutex);
     if (socket) {
-        if (socket->send(message.serialize())) {
-            SINFO("Successfully sent " << message.methodLine << " to peer " << name << ".");
+        size_t byesSent = 0;
+        if (socket->send(message.serialize(), &byesSent)) {
+            SINFO("No error sending " << message.methodLine << " to peer " << name << " (" << byesSent << " bytes actually sent).");
         } else {
-            SHMMM("Could not send " << message.methodLine << " to peer " << name << ".");
+            SHMMM("Error sending " << message.methodLine << " to peer " << name << ".");
         }
     } else {
         SINFO("Tried to send " << message.methodLine << " to peer " << name << ", but not available.");

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -233,9 +233,9 @@ bool SQLitePeer::isPermafollower(const STable& params) {
 void SQLitePeer::sendMessage(const SData& message) {
     lock_guard<decltype(peerMutex)> lock(peerMutex);
     if (socket) {
-        size_t byesSent = 0;
-        if (socket->send(message.serialize(), &byesSent)) {
-            SINFO("No error sending " << message.methodLine << " to peer " << name << " (" << byesSent << " bytes actually sent).");
+        size_t bytesSent = 0;
+        if (socket->send(message.serialize(), &bytesSent)) {
+            SINFO("No error sending " << message.methodLine << " to peer " << name << " (" << bytesSent << " bytes actually sent).");
         } else {
             SHMMM("Error sending " << message.methodLine << " to peer " << name << ".");
         }


### PR DESCRIPTION
### Details
This is just a misleading message. It reports "success" if it doesn't get an error. If the socket in question is still being established, the message is actually just queued to send later, and this is deemed "success" even though the socket isn't actually opened yet.

This change clarifies the message.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/272649

### Tests
Watch logs and see messages like:
```
2023-04-04T14:13:15.740832-05:00 expensidev2004 bedrock10001: xxxxxx (SQLitePeer.cpp:238) sendMessage [sync] [info] {cluster_node_2} No error sending COMMIT_TRANSACTION to peer cluster_node_2 (222 bytes actually sent).
```