### PR TITLE
Give the plugin its own db handle for stateChanged

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -129,6 +129,10 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, cons
 {
     SASSERT(_originalPriority >= 0);
     onPrepareHandlerEnabled = false;
+    
+    // We create a copy of the database handle here so that the sync node can operate on its handle and the plugin gets
+    // its own handle to operate on. This avoids conflicts where the sync thread and the plugin are trying to both run
+    // queries at the same time. This also avoids the need to create any share locking between the two.
     pluginDB = new SQLite(_db);
     SINFO("[NOTIFY] setting commit count to: " << _db.getCommitCount());
     _localCommitNotifier.notifyThrough(_db.getCommitCount());
@@ -1820,9 +1824,6 @@ void SQLiteNode::_changeState(SQLiteNodeState newState) {
 
     if (newState != _state) {
         // First, we notify all plugins about the state change
-        // We create a copy of the database handle here so that the sync node can operate on its handle and the plugin gets
-        // its own handle to operate on. This avoids conflicts where the sync thread and the plugin are trying to both run 
-        // queries at the same time. This also avoids the need to create any share locking between the two.
         _server.notifyStateChangeToPlugins(*pluginDB, newState);
 
         // If we were following, and now we're not, we give up an any replications.

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -356,4 +356,8 @@ class SQLiteNode : public STCPManager {
     // while we're online.
     // In the event that this list becomes longer than half the cluster size, the node kills itself and logs that it's in an unrecoverable state.
     set<string> _forkedFrom;
+
+    // A pointer to a SQLite instance that is passed to plugin's stateChanged function. This prevents plugins from operating on the same handle that
+    // the sync node is when they run queries in stateChanged.
+    SQLite* pluginDB;
 };


### PR DESCRIPTION
### Details
Currently, for the `stateChanged` function, we pass the plugin the sync thread's database handle. This works most of the time however because there is no locking around this handle it is possible that a plugin and the sync thread try to operate on the database at the same time. This is not supported, and causes SQLite to report database corruption for the second caller. 

This change creates a new database handle specifically for the stateChanged handler, so that the sync thread may use its own handle and the plugin gets it's own as well. This should prevent the crashes we've seen. 

### Fixed Issues
Multiple crashes during deploys.

### Tests
The automated tests still pass. Since this bug is triggered by a race condition, I was unable to replicate the crashes we've seen in dev. However I'm reasonably sure this is the fix, and the downside of deploying this is essentially none. 
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
