### PR TITLE
Add metric QUEUE_PAGE_LOCK

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -134,6 +134,7 @@ void BedrockCommand::finalizeTimingInfo() {
     uint64_t queueWorkerTotal = 0;
     uint64_t queueSyncTotal = 0;
     uint64_t queueBlockingTotal = 0;
+    uint64_t queuePageLockTotal = 0;
     for (const auto& entry: timingInfo) {
         if (get<0>(entry) == PREPEEK) {
             prePeekTotal += get<2>(entry) - get<1>(entry);
@@ -162,6 +163,8 @@ void BedrockCommand::finalizeTimingInfo() {
             queueBlockingTotal += get<2>(entry) - get<1>(entry);
         } else if (get<0>(entry) == QUEUE_SYNC) {
             queueSyncTotal += get<2>(entry) - get<1>(entry);
+        } else if (get<0>(entry) == QUEUE_PAGE_LOCK) {
+            queuePageLockTotal += get<2>(entry) - get<1>(entry);
         }
     }
 
@@ -169,8 +172,8 @@ void BedrockCommand::finalizeTimingInfo() {
     uint64_t totalTime = STimeNow() - creationTime;
 
     // Time that wasn't accounted for in all the other metrics.
-    uint64_t unaccountedTime = totalTime - (prePeekTotal + peekTotal + processTotal + postProcessTotal +commitWorkerTotal + commitSyncTotal +
-                                            escalationTimeUS + queueWorkerTotal + queueBlockingTotal + queueSyncTotal);
+    uint64_t unaccountedTime = totalTime - (prePeekTotal + peekTotal + processTotal + postProcessTotal + commitWorkerTotal + commitSyncTotal +
+                                            escalationTimeUS + queueWorkerTotal + queueBlockingTotal + queueSyncTotal + queuePageLockTotal);
 
     // Build a map of the values we care about.
     map<string, uint64_t> valuePairs = {
@@ -241,6 +244,7 @@ void BedrockCommand::finalizeTimingInfo() {
           "worker:" << queueWorkerTotal/1000 << ", "
           "sync:" << queueSyncTotal/1000 << ", "
           "blocking:" << queueBlockingTotal/1000 << ", "
+          "pageLock:" << queuePageLockTotal/1000 << ", "
           "escalation:" << escalationTimeUS/1000 <<
           ". Blocking: "
           "peek:" << blockingPeekTotal/1000 << ", "

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -25,6 +25,7 @@ class BedrockCommand : public SQLiteCommand {
         QUEUE_WORKER,
         QUEUE_SYNC,
         QUEUE_BLOCKING,
+        QUEUE_PAGE_LOCK,
         BLOCKING_PEEK,
         BLOCKING_PROCESS,
         BLOCKING_COMMIT_WORKER,
@@ -182,7 +183,7 @@ class BedrockCommand : public SQLiteCommand {
     static size_t getCommandCount() { return _commandCount.load(); }
 
     // True if this command should be escalated immediately. This can be true for any command that does all of its work
-    // in `process` instead of peek, as it will always be escalated to leader 
+    // in `process` instead of peek, as it will always be escalated to leader
     const bool escalateImmediately;
 
     // Record the state we were acting under in the last call to `peek` or `process`.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -499,8 +499,8 @@ void BedrockServer::sync()
                             core.prePeekCommand(command);
                         }
 
-                        // This command finsihed in prePeek, which likely means it threw. 
-                        // We'll respond to it now, either directly or by sending it back to the sync thread. 
+                        // This command finsihed in prePeek, which likely means it threw.
+                        // We'll respond to it now, either directly or by sending it back to the sync thread.
                         if (command->complete) {
                             SINFO("Command completed in prePeek, replying now.");
                             _reply(command);
@@ -863,13 +863,16 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                 }
             }
 
-            uint64_t conflictLockStartTime = 0;
-            if (lastConflictPage) {
-                conflictLockStartTime = STimeNow();
-            }
-            PageLockGuard pageLock(lastConflictPage);
-            if (lastConflictPage) {
-                SINFO("Waited " << (STimeNow() - conflictLockStartTime) << "us for lock on db page " << lastConflictPage << ".");
+            {
+                BedrockCore::AutoTimer timer(command, BedrockCommand::QUEUE_PAGE_LOCK);
+                uint64_t conflictLockStartTime = 0;
+                if (lastConflictPage) {
+                    conflictLockStartTime = STimeNow();
+                }
+                PageLockGuard pageLock(lastConflictPage);
+                if (lastConflictPage) {
+                    SINFO("Waited " << (STimeNow() - conflictLockStartTime) << "us for lock on db page " << lastConflictPage << ".");
+                }
             }
 
             // If the command has any httpsRequests from a previous `peek`, we won't peek it again unless the

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -873,7 +873,6 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                 SINFO("Waited " << (STimeNow() - conflictLockStartTime) << "us for lock on db page " << lastConflictPage << ".");
             }
             delete timer;
-            }
 
             // If the command has any httpsRequests from a previous `peek`, we won't peek it again unless the
             // command has specifically asked for that.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -863,8 +863,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                 }
             }
 
-            {
-                BedrockCore::AutoTimer timer(command, BedrockCommand::QUEUE_PAGE_LOCK);
+                BedrockCore::AutoTimer *timer = new BedrockCore::AutoTimer(command, BedrockCommand::QUEUE_PAGE_LOCK);
                 uint64_t conflictLockStartTime = 0;
                 if (lastConflictPage) {
                     conflictLockStartTime = STimeNow();
@@ -873,6 +872,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                 if (lastConflictPage) {
                     SINFO("Waited " << (STimeNow() - conflictLockStartTime) << "us for lock on db page " << lastConflictPage << ".");
                 }
+                delete timer;
             }
 
             // If the command has any httpsRequests from a previous `peek`, we won't peek it again unless the

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -863,16 +863,16 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                 }
             }
 
-                BedrockCore::AutoTimer *timer = new BedrockCore::AutoTimer(command, BedrockCommand::QUEUE_PAGE_LOCK);
-                uint64_t conflictLockStartTime = 0;
-                if (lastConflictPage) {
-                    conflictLockStartTime = STimeNow();
-                }
-                PageLockGuard pageLock(lastConflictPage);
-                if (lastConflictPage) {
-                    SINFO("Waited " << (STimeNow() - conflictLockStartTime) << "us for lock on db page " << lastConflictPage << ".");
-                }
-                delete timer;
+            auto *timer = new BedrockCore::AutoTimer(command, BedrockCommand::QUEUE_PAGE_LOCK);
+            uint64_t conflictLockStartTime = 0;
+            if (lastConflictPage) {
+                conflictLockStartTime = STimeNow();
+            }
+            PageLockGuard pageLock(lastConflictPage);
+            if (lastConflictPage) {
+                SINFO("Waited " << (STimeNow() - conflictLockStartTime) << "us for lock on db page " << lastConflictPage << ".");
+            }
+            delete timer;
             }
 
             // If the command has any httpsRequests from a previous `peek`, we won't peek it again unless the


### PR DESCRIPTION
### Details

Let's monitor how much time commands spend waiting on this lock, vs how much time they spend waiting on the blockingCommit queue.

HOLD on changing the logs2statsd script, which I will do if you approve this PR.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/280374#issuecomment-1620093083

### Tests

1. Add `usleep(5000);` on line 871 of `BedrockServer.cpp`
2. Run a bunch of commands in parallel that will conflict
3. Check logs for a command that logged:
```
2023-07-13T09:57:26.691163-05:00 expensidev2004 bedrock: daTvxj we@dont.know (BedrockServer.cpp:875) runCommand [socket3] [info] Waited 5768us for lock on db page 12620.

...

2023-07-13T09:57:26.699863-05:00 expensidev2004 bedrock: daTvxj we@dont.know (BedrockServer.cpp:875) runCommand [socket3] [info] Waited 5070us for lock on db page 12620.

...

2023-07-13T09:57:26.706257-05:00 expensidev2004 bedrock: daTvxj we@dont.know (BedrockServer.cpp:875) runCommand [socket3] [info] Waited 5198us for lock on db page 12620.

...

2023-07-13T09:57:26.707682-05:00 expensidev2004 bedrock: daTvxj we@dont.know (BedrockCommand.cpp:233) finalizeTimingInfo [socket3] [info] command 'UpdateRNVPLastReadTime' timing info (ms): prePeek: 0 (count: 0), peek:4 (count:4), process:2 (count:4), postProcess:0 (count:0), total:26, unaccounted:0. Commit: worker:3, sync:0. Queue: worker:0, sync:0, blocking:0, pageLock:16, escalation:0. Blocking: peek:0, process:0, commit:0. Upstream: peek:0, process:0, total:0, unaccounted:0.
```
See `pageLock:16`

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
