### PR TITLE
Record tables accessed per command

### DIFF
--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -192,6 +192,8 @@ class BedrockCommand : public SQLiteCommand {
     // This is a timestamp in *microseconds* for when this command should timeout.
     uint64_t _timeout;
 
+    set<string> _tablesUsed;
+
     static atomic<size_t> _commandCount;
 
     static const string defaultPluginName;

--- a/BedrockConflictManager.cpp
+++ b/BedrockConflictManager.cpp
@@ -18,7 +18,7 @@ void BedrockConflictManager::recordTables(const string& commandName, const set<s
 
         // And for each table (that's not a journal).
         for (auto& table : tables) {
-            // Skip journal.
+            // Skip journals, they change on every instance of a command running and thus aren't useful for profiling which commands access which tables most frequently.
             if (SStartsWith(table, "journal")) {
                 continue;
             }

--- a/BedrockConflictManager.cpp
+++ b/BedrockConflictManager.cpp
@@ -35,3 +35,25 @@ void BedrockConflictManager::recordTables(const string& commandName, const set<s
     // And increase the count for each used table.
     SINFO("Command " << commandName << " used tables: " << SComposeList(tables));
 }
+
+string BedrockConflictManager::generateReport() {
+    stringstream out;
+    {
+        lock_guard<mutex> lock(m);
+        for (auto& p : _commandInfo) {
+            const string& commandName = p.first;
+            const BedrockConflictManagerCommandInfo& commandInfo = p.second;
+
+            out << "Command: " << commandName << endl;
+            out << "Total Count: " << commandInfo.count << endl;
+            out << "Table usage:" << endl;
+            for (const auto& t : commandInfo.tableUseCounts) {
+                const string& tableName = t.first;
+                const size_t& count = t.second;
+                out << tableName << ": " << count << endl;
+                out << endl;
+            }
+        }
+    }
+    return out.str();
+}

--- a/BedrockConflictManager.cpp
+++ b/BedrockConflictManager.cpp
@@ -1,0 +1,37 @@
+#include "BedrockConflictManager.h"
+#include <libstuff/libstuff.h>
+
+BedrockConflictManager::BedrockConflictManager() {
+}
+
+void BedrockConflictManager::recordTables(const string& commandName, const set<string>& tables) {
+    {
+        lock_guard<mutex> lock(m);
+        auto commandInfo = _commandInfo.find(commandName);
+        if (commandInfo == _commandInfo.end()) {
+            commandInfo = _commandInfo.emplace(make_pair(commandName, BedrockConflictManagerCommandInfo())).first;
+        }
+
+        // Increase the count of the command in general.
+        commandInfo->second.count++;
+
+        // And for each table (that's not a journal).
+        for (auto& t : tables) {
+            // Skip journal.
+            if (SStartsWith(t, "journal")) {
+                continue;
+            }
+
+            // Does this command already have this table?
+            auto tableInfo = commandInfo->second.tableUseCounts.find(t);
+            if (tableInfo == commandInfo->second.tableUseCounts.end()) {
+                tableInfo = commandInfo->second.tableUseCounts.emplace(make_pair(t, 1)).first;
+            } else {
+                tableInfo->second++;
+            }
+        }
+    }
+
+    // And increase the count for each used table.
+    SINFO("Command " << commandName << " used tables: " << SComposeList(tables));
+}

--- a/BedrockConflictManager.cpp
+++ b/BedrockConflictManager.cpp
@@ -22,6 +22,10 @@ void BedrockConflictManager::recordTables(const string& commandName, const set<s
                 continue;
             }
 
+            if (t == "json_each") {
+                continue;
+            }
+
             // Does this command already have this table?
             auto tableInfo = commandInfo->second.tableUseCounts.find(t);
             if (tableInfo == commandInfo->second.tableUseCounts.end()) {
@@ -46,13 +50,13 @@ string BedrockConflictManager::generateReport() {
 
             out << "Command: " << commandName << endl;
             out << "Total Count: " << commandInfo.count << endl;
-            out << "Table usage:" << endl;
+            out << "Table usage" << endl;
             for (const auto& t : commandInfo.tableUseCounts) {
                 const string& tableName = t.first;
                 const size_t& count = t.second;
-                out << tableName << ": " << count << endl;
-                out << endl;
+                out << "    " << tableName << ": " << count << endl;
             }
+            out << endl;
         }
     }
     return out.str();

--- a/BedrockConflictManager.h
+++ b/BedrockConflictManager.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <map>
+#include <mutex>
+#include <set>
+#include <string>
+
+using namespace std;
+
+class BedrockConflictManagerCommandInfo {
+  public:
+    size_t count = 0;
+    map<string, size_t> tableUseCounts;
+};
+
+class BedrockConflictManager {
+  public:
+    BedrockConflictManager();
+    void recordTables(const string& commandName, const set<string>& tables);
+
+  private:
+    mutex m;
+    map<string, BedrockConflictManagerCommandInfo> _commandInfo;
+};

--- a/BedrockConflictManager.h
+++ b/BedrockConflictManager.h
@@ -16,6 +16,7 @@ class BedrockConflictManager {
   public:
     BedrockConflictManager();
     void recordTables(const string& commandName, const set<string>& tables);
+    string generateReport();
 
   private:
     mutex m;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -398,7 +398,7 @@ void BedrockServer::sync()
             if (_syncNode->commitSucceeded()) {
                 if (command) {
                     SINFO("[performance] Sync thread finished committing command " << command->request.methodLine);
-                    SINFO("Tables used: " << SComposeList(db.getTablesUsed()));
+                    _conflictManager.recordTables(command->request.methodLine, db.getTablesUsed());
 
                     // Otherwise, save the commit count, mark this command as complete, and reply.
                     command->response["commitCount"] = to_string(db.getCommitCount());
@@ -969,7 +969,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                         _syncNode->notifyCommit();
                         SINFO("Committed leader transaction #" << transactionID << "(" << transactionHash << "). Command: '" << command->request.methodLine << "', blocking: "
                               << (isBlocking ? "true" : "false"));
-                        SINFO("Tables used: " << SComposeList(db.getTablesUsed()));
+                        _conflictManager.recordTables(command->request.methodLine, db.getTablesUsed());
                         // So we must still be leading, and at this point our commit has succeeded, let's
                         // mark it as complete. We add the currentCommit count here as well.
                         command->response["commitCount"] = to_string(db.getCommitCount());

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1690,6 +1690,7 @@ bool BedrockServer::_isControlCommand(const unique_ptr<BedrockCommand>& command)
         SIEquals(command->request.methodLine, "SuppressCommandPort")    ||
         SIEquals(command->request.methodLine, "ClearCommandPort")       ||
         SIEquals(command->request.methodLine, "ClearCrashCommands")     ||
+        SIEquals(command->request.methodLine, "ConflictReport")         ||
         SIEquals(command->request.methodLine, "Detach")                 ||
         SIEquals(command->request.methodLine, "Attach")                 ||
         SIEquals(command->request.methodLine, "SetConflictParams")      ||
@@ -1723,6 +1724,8 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
     } else if (SIEquals(command->request.methodLine, "ClearCrashCommands")) {
         unique_lock<decltype(_crashCommandMutex)> lock(_crashCommandMutex);
         _crashCommands.clear();
+    } else if (SIEquals(command->request.methodLine, "ConflictReport")) {
+        response.content = _conflictManager.generateReport();
     } else if (SIEquals(command->request.methodLine, "Detach")) {
         response.methodLine = "203 DETACHING";
         _beginShutdown("Detach", true);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -398,6 +398,7 @@ void BedrockServer::sync()
             if (_syncNode->commitSucceeded()) {
                 if (command) {
                     SINFO("[performance] Sync thread finished committing command " << command->request.methodLine);
+                    SINFO("Tables used: " << SComposeList(db.getTablesUsed()));
 
                     // Otherwise, save the commit count, mark this command as complete, and reply.
                     command->response["commitCount"] = to_string(db.getCommitCount());
@@ -968,6 +969,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                         _syncNode->notifyCommit();
                         SINFO("Committed leader transaction #" << transactionID << "(" << transactionHash << "). Command: '" << command->request.methodLine << "', blocking: "
                               << (isBlocking ? "true" : "false"));
+                        SINFO("Tables used: " << SComposeList(db.getTablesUsed()));
                         // So we must still be leading, and at this point our commit has succeeded, let's
                         // mark it as complete. We add the currentCommit count here as well.
                         command->response["commitCount"] = to_string(db.getCommitCount());

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -5,6 +5,7 @@
 #include <sqlitecluster/SQLiteClusterMessenger.h>
 #include "BedrockPlugin.h"
 #include "BedrockCommandQueue.h"
+#include "BedrockConflictManager.h"
 #include "BedrockTimeoutCommandQueue.h"
 
 class SQLitePeer;
@@ -258,6 +259,8 @@ class BedrockServer : public SQLiteServer {
 
     // Commands that aren't currently being processed are kept here.
     BedrockCommandQueue _commandQueue;
+
+    BedrockConflictManager _conflictManager;
 
     // These are commands that will be processed in a blacking fashion.
     BedrockCommandQueue _blockingCommandQueue;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -854,6 +854,11 @@ int SQLite::_authorize(int actionCode, const char* detail1, const char* detail2,
         return SQLITE_DENY;
     }
 
+    // Record all tables touched.
+    if (set<int>{SQLITE_INSERT, SQLITE_DELETE, SQLITE_READ, SQLITE_UPDATE}.count(actionCode)) {
+        SINFO("Touching " << detail2);
+    }
+
     // Here's where we can check for non-deterministic functions for the cache.
     if (actionCode == SQLITE_FUNCTION && detail2) {
         if (!strcmp(detail2, "random") ||

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -41,6 +41,10 @@ string SQLite::initializeFilename(const string& filename) {
     }
 }
 
+const set<string>& SQLite::getTablesUsed() const {
+    return _tablesUsed;
+}
+
 SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames, bool hctree) {
     static struct SharedDataLookupMapType {
         map<string, SharedData*> m;
@@ -342,6 +346,7 @@ bool SQLite::beginTransaction(TRANSACTION_TYPE type) {
     // the above `BEGIN CONCURRENT` and the `getCommitCount` call in a lock, which is worse.
     _dbCountAtStart = getCommitCount();
     _queryCache.clear();
+    _tablesUsed.clear();
     _queryCount = 0;
     _cacheHits = 0;
     _beginElapsed = STimeNow() - before;
@@ -856,7 +861,7 @@ int SQLite::_authorize(int actionCode, const char* detail1, const char* detail2,
 
     // Record all tables touched.
     if (set<int>{SQLITE_INSERT, SQLITE_DELETE, SQLITE_READ, SQLITE_UPDATE}.count(actionCode)) {
-        SINFO("Touching " << detail2);
+        _tablesUsed.insert(detail1);
     }
 
     // Here's where we can check for non-deterministic functions for the cache.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -122,6 +122,8 @@ class SQLite {
     void setUpdateNoopMode(bool enabled);
     bool getUpdateNoopMode() const;
 
+    const set<string>& getTablesUsed() const;
+
     // Prepare to commit or rollback the transaction. This also inserts the current uncommitted query into the
     // journal; no additional writes are allowed until the next transaction has begun.
     // The transactionID and transactionHash, if passed, will be updated with the values prepared for this transaction.
@@ -448,6 +450,9 @@ class SQLite {
     // A map of queries to their cached results. This is populated only with deterministic queries, and is reset on any
     // write, rollback, or commit.
     map<string, SQResult> _queryCache;
+
+    // List of table names used during this transaction.
+    set<string> _tablesUsed;
 
     // Number of queries that have been attempted in this transaction (for metrics only).
     int64_t _queryCount = 0;

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -3,25 +3,15 @@
 
 struct StatusHandlingCommandsTest : tpunit::TestFixture {
     StatusHandlingCommandsTest()
-        : tpunit::TestFixture("StatusHandlingCommands",
-                              BEFORE_CLASS(StatusHandlingCommandsTest::setup),
-                              AFTER_CLASS(StatusHandlingCommandsTest::teardown),
-                              TEST(StatusHandlingCommandsTest::test)) { }
-
-    BedrockClusterTester* tester;
-
-    void setup () {
-        tester = new BedrockClusterTester();
-    }
-
-    void teardown() {
-        delete tester;
-    }
+        : tpunit::TestFixture("StatusHandlingCommands", TEST(StatusHandlingCommandsTest::test)) { }
 
     void test() {
-        vector<string> results(3);
-        BedrockTester& leader = tester->getTester(0);
-        BedrockTester& follower = tester->getTester(1);
+        BedrockClusterTester tester;
+        BedrockTester& leader = tester.getTester(0);
+        BedrockTester& follower = tester.getTester(1);
+        vector<string> results(2);
+
+        leader.stopServer();
 
         thread healthCheckThread([this, &results, &follower](){
             SData cmd("GET /status/handlingCommands HTTP/1.1");
@@ -39,30 +29,20 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture {
                 } else if (result == "HTTP/1.1 200 FOLLOWING") {
                     results[1] = result;
                     foundFollower = true;
-                } else if (result == "HTTP/1.1 200 STANDINGDOWN") {
-                    results[2] = result;
-                    foundStandingdown = true;
+
+                    // If we get here, it's not going back to leading/standingdown.
+                    break;
                 }
             }
         });
 
-        leader.stopServer();
-
-        // Execute a slow query while the follower is leading so when the
-        // leader is brought back up, it will be STANDINGDOWN until it finishes
-        thread slowQueryThread([this, &follower](){
-            SData slow("slowquery");
-            slow["timeout"] = "5000"; // 5s
-            follower.executeWaitVerifyContent(slow, "555 Timeout peeking command");
-        });
-
+        sleep(1);
         leader.startServer(false);
-        slowQueryThread.join();
         healthCheckThread.join();
 
         ASSERT_EQUAL(results[0], "HTTP/1.1 200 LEADING")
         ASSERT_EQUAL(results[1], "HTTP/1.1 200 FOLLOWING")
-        ASSERT_EQUAL(results[2], "HTTP/1.1 200 STANDINGDOWN")
+        // We don't test STANDINGDOWN because it's unreliable to get it to show up in the status, we can move straight through it too quickly.
     }
 
 } __StatusHandlingCommandsTest;


### PR DESCRIPTION
### Details

### Fixed Issues
Start of https://github.com/Expensify/Expensify/issues/261154

### Tests
Running a few commands in newDot and then running the `ConflictReport` command gives:
```
ConflictReport

200 OK
nodeName: auth
totalTime: 426
unaccountedTime: 426
Content-Length: 510

Command: CreateReportAction
Total Count: 2
Table usage
    accounts: 2
    logins: 2
    nameValuePairs: 2
    reportActions: 2
    reportNameValuePairs: 2
    reports: 2
    sharedNameValuePairs: 2
    sharedReports: 2

Command: SetNameValuePair
Total Count: 4
Table usage
    accounts: 4
    logins: 4
    nameValuePairs: 4

Command: UpdateRNVPLastReadTime
Total Count: 10
Table usage
    accounts: 10
    logins: 10
    nameValuePairs: 10
    reportNameValuePairs: 10
    reports: 10
    sharedReports: 10

```
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
