### PR TITLE
Count failures from setup and teardown

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -152,17 +152,7 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
 
                // Run the test.
                printf("--------------\n");
-               fixture->_stats._assertions = 0;
-               fixture->_stats._exceptions = 0;
-               tpunit_detail_do_methods(fixture->_before_classes);
-               if (fixture->_stats._assertions || fixture->_stats._exceptions) {
-                  cout << "1 Got exception or assertion in before_classes" << endl;
-               }
-               tpunit_detail_do_tests(fixture);
-               tpunit_detail_do_methods(fixture->_after_classes);
-               if (fixture->_stats._assertions || fixture->_stats._exceptions) {
-                  cout << "1 Got exception or assertion in _after_classes" << endl;
-               }
+               tpunit_run_test_class(fixture);
 
                continue; // Don't bother checking the rest of the tests.
             }
@@ -286,17 +276,7 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
 
                // Run the test.
                printf("--------------\n");
-               fixture->_stats._assertions = 0;
-               fixture->_stats._exceptions = 0;
-               tpunit_detail_do_methods(fixture->_before_classes);
-               if (fixture->_stats._assertions || fixture->_stats._exceptions) {
-                  cout << "3 Got exception or assertion in before_classes" << endl;
-               }
-               tpunit_detail_do_tests(fixture);
-               tpunit_detail_do_methods(fixture->_after_classes);
-               if (fixture->_stats._assertions || fixture->_stats._exceptions) {
-                  cout << "3 Got exception or assertion in _after_classes" << endl;
-               }
+               tpunit_run_test_class(fixture);
 
                continue; // Don't bother checking the rest of the tests.
             }

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -93,6 +93,27 @@ int tpunit::TestFixture::tpunit_detail_do_run(int threads, std::function<void()>
     return tpunit_detail_do_run(include, exclude, before, after, threads, threadInitFunction);
 }
 
+void tpunit::TestFixture::tpunit_run_test_class(TestFixture* f) {
+   f->_stats._assertions = 0;
+   f->_stats._exceptions = 0;
+   tpunit_detail_do_methods(f->_before_classes);
+   if (f->_stats._assertions || f->_stats._exceptions) {
+      tpunit_detail_stats()._failures++;
+      tpunit_detail_stats()._failureNames.emplace(f->_name + "::BEFORE_CLASS"s);
+      cout << "\xE2\x9D\x8C !FAILED! \xE2\x9D\x8C initializing " << f->_name << ". Skipping tests." << endl;
+   } else {
+       tpunit_detail_do_tests(f);
+   }
+   f->_stats._assertions = 0;
+   f->_stats._exceptions = 0;
+   tpunit_detail_do_methods(f->_after_classes);
+   if (f->_stats._assertions || f->_stats._exceptions) {
+      tpunit_detail_stats()._failures++;
+      tpunit_detail_stats()._failureNames.emplace(f->_name + "::AFTER_CLASS"s);
+      cout << "\xE2\x9D\x8C !FAILED! \xE2\x9D\x8C cleaning up " << f->_name << "." << endl;
+   }
+}
+
 int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const set<string>& exclude,
                                               const list<string>& before, const list<string>& after, int threads,
                                               std::function<void()> threadInitFunction) {
@@ -236,17 +257,7 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
                        }
                    }
 
-                   f->_stats._assertions = 0;
-                   f->_stats._exceptions = 0;
-                   tpunit_detail_do_methods(f->_before_classes);
-                   if (f->_stats._assertions || f->_stats._exceptions) {
-                      cout << "2 Got exception or assertion in before_classes" << endl;
-                   }
-                   tpunit_detail_do_tests(f);
-                   tpunit_detail_do_methods(f->_after_classes);
-                   if (f->_stats._assertions || f->_stats._exceptions) {
-                      cout << "2 Got exception or assertion in _after_classes" << endl;
-                   }
+                   tpunit_run_test_class(f);
                 }
             } catch (ShutdownException se) {
                 // This will have broken us out of our main loop, so we'll just exit. We also set the exit flag to let

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -131,9 +131,17 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
 
                // Run the test.
                printf("--------------\n");
+               fixture->_stats._assertions = 0;
+               fixture->_stats._exceptions = 0;
                tpunit_detail_do_methods(fixture->_before_classes);
+               if (fixture->_stats._assertions || fixture->_stats._exceptions) {
+                  cout << "1 Got exception or assertion in before_classes" << endl;
+               }
                tpunit_detail_do_tests(fixture);
                tpunit_detail_do_methods(fixture->_after_classes);
+               if (fixture->_stats._assertions || fixture->_stats._exceptions) {
+                  cout << "1 Got exception or assertion in _after_classes" << endl;
+               }
 
                continue; // Don't bother checking the rest of the tests.
             }
@@ -227,9 +235,18 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
                            currentTestName = "UNSPECIFIED";
                        }
                    }
+
+                   f->_stats._assertions = 0;
+                   f->_stats._exceptions = 0;
                    tpunit_detail_do_methods(f->_before_classes);
+                   if (f->_stats._assertions || f->_stats._exceptions) {
+                      cout << "2 Got exception or assertion in before_classes" << endl;
+                   }
                    tpunit_detail_do_tests(f);
                    tpunit_detail_do_methods(f->_after_classes);
+                   if (f->_stats._assertions || f->_stats._exceptions) {
+                      cout << "2 Got exception or assertion in _after_classes" << endl;
+                   }
                 }
             } catch (ShutdownException se) {
                 // This will have broken us out of our main loop, so we'll just exit. We also set the exit flag to let
@@ -258,9 +275,17 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
 
                // Run the test.
                printf("--------------\n");
+               fixture->_stats._assertions = 0;
+               fixture->_stats._exceptions = 0;
                tpunit_detail_do_methods(fixture->_before_classes);
+               if (fixture->_stats._assertions || fixture->_stats._exceptions) {
+                  cout << "3 Got exception or assertion in before_classes" << endl;
+               }
                tpunit_detail_do_tests(fixture);
                tpunit_detail_do_methods(fixture->_after_classes);
+               if (fixture->_stats._assertions || fixture->_stats._exceptions) {
+                  cout << "3 Got exception or assertion in _after_classes" << endl;
+               }
 
                continue; // Don't bother checking the rest of the tests.
             }

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -365,6 +365,8 @@ namespace tpunit {
 
       private:
 
+         static void tpunit_run_test_class(TestFixture*);
+
          static void tpunit_detail_do_method(method* m);
 
          static void tpunit_detail_do_methods(method* m);


### PR DESCRIPTION
### Details

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/287726

### Tests
Test by checking out Auth at commit `9284b1bb49`.

Because of the `too many GOT entries` bug (that has been fixed since), you can delete some tests. `rm -rf test/test/command/Update*` will work to get it to build.

Run the `SharePolicy` test. See that it fails:
```
vagrant@expensidev2004:/vagrant/Auth/test$ ./authtest -only SharePolicy
   exception #1 from SharePolicyTest::setup with cause: Expected '200 OK', got: 401 User must be on the policy to create a policy room
❌ !FAILED! ❌ initializing SharePolicy. Skipping tests.

[ TEST RESULTS ] Passed: 0, Failed: 1

Failures:
SharePolicy::BEFORE_CLASS
vagrant@expensidev2004:/vagrant/Auth/test$
```
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes

Auth still works:
```

[ TEST RESULTS ] Passed: 2130, Failed: 0
```