### PR TITLE
Add transaction ID to logs for leader.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -937,6 +937,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                     // conflict as long as we don't commit while it's performing a transaction. This is scoped
                     // to the minimum time required.
                     bool commitSuccess = false;
+                    uint64_t transactionID = 0;
                     {
                         // There used to be a mutex protecting this state change, with the idea that if we
                         // prevented state changes, we couldn't fall out of leading in the middle of processing a
@@ -956,7 +957,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                             core.rollback();
                         } else {
                             BedrockCore::AutoTimer timer(command, BedrockCommand::COMMIT_WORKER);
-                            commitSuccess = core.commit(SQLiteNode::stateName(_replicationState));
+                            commitSuccess = core.commit(SQLiteNode::stateName(_replicationState), transactionID);
                         }
                     }
                     if (commitSuccess) {
@@ -964,7 +965,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                         // loop and send it to followers. NOTE: we don't check for null here, that should be
                         // impossible inside a worker thread.
                         _syncNode->notifyCommit();
-                        SINFO("Successfully committed " << command->request.methodLine << " on worker thread. blocking: "
+                        SINFO("Successfully committed " << command->request.methodLine << ", transaction #" <<  transactionID << ", blocking: "
                               << (isBlocking ? "true" : "false"));
                         // So we must still be leading, and at this point our commit has succeeded, let's
                         // mark it as complete. We add the currentCommit count here as well.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -938,6 +938,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                     // to the minimum time required.
                     bool commitSuccess = false;
                     uint64_t transactionID = 0;
+                    string transactionHash;
                     {
                         // There used to be a mutex protecting this state change, with the idea that if we
                         // prevented state changes, we couldn't fall out of leading in the middle of processing a
@@ -957,7 +958,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                             core.rollback();
                         } else {
                             BedrockCore::AutoTimer timer(command, BedrockCommand::COMMIT_WORKER);
-                            commitSuccess = core.commit(SQLiteNode::stateName(_replicationState), transactionID);
+                            commitSuccess = core.commit(SQLiteNode::stateName(_replicationState), transactionID, transactionHash);
                         }
                     }
                     if (commitSuccess) {
@@ -965,7 +966,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                         // loop and send it to followers. NOTE: we don't check for null here, that should be
                         // impossible inside a worker thread.
                         _syncNode->notifyCommit();
-                        SINFO("Successfully committed " << command->request.methodLine << ", transaction #" <<  transactionID << ", blocking: "
+                        SINFO("Committed leader transaction #" << transactionID << "(" << transactionHash << "). Command: '" << command->request.methodLine << "', blocking: "
                               << (isBlocking ? "true" : "false"));
                         // So we must still be leading, and at this point our commit has succeeded, let's
                         // mark it as complete. We add the currentCommit count here as well.

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -576,7 +576,6 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash) {
     string committedQuery, committedHash;
     uint64_t commitCount = _sharedData.commitCount;
 
-
     // Queue up the journal entry
     string lastCommittedHash = getCommittedHash(); // This is why we need the lock.
     _uncommittedHash = SToHex(SHashSHA1(lastCommittedHash + _uncommittedQuery));

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -561,7 +561,7 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
     return true;
 }
 
-bool SQLite::prepare() {
+bool SQLite::prepare(uint64_t* commitID) {
     SASSERT(_insideTransaction);
 
     // We lock this here, so that we can guarantee the order in which commits show up in the database.
@@ -575,6 +575,9 @@ bool SQLite::prepare() {
     // SharedData object to get these values as we know it can't currently change.
     string committedQuery, committedHash;
     uint64_t commitCount = _sharedData.commitCount;
+    if (commitID) {
+        *commitID = commitCount + 1;
+    }
 
     // Queue up the journal entry
     string lastCommittedHash = getCommittedHash(); // This is why we need the lock.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -124,7 +124,9 @@ class SQLite {
 
     // Prepare to commit or rollback the transaction. This also inserts the current uncommitted query into the
     // journal; no additional writes are allowed until the next transaction has begun.
-    bool prepare(uint64_t* commitID = nullptr);
+    // The transactionID and transactionHash, if passed, will be updated with the values prepared for this transaction.
+    // Note that if this transaction fails to commit, these will not ultimately be accurate.
+    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr);
 
     // This enables or disables automatic re-writing. This feature is to support mocked requests and load testing. This
     // overloads set_authorizer to allow a plugin to deny certain queries from running (currently based only on the

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -124,7 +124,7 @@ class SQLite {
 
     // Prepare to commit or rollback the transaction. This also inserts the current uncommitted query into the
     // journal; no additional writes are allowed until the next transaction has begun.
-    bool prepare();
+    bool prepare(uint64_t* commitID = nullptr);
 
     // This enables or disables automatic re-writing. This feature is to support mocked requests and load testing. This
     // overloads set_authorizer to allow a plugin to deny certain queries from running (currently based only on the

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -6,9 +6,9 @@
 SQLiteCore::SQLiteCore(SQLite& db) : _db(db)
 { }
 
-bool SQLiteCore::commit(const string& description, uint64_t& commitID) {
+bool SQLiteCore::commit(const string& description, uint64_t& commitID, string& transactionHash) {
     // This should always succeed.
-    SASSERT(_db.prepare(&commitID));
+    SASSERT(_db.prepare(&commitID, &transactionHash));
 
     // If there's nothing to commit, we won't bother, but warn, as we should have noticed this already.
     if (_db.getUncommittedHash().empty()) {

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -6,9 +6,9 @@
 SQLiteCore::SQLiteCore(SQLite& db) : _db(db)
 { }
 
-bool SQLiteCore::commit(const string& description) {
+bool SQLiteCore::commit(const string& description, uint64_t& commitID) {
     // This should always succeed.
-    SASSERT(_db.prepare());
+    SASSERT(_db.prepare(&commitID));
 
     // If there's nothing to commit, we won't bother, but warn, as we should have noticed this already.
     if (_db.getUncommittedHash().empty()) {

--- a/sqlitecluster/SQLiteCore.h
+++ b/sqlitecluster/SQLiteCore.h
@@ -8,7 +8,7 @@ class SQLiteCore {
 
     // Commit the outstanding transaction on the DB.
     // Returns true on successful commit, false on conflict.
-    bool commit(const string& description);
+    bool commit(const string& description, uint64_t& commitID);
 
     // Roll back a transaction if we've decided not to commit it.
     void rollback();

--- a/sqlitecluster/SQLiteCore.h
+++ b/sqlitecluster/SQLiteCore.h
@@ -8,7 +8,7 @@ class SQLiteCore {
 
     // Commit the outstanding transaction on the DB.
     // Returns true on successful commit, false on conflict.
-    bool commit(const string& description, uint64_t& commitID);
+    bool commit(const string& description, uint64_t& commitID, string& transactionHash);
 
     // Roll back a transaction if we've decided not to commit it.
     void rollback();


### PR DESCRIPTION
### Details

Adds logging on leader to match logging on followers for what commit, with what hash, is committed at what time. Example logs from the entire cluster:
```
2023-04-07T14:12:17.896758-05:00 expensidev2004 bedrock10001: LZ6iq7 (BedrockServer.cpp:969) runCommand [blockingCommit] [info] Committed leader transaction #445(43090CA65B7B5D372A62148C9877BEA42355B01D). Command: 'idcollision b2', blocking: true
2023-04-07T14:12:17.897954-05:00 expensidev2004 bedrock10004: xxxxxx (SQLiteNode.cpp:2290) _handleCommitTransaction [replicate888] [info] {cluster_node_1/FOLLOWING} Committed follower transaction #445 (43090CA65B7B5D372A62148C9877BEA42355B01D) in 0 ms (0+0+0+0+0+0ms)
2023-04-07T14:12:17.898078-05:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:2290) _handleCommitTransaction [replicate886] [info] {cluster_node_2/FOLLOWING} Committed follower transaction #445 (43090CA65B7B5D372A62148C9877BEA42355B01D) in 0 ms (0+0+0+0+0+0ms)
```

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/273612

### Tests
No tests, only changes logging. Auth was compiled against the new code to verify it wasn't broken.