### PR TITLE
Add an upgrade complete flag for plugins

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -372,6 +372,7 @@ void BedrockServer::sync()
                 // If we're not doing an upgrade, we don't need to keep suppressing multi-write, and we're done with
                 // the upgradeInProgress flag.
                 _upgradeInProgress = false;
+                _upgradeCompleted = true;
                 SINFO("UpgradeDB skipped, done.");
             }
         }
@@ -389,6 +390,7 @@ void BedrockServer::sync()
             if (_upgradeInProgress) {
                 if (_syncNode->commitSucceeded()) {
                     _upgradeInProgress = false;
+                    _upgradeCompleted = true;
                     SINFO("UpgradeDB succeeded, done.");
                 } else {
                     SINFO("UpgradeDB failed, trying again.");
@@ -1184,6 +1186,7 @@ void BedrockServer::_resetServer() {
     _commandPortPublic = nullptr;
     _commandPortPrivate = nullptr;
     _pluginsDetached = false;
+    _upgradeCompleted = false;
 
     // Tell any plugins that they can attach now
     for (auto plugin : plugins) {
@@ -1204,7 +1207,7 @@ BedrockServer::BedrockServer(const SData& args_)
     _multiWriteEnabled(args.test("-enableMultiWrite")), _enableConflictPageLocks(args.test("-enableConflictPageLocks")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),
     _controlPort(nullptr), _commandPortPublic(nullptr), _commandPortPrivate(nullptr), _maxConflictRetries(3),
     _lastQuorumCommandTime(STimeNow()), _pluginsDetached(false), _socketThreadNumber(0),
-    _outstandingSocketThreads(0), _shouldBlockNewSocketThreads(false)
+    _outstandingSocketThreads(0), _shouldBlockNewSocketThreads(false), _upgradeCompleted(false)
 {
     _version = VERSION;
 
@@ -1586,6 +1589,10 @@ void BedrockServer::setDetach(bool detach) {
 
 bool BedrockServer::isDetached() {
     return _detach && _syncThreadComplete && _pluginsDetached;
+}
+
+bool BedrockServer::isUpgradeComplete() {
+    return _upgradeCompleted;
 }
 
 void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -231,6 +231,9 @@ class BedrockServer : public SQLiteServer {
     // Returns if we are detached and the sync thread has exited.
     bool isDetached();
 
+    // Returns if all plugins have completed calling UpgradeDB
+    bool isUpgradeComplete();
+
     // See if there's a plugin that can turn this request into a command.
     // If not, we'll create a command that returns `430 Unrecognized command`.
     unique_ptr<BedrockCommand> getCommandFromPlugins(SData&& request);
@@ -486,6 +489,10 @@ class BedrockServer : public SQLiteServer {
     // If we hit the point where we're unable to create new socket threads, we block doing so.
     bool _shouldBlockNewSocketThreads;
     mutex _newSocketThreadBlockedMutex;
+
+    // This gets set to true when the database upgrade is completed, letting workers or plugins know that the database
+    // tables in any expected schemas should now be available.
+    atomic<bool> _upgradeCompleted;
 
     // This mutex prevents the check for whether there are outstanding commands preventing shutdown from running at the
     // same time a control port command is running (which would indicate that there is a command blocking shutdown -

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -518,8 +518,10 @@ void BedrockPlugin_TestPlugin::stateChanged(SQLite& db, SQLiteNodeState newState
     // so this function cannot do any sort of waiting or it will block the sync thread. By offloading this,
     // we can let the code wait for a condition to be met before it actually runs. In our case, we want to
     // wait until upgradeDatabase has completed so that we can run a query on a table.
-    thread([&]() {
+    SINFO("Running stateChanged new state " << SQLiteNode::stateName(newState));
+    thread([&, newState]() {
         if (newState != SQLiteNodeState::LEADING) {
+            SINFO("Returning early stateChanged new state " << SQLiteNode::stateName(newState));
             return;
         }
         SINFO("Sleeping until the server is done upgrading.");

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -23,6 +23,7 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
     virtual const string& getName() const;
     static const string name;
     virtual bool preventAttach();
+    void stateChanged(SQLite& db, SQLiteNodeState newState);
 
     virtual unique_ptr<BedrockCommand> getCommand(SQLiteCommand&& baseCommand);
 
@@ -33,6 +34,9 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
     // of one command from another, even if the first command never sends a response.
     static mutex dataLock;
     static map<string, string> arbitraryData;
+
+    // Tests setting of an ID value in stateChanged after an upgrade is completed.
+    atomic<int64_t> _maxID;
 };
 
 class TestPluginCommand : public BedrockCommand {


### PR DESCRIPTION
### Details
This adds an upgradeComplete flag to BedrockServer, this flag is exposed via a r/o function so that plugins can know when `_upgradeDB()` has completed. This is useful for plugins that run `stateChanged()` functions on a change to `LEADING` and need to run a query on the database inside of `stateChanged()`.

### Fixed Issues
Needed for https://github.com/Expensify/Expensify/issues/299490

### Tests
Added tests to TestPlugin.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
