### PR TITLE
Make sure to complete and then to reply after a throw in prePeek

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -105,18 +105,19 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command) {
         } catch (const SQLite::timeout_error& e) {
             // Some plugins want to alert timeout errors themselves, and make them silent on bedrock.
             if (!command->shouldSuppressTimeoutWarnings()) {
-                SALERT("Command " << command->request.methodLine << " timed out after " << e.time()/1000 << "ms.");
+                SALERT("Command " << command->request.methodLine << " timed out after " << e.time() / 1000 << "ms.");
             }
             STHROW("555 Timeout prePeeking command");
         } catch (const SException& e) {
             _handleCommandException(command, e);
             command->complete = true;
         } catch (...) {
-            SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
+            SALERT("Unhandled exception typename: " << SGetCurrentExceptionName()
+                                                    << ", command: " << request.methodLine);
             command->response.methodLine = "500 Unhandled Exception";
             command->complete = true;
         }
-    catch (const SException& e) {
+    } catch (const SException& e) {
         _handleCommandException(command, e);
         command->complete = true;
     }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -107,11 +107,14 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command) {
             SALERT("Command " << command->request.methodLine << " timed out after " << e.time()/1000 << "ms.");
         }
         STHROW("555 Timeout prePeeking command");
+        command->complete = true;
     } catch (const SException& e) {
         _handleCommandException(command, e);
+        command->complete = true;
     } catch (...) {
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
         command->response.methodLine = "500 Unhandled Exception";
+        command->complete = true;
     }
 
     // Back out of the current transaction, it doesn't need to do anything.

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -73,47 +73,51 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command) {
     STable& content = command->jsonContent;
 
     try {
-        SDEBUG("prePeeking at '" << request.methodLine << "' with priority: " << command->priority);
-        uint64_t timeout = _getRemainingTime(command, false);
-        command->prePeekCount++;
+        try {
+            SDEBUG("prePeeking at '" << request.methodLine << "' with priority: " << command->priority);
+            uint64_t timeout = _getRemainingTime(command, false);
+            command->prePeekCount++;
 
-        _db.startTiming(timeout);
+            _db.startTiming(timeout);
 
-        if (!_db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED)) {
-            STHROW("501 Failed to begin shared prePeek transaction");
-        }
-
-        // Make sure no writes happen while in prePeek command
-        _db.setQueryOnly(true);
-
-        // prePeek.
-        command->reset(BedrockCommand::STAGE::PREPEEK);
-        command->prePeek(_db);
-        SDEBUG("Plugin '" << command->getName() << "' prePeeked command '" << request.methodLine << "'");
-
-        if (!content.empty()) {
-            // Make sure we're not overwriting anything different.
-            string newContent = SComposeJSONObject(content);
-            if (response.content != newContent) {
-                if (!response.content.empty()) {
-                    SWARN("Replacing existing response content in " << request.methodLine);
-                }
-                response.content = newContent;
+            if (!_db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED)) {
+                STHROW("501 Failed to begin shared prePeek transaction");
             }
+
+            // Make sure no writes happen while in prePeek command
+            _db.setQueryOnly(true);
+
+            // prePeek.
+            command->reset(BedrockCommand::STAGE::PREPEEK);
+            command->prePeek(_db);
+            SDEBUG("Plugin '" << command->getName() << "' prePeeked command '" << request.methodLine << "'");
+
+            if (!content.empty()) {
+                // Make sure we're not overwriting anything different.
+                string newContent = SComposeJSONObject(content);
+                if (response.content != newContent) {
+                    if (!response.content.empty()) {
+                        SWARN("Replacing existing response content in " << request.methodLine);
+                    }
+                    response.content = newContent;
+                }
+            }
+        } catch (const SQLite::timeout_error& e) {
+            // Some plugins want to alert timeout errors themselves, and make them silent on bedrock.
+            if (!command->shouldSuppressTimeoutWarnings()) {
+                SALERT("Command " << command->request.methodLine << " timed out after " << e.time()/1000 << "ms.");
+            }
+            STHROW("555 Timeout prePeeking command");
+        } catch (const SException& e) {
+            _handleCommandException(command, e);
+            command->complete = true;
+        } catch (...) {
+            SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
+            command->response.methodLine = "500 Unhandled Exception";
+            command->complete = true;
         }
-    } catch (const SQLite::timeout_error& e) {
-        // Some plugins want to alert timeout errors themselves, and make them silent on bedrock.
-        if (!command->shouldSuppressTimeoutWarnings()) {
-            SALERT("Command " << command->request.methodLine << " timed out after " << e.time()/1000 << "ms.");
-        }
-        STHROW("555 Timeout prePeeking command");
-        command->complete = true;
-    } catch (const SException& e) {
+    catch (const SException& e) {
         _handleCommandException(command, e);
-        command->complete = true;
-    } catch (...) {
-        SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
-        command->response.methodLine = "500 Unhandled Exception";
         command->complete = true;
     }
 

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -108,17 +108,13 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command) {
                 SALERT("Command " << command->request.methodLine << " timed out after " << e.time() / 1000 << "ms.");
             }
             STHROW("555 Timeout prePeeking command");
-        } catch (const SException& e) {
-            _handleCommandException(command, e);
-            command->complete = true;
-        } catch (...) {
-            SALERT("Unhandled exception typename: " << SGetCurrentExceptionName()
-                                                    << ", command: " << request.methodLine);
-            command->response.methodLine = "500 Unhandled Exception";
-            command->complete = true;
         }
     } catch (const SException& e) {
         _handleCommandException(command, e);
+        command->complete = true;
+    } catch (...) {
+        SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
+        command->response.methodLine = "500 Unhandled Exception";
         command->complete = true;
     }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -844,6 +844,13 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
             // If the command should run prePeek, do that now .
             if (!command->repeek && !command->httpsRequests.size() && command->shouldPrePeek()) {
                 core.prePeekCommand(command);
+
+                if (command->complete) {
+                    _reply(command);
+
+                    // Don't need to retry.
+                    break;
+                }
             }
 
             // If the command has any httpsRequests from a previous `peek`, we won't peek it again unless the

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -395,7 +395,8 @@ void BedrockServer::sync()
                 continue;
             }
 
-            if (command->shouldPostProcess()) {
+            if (command->shouldPostProcess() && command->response.methodLine == "200 OK") {
+                // PostProcess if the command should run postProcess, and there have been no errors thrown thus far.
                 core.postProcessCommand(command);
             }
 
@@ -1019,7 +1020,8 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
             // If the command was completed above, then we'll go ahead and respond. Otherwise there must have been
             // a conflict or the command was abandoned for a checkpoint, and we'll retry.
             if (command->complete) {
-                if (command->shouldPostProcess()) {
+                if (command->shouldPostProcess() && command->response.methodLine == "200 OK") {
+                    // PostProcess if the command should run postProcess, and there have been no errors thrown thus far.
                     core.postProcessCommand(command);
                 }
                 _reply(command);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -847,8 +847,6 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
 
                 if (command->complete) {
                     _reply(command);
-
-                    // Don't need to retry.
                     break;
                 }
             }


### PR DESCRIPTION
@tylerkaraszewski will you please review?

This PR makes sure we complete and reply to a command if it throws in `prePeek`.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/291462

### Tests
1. This gets tested with our Auth command tests