### PR TITLE
[HOLD] Remove regularization logic

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -76,21 +76,6 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command) {
         try {
             SDEBUG("prePeeking at '" << request.methodLine << "' with priority: " << command->priority);
 
-            // Regularize case
-            list<string> lowerCaseAttributes = {"email", "partnerUserID", "partnerName"};
-            for (string attribute : lowerCaseAttributes) {
-                if (request.isSet(attribute)) {
-                    const_cast<SData&>(request)[attribute] = SToLower(request[attribute]);
-                }
-            }
-
-            list<string> upperCaseAttributes = {"validateCode"};
-            for (string attribute : upperCaseAttributes) {
-                if (request.isSet(attribute)) {
-                    const_cast<SData&>(request)[attribute] = SToUpper(request[attribute]);
-                }
-            }
-
             uint64_t timeout = _getRemainingTime(command, false);
             command->prePeekCount++;
 


### PR DESCRIPTION
HELD on https://github.com/Expensify/Auth/pull/8248 which consolidates the regularization logic into a singular method shared between `peek()` and `prePeek()`. 

### Details

Removes now duplicated regularization logic from auth 

### Fixed Issues
Fixes N/A

### Tests

1. Set your authToken to expire in 1 minute [here]()
2. Log into oldApp using a magic code
3. Wait one minute and try to access an expense
4. Confirm you are _not_ logged out 

Check the logs and confirm that the `Authenticate` call has a regularized version of your simulator device id 

```
2023-07-07T23:57:35.982785+00:00 expensidev2004 php-fpm: LVGP0K /api.php nikki@beep.com !iphone8.5.36.4! ?api? [info] [mobile] Bedrock\Client - Starting a request ~~ command: 'Authenticate' clusterName: 'auth' headers: '[partnerUserID: 'Simulator.258626cf-ed15-4457-b86c-75f1ab568170' partnerUserSecret: '<REDACTED>' partnerName: 'iphone' partnerPassword: '<REDACTED>' rememberDevice: '' twoFactorDeviceToken: '<REDACTED>' twoFactorAuthCode: '<REDACTED>' useExpensifyLogin: 'false' isViaExpensifyCash: '' authToken: '<REDACTED>' logParam: 'nikki@beep.com' requestID: 'LVGP0K' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '290000']'
...
2023-07-07T23:57:35.986991+00:00 expensidev2004 bedrock: LVGP0K nikki@beep.com (Authenticate.cpp:111) prePeek [socket69] [info] Attempting authenticate for partnerUserID=simulator.258626cf-ed15-4457-b86c-75f1ab568170, partnerName=iphone
```
 
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
