### PR TITLE
Add logging in reply

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1504,6 +1504,7 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
     const string& pluginName = command->request["plugin"];
 
     if (command->socket) {
+        SINFO("[performance] Command " << command->response.methodLine << " has a socket, going to try to reply.");
         if (!pluginName.empty()) {
             // Let the plugin handle it
             SINFO("Plugin '" << pluginName << "' handling response '" << command->response.methodLine
@@ -1516,13 +1517,13 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
             }
         } else {
             // Otherwise we send the standard response.
-            SDEBUG("About to reply to command " << command->request.methodLine);
+            SINFO("[performance] About to reply to command " << command->request.methodLine);
             if (!command->socket->send(command->response.serialize())) {
                 // If we can't send (client closed the socket?), alert our plugin it's response was never sent.
                 SINFO("No socket to reply for: '" << command->request.methodLine << "' #" << command->initiatingClientID);
                 command->handleFailedReply();
             } else {
-                SDEBUG("Replied");
+                SINFO("[performance] Replied");
             }
         }
 
@@ -1538,6 +1539,7 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
         }
         command->handleFailedReply();
     }
+    SINFO("[performance] Finished replying to command " << command->request.methodLine << " moving on to the next command.");
 }
 
 


### PR DESCRIPTION
### Details
Adds logging in `_reply()` to figure out why we spending 15 minutes replying to some commands. 

```
2023-07-31T16:30:55.587709+00:00 db1.sjc bedrock: Gjm3Wq REDACTED (BedrockCommand.cpp:233) finalizeTimingInfo [blockingCommit] [info] command 'SharePolicy' timing info (ms): prePeek: 0 (count: 0), peek:11 (count:4), process:1090 (count:4), postProcess:0 (count:0), total:2373238, unaccounted:0. Commit: worker:44, sync:0. Queue: worker:0, sync:0, blocking:2372091, pageLock:0, escalation:0. Blocking: peek:0, process:0, commit:0. Upstream: peek:0, process:0, total:0, unaccounted:0.
2023-07-31T16:46:49.846203+00:00 db1.sjc bedrock: Gjm3Wq REDACTED (AuthCommand.cpp:39) ~AuthCommand [blockingCommit] [info] Command 'SharePolicy' spent 232 milliseconds processing JSON
```

### Fixed Issues
Debugging in production

### Tests
Ran Conflict Spam test, verified logs show up.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
