### PR TITLE
Add logging inside the blocking commit queue

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -684,7 +684,7 @@ void BedrockServer::worker(int threadId)
             });
 
             // Get the next one.
-            command = commandQueue.get(1000000);
+            command = commandQueue.get(1000000, !threadId);
 
             SAUTOPREFIX(command->request);
             SINFO("Dequeued command " << command->request.methodLine << " (" << command->id << ") in worker, "


### PR DESCRIPTION
### Details
Adds logging around the queue locks for only the blocking commit thread. This is super noisey but its meant to be reverted. 

### Fixed Issues
Diagnosis of production issues.

### Tests
Ran tests, confirmed logs only show in blocking thread. 
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
