### PR TITLE
Return early if prePeek() completes the command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -498,6 +498,15 @@ void BedrockServer::sync()
                         if (command->shouldPrePeek() && !command->repeek) {
                             core.prePeekCommand(command);
                         }
+
+                        // This command finsihed in prePeek, which likely means it threw. 
+                        // We'll respond to it now, either directly or by sending it back to the sync thread. 
+                        if (command->complete) {
+                            SINFO("Command completed in prePeek, replying now.");
+                            _reply(command);
+                            break;
+                        }
+
                         BedrockCore::RESULT result = core.peekCommand(command, true);
                         if (result == BedrockCore::RESULT::COMPLETE) {
                             // This command completed in peek, respond to it appropriately, either directly or by sending it

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -165,6 +165,9 @@ bool BedrockPlugin_TestPlugin::preventAttach() {
 
 void TestPluginCommand::prePeek(SQLite& db) {
     if (request.methodLine == "prepeekcommand" || request.methodLine == "prepeekpostprocesscommand") {
+        if (request["shouldThrow"] == "true") {
+            STHROW("501 ERROR");
+        }
         jsonContent["prePeekInfo"] = "this was returned in prePeekInfo";
     } else {
         STHROW("500 no prePeek defined, shouldPrePeek should be false");

--- a/test/clustertest/tests/PrePeekPostProcessTest.cpp
+++ b/test/clustertest/tests/PrePeekPostProcessTest.cpp
@@ -6,6 +6,7 @@ struct PrePeekPostProcessTest : tpunit::TestFixture {
     PrePeekPostProcessTest() : tpunit::TestFixture("PrePeekPostProcess", BEFORE_CLASS(PrePeekPostProcessTest::setup),
                                                                          AFTER_CLASS(PrePeekPostProcessTest::teardown),
                                                                          TEST(PrePeekPostProcessTest::prePeek),
+                                                                         TEST(PrePeekPostProcessTest::prePeekThrow),
                                                                          TEST(PrePeekPostProcessTest::postProcess),
                                                                          TEST(PrePeekPostProcessTest::prePeekPostProcess)) { }
 
@@ -31,6 +32,13 @@ struct PrePeekPostProcessTest : tpunit::TestFixture {
 
         // No counted row has been inserted into the test table yet, so the "peekCount" should be zero.
         ASSERT_EQUAL(response["peekCount"], "0");
+    }
+
+    void prePeekThrow() {
+        BedrockTester& brtester = tester->getTester(1);
+        SData cmd("prepeekcommand");
+        cmd["shouldThrow"] = "true";
+        brtester.executeWaitVerifyContent({cmd}, "501 ERROR");
     }
 
     void postProcess()


### PR DESCRIPTION
### Details
This returns early if a command completes in prePeek(). Currently if a command throws an error in prePeek() we ignore it and continue to peek() and process()

### Fixed Issues
Found working on https://github.com/Expensify/Expensify/issues/275085

### Tests
Added tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
