### PR TITLE
Regularize the same parameters in prePeek() that we do for peek() in Auth

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -75,6 +75,22 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command) {
     try {
         try {
             SDEBUG("prePeeking at '" << request.methodLine << "' with priority: " << command->priority);
+
+            // Regularize case
+            list<string> lowerCaseAttributes = {"email", "partnerUserID", "partnerName"};
+            for (string attribute : lowerCaseAttributes) {
+                if (request.isSet(attribute)) {
+                    const_cast<SData&>(request)[attribute] = SToLower(request[attribute]);
+                }
+            }
+
+            list<string> upperCaseAttrs = {"validateCode"};
+            for (string attribute : upperCaseAttrs) {
+                if (request.isSet(attribute)) {
+                    const_cast<SData&>(request)[attribute] = SToUpper(request[attribute]);
+                }
+            }
+
             uint64_t timeout = _getRemainingTime(command, false);
             command->prePeekCount++;
 


### PR DESCRIPTION
### Details

Adds the attribute case regularization that we run for [`peek()`](https://github.com/Expensify/Auth/blob/3c807bfad23ac38d76d7c43ce74659dd02657d82/auth/AuthCommand.cpp#L332) to `prePeek()`

cc: @johnmlee101 since you have context 
       @joelbettner since you are in the blame for `prePeek()`) and 
       @Li357 since you migrated `Authenticate` to prePeek

### Fixed Issues
Should mitigate the re-authentication issues we've seen in https://github.com/Expensify/Expensify/issues/278513

### Tests
Added `SINFO("<command><method> request partnerUserID: " << request["partnerUserID"]);` to the top of `peek()` and `prePeek()` for CreateLogin.cpp and Authenticate.cpp respectively. 


Here's CreateLogin, which uses `peek()` 
```
2023-07-07T01:51:43.342481+00:00 expensidev2004 php-fpm: N2JOxH /api.php zelda@hyrule.com !iphone8.5.36.4! ?api? [info] [mobile] Bedrock\Client - Starting a request ~~ command: 'CreateLogin' clusterName: 'auth' headers: '[authToken: '<REDACTED>' partnerName: 'iphone' partnerPassword: '<REDACTED>' partnerUserID: 'Simulator.f6b9bdc5-5f89-483f-9b54-cc458bbc9e29' partnerUserSecret: '<REDACTED>' deviceInfo: '' logParam: 'zelda@hyrule.com' requestID: 'N2JOxH' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
...
2023-07-07T01:51:43.345578+00:00 expensidev2004 bedrock: N2JOxH zelda@hyrule.com (CreateLogin.cpp:22) process [socket15] [info] CreateLogin::peek() request partnerUserID: simulator.f6b9bdc5-5f89-483f-9b54-cc458bbc9e29
```


Here's authenticate, which uses `prePeek()`

pre-changes: 
```
2023-07-07T01:56:55.646071+00:00 expensidev2004 php-fpm: hwUUtM /api.php zelda@hyrule.com !iphone8.5.36.4! ?api? [info] [mobile] Bedrock\Client - Starting a request ~~ command: 'Authenticate' clusterName: 'auth' headers: '[partnerUserID: 'Simulator.f6b9bdc5-5f89-483f-9b54-cc458bbc9e29' partnerUserSecret: '<REDACTED>' partnerName: 'iphone' partnerPassword: '<REDACTED>' rememberDevice: '' twoFactorDeviceToken: '<REDACTED>' twoFactorAuthCode: '<REDACTED>' useExpensifyLogin: 'false' isViaExpensifyCash: '' authToken: '<REDACTED>' logParam: 'zelda@hyrule.com' requestID: 'hwUUtM' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
...
2023-07-07T01:56:55.647904+00:00 expensidev2004 bedrock: hwUUtM zelda@hyrule.com (Authenticate.cpp:52) prePeek [socket20] [info] Authenticate::prePeek() request partnerUserID: Simulator.f6b9bdc5-5f89-483f-9b54-cc458bbc9e29
```

 post-changes
```
2023-07-07T02:00:50.076537+00:00 expensidev2004 php-fpm: 67K2gc /api.php zelda@hyrule.com !iphone8.5.36.4! ?api? [info] [mobile] Bedrock\Client - Starting a request ~~ command: 'Authenticate' clusterName: 'auth' headers: '[partnerUserID: 'Simulator.1a885529-d817-42fe-8152-332637fd9c6b' partnerUserSecret: '<REDACTED>' partnerName: 'iphone' partnerPassword: '<REDACTED>' rememberDevice: '' twoFactorDeviceToken: '<REDACTED>' twoFactorAuthCode: '<REDACTED>' useExpensifyLogin: 'false' isViaExpensifyCash: '' authToken: '<REDACTED>' logParam: 'zelda@hyrule.com' requestID: '67K2gc' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
2023-07-07T02:00:50.078456+00:00 expensidev2004 bedrock: 67K2gc zelda@hyrule.com (Authenticate.cpp:52) prePeek [socket18] [info] Authenticate::prePeek() request partnerUserID: simulator.1a885529-d817-42fe-8152-332637fd9c6b
```

Also tested the following 
1. Set your authToken to expire in 1 minute [here]()
2. Log into oldApp using a magic code
3. Wait one minute and try to access an expense
4. Confirm you are _not_ logged out 


_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
