### PR TITLE
Measure time spent in blocking queue 

### DIFF
--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -1,0 +1,13 @@
+#include <BedrockBlockingCommandQueue.h>
+
+void BedrockBlockingCommandQueue::startTiming(unique_ptr<BedrockCommand>& command) {
+    command->startTiming(BedrockCommand::QUEUE_BLOCKING);
+}
+
+void BedrockBlockingCommandQueue::stopTiming(unique_ptr<BedrockCommand>& command) {
+    command->stopTiming(BedrockCommand::QUEUE_BLOCKING);
+}
+
+BedrockBlockingCommandQueue::BedrockBlockingCommandQueue() :
+  BedrockCommandQueue(function<void(unique_ptr<BedrockCommand>&)>(startTiming), function<void(unique_ptr<BedrockCommand>&)>(stopTiming))
+{ }

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -1,7 +1,8 @@
 #pragma once
 #include <libstuff/libstuff.h>
 #include "BedrockCommandQueue.h"
-#include "BedrockCommand.h"
+
+class BedrockCommand;
 
 class BedrockBlockingCommandQueue : public BedrockCommandQueue {
   public:

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <libstuff/libstuff.h>
+#include "BedrockCommandQueue.h"
+#include "BedrockCommand.h"
+
+class BedrockBlockingCommandQueue : public BedrockCommandQueue {
+  public:
+    BedrockBlockingCommandQueue();
+
+    // Functions to start and stop timing on the commands when they're inserted/removed from the queue.
+    static void startTiming(unique_ptr<BedrockCommand>& command);
+    static void stopTiming(unique_ptr<BedrockCommand>& command);
+};

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <libstuff/libstuff.h>
 #include "BedrockCommandQueue.h"
 
 class BedrockCommand;

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -205,23 +205,6 @@ void BedrockCommand::finalizeTimingInfo() {
         }
     }
 
-    // TODO: I'll remove the next SINFO at the end, I'll keep it while testing logsToStatsd.pl
-    SINFO("command '" << methodName << "' timing info (ms): "
-          << peekTotal/1000 << " (" << peekCount << "), "
-          << processTotal/1000 << " (" << processCount << "), "
-          << commitWorkerTotal/1000 << ", "
-          << commitSyncTotal/1000 << ", "
-          << queueWorkerTotal/1000 << ", "
-          << queueSyncTotal/1000 << ", "
-          << totalTime/1000 << ", "
-          << unaccountedTime/1000 << ", "
-          << escalationTimeUS/1000 << ". Upstream: "
-          << upstreamPeekTime/1000 << ", "
-          << upstreamProcessTime/1000 << ", "
-          << upstreamTotalTime/1000 << ", "
-          << upstreamUnaccountedTime/1000 << "."
-    );
-
     SINFO("command '" << methodName << "' timing info (ms): "
           "peek:" << peekTotal/1000 << " (count:" << peekCount << "), "
           "process:" << processTotal/1000 << " (count:" << processCount << "), "

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -126,6 +126,7 @@ void BedrockCommand::finalizeTimingInfo() {
     uint64_t commitSyncTotal = 0;
     uint64_t queueWorkerTotal = 0;
     uint64_t queueSyncTotal = 0;
+    uint64_t queueBlockingTotal = 0;
     for (const auto& entry: timingInfo) {
         if (get<0>(entry) == PEEK) {
             peekTotal += get<2>(entry) - get<1>(entry);
@@ -137,6 +138,8 @@ void BedrockCommand::finalizeTimingInfo() {
             commitSyncTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == QUEUE_WORKER) {
             queueWorkerTotal += get<2>(entry) - get<1>(entry);
+        } else if (get<0>(entry) == QUEUE_BLOCKING) {
+            queueBlockingTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == QUEUE_SYNC) {
             queueSyncTotal += get<2>(entry) - get<1>(entry);
         }
@@ -147,7 +150,7 @@ void BedrockCommand::finalizeTimingInfo() {
 
     // Time that wasn't accounted for in all the other metrics.
     uint64_t unaccountedTime = totalTime - (peekTotal + processTotal + commitWorkerTotal + commitSyncTotal +
-                                            escalationTimeUS + queueWorkerTotal + queueSyncTotal);
+                                            escalationTimeUS + queueWorkerTotal + queueBlockingTotal + queueSyncTotal);
 
     // Build a map of the values we care about.
     map<string, uint64_t> valuePairs = {
@@ -210,6 +213,7 @@ void BedrockCommand::finalizeTimingInfo() {
           << commitSyncTotal/1000 << ", "
           << queueWorkerTotal/1000 << ", "
           << queueSyncTotal/1000 << ", "
+          << queueBlockingTotal/1000 << ", "
           << totalTime/1000 << ", "
           << unaccountedTime/1000 << ", "
           << escalationTimeUS/1000 << ". Upstream: "

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -205,7 +205,7 @@ void BedrockCommand::finalizeTimingInfo() {
         }
     }
 
-    // Log all this info.
+    // TODO: I'll remove the next SINFO at the end, I'll keep it while testing logsToStatsd.pl
     SINFO("command '" << methodName << "' timing info (ms): "
           << peekTotal/1000 << " (" << peekCount << "), "
           << processTotal/1000 << " (" << processCount << "), "
@@ -213,7 +213,6 @@ void BedrockCommand::finalizeTimingInfo() {
           << commitSyncTotal/1000 << ", "
           << queueWorkerTotal/1000 << ", "
           << queueSyncTotal/1000 << ", "
-          << queueBlockingTotal/1000 << ", "
           << totalTime/1000 << ", "
           << unaccountedTime/1000 << ", "
           << escalationTimeUS/1000 << ". Upstream: "
@@ -221,6 +220,26 @@ void BedrockCommand::finalizeTimingInfo() {
           << upstreamProcessTime/1000 << ", "
           << upstreamTotalTime/1000 << ", "
           << upstreamUnaccountedTime/1000 << "."
+    );
+
+    SINFO("command '" << methodName << "' timing info (ms): "
+          "peek:" << peekTotal/1000 << " (count:" << peekCount << "), "
+          "process:" << processTotal/1000 << " (count:" << processCount << "), "
+          "total:" << totalTime/1000 << ", "
+          "unaccounted:" << unaccountedTime/1000 <<
+          ". Commit: "
+          "worker:" << commitWorkerTotal/1000 << ", "
+          "sync:"<< commitSyncTotal/1000 <<
+          ". Queue: "
+          "worker:" << queueWorkerTotal/1000 << ", "
+          "sync:" << queueSyncTotal/1000 << ", "
+          "blocking:" << queueBlockingTotal/1000 << ", "
+          "escalation:" << escalationTimeUS/1000 <<
+          ". Upstream: "
+          "peek:" << upstreamPeekTime/1000 << ", "
+          "process:"<< upstreamProcessTime/1000 << ", "
+          "total:" << upstreamTotalTime/1000 << ", "
+          "unaccounted:" << upstreamUnaccountedTime/1000 << "."
     );
 
     // And here's where we set our own values.

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -22,6 +22,7 @@ class BedrockCommand : public SQLiteCommand {
         COMMIT_SYNC,
         QUEUE_WORKER,
         QUEUE_SYNC,
+        QUEUE_BLOCKING,
     };
 
     enum class STAGE {

--- a/BedrockCommandQueue.cpp
+++ b/BedrockCommandQueue.cpp
@@ -12,6 +12,12 @@ BedrockCommandQueue::BedrockCommandQueue() :
   SScheduledPriorityQueue<unique_ptr<BedrockCommand>>(function<void(unique_ptr<BedrockCommand>&)>(startTiming), function<void(unique_ptr<BedrockCommand>&)>(stopTiming))
 { }
 
+BedrockCommandQueue::BedrockCommandQueue(
+    function<void(unique_ptr<BedrockCommand>& item)> startFunction,
+    function<void(unique_ptr<BedrockCommand>& item)> endFunction
+) : SScheduledPriorityQueue<unique_ptr<BedrockCommand>>(startFunction, endFunction)
+{ }
+
 list<string> BedrockCommandQueue::getRequestMethodLines() {
     list<string> returnVal;
     SAUTOLOCK(_queueMutex);

--- a/BedrockCommandQueue.h
+++ b/BedrockCommandQueue.h
@@ -6,6 +6,10 @@
 class BedrockCommandQueue : public SScheduledPriorityQueue<unique_ptr<BedrockCommand>> {
   public:
     BedrockCommandQueue();
+    BedrockCommandQueue(
+      function<void(unique_ptr<BedrockCommand>& item)> startFunction,
+      function<void(unique_ptr<BedrockCommand>& item)> endFunction
+    );
 
     // Functions to start and stop timing on the commands when they're inserted/removed from the queue.
     static void startTiming(unique_ptr<BedrockCommand>& command);

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -5,6 +5,7 @@
 #include <sqlitecluster/SQLiteClusterMessenger.h>
 #include "BedrockPlugin.h"
 #include "BedrockCommandQueue.h"
+#include "BedrockBlockingCommandQueue.h"
 #include "BedrockTimeoutCommandQueue.h"
 
 class SQLitePeer;
@@ -260,7 +261,7 @@ class BedrockServer : public SQLiteServer {
     BedrockCommandQueue _commandQueue;
 
     // These are commands that will be processed in a blacking fashion.
-    BedrockCommandQueue _blockingCommandQueue;
+    BedrockBlockingCommandQueue _blockingCommandQueue;
 
     // Each time we read a new request from a client, we give it a unique ID.
     atomic<uint64_t> _requestCount;


### PR DESCRIPTION
### Details

Implementation of @tylerkaraszewski 's suggestion: https://github.com/Expensify/Bedrock/pull/1499#issuecomment-1535303430

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/280378

### Tests

I tested this by using an account with a corporate policy that had around 5000k reports. Then using the following JS snippet, I lunched 10 requests in parallel to add new admins:

```js
[...Array(10)].forEach((_, i) => API.policy_employees_merge({policyID: g_policyPage.policy.id, employees: [{email:`admin_a_${i}@many-reports.com`, role: 'admin'}]}))
```
This caused some commands to be send to the blocking queue.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
