### PR TITLE
Fix BlockWrites

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1816,7 +1816,7 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
     } else if (SIEquals(command->request.methodLine, "UnblockWrites")) {
         lock_guard lock(__quiesceLock);
         if (!__quiesceThread) {
-            response.methodLine = "400 Existing lock not found";
+            response.methodLine = "200 Not Blocked";
         } else {
             __quiesceShouldUnlock = true;
             __quiesceThread->join();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1780,7 +1780,10 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
         if (dbPoolCopy) {
             SQLiteScopedHandle dbScope(*_dbPool, _dbPool->getIndex());
             SQLite& db = dbScope.db();
-            db.exclusiveLockDB();
+            bool result = db.exclusiveLockDB();
+            if (!result) {
+                response.methodLine = "500 lock failed";
+            }
         } else {
             response.methodLine = "404 DB Pool Not Found";
         }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -314,8 +314,8 @@ SQLite::~SQLite() {
     DBINFO("Database closed.");
 }
 
-bool SQLite::exclusiveLockDB() {
-    return _sharedData.commitLock.try_lock_for(5s);
+void SQLite::exclusiveLockDB() {
+    _sharedData.commitLock.lock();
 }
 
 void SQLite::exclusiveUnlockDB() {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -314,8 +314,8 @@ SQLite::~SQLite() {
     DBINFO("Database closed.");
 }
 
-void SQLite::exclusiveLockDB() {
-    _sharedData.commitLock.lock();
+bool SQLite::exclusiveLockDB() {
+    return _sharedData.commitLock.try_lock_for(5s);
 }
 
 void SQLite::exclusiveUnlockDB() {

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -250,7 +250,7 @@ class SQLite {
     // Set this DB handle to be query-only to prevent accidental writes in places we don't expect them.
     void setQueryOnly(bool enabled);
 
-    bool exclusiveLockDB();
+    void exclusiveLockDB();
     void exclusiveUnlockDB();
 
   private:

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -307,6 +307,9 @@ class SQLite {
         // no ill effects, but currently we use it to set a floor on the number of frames we will try and checkpoint.
         atomic<size_t> outstandingFramesToCheckpoint = 0;
 
+        // This can be locked in exclusive mode to prevent all writes. This exists to support the `BlockWrites` command.
+        shared_mutex writeLock;
+
       private:
         // The data required to replicate transactions, in two lists, depending on whether this has only been prepared
         // or if it's been committed.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -250,7 +250,7 @@ class SQLite {
     // Set this DB handle to be query-only to prevent accidental writes in places we don't expect them.
     void setQueryOnly(bool enabled);
 
-    void exclusiveLockDB();
+    bool exclusiveLockDB();
     void exclusiveUnlockDB();
 
   private:


### PR DESCRIPTION
### Details
So, the issue here is that you can't call `lock` and `unlock` on the same mutex from two different threads and have it work correctly. So this has the `Block` command start a thread and the `Unblock` command tell that thread to end.

~I think there might be a remaining issue, not with the locking,but with the fact that this basically blocks *commtis* rather than writes. The filesystem may still change while this is blocked, and that might be an issue. What are your thoughts on this @fukawi2 ?~

Addressed

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/276570

### Tests
Test by sending the commands by and.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
