### PR TITLE
Adding prePeek and postProcess transactions to bedrock commands

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -9,6 +9,7 @@ const string BedrockCommand::defaultPluginName("NO_PLUGIN");
 BedrockCommand::BedrockCommand(SQLiteCommand&& baseCommand, BedrockPlugin* plugin, bool escalateImmediately_) :
     SQLiteCommand(move(baseCommand)),
     priority(PRIORITY_NORMAL),
+    prePeekCount(0),
     peekCount(0),
     processCount(0),
     repeek(false),
@@ -120,6 +121,7 @@ void BedrockCommand::reset(BedrockCommand::STAGE stage) {
 }
 
 void BedrockCommand::finalizeTimingInfo() {
+    uint64_t prePeekTotal = 0;
     uint64_t peekTotal = 0;
     uint64_t processTotal = 0;
     uint64_t commitWorkerTotal = 0;

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -115,7 +115,7 @@ bool BedrockCommand::areHttpsRequestsComplete() const {
 }
 
 void BedrockCommand::reset(BedrockCommand::STAGE stage) {
-    if (stage == STAGE::PEEK) {
+    if (stage == STAGE::PEEK && !shouldPrePeek()) {
         jsonContent.clear();
         response.clear();
     }

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -48,7 +48,7 @@ class BedrockCommand : public SQLiteCommand {
     // Optionally called to execute read-only operations for a command in a separate transaction than the transaction
     // that can execute write operations for a command (i.e. the transaction that runs peek and process). This must be
     // called before the transaction that executes write operations.
-    virtual bool prePeek(SQLite& db) { STHROW("500 Base class prePeek called"); }
+    virtual void prePeek(SQLite& db) { STHROW("500 Base class prePeek called"); }
 
     // Called to attempt to handle a command in a read-only fashion. Should return true if the command has been
     // completely handled and a response has been written into `command.response`, which can be returned to the client.

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -16,8 +16,10 @@ class BedrockCommand : public SQLiteCommand {
 
     enum TIMING_INFO {
         INVALID,
+        PREPEEK,
         PEEK,
         PROCESS,
+        POSTPROCESS,
         COMMIT_WORKER,
         COMMIT_SYNC,
         QUEUE_WORKER,
@@ -26,8 +28,10 @@ class BedrockCommand : public SQLiteCommand {
     };
 
     enum class STAGE {
+        PREPEEK,
         PEEK,
-        PROCESS
+        PROCESS,
+        POSTPROCESS
     };
 
     // Times in *milliseconds*.

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -116,6 +116,10 @@ class BedrockCommand : public SQLiteCommand {
     // Set to true if we don't want to log timeout alerts, and let the caller deal with it.
     virtual bool shouldSuppressTimeoutWarnings() { return false; }
 
+    virtual bool shouldPrePeek() { return false; }
+
+    virtual bool shouldPostProcess() { return false; }
+
     // A command can set this to true to indicate it would like to have `peek` called again after completing a HTTPS
     // request. This allows a single command to make multiple serial HTTPS requests. The command should clear this when
     // all HTTPS requests are complete. It will be automatically cleared if the command throws an exception.

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -30,8 +30,7 @@ class BedrockCommand : public SQLiteCommand {
     enum class STAGE {
         PREPEEK,
         PEEK,
-        PROCESS,
-        POSTPROCESS
+        PROCESS
     };
 
     // Times in *milliseconds*.

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -63,7 +63,7 @@ class BedrockCommand : public SQLiteCommand {
     // Optionally called to execute read-only operations for a command in a separate transaction than the transaction
     // that can execute write operations for a command (i.e. the transaction that runs peek and process). This must be
     // called after the transaction that executes write operations.
-    virtual bool postProcess(SQLite& db) { STHROW("500 Base class prePeek called"); }
+    virtual bool postProcess(SQLite& db) { STHROW("500 Base class postProcess called"); }
 
     // Reset the command after a commit conflict. This is called both before `peek` and `process`. Typically, we don't
     // want to reset anything in `process`, because we may have specifically stored values there in `peek` that we want
@@ -106,6 +106,7 @@ class BedrockCommand : public SQLiteCommand {
     int prePeekCount;
     int peekCount;
     int processCount;
+    int postProcessCount;
 
     // A plugin can optionally handle a command for which the reply to the caller was undeliverable.
     // Note that it gets no reference to the DB, this happens after the transaction is already complete.

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -41,6 +41,11 @@ class BedrockCommand : public SQLiteCommand {
     // Destructor.
     virtual ~BedrockCommand();
 
+    // Optionally called to execute read-only operations for a command in a separate transaction than the transaction
+    // that can execute write operations for a command (i.e. the transaction that runs peek and process). This must be
+    // called before the transaction that executes write operations.
+    virtual bool prePeek(SQLite& db) { STHROW("500 Base class prePeek called"); }
+
     // Called to attempt to handle a command in a read-only fashion. Should return true if the command has been
     // completely handled and a response has been written into `command.response`, which can be returned to the client.
     // Should return `false` if the command needs to write to the database or otherwise could not be finished in a
@@ -50,6 +55,11 @@ class BedrockCommand : public SQLiteCommand {
     // Called after a command has returned `false` to peek, and will attempt to commit and distribute a transaction
     // with any changes to the DB made by this plugin.
     virtual void process(SQLite& db) { STHROW("500 Base class process called"); }
+
+    // Optionally called to execute read-only operations for a command in a separate transaction than the transaction
+    // that can execute write operations for a command (i.e. the transaction that runs peek and process). This must be
+    // called after the transaction that executes write operations.
+    virtual bool postProcess(SQLite& db) { STHROW("500 Base class prePeek called"); }
 
     // Reset the command after a commit conflict. This is called both before `peek` and `process`. Typically, we don't
     // want to reset anything in `process`, because we may have specifically stored values there in `peek` that we want

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -98,7 +98,8 @@ class BedrockCommand : public SQLiteCommand {
     // Each command is assigned a priority.
     Priority priority;
 
-    // We track how many times we `peek` and `process` each command.
+    // We track how many times we `prePeek`, `peek` and `process` each command.
+    int prePeekCount;
     int peekCount;
     int processCount;
 

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -30,7 +30,8 @@ class BedrockCommand : public SQLiteCommand {
     enum class STAGE {
         PREPEEK,
         PEEK,
-        PROCESS
+        PROCESS,
+        POSTPROCESS
     };
 
     // Times in *milliseconds*.

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -63,7 +63,7 @@ class BedrockCommand : public SQLiteCommand {
     // Optionally called to execute read-only operations for a command in a separate transaction than the transaction
     // that can execute write operations for a command (i.e. the transaction that runs peek and process). This must be
     // called after the transaction that executes write operations.
-    virtual bool postProcess(SQLite& db) { STHROW("500 Base class postProcess called"); }
+    virtual void postProcess(SQLite& db) { STHROW("500 Base class postProcess called"); }
 
     // Reset the command after a commit conflict. This is called both before `peek` and `process`. Typically, we don't
     // want to reset anything in `process`, because we may have specifically stored values there in `peek` that we want

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -91,10 +91,6 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command) {
         command->prePeek(_db);
         SDEBUG("Plugin '" << command->getName() << "' prePeeked command '" << request.methodLine << "'");
 
-        if (command->httpsRequests.size()) {
-            STHROW("405 https requests cannot be made in prePeek");
-        }
-
         if (!content.empty()) {
             // Make sure we're not overwriting anything different.
             string newContent = SComposeJSONObject(content);

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -354,11 +354,6 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command) {
         command->postProcess(_db);
         SDEBUG("Plugin '" << command->getName() << "' postProcess command '" << request.methodLine << "'");
 
-        // If no response was set, assume 200 OK
-        if (response.methodLine == "") {
-            response.methodLine = "200 OK";
-        }
-
         // Success. If a command has set "content", encode it in the response.
         SINFO("Responding '" << response.methodLine << "' to read-only '" << request.methodLine << "'.");
         if (!content.empty()) {

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -209,7 +209,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
     }
 
     // Unless an exception handler set this to something different, the command is complete.
-    command->complete = returnValue == RESULT::COMPLETE;
+    command->complete = returnValue == RESULT::COMPLETE && !command->shouldPostProcess();
 
     // Back out of the current transaction, it doesn't need to do anything.
     _db.rollback();
@@ -327,7 +327,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
     _db.resetTiming();
 
     // Done, return whether or not we need the parent to commit our transaction.
-    command->complete = !needsCommit;
+    command->complete = !needsCommit && !command->shouldPostProcess();
 
     return needsCommit ? RESULT::NEEDS_COMMIT : RESULT::NO_COMMIT_REQUIRED;
 }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -77,7 +77,7 @@ BedrockCore::RESULT BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& comm
     // We catch any exception and handle in `_handleCommandException`.
     RESULT returnValue = RESULT::COMPLETE;
     try {
-        SDEBUG("Peeking at '" << request.methodLine << "' with priority: " << command->priority);
+        SDEBUG("prePeeking at '" << request.methodLine << "' with priority: " << command->priority);
         uint64_t timeout = _getRemainingTime(command, false);
         command->prePeekCount++;
 
@@ -134,11 +134,8 @@ BedrockCore::RESULT BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& comm
     } catch (const SException& e) {
         _handleCommandException(command, e);
     } catch (const SHTTPSManager::NotLeading& e) {
-        command->repeek = false;
-        returnValue = RESULT::SHOULD_PROCESS;
-        SINFO("Command '" << request.methodLine << "' wants to make HTTPS request, queuing for processing.");
+        STHROW("405 https requests cannot be made in prePeek")
     } catch (...) {
-        command->repeek = false;
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
         command->response.methodLine = "500 Unhandled Exception";
     }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -441,7 +441,7 @@ BedrockCore::RESULT BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& 
     _db.setQueryOnly(false);
 
     // Done.
-    return returnValue;
+    return RESULT::COMPLETE;
 }
 
 void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e) {

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -209,7 +209,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
     }
 
     // Unless an exception handler set this to something different, the command is complete.
-    command->complete = returnValue == RESULT::COMPLETE && !command->shouldPostProcess();
+    command->complete = returnValue == RESULT::COMPLETE;
 
     // Back out of the current transaction, it doesn't need to do anything.
     _db.rollback();
@@ -327,7 +327,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
     _db.resetTiming();
 
     // Done, return whether or not we need the parent to commit our transaction.
-    command->complete = !needsCommit && !command->shouldPostProcess();
+    command->complete = !needsCommit;
 
     return needsCommit ? RESULT::NEEDS_COMMIT : RESULT::NO_COMMIT_REQUIRED;
 }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -319,7 +319,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
     return needsCommit ? RESULT::NEEDS_COMMIT : RESULT::NO_COMMIT_REQUIRED;
 }
 
-BedrockCore::RESULT BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command) {
+void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command) {
     AutoTimer timer(command, BedrockCommand::POSTPROCESS);
     BedrockServer::ScopedStateSnapshot snapshot(_server);
     command->lastPeekedOrProcessedInState = _server.getState();
@@ -393,9 +393,6 @@ BedrockCore::RESULT BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& 
 
     // Reset, we can write now.
     _db.setQueryOnly(false);
-
-    // Done.
-    return RESULT::COMPLETE;
 }
 
 void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e) {

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -134,7 +134,7 @@ BedrockCore::RESULT BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& comm
     } catch (const SException& e) {
         _handleCommandException(command, e);
     } catch (const SHTTPSManager::NotLeading& e) {
-        STHROW("405 https requests cannot be made in prePeek")
+        STHROW("405 https requests cannot be made in prePeek");
     } catch (...) {
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
         command->response.methodLine = "500 Unhandled Exception";

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -98,6 +98,7 @@ BedrockCore::RESULT BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& comm
 
             if (!completed) {
                 SDEBUG("Command '" << request.methodLine << "' not finished in prePeek, re-queuing.");
+                _db.rollback();
                 _db.resetTiming();
                 return RESULT::SHOULD_PEEK;
             }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -389,8 +389,8 @@ BedrockCore::RESULT BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& 
             SDEBUG("Plugin '" << command->getName() << "' postProcess command '" << request.methodLine << "'");
 
             if (!completed) {
-                SDEBUG("Command '" << request.methodLine << "' not finished in prePeek, re-queuing.");
-                STHROW("Command '" << request.methodLine << "' should always complete in post process");
+                SDEBUG("Command '" << request.methodLine << "' not finished in postProcess, re-queuing.");
+                STHROW("501 Command incomplete in post process");
             }
 
         } catch (const SQLite::timeout_error& e) {
@@ -398,7 +398,7 @@ BedrockCore::RESULT BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& 
             if (!command->shouldSuppressTimeoutWarnings()) {
                 SALERT("Command " << command->request.methodLine << " timed out after " << e.time()/1000 << "ms.");
             }
-            STHROW("555 Timeout prePeeking command");
+            STHROW("555 Timeout postProcessing command");
         }
 
         // If no response was set, assume 200 OK

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -96,6 +96,10 @@ BedrockCore::RESULT BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& comm
             bool completed = command->prePeek(_db);
             SDEBUG("Plugin '" << command->getName() << "' prePeeked command '" << request.methodLine << "'");
 
+            if (command->httpsRequests.size()) {
+                STHROW("405 https requests cannot be made in prePeek");
+            }
+
             if (!completed) {
                 SDEBUG("Command '" << request.methodLine << "' not finished in prePeek, re-queuing.");
                 _db.rollback();
@@ -133,8 +137,6 @@ BedrockCore::RESULT BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& comm
         }
     } catch (const SException& e) {
         _handleCommandException(command, e);
-    } catch (const SHTTPSManager::NotLeading& e) {
-        STHROW("405 https requests cannot be made in prePeek");
     } catch (...) {
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
         command->response.methodLine = "500 Unhandled Exception";
@@ -424,8 +426,6 @@ BedrockCore::RESULT BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& 
         }
     } catch (const SException& e) {
         _handleCommandException(command, e);
-    } catch (const SHTTPSManager::NotLeading& e) {
-        STHROW("405 https requests cannot be made in prePeek");
     } catch (...) {
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
         command->response.methodLine = "500 Unhandled Exception";

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -357,6 +357,93 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
     return needsCommit ? RESULT::NEEDS_COMMIT : RESULT::NO_COMMIT_REQUIRED;
 }
 
+BedrockCore::RESULT BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command) {
+    AutoTimer timer(command, BedrockCommand::POSTPROCESS);
+    BedrockServer::ScopedStateSnapshot snapshot(_server);
+    command->lastPeekedOrProcessedInState = _server.getState();
+
+    // Convenience references to commonly used properties.
+    const SData& request = command->request;
+    SData& response = command->response;
+    STable& content = command->jsonContent;
+
+    // We catch any exception and handle in `_handleCommandException`.
+    try {
+        SDEBUG("postProcessing at '" << request.methodLine << "' with priority: " << command->priority);
+        uint64_t timeout = _getRemainingTime(command, false);
+        command->postProcessCount++;
+
+        _db.startTiming(timeout);
+
+        try {
+            if (!_db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED)) {
+                STHROW("501 Failed to begin shared postProcess transaction");
+            }
+
+            // Make sure no writes happen while in postProcess command
+            _db.setQueryOnly(true);
+
+            // postProcess.
+            command->reset(BedrockCommand::STAGE::POSTPROCESS);
+            bool completed = command->postProcess(_db);
+            SDEBUG("Plugin '" << command->getName() << "' postProcess command '" << request.methodLine << "'");
+
+            if (!completed) {
+                SDEBUG("Command '" << request.methodLine << "' not finished in prePeek, re-queuing.");
+                STHROW("Command '" << request.methodLine << "' should always complete in post process");
+            }
+
+        } catch (const SQLite::timeout_error& e) {
+            // Some plugins want to alert timeout errors themselves, and make them silent on bedrock.
+            if (!command->shouldSuppressTimeoutWarnings()) {
+                SALERT("Command " << command->request.methodLine << " timed out after " << e.time()/1000 << "ms.");
+            }
+            STHROW("555 Timeout prePeeking command");
+        }
+
+        // If no response was set, assume 200 OK
+        if (response.methodLine == "") {
+            response.methodLine = "200 OK";
+        }
+
+        // Add the commitCount header to the response.
+        response["commitCount"] = to_string(_db.getCommitCount());
+
+        // Success. If a command has set "content", encode it in the response.
+        SINFO("Responding '" << response.methodLine << "' to read-only '" << request.methodLine << "'.");
+        if (!content.empty()) {
+            // Make sure we're not overwriting anything different.
+            string newContent = SComposeJSONObject(content);
+            if (response.content != newContent) {
+                if (!response.content.empty()) {
+                    SWARN("Replacing existing response content in " << request.methodLine);
+                }
+                response.content = newContent;
+            }
+        }
+    } catch (const SException& e) {
+        _handleCommandException(command, e);
+    } catch (const SHTTPSManager::NotLeading& e) {
+        STHROW("405 https requests cannot be made in prePeek");
+    } catch (...) {
+        SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
+        command->response.methodLine = "500 Unhandled Exception";
+    }
+
+    // The command is complete.
+    command->complete = true;
+
+    // Back out of the current transaction, it doesn't need to do anything.
+    _db.rollback();
+    _db.resetTiming();
+
+    // Reset, we can write now.
+    _db.setQueryOnly(false);
+
+    // Done.
+    return returnValue;
+}
+
 void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e) {
     string msg = "Error processing command '" + command->request.methodLine + "' (" + e.what() + "), ignoring.";
     if (!e.body.empty()) {

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -93,11 +93,11 @@ BedrockCore::RESULT BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& comm
 
             // prePeek.
             command->reset(BedrockCommand::STAGE::PREPEEK);
-            bool completed = command->prePeek(_db);
+            bool skipToProcess = command->prePeek(_db);
             SDEBUG("Plugin '" << command->getName() << "' prePeeked command '" << request.methodLine << "'");
 
-            if (!completed) {
-                SDEBUG("Command '" << request.methodLine << "' not finished in prePeek, re-queuing.");
+            if (!skipToProcess) {
+                SDEBUG("Command '" << request.methodLine << "' not finished with reads in prePeek, re-queuing for peek.");
                 _db.resetTiming();
                 _db.setQueryOnly(false);
                 return RESULT::SHOULD_PEEK;

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -66,8 +66,6 @@ bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command) {
 
 void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command) {
     AutoTimer timer(command, BedrockCommand::PREPEEK);
-    BedrockServer::ScopedStateSnapshot snapshot(_server);
-    command->lastPeekedOrProcessedInState = _server.getState();
 
     // Convenience references to commonly used properties.
     const SData& request = command->request;
@@ -334,8 +332,6 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
 
 void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command) {
     AutoTimer timer(command, BedrockCommand::POSTPROCESS);
-    BedrockServer::ScopedStateSnapshot snapshot(_server);
-    command->lastPeekedOrProcessedInState = _server.getState();
 
     // Convenience references to commonly used properties.
     const SData& request = command->request;

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -64,7 +64,7 @@ bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command) {
     return false;
 }
 
-BedrockCore::RESULT BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool exclusive) {
+BedrockCore::RESULT BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command) {
     AutoTimer timer(command, BedrockCommand::PREPEEK);
     BedrockServer::ScopedStateSnapshot snapshot(_server);
     command->lastPeekedOrProcessedInState = _server.getState();
@@ -84,8 +84,8 @@ BedrockCore::RESULT BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& comm
         _db.startTiming(timeout);
 
         try {
-            if (!_db.beginTransaction(exclusive ? SQLite::TRANSACTION_TYPE::EXCLUSIVE : SQLite::TRANSACTION_TYPE::SHARED)) {
-                STHROW("501 Failed to begin " + (exclusive ? "exclusive"s : "shared"s) + " transaction");
+            if (!_db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED)) {
+                STHROW("501 Failed to begin shared prePeek transaction");
             }
 
             // Make sure no writes happen while in prePeek command

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -11,11 +11,10 @@ class BedrockCore : public SQLiteCore {
     enum class RESULT {
         INVALID = 0,
         COMPLETE = 1,
-        SHOULD_PEEK = 2,
-        SHOULD_PROCESS = 3,
-        NEEDS_COMMIT = 4,
-        NO_COMMIT_REQUIRED = 5,
-        SERVER_NOT_LEADING = 6
+        SHOULD_PROCESS = 2,
+        NEEDS_COMMIT = 3,
+        NO_COMMIT_REQUIRED = 4,
+        SERVER_NOT_LEADING = 5
     };
 
     // Automatic timing class that records an entry corresponding to its lifespan.
@@ -37,7 +36,7 @@ class BedrockCore : public SQLiteCore {
     // the command hasn't timed out.
     bool isTimedOut(unique_ptr<BedrockCommand>& command);
 
-    RESULT prePeekCommand(unique_ptr<BedrockCommand>& command);
+    void prePeekCommand(unique_ptr<BedrockCommand>& command);
 
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same
     // command, and it *may be called multiple times*. Preventing duplicate actions on calling peek multiple times is

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -11,10 +11,11 @@ class BedrockCore : public SQLiteCore {
     enum class RESULT {
         INVALID = 0,
         COMPLETE = 1,
-        SHOULD_PROCESS = 2,
-        NEEDS_COMMIT = 3,
-        NO_COMMIT_REQUIRED = 4,
-        SERVER_NOT_LEADING = 5
+        SHOULD_PEEK = 2,
+        SHOULD_PROCESS = 3,
+        NEEDS_COMMIT = 4,
+        NO_COMMIT_REQUIRED = 5,
+        SERVER_NOT_LEADING = 6
     };
 
     // Automatic timing class that records an entry corresponding to its lifespan.

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -37,6 +37,8 @@ class BedrockCore : public SQLiteCore {
     // the command hasn't timed out.
     bool isTimedOut(unique_ptr<BedrockCommand>& command);
 
+    RESULT prePeekCommand(unique_ptr<BedrockCommand>& command, bool exclusive = false);
+
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same
     // command, and it *may be called multiple times*. Preventing duplicate actions on calling peek multiple times is
     // up to the implementer, and may happen *across multiple servers*. I.e., a follower server may call `peek`, and on

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -59,7 +59,7 @@ class BedrockCore : public SQLiteCore {
     // this command *will be passed to process again in the future to retry*.
     RESULT processCommand(unique_ptr<BedrockCommand>& command, bool exclusive = false);
 
-    RESULT postProcessCommand(unique_ptr<BedrockCommand>& command);
+    void postProcessCommand(unique_ptr<BedrockCommand>& command);
 
   private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -37,7 +37,7 @@ class BedrockCore : public SQLiteCore {
     // the command hasn't timed out.
     bool isTimedOut(unique_ptr<BedrockCommand>& command);
 
-    RESULT prePeekCommand(unique_ptr<BedrockCommand>& command, bool exclusive = false);
+    RESULT prePeekCommand(unique_ptr<BedrockCommand>& command);
 
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same
     // command, and it *may be called multiple times*. Preventing duplicate actions on calling peek multiple times is
@@ -59,6 +59,8 @@ class BedrockCore : public SQLiteCore {
     // `COMMIT` and replicate the transaction to follower nodes. It's allowable for this `COMMIT` to fail, in which case
     // this command *will be passed to process again in the future to retry*.
     RESULT processCommand(unique_ptr<BedrockCommand>& command, bool exclusive = false);
+
+    RESULT postProcessCommand(unique_ptr<BedrockCommand>& command);
 
   private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -838,7 +838,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
             BedrockCore::RESULT peekResult = BedrockCore::RESULT::INVALID;
             if (!command->repeek && !command->httpsRequests.size() && command->shouldPrePeek()) {
                 peekResult = core.prePeekCommand(command);
-                if (peekResult != BedrockCore::RESULT::SHOULD_PEEK && peekResult != BedrockCore::RESULT::COMPLETE) {
+                if (peekResult != BedrockCore::RESULT::SHOULD_PEEK && peekResult != BedrockCore::RESULT::SHOULD_PROCESS) {
                     STHROW("500 Invalid prePeekResult");
                 }
             }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -834,10 +834,13 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
             state = _replicationState.load();
             canWriteParallel = canWriteParallel && (state == SQLiteNodeState::LEADING);
 
-            // If the command should run prePeek opertions, do that now and assign the result to the peekResult.
+            // If the command should run prePeek, do that now and assign the result to the peekResult.
             BedrockCore::RESULT peekResult = BedrockCore::RESULT::INVALID;
-            if (!command->repeek && !command->httpsRequests.size() && shouldPrePeek()) {
+            if (!command->repeek && !command->httpsRequests.size() && command->shouldPrePeek()) {
                 peekResult = core.prePeekCommand(command);
+                if (peekResult != BedrockCore::RESULT::SHOULD_PEEK && peekResult != BedrockCore::RESULT::COMPLETE) {
+                    STHROW("500 Invalid prePeekResult");
+                }
             }
 
             // If the command has any httpsRequests from a previous `peek`, we won't peek it again unless the

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -992,9 +992,6 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                 } else if (result == BedrockCore::RESULT::NO_COMMIT_REQUIRED) {
                     // Nothing to do in this case, `command->complete` will be set and we'll finish as we fall out
                     // of this block.
-                    if (command->shouldPostProcess()) {
-                        core.postProcessCommand(command);
-                    }
                 } else if (result == BedrockCore::RESULT::SERVER_NOT_LEADING) {
                     // We won't write regardless.
                     core.rollback();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -396,11 +396,7 @@ void BedrockServer::sync()
             }
 
             if (command->shouldPostProcess()) {
-                BedrockCore::RESULT postProcessResult = BedrockCore::RESULT::INVALID;
-                postProcessResult = core.postProcessCommand(command);
-                if (postProcessResult != BedrockCore::RESULT::COMPLETE) {
-                    STHROW("500 Invalid postProcess result");
-                }
+                core.postProcessCommand(command);
             }
 
             if (_syncNode->commitSucceeded()) {
@@ -992,10 +988,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                         command->response["commitCount"] = to_string(db.getCommitCount());
 
                         if (command->shouldPostProcess()) {
-                            result = core.postProcessCommand(command);
-                            if (result != BedrockCore::RESULT::COMPLETE) {
-                                STHROW("500 Invalid postProcess result");
-                            }
+                            core.postProcessCommand(command);
                         }
                         command->complete = true;
                     } else {
@@ -1005,10 +998,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                     // Nothing to do in this case, `command->complete` will be set and we'll finish as we fall out
                     // of this block.
                     if (command->shouldPostProcess()) {
-                        result = core.postProcessCommand(command);
-                        if (result != BedrockCore::RESULT::COMPLETE) {
-                            STHROW("500 Invalid postProcess result");
-                        }
+                        core.postProcessCommand(command);
                     }
                 } else if (result == BedrockCore::RESULT::SERVER_NOT_LEADING) {
                     // We won't write regardless.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -493,11 +493,10 @@ void BedrockServer::sync()
                     // risk duplicating that request. If your command creates an HTTPS request, it needs to explicitly
                     // re-verify that any checks made in peek are still valid in process.
                     if (!command->httpsRequests.size()) {
-                        BedrockCore::RESULT result = BedrockCore::RESULT::INVALID;
                         if (command->shouldPrePeek()) {
                             core.prePeekCommand(command);
                         }
-                        result = core.peekCommand(command, true);
+                        BedrockCore::RESULT result = core.peekCommand(command, true);
                         if (result == BedrockCore::RESULT::COMPLETE) {
                             // This command completed in peek, respond to it appropriately, either directly or by sending it
                             // back to the sync thread.
@@ -842,8 +841,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
             state = _replicationState.load();
             canWriteParallel = canWriteParallel && (state == SQLiteNodeState::LEADING);
 
-            // If the command should run prePeek, do that now and assign the result to the peekResult.
-            BedrockCore::RESULT peekResult = BedrockCore::RESULT::INVALID;
+            // If the command should run prePeek, do that now .
             if (!command->repeek && !command->httpsRequests.size() && command->shouldPrePeek()) {
                 core.prePeekCommand(command);
             }
@@ -852,6 +850,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
             // command has specifically asked for that.
             // If peek succeeds, then it's finished, and all we need to do is respond to the command at the bottom.
             bool calledPeek = false;
+            BedrockCore::RESULT peekResult = BedrockCore::RESULT::INVALID;
             if (command->repeek || !command->httpsRequests.size()) {
                 peekResult = core.peekCommand(command, isBlocking);
                 calledPeek = true;

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -95,6 +95,9 @@ unique_ptr<BedrockCommand> BedrockPlugin_TestPlugin::getCommand(SQLiteCommand&& 
         "idcollision",
         "slowprocessquery",
         "bigquery",
+        "prepeekcommand",
+        "postprocesscommand",
+        "prepeekpostprocesscommand",
     };
     for (auto& cmdName : supportedCommands) {
         if (SStartsWith(baseCommand.request.methodLine, cmdName)) {

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -321,6 +321,17 @@ bool TestPluginCommand::peek(SQLite& db) {
             // case
             return false;
         }
+    } else if (request.methodLine == "prepeekcommand" || request.methodLine == "postprocesscommand" || request.methodLine == "prepeekpostprocesscommand") {
+        // Do something in here that reads from the database and sets a jsonResponse
+        jsonContent["peekInfo"] = "this was returned in peekInfo";
+        SQResult result;
+        db.read("SELECT COUNT(*) FROM test WHERE id = 999999999", result);
+        jsonContent["peekCount"] = result[0][0];
+        if (request.methodLine == "prepeekcommand") {
+            return true;
+        } else {
+            return false;
+        }
     } else if (request.methodLine == "testescalate") {
         string serverState = SQLiteNode::stateName(plugin().server.getState());
         string statString = "Peeking testescalate (" + serverState + ")\n";

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -152,9 +152,7 @@ void TestPluginCommand::reset(BedrockCommand::STAGE stage) {
 };
 
 bool TestPluginCommand::shouldPrePeek() {
-    if (request.methodLine == "prepeekcommand") {
-        return true;
-    } else if (request.methodLine == "testescalate") {
+    if (request.methodLine == "prepeekcommand" || request.methodLine == "prepeekpostprocesscommand") {
         return true;
     } else {
         return false;
@@ -162,9 +160,7 @@ bool TestPluginCommand::shouldPrePeek() {
 }
 
 bool TestPluginCommand::shouldPostProcess() {
-    if (request.methodLine == "postprocesscommand") {
-        return true;
-    } else if (request.methodLine == "prepeekpostprocesscommand") {
+    if (request.methodLine == "postprocesscommand" || request.methodLine == "prepeekpostprocesscommand") {
         return true;
     } else {
         return false;
@@ -176,10 +172,8 @@ bool BedrockPlugin_TestPlugin::preventAttach() {
 }
 
 void TestPluginCommand::prePeek(SQLite& db) {
-    if (request.methodLine == "prepeekcommand") {
-        SINFO("running a prePeek");
-    } else if (request.methodLine == "prepeekpostprocesscommand") {
-        SINFO("running a prePeek");
+    if (request.methodLine == "prepeekcommand" || request.methodLine == "prepeekpostprocesscommand") {
+        jsonContent["prePeekInfo"] = "this was returned in prePeekInfo";
     } else {
         STHROW("500 no prePeek defined, shouldPrePeek should be false");
     }
@@ -475,10 +469,8 @@ void TestPluginCommand::process(SQLite& db) {
 }
 
 void TestPluginCommand::postProcess(SQLite& db) {
-    if (request.methodLine == "postprocesscommand") {
-        SINFO("running a postProcess");
-    } else if (request.methodLine == "prepeekpostprocesscommand") {
-        SINFO("running a postProcess");
+    if (request.methodLine == "postprocesscommand" || request.methodLine == "prepeekpostprocesscommand") {
+        jsonContent["postProcessInfo"] = "this was returned in postProcessInfo";
     } else {
         STHROW("500 no prePeek defined, shouldPrePeek should be false");
     }

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -468,12 +468,23 @@ void TestPluginCommand::process(SQLite& db) {
         string statString = "Processing testescalate (" + serverState + ")\n";
         fileAppend(request["tempFile"], statString);
         return;
+    } else if (request.methodLine == "postprocesscommand") {
+        jsonContent["processInfo"] = "this was returned in processInfo";
+        db.write("INSERT INTO test (id, value) VALUES (999999999, 'this is a test');");
+        return;
+    } else if (request.methodLine == "prepeekpostprocesscommand") {
+        jsonContent["processInfo"] = "this was returned in processInfo";
+        db.write("DELETE FROM test WHERE id = 999999999;");
+        return;
     }
 }
 
 void TestPluginCommand::postProcess(SQLite& db) {
     if (request.methodLine == "postprocesscommand" || request.methodLine == "prepeekpostprocesscommand") {
         jsonContent["postProcessInfo"] = "this was returned in postProcessInfo";
+        SQResult result;
+        db.read("SELECT COUNT(*) FROM test WHERE id = 999999999", result);
+        jsonContent["postProcessCount"] = result[0][0];
     } else {
         STHROW("500 no prePeek defined, shouldPrePeek should be false");
     }

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -151,10 +151,39 @@ void TestPluginCommand::reset(BedrockCommand::STAGE stage) {
     BedrockCommand::reset(stage);
 };
 
+bool TestPluginCommand::shouldPrePeek() {
+    if (request.methodLine == "prepeekcommand") {
+        return true;
+    } else if (request.methodLine == "testescalate") {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool TestPluginCommand::shouldPostProcess() {
+    if (request.methodLine == "postprocesscommand") {
+        return true;
+    } else if (request.methodLine == "prepeekpostprocesscommand") {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 bool BedrockPlugin_TestPlugin::preventAttach() {
     return shouldPreventAttach;
 }
 
+void TestPluginCommand::prePeek(SQLite& db) {
+    if (request.methodLine == "prepeekcommand") {
+        SINFO("running a prePeek");
+    } else if (request.methodLine == "prepeekpostprocesscommand") {
+        SINFO("running a prePeek");
+    } else {
+        STHROW("500 no prePeek defined, shouldPrePeek should be false");
+    }
+}
 bool TestPluginCommand::peek(SQLite& db) {
     // Always blacklist on userID.
     crashIdentifyingValues.insert("userID");
@@ -442,6 +471,16 @@ void TestPluginCommand::process(SQLite& db) {
         string statString = "Processing testescalate (" + serverState + ")\n";
         fileAppend(request["tempFile"], statString);
         return;
+    }
+}
+
+void TestPluginCommand::postProcess(SQLite& db) {
+    if (request.methodLine == "postprocesscommand") {
+        SINFO("running a postProcess");
+    } else if (request.methodLine == "prepeekpostprocesscommand") {
+        SINFO("running a postProcess");
+    } else {
+        STHROW("500 no prePeek defined, shouldPrePeek should be false");
     }
 }
 

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -152,19 +152,11 @@ void TestPluginCommand::reset(BedrockCommand::STAGE stage) {
 };
 
 bool TestPluginCommand::shouldPrePeek() {
-    if (request.methodLine == "prepeekcommand" || request.methodLine == "prepeekpostprocesscommand") {
-        return true;
-    } else {
-        return false;
-    }
+    return request.methodLine == "prepeekcommand" || request.methodLine == "prepeekpostprocesscommand";
 }
 
 bool TestPluginCommand::shouldPostProcess() {
-    if (request.methodLine == "postprocesscommand" || request.methodLine == "prepeekpostprocesscommand") {
-        return true;
-    } else {
-        return false;
-    }
+    return request.methodLine == "postprocesscommand" || request.methodLine == "prepeekpostprocesscommand";
 }
 
 bool BedrockPlugin_TestPlugin::preventAttach() {

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -39,8 +39,12 @@ class TestPluginCommand : public BedrockCommand {
   public:
     TestPluginCommand(SQLiteCommand&& baseCommand, BedrockPlugin_TestPlugin* plugin);
     ~TestPluginCommand();
+    virtual void prePeek(SQLite& db);
     virtual bool peek(SQLite& db);
     virtual void process(SQLite& db);
+    virtual void postProcess(SQLite& db);
+    virtual bool shouldPrePeek();
+    virtual bool shouldPostProcess();
     virtual void reset(BedrockCommand::STAGE stage) override;
 
   private:

--- a/test/clustertest/tests/PrePeekPostProcessTest.cpp
+++ b/test/clustertest/tests/PrePeekPostProcessTest.cpp
@@ -38,7 +38,16 @@ struct PrePeekPostProcessTest : tpunit::TestFixture {
         BedrockTester& brtester = tester->getTester(1);
         SData cmd("postprocesscommand");
         STable response = SParseJSONObject(brtester.executeWaitMultipleData({cmd})[0].content);
+
+        // Confirm that the information returned from peek, process and postProcess is all in the response.
+        ASSERT_EQUAL(response["peekInfo"], "this was returned in peekInfo");
+        ASSERT_EQUAL(response["processInfo"], "this was returned in processInfo");
         ASSERT_EQUAL(response["postProcessInfo"], "this was returned in postProcessInfo");
+
+        // postprocesscommand inserts a row in the "test" table during the process. We need to make sure that the
+        // inserted row does not exist during peek, and that it does exist during postProcess.
+        ASSERT_EQUAL(response["peekCount"], "0");
+        ASSERT_EQUAL(response["postProcessCount"], "1");
     }
 
     void prePeekPostProcess ()

--- a/test/clustertest/tests/PrePeekPostProcessTest.cpp
+++ b/test/clustertest/tests/PrePeekPostProcessTest.cpp
@@ -1,0 +1,35 @@
+#include <BedrockCommand.h>
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
+
+struct PrePeekPostProcessTest : tpunit::TestFixture {
+    PrePeekPostProcessTest() : tpunit::TestFixture("PrePeekPostProcess", BEFORE_CLASS(PrePeekPostProcessTest::setup),
+                                                                         AFTER_CLASS(PrePeekPostProcessTest::teardown),
+                                                                         TEST(PrePeekPostProcessTest::prePeek),
+                                                                         TEST(PrePeekPostProcessTest::postProcess),
+                                                                         TEST(PrePeekPostProcessTest::prePeekPostProcess)) { }
+
+    BedrockClusterTester* tester;
+
+    void setup() {
+        tester = new BedrockClusterTester();
+    }
+
+    void teardown() {
+        delete tester;
+    }
+
+    void prePeek()
+    {
+    }
+
+    void postProcess()
+    {
+    }
+
+    void prePeekPostProcess ()
+    {
+    }
+
+} __PrePeekPostProcessTest;
+

--- a/test/clustertest/tests/PrePeekPostProcessTest.cpp
+++ b/test/clustertest/tests/PrePeekPostProcessTest.cpp
@@ -24,7 +24,13 @@ struct PrePeekPostProcessTest : tpunit::TestFixture {
         BedrockTester& brtester = tester->getTester(1);
         SData cmd("prepeekcommand");
         STable response = SParseJSONObject(brtester.executeWaitMultipleData({cmd})[0].content);
+
+        // Confirm that information returned from prePeek and peek is all in the response.
         ASSERT_EQUAL(response["prePeekInfo"], "this was returned in prePeekInfo");
+        ASSERT_EQUAL(response["peekInfo"], "this was returned in peekInfo");
+
+        // No counted row has been inserted into the test table yet, so the "peekCount" should be zero.
+        ASSERT_EQUAL(response["peekCount"], "0");
     }
 
     void postProcess()

--- a/test/clustertest/tests/PrePeekPostProcessTest.cpp
+++ b/test/clustertest/tests/PrePeekPostProcessTest.cpp
@@ -55,8 +55,17 @@ struct PrePeekPostProcessTest : tpunit::TestFixture {
         BedrockTester& brtester = tester->getTester(1);
         SData cmd("prepeekpostprocesscommand");
         STable response = SParseJSONObject(brtester.executeWaitMultipleData({cmd})[0].content);
+
+        // Confirm that the information returned from prePeek, peek, process and postProcess is all in the response.
         ASSERT_EQUAL(response["prePeekInfo"], "this was returned in prePeekInfo");
+        ASSERT_EQUAL(response["peekInfo"], "this was returned in peekInfo");
+        ASSERT_EQUAL(response["processInfo"], "this was returned in processInfo");
         ASSERT_EQUAL(response["postProcessInfo"], "this was returned in postProcessInfo");
+
+        // prepeekpostprocesscommand deletes a row from the "test" table during the process. We need to make sure the
+        // row exists during peek, and that it no longer exists during postProcess.
+        ASSERT_EQUAL(response["peekCount"], "1");
+        ASSERT_EQUAL(response["postProcessCount"], "0");
     }
 
 } __PrePeekPostProcessTest;

--- a/test/clustertest/tests/PrePeekPostProcessTest.cpp
+++ b/test/clustertest/tests/PrePeekPostProcessTest.cpp
@@ -21,14 +21,27 @@ struct PrePeekPostProcessTest : tpunit::TestFixture {
 
     void prePeek()
     {
+        BedrockTester& brtester = tester->getTester(1);
+        SData cmd("prepeekcommand");
+        STable response = SParseJSONObject(brtester.executeWaitMultipleData({cmd})[0].content);
+        ASSERT_EQUAL(response["prePeekInfo"], "this was returned in prePeekInfo");
     }
 
     void postProcess()
     {
+        BedrockTester& brtester = tester->getTester(1);
+        SData cmd("postprocesscommand");
+        STable response = SParseJSONObject(brtester.executeWaitMultipleData({cmd})[0].content);
+        ASSERT_EQUAL(response["postProcessInfo"], "this was returned in postProcessInfo");
     }
 
     void prePeekPostProcess ()
     {
+        BedrockTester& brtester = tester->getTester(1);
+        SData cmd("prepeekpostprocesscommand");
+        STable response = SParseJSONObject(brtester.executeWaitMultipleData({cmd})[0].content);
+        ASSERT_EQUAL(response["prePeekInfo"], "this was returned in prePeekInfo");
+        ASSERT_EQUAL(response["postProcessInfo"], "this was returned in postProcessInfo");
     }
 
 } __PrePeekPostProcessTest;


### PR DESCRIPTION
### Details
This PR adds the `prePeekCommand` and a `postProcessCommand` methods to bedrock, and then calls those methods if necessary. The `prePeekCommand` and `postProcessCommand` methods run against the database in separate transactions from the existing `peekCommand` and `processCommand` methods.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/287576

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
