### PR TITLE
Add onPrepareHandler into SQLiteNode for Quorum Commits

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -285,6 +285,9 @@ void BedrockServer::sync()
                 _syncNode->onPrepareHandlerEnabled = enabled;
                 _syncNode->onPrepareHandler = onPrepareHandler;
             }
+        } else {
+            _syncNode->onPrepareHandlerEnabled = false;
+            _syncNode->onPrepareHandler = nullptr;
         }
         while (_syncNode->update()) {}
         SQLiteNodeState nodeState = _syncNode->getState();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -278,6 +278,14 @@ void BedrockServer::sync()
         // Ok, let the sync node to it's updating for as many iterations as it requires. We'll update the replication
         // state when it's finished.
         SQLiteNodeState preUpdateState = _syncNode->getState();
+        if(committingCommand) {
+            void (*onPrepareHandler)(SQLite& db, int64_t tableID) = nullptr;
+            bool enabled = command->shouldEnableOnPrepareNotification(db, &onPrepareHandler);
+            if (enabled) {
+                _syncNode->onPrepareHandlerEnabled = enabled;
+                _syncNode->onPrepareHandler = onPrepareHandler;
+            }
+        }
         while (_syncNode->update()) {}
         SQLiteNodeState nodeState = _syncNode->getState();
         _replicationState.store(nodeState);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -278,7 +278,7 @@ void BedrockServer::sync()
         // Ok, let the sync node to it's updating for as many iterations as it requires. We'll update the replication
         // state when it's finished.
         SQLiteNodeState preUpdateState = _syncNode->getState();
-        if(committingCommand) {
+        if(command && committingCommand) {
             void (*onPrepareHandler)(SQLite& db, int64_t tableID) = nullptr;
             bool enabled = command->shouldEnableOnPrepareNotification(db, &onPrepareHandler);
             if (enabled) {

--- a/libstuff/AutoScopeOnPrepare.cpp
+++ b/libstuff/AutoScopeOnPrepare.cpp
@@ -1,0 +1,16 @@
+#include "AutoScopeOnPrepare.h"
+
+AutoScopeOnPrepare::AutoScopeOnPrepare(bool enable, SQLite& db, void (*handler)(SQLite& _db, int64_t tableID))
+    : _enable(enable), _db(db), _handler(handler) {
+    if (_enable) {
+        _db.setOnPrepareHandler(_handler);
+        _db.enablePrepareNotifications(true);
+    }
+}
+
+AutoScopeOnPrepare ::~AutoScopeOnPrepare() {
+    if (_enable) {
+        _db.setOnPrepareHandler(nullptr);
+        _db.enablePrepareNotifications(false);
+    }
+}

--- a/libstuff/AutoScopeOnPrepare.h
+++ b/libstuff/AutoScopeOnPrepare.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "../SQLiteCluster/SQLite.h"
+using namespace std;
+
+// RAII-style mechanism for automatically setting and unsetting an on prepare handler
+class AutoScopeOnPrepare {
+  public:
+    AutoScopeOnPrepare(bool enable, SQLite& db, void (*handler)(SQLite& _db, int64_t tableID));
+    ~AutoScopeOnPrepare();
+
+  private:
+    bool _enable;
+    SQLite& _db;
+    void (*_handler)(SQLite& _db, int64_t tableID);
+};

--- a/libstuff/AutoScopeOnPrepare.h
+++ b/libstuff/AutoScopeOnPrepare.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "../SQLiteCluster/SQLite.h"
+#include <sqlitecluster/SQLite.h>
 using namespace std;
 
 // RAII-style mechanism for automatically setting and unsetting an on prepare handler

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -1,3 +1,4 @@
+#include <libstuff/AutoScopeOnPrepare.h>
 #include <libstuff/libstuff.h>
 #include "SQLiteCore.h"
 #include "SQLite.h"
@@ -5,28 +6,6 @@
     
 SQLiteCore::SQLiteCore(SQLite& db) : _db(db)
 { }
-
-// RAII-style mechanism for automatically setting and unsetting an on prepare handler
-class AutoScopeOnPrepare {
-  public:
-    AutoScopeOnPrepare(bool enable, SQLite& db, void (*handler)(SQLite& _db, int64_t tableID)) : _enable(enable), _db(db), _handler(handler) {
-        if (_enable) {
-            _db.setOnPrepareHandler(_handler);
-            _db.enablePrepareNotifications(true);
-        }
-    }
-    ~AutoScopeOnPrepare() {
-        if (_enable) {
-            _db.setOnPrepareHandler(nullptr);
-            _db.enablePrepareNotifications(false);
-        }
-    }
-
-  private:
-    bool _enable;
-    SQLite& _db;
-    void (*_handler)(SQLite& _db, int64_t tableID);
-};
 
 bool SQLiteCore::commit(const string& description, uint64_t& commitID, string& transactionHash,
                         bool needsPluginNotification, void (*notificationHandler)(SQLite& _db, int64_t tableID)) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1024,7 +1024,7 @@ bool SQLiteNode::update() {
             // There's no handling for a failed prepare. This should only happen if the DB has been corrupted or
             // something catastrophic like that.
             {
-                AutoScopeOnPrepare(onPrepareHandlerEnabled, _db, onPrepareHandler);
+                AutoScopeOnPrepare onPrepare(onPrepareHandlerEnabled, _db, onPrepareHandler);
                 SASSERT(_db.prepare());
             }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2,6 +2,7 @@
 
 #include <unistd.h>
 
+#include <libstuff/AutoScopeOnPrepare.h>
 #include <libstuff/libstuff.h>
 #include <libstuff/SRandom.h>
 #include <libstuff/SQResult.h>
@@ -57,29 +58,6 @@
 
 #undef SLOGPREFIX
 #define SLOGPREFIX "{" << _name << "/" << SQLiteNode::stateName(_state) << "} "
-
-// RAII-style mechanism for automatically setting and unsetting an on prepare handler
-class AutoScopeOnPrepare {
-  public:
-    AutoScopeOnPrepare(bool enable, SQLite& db, void (*handler)(SQLite& _db, int64_t tableID))
-        : _enable(enable), _db(db), _handler(handler) {
-        if (_enable) {
-            _db.setOnPrepareHandler(_handler);
-            _db.enablePrepareNotifications(true);
-        }
-    }
-    ~AutoScopeOnPrepare() {
-        if (_enable) {
-            _db.setOnPrepareHandler(nullptr);
-            _db.enablePrepareNotifications(false);
-        }
-    }
-
-  private:
-    bool _enable;
-    SQLite& _db;
-    void (*_handler)(SQLite& _db, int64_t tableID);
-};
 
 // Initializations for static vars.
 const uint64_t SQLiteNode::RECV_TIMEOUT{STIME_US_PER_S * 30};

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -164,6 +164,11 @@ class SQLiteNode : public STCPManager {
     // access _peerList and peer->name, both of which are const. So it is safe
     // to call from other public functions.
     SQLitePeer* getPeerByName(const string& name) const;
+
+    // Pointer to the current on prepare handler to be passed on commit to SQLite
+    void (*onPrepareHandler)(SQLite& _db, int64_t tableID);
+    bool onPrepareHandlerEnabled;
+
   private:
     // Utility class that can decrement _replicationThreadCount when objects go out of scope.
     template <typename CounterType>


### PR DESCRIPTION
### Details
This code adds support for onPrepareHandler in the syncNode. We missed this the first time around. Since this code is only called in the sync thread, none of it is locked in a mutex. 

### Fixed Issues
Related to https://github.com/Expensify/Expensify/issues/299495

### Tests
Ran the existing tests 50 times
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
