### PR TITLE
Add 'quiesce' command for Phil to use with ZFS

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1692,6 +1692,8 @@ bool BedrockServer::_isControlCommand(const unique_ptr<BedrockCommand>& command)
         SIEquals(command->request.methodLine, "Attach")                 ||
         SIEquals(command->request.methodLine, "SetConflictParams")      ||
         SIEquals(command->request.methodLine, "EnableSQLTracing")       ||
+        SIEquals(command->request.methodLine, "BlockWrites")            ||
+        SIEquals(command->request.methodLine, "UnblockWrites")          ||
         SIEquals(command->request.methodLine, "CRASH_COMMAND")
         ) {
         return true;
@@ -1767,6 +1769,24 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
             SINFO("Setting _maxConflictRetries to " << _maxConflictRetries);
             response["previousMaxConflictRetries"] = to_string(_maxConflictRetries.load());
             _maxConflictRetries.store(maxConflictRetries);
+        }
+    } else if (SIEquals(command->request.methodLine, "BlockWrites")) {
+        shared_ptr<SQLitePool> dbPoolCopy = _dbPool;
+        if (dbPoolCopy) {
+            SQLiteScopedHandle dbScope(*_dbPool, _dbPool->getIndex());
+            SQLite& db = dbScope.db();
+            db.exclusiveLockDB();
+        } else {
+            response.methodLine = "404 DB Pool Not Found";
+        }
+    } else if (SIEquals(command->request.methodLine, "UnblockWrites")) {
+        shared_ptr<SQLitePool> dbPoolCopy = _dbPool;
+        if (dbPoolCopy) {
+            SQLiteScopedHandle dbScope(*_dbPool, _dbPool->getIndex());
+            SQLite& db = dbScope.db();
+            db.exclusiveUnlockDB();
+        } else {
+            response.methodLine = "404 DB Pool Not Found";
         }
     }
 }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -310,6 +310,14 @@ SQLite::~SQLite() {
     DBINFO("Database closed.");
 }
 
+void SQLite::exclusiveLockDB() {
+    _sharedData.commitLock.lock();
+}
+
+void SQLite::exclusiveUnlockDB() {
+    _sharedData.commitLock.unlock();
+}
+
 bool SQLite::beginTransaction(TRANSACTION_TYPE type) {
     if (type == TRANSACTION_TYPE::EXCLUSIVE) {
         if (isSyncThread) {

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -248,6 +248,9 @@ class SQLite {
     // Set this DB handle to be query-only to prevent accidental writes in places we don't expect them.
     void setQueryOnly(bool enabled);
 
+    void exclusiveLockDB();
+    void exclusiveUnlockDB();
+
   private:
     // This structure contains all of the data that's shared between a set of SQLite objects that share the same
     // underlying database file.


### PR DESCRIPTION
### Details
This is an experimental version of the `Quiesce` command that @fukawi2 needs to continue his ZFS project. It has not been tested. It might break things. I intened to let @fukawi2 merge it and play with it on db2.rno. If it breaks, we can iterate on it.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/276570
Part of https://github.com/Expensify/Expensify/issues/271360

### Tests
Do it live