### PR TITLE
Add blocking timing info

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -134,14 +134,17 @@ void BedrockCommand::finalizeTimingInfo() {
         if (get<0>(entry) == PEEK) {
             peekTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == BLOCKING_PEEK) {
+            peekTotal += get<2>(entry) - get<1>(entry);
             blockingPeekTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == PROCESS) {
             processTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == BLOCKING_PROCESS) {
+            processTotal += get<2>(entry) - get<1>(entry);
             blockingProcessTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == COMMIT_WORKER) {
             commitWorkerTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == BLOCKING_COMMIT_WORKER) {
+            commitWorkerTotal += get<2>(entry) - get<1>(entry);
             blockingCommitWorkerTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == COMMIT_SYNC) {
             commitSyncTotal += get<2>(entry) - get<1>(entry);

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -229,7 +229,7 @@ void BedrockCommand::finalizeTimingInfo() {
           "escalation:" << escalationTimeUS/1000 <<
           ". Blocking: "
           "peek:" << blockingPeekTotal/1000 << ", "
-          "process:" << blockingProcessTotal/1000 <<
+          "process:" << blockingProcessTotal/1000 << ", "
           "commit:" << blockingCommitWorkerTotal/1000 <<
           ". Upstream: "
           "peek:" << upstreamPeekTime/1000 << ", "

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -121,8 +121,11 @@ void BedrockCommand::reset(BedrockCommand::STAGE stage) {
 
 void BedrockCommand::finalizeTimingInfo() {
     uint64_t peekTotal = 0;
+    uint64_t blockingPeekTotal = 0;
     uint64_t processTotal = 0;
+    uint64_t blockingProcessTotal = 0;
     uint64_t commitWorkerTotal = 0;
+    uint64_t blockingCommitWorkerTotal = 0;
     uint64_t commitSyncTotal = 0;
     uint64_t queueWorkerTotal = 0;
     uint64_t queueSyncTotal = 0;
@@ -130,10 +133,16 @@ void BedrockCommand::finalizeTimingInfo() {
     for (const auto& entry: timingInfo) {
         if (get<0>(entry) == PEEK) {
             peekTotal += get<2>(entry) - get<1>(entry);
+        } else if (get<0>(entry) == BLOCKING_PEEK) {
+            blockingPeekTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == PROCESS) {
             processTotal += get<2>(entry) - get<1>(entry);
+        } else if (get<0>(entry) == BLOCKING_PROCESS) {
+            blockingProcessTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == COMMIT_WORKER) {
             commitWorkerTotal += get<2>(entry) - get<1>(entry);
+        } else if (get<0>(entry) == BLOCKING_COMMIT_WORKER) {
+            blockingCommitWorkerTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == COMMIT_SYNC) {
             commitSyncTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == QUEUE_WORKER) {
@@ -218,6 +227,10 @@ void BedrockCommand::finalizeTimingInfo() {
           "sync:" << queueSyncTotal/1000 << ", "
           "blocking:" << queueBlockingTotal/1000 << ", "
           "escalation:" << escalationTimeUS/1000 <<
+          ". Blocking: "
+          "peek:" << blockingPeekTotal/1000 << ", "
+          "process:" << blockingProcessTotal/1000 <<
+          "commit:" << blockingCommitWorkerTotal/1000 <<
           ". Upstream: "
           "peek:" << upstreamPeekTime/1000 << ", "
           "process:"<< upstreamProcessTime/1000 << ", "

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -26,7 +26,6 @@ class BedrockCommand : public SQLiteCommand {
         BLOCKING_PEEK,
         BLOCKING_PROCESS,
         BLOCKING_COMMIT_WORKER,
-        NONE,
     };
 
     enum class STAGE {

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -23,6 +23,10 @@ class BedrockCommand : public SQLiteCommand {
         QUEUE_WORKER,
         QUEUE_SYNC,
         QUEUE_BLOCKING,
+        BLOCKING_PEEK,
+        BLOCKING_PROCESS,
+        BLOCKING_COMMIT_WORKER,
+        NONE,
     };
 
     enum class STAGE {

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -65,7 +65,7 @@ bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command) {
 }
 
 BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command, bool exclusive) {
-    AutoTimer timer(command, BedrockCommand::PEEK);
+    AutoTimer timer(command, BedrockCommand::PEEK, exclusive ? BedrockCommand::BLOCKING_PEEK : BedrockCommand::NONE);
     BedrockServer::ScopedStateSnapshot snapshot(_server);
     command->lastPeekedOrProcessedInState = _server.getState();
 
@@ -159,7 +159,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
 }
 
 BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& command, bool exclusive) {
-    AutoTimer timer(command, BedrockCommand::PROCESS);
+    AutoTimer timer(command, BedrockCommand::PROCESS, exclusive ? BedrockCommand::BLOCKING_PROCESS : BedrockCommand::NONE);
     BedrockServer::ScopedStateSnapshot snapshot(_server);
 
     // We need to be leading (including standing down) and we need to have peeked this command in the same set of

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -65,7 +65,7 @@ bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command) {
 }
 
 BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command, bool exclusive) {
-    AutoTimer timer(command, BedrockCommand::PEEK, exclusive ? BedrockCommand::BLOCKING_PEEK : BedrockCommand::NONE);
+    AutoTimer timer(command, exclusive ? BedrockCommand::BLOCKING_PEEK : BedrockCommand::PEEK);
     BedrockServer::ScopedStateSnapshot snapshot(_server);
     command->lastPeekedOrProcessedInState = _server.getState();
 
@@ -159,7 +159,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
 }
 
 BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& command, bool exclusive) {
-    AutoTimer timer(command, BedrockCommand::PROCESS, exclusive ? BedrockCommand::BLOCKING_PROCESS : BedrockCommand::NONE);
+    AutoTimer timer(command, exclusive ? BedrockCommand::BLOCKING_PROCESS : BedrockCommand::PROCESS);
     BedrockServer::ScopedStateSnapshot snapshot(_server);
 
     // We need to be leading (including standing down) and we need to have peeked this command in the same set of

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -20,19 +20,15 @@ class BedrockCore : public SQLiteCore {
     // Automatic timing class that records an entry corresponding to its lifespan.
     class AutoTimer {
       public:
-        AutoTimer(unique_ptr<BedrockCommand>& command, BedrockCommand::TIMING_INFO type, BedrockCommand::TIMING_INFO blockingType) :
-        _command(command), _type(type), _blockingType(blockingType), _start(STimeNow()) { }
+        AutoTimer(unique_ptr<BedrockCommand>& command, BedrockCommand::TIMING_INFO type) :
+        _command(command), _type(type), _start(STimeNow()) { }
         ~AutoTimer() {
           int64_t now = STimeNow();
           _command->timingInfo.emplace_back(make_tuple(_type, _start, now));
-          if (_blockingType != BedrockCommand::NONE) {
-            _command->timingInfo.emplace_back(make_tuple(_blockingType, _start, now));
-          }
         }
       private:
         unique_ptr<BedrockCommand>& _command;
         BedrockCommand::TIMING_INFO _type;
-        BedrockCommand::TIMING_INFO _blockingType;
         uint64_t _start;
     };
 

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -20,14 +20,19 @@ class BedrockCore : public SQLiteCore {
     // Automatic timing class that records an entry corresponding to its lifespan.
     class AutoTimer {
       public:
-        AutoTimer(unique_ptr<BedrockCommand>& command, BedrockCommand::TIMING_INFO type) :
-        _command(command), _type(type), _start(STimeNow()) { }
+        AutoTimer(unique_ptr<BedrockCommand>& command, BedrockCommand::TIMING_INFO type, BedrockCommand::TIMING_INFO blockingType) :
+        _command(command), _type(type), _blockingType(blockingType), _start(STimeNow()) { }
         ~AutoTimer() {
-            _command->timingInfo.emplace_back(make_tuple(_type, _start, STimeNow()));
+          int64_t now = STimeNow();
+          _command->timingInfo.emplace_back(make_tuple(_type, _start, now));
+          if (_blockingType != BedrockCommand::NONE) {
+            _command->timingInfo.emplace_back(make_tuple(_blockingType, _start, now));
+          }
         }
       private:
         unique_ptr<BedrockCommand>& _command;
         BedrockCommand::TIMING_INFO _type;
+        BedrockCommand::TIMING_INFO _blockingType;
         uint64_t _start;
     };
 

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -23,8 +23,7 @@ class BedrockCore : public SQLiteCore {
         AutoTimer(unique_ptr<BedrockCommand>& command, BedrockCommand::TIMING_INFO type) :
         _command(command), _type(type), _start(STimeNow()) { }
         ~AutoTimer() {
-          int64_t now = STimeNow();
-          _command->timingInfo.emplace_back(make_tuple(_type, _start, now));
+          _command->timingInfo.emplace_back(make_tuple(_type, _start, STimeNow()));
         }
       private:
         unique_ptr<BedrockCommand>& _command;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -958,7 +958,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                                    << " during worker commit. Rolling back transaction!");
                             core.rollback();
                         } else {
-                            BedrockCore::AutoTimer timer(command, BedrockCommand::COMMIT_WORKER, isBlocking ? BedrockCommand::BLOCKING_COMMIT_WORKER : BedrockCommand::NONE);
+                            BedrockCore::AutoTimer timer(command, isBlocking ? BedrockCommand::BLOCKING_COMMIT_WORKER : BedrockCommand::COMMIT_WORKER);
                             commitSuccess = core.commit(SQLiteNode::stateName(_replicationState), transactionID, transactionHash);
                         }
                     }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -958,7 +958,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                                    << " during worker commit. Rolling back transaction!");
                             core.rollback();
                         } else {
-                            BedrockCore::AutoTimer timer(command, BedrockCommand::COMMIT_WORKER);
+                            BedrockCore::AutoTimer timer(command, BedrockCommand::COMMIT_WORKER, isBlocking ? BedrockCommand::BLOCKING_COMMIT_WORKER : BedrockCommand::NONE);
                             commitSuccess = core.commit(SQLiteNode::stateName(_replicationState), transactionID, transactionHash);
                         }
                     }


### PR DESCRIPTION
### Details

Add some values to the enum `TIMING_INFO` to represent the "blocking" version of some existing values

When the command is running in blocking thread, we pass the `TIMING_INFO` of the blocking type to `AutoTimer`.

Timing info log line:
- To keep our original metrics the same, `processTotal` becomes `PROCESS + BLOCKING_PROCESS`. Same for peek and commitWorker.
- We log a blockingCommit version for process, peek and commitWorker. These come from `BLOCKING_PROCESS`, `BLOCKING_PEEK` and `BLOCKING_COMMIT_WORKER` respectively.


Some slack conversations for more context:

- https://expensify.slack.com/archives/C056AV5V8UX/p1684958323470639?thread_ts=1684771327.930789&cid=C056AV5V8UX
- https://expensify.slack.com/archives/C03TQ48KC/p1684872537937739

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/280378

### Tests

I tested this by using an account with a corporate policy that had around 5000k reports. Then using the following JS snippet, I lunched 10 requests in parallel to add new admins:

```js
[...Array(10)].forEach((_, i) => API.policy_employees_merge({policyID: g_policyPage.policy.id, employees: [{email:`admin_a_${i}@many-reports.com`, role: 'admin'}]}))
```
This caused some commands to be send to the blocking queue.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
