### PR TITLE
Add an onPrepare handler for plugins

### DIFF
--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -86,6 +86,13 @@ class BedrockCommand : public SQLiteCommand {
         return false;
     }
 
+    // Bedrock will call this before each `processCommand` (note: not `peekCommand`) for each plugin to allow it to
+    // enable query rewriting. If a plugin would like to enable query rewriting, this should return true, and it should
+    // set the rewriteHandler it would like to use.
+    virtual bool shouldEnableOnCommitNotification(const SQLite& db, void (**onCommitHandler)()) {
+        return false;
+    }
+
     // Start recording time for a given action type.
     void startTiming(TIMING_INFO type);
 

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -89,7 +89,7 @@ class BedrockCommand : public SQLiteCommand {
     // Bedrock will call this before writing to the database after it has prepared a transaction for each plugin to allow it to
     // enable a handler function for prepare If a plugin would like to perform operations after prepare but before commit, this should 
     // return true, and it should set the prepareHandler it would like to use.
-    virtual bool shouldEnableOnPrepareNotification(const SQLite& db, void (**onPrepareHandler)()) {
+    virtual bool shouldEnableOnPrepareNotification(const SQLite& db, void (**onPrepareHandler)(SQLite& _db, int64_t tableID)) {
         return false;
     }
 

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -86,10 +86,10 @@ class BedrockCommand : public SQLiteCommand {
         return false;
     }
 
-    // Bedrock will call this before each `processCommand` (note: not `peekCommand`) for each plugin to allow it to
-    // enable query rewriting. If a plugin would like to enable query rewriting, this should return true, and it should
-    // set the rewriteHandler it would like to use.
-    virtual bool shouldEnableOnCommitNotification(const SQLite& db, void (**onCommitHandler)()) {
+    // Bedrock will call this before writing to the database after it has prepared a transaction for each plugin to allow it to
+    // enable a handler function for prepare If a plugin would like to perform operations after prepare but before commit, this should 
+    // return true, and it should set the prepareHandler it would like to use.
+    virtual bool shouldEnableOnPrepareNotification(const SQLite& db, void (**onPrepareHandler)()) {
         return false;
     }
 

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -29,28 +29,6 @@ class AutoScopeRewrite {
     bool (*_handler)(int, const char*, string&);
 };
 
-// RAII-style mechanism for automatically setting and unsetting an on prepare handler
-class AutoScopeOnPrepare {
-  public:
-    AutoScopeOnPrepare(bool enable, SQLite& db, void (*handler)(SQLite& _db, int64_t tableID)) : _enable(enable), _db(db), _handler(handler) {
-        if (_enable) {
-            _db.setOnPrepareHandler(_handler);
-            _db.enablePrepareNotifications(true);
-        }
-    }
-    ~AutoScopeOnPrepare() {
-        if (_enable) {
-            _db.setOnPrepareHandler(nullptr);
-            _db.enablePrepareNotifications(false);
-        }
-    }
-
-  private:
-    bool _enable;
-    SQLite& _db;
-    void (*_handler)(SQLite& _db, int64_t tableID);
-};
-
 uint64_t BedrockCore::_getRemainingTime(const unique_ptr<BedrockCommand>& command, bool isProcessing) {
     int64_t timeout = command->timeout();
     int64_t now = STimeNow();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -997,7 +997,10 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                             core.rollback();
                         } else {
                             BedrockCore::AutoTimer timer(command, isBlocking ? BedrockCommand::BLOCKING_COMMIT_WORKER : BedrockCommand::COMMIT_WORKER);
-                            commitSuccess = core.commit(SQLiteNode::stateName(_replicationState), transactionID, transactionHash);
+                            void (*onPrepareHandler)(SQLite& db, int64_t tableID) = nullptr;
+                            bool enableOnPrepareNotifications = command->shouldEnableOnPrepareNotification(db, &onPrepareHandler);
+                            commitSuccess = core.commit(SQLiteNode::stateName(_replicationState), transactionID,
+                                                        transactionHash, enableOnPrepareNotifications, onPrepareHandler);
                         }
                     }
                     if (commitSuccess) {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -598,6 +598,9 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash) {
         _mutexLocked = true;
     }
 
+    // We pass the journal number selected to the handler so that a caller can utilize the
+    // same method bedrock does for accessing 1 table per thread, in order to attempt to
+    // reduce conflicts on tables that are written do on every command
     _journalName = _journalNames[_sharedData.nextJournalCount++ % _journalNames.size()];
     if (_shouldNotifyPluginsOnPrepare) {
         (*_onPrepareHandler)(*this, SToInt64(SAfter(_journalName, "journal")));

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -600,7 +600,7 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash) {
 
     // We pass the journal number selected to the handler so that a caller can utilize the
     // same method bedrock does for accessing 1 table per thread, in order to attempt to
-    // reduce conflicts on tables that are written do on every command
+    // reduce conflicts on tables that are written to on every command
     const int64_t journalID = _sharedData.nextJournalCount++;
     _journalName = _journalNames[journalID % _journalNames.size()];
     if (_shouldNotifyPluginsOnPrepare) {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -601,9 +601,10 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash) {
     // We pass the journal number selected to the handler so that a caller can utilize the
     // same method bedrock does for accessing 1 table per thread, in order to attempt to
     // reduce conflicts on tables that are written do on every command
-    _journalName = _journalNames[_sharedData.nextJournalCount++ % _journalNames.size()];
+    const int64_t journalID = _sharedData.nextJournalCount++;
+    _journalName = _journalNames[journalID % _journalNames.size()];
     if (_shouldNotifyPluginsOnPrepare) {
-        (*_onPrepareHandler)(*this, SToInt64(SAfter(_journalName, "journal")));
+        (*_onPrepareHandler)(*this, journalID);
     }
 
     // Now that we've locked anybody else from committing, look up the state of the database. We don't need to lock the

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -689,6 +689,9 @@ int SQLite::commit(const string& description, function<void()>* preCheckpointCal
     // If there were conflicting commits, will return SQLITE_BUSY_SNAPSHOT
     SASSERT(result == SQLITE_OK || result == SQLITE_BUSY_SNAPSHOT);
     if (result == SQLITE_OK) {
+        if (_onCommitHandlder != nullptr) {
+            (*_onCommitHandlder)();
+        }
         char time[16];
         snprintf(time, 16, "%.2fms", (double)(STimeNow() - beforeCommit) / 1000.0);
 
@@ -871,6 +874,10 @@ void SQLite::enableRewrite(bool enable) {
 
 void SQLite::setRewriteHandler(bool (*handler)(int, const char*, string&)) {
     _rewriteHandler = handler;
+}
+
+void SQLite::setOnCommitHandler(void (*handler)()) {
+    _onCommitHandlder = handler;
 }
 
 int SQLite::_sqliteAuthorizerCallback(void* pUserData, int actionCode, const char* detail1, const char* detail2,

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -160,10 +160,13 @@ class SQLite {
     void enablePrepareNotifications(bool enable);
 
     // Update the on prepare handler.
-    // The on prepare handler allows a plugin to run code inside the commit lock. This code should be time sensitive
+    // The on prepare handler accepts a reference to this SQLiteDB object and an int tableID. The tableID is the
+    // same ID that is used for the journal number in the current running thread. This allows the handler to utilize
+    // SQLite.cpp's method for avoiding conflicts on tables written on every command. 
+    // IMPORTANT: The on prepare handler allows a plugin to run code inside the commit lock. This code should be time sensitive
     // as increases to the amount of time this lock is held increase conflict chances and decreases the parallelness
-    // of bedrock commands.
-    // Important: there can be only one on-prepare handler for a given DB at once.
+    // of bedrock commands. 
+    // IMPORTANT: there can be only one on-prepare handler for a given DB at once.
     void setOnPrepareHandler(void (*handler)(SQLite& _db, int64_t tableID));
 
     // Commits the current transaction to disk. Returns an sqlite3 result code.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -164,7 +164,7 @@ class SQLite {
     // as increases to the amount of time this lock is held increase conflict chances and decreases the parallelness
     // of bedrock commands.
     // Important: there can be only one on-prepare handler for a given DB at once.
-    void setOnPrepareHandler(void (*handler)());
+    void setOnPrepareHandler(void (*handler)(SQLite& _db, int64_t tableID));
 
     // Commits the current transaction to disk. Returns an sqlite3 result code.
     // preCheckpointCallback is an optional callback that will be called before the checkpoint code runs, after the commit has completed. Note that if the commit fails, this is not called.
@@ -441,7 +441,7 @@ class SQLite {
     bool _shouldNotifyPluginsOnPrepare = false;
 
     // Pointer to the current on prepare handler.
-    void (*_onPrepareHandler)();
+    void (*_onPrepareHandler)(SQLite& _db, int64_t tableID);
 
     // Causes the current query to skip re-write checking if it's already a re-written query.
     bool _currentlyRunningRewritten = false;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -153,6 +153,13 @@ class SQLite {
     // Important: there can be only one re-write handler for a given DB at once.
     void setRewriteHandler(bool (*handler)(int, const char*, string&));
 
+    // Update the on commit handler.
+    // The on commit handler allows a plugin to run code inside the commit lock. This code should be time sensitive
+    // as increases to the amount of time this lock is held increase conflict chances and decreases the parallelness
+    // of bedrock commands.
+    // Important: there can be only one on-commit handler for a given DB at once.
+    void setOnCommitHandler(void (*handler)());
+
     // Commits the current transaction to disk. Returns an sqlite3 result code.
     // preCheckpointCallback is an optional callback that will be called before the checkpoint code runs, after the commit has completed. Note that if the commit fails, this is not called.
     // The main purpose of this is to allow replications in SQLiteNode to notify other waiting threads that the commit has finished even before the checkpoint is done.
@@ -423,6 +430,9 @@ class SQLite {
 
     // When the rewrite handler indicates a query needs to be re-written, the new query is set here.
     string _rewrittenQuery;
+
+    // Pointer to the current on commit handler.
+    void (*_onCommitHandler)();
 
     // Causes the current query to skip re-write checking if it's already a re-written query.
     bool _currentlyRunningRewritten = false;

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -6,9 +6,38 @@
 SQLiteCore::SQLiteCore(SQLite& db) : _db(db)
 { }
 
-bool SQLiteCore::commit(const string& description, uint64_t& commitID, string& transactionHash) {
-    // This should always succeed.
-    SASSERT(_db.prepare(&commitID, &transactionHash));
+// RAII-style mechanism for automatically setting and unsetting an on prepare handler
+class AutoScopeOnPrepare {
+  public:
+    AutoScopeOnPrepare(bool enable, SQLite& db, void (*handler)(SQLite& _db, int64_t tableID)) : _enable(enable), _db(db), _handler(handler) {
+        if (_enable) {
+            _db.setOnPrepareHandler(_handler);
+            _db.enablePrepareNotifications(true);
+        }
+    }
+    ~AutoScopeOnPrepare() {
+        if (_enable) {
+            _db.setOnPrepareHandler(nullptr);
+            _db.enablePrepareNotifications(false);
+        }
+    }
+
+  private:
+    bool _enable;
+    SQLite& _db;
+    void (*_handler)(SQLite& _db, int64_t tableID);
+};
+
+bool SQLiteCore::commit(const string& description, uint64_t& commitID, string& transactionHash,
+                        bool needsPluginNotification, void (*notificationHandler)(SQLite& _db, int64_t tableID)) {
+    
+    // This handler only needs to exist in prepare so we scope it here to automatically unset
+    // the handler function once we are done with prepare.
+    {
+        AutoScopeOnPrepare onPrepare(needsPluginNotification, _db, notificationHandler);
+        // This should always succeed.
+        SASSERT(_db.prepare(&commitID, &transactionHash));
+    }
 
     // If there's nothing to commit, we won't bother, but warn, as we should have noticed this already.
     if (_db.getUncommittedHash().empty()) {

--- a/sqlitecluster/SQLiteCore.h
+++ b/sqlitecluster/SQLiteCore.h
@@ -8,7 +8,8 @@ class SQLiteCore {
 
     // Commit the outstanding transaction on the DB.
     // Returns true on successful commit, false on conflict.
-    bool commit(const string& description, uint64_t& commitID, string& transactionHash);
+    bool commit(const string& description, uint64_t& commitID, string& transactionHash, bool needsPluginNotifiation, 
+                void (*notificationHandler)(SQLite& _db, int64_t tableID) = nullptr);
 
     // Roll back a transaction if we've decided not to commit it.
     void rollback();

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -23,6 +23,7 @@ class BedrockPlugin_TestPlugin : public BedrockPlugin
     virtual const string& getName() const;
     static const string name;
     virtual bool preventAttach();
+    static void onPrepareHandler(SQLite& db, int64_t tableID);
 
     virtual unique_ptr<BedrockCommand> getCommand(SQLiteCommand&& baseCommand);
 
@@ -46,6 +47,7 @@ class TestPluginCommand : public BedrockCommand {
     virtual bool shouldPrePeek();
     virtual bool shouldPostProcess();
     virtual void reset(BedrockCommand::STAGE stage) override;
+    bool shouldEnableOnPrepareNotification(const SQLite& db, void (**handler)(SQLite& _db, int64_t tableID));
 
   private:
     BedrockPlugin_TestPlugin& plugin() { return static_cast<BedrockPlugin_TestPlugin&>(*_plugin); }


### PR DESCRIPTION
### Details
@iwiznia Please review. This adds the ability for plugins to specify a handler per command that runs arbitrary code after a transaction is prepared but before it is committed. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/299495

### Tests
Added tests to the TestPlugin.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
