### PR TITLE
Do not reset with postProcess

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -350,7 +350,6 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command) {
         _db.setQueryOnly(true);
 
         // postProcess.
-        command->reset(BedrockCommand::STAGE::POSTPROCESS);
         command->postProcess(_db);
         SDEBUG("Plugin '" << command->getName() << "' postProcess command '" << request.methodLine << "'");
 


### PR DESCRIPTION
@tylerkaraszewski will you please review?

This PR prevents us from resetting the command when in postProcess

### Tests
1. Confirm all automated tests still pass