### PR TITLE
Revert "Use a handle from the existing pool instead of a new one"

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -129,7 +129,11 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, cons
 {
     SASSERT(_originalPriority >= 0);
     onPrepareHandlerEnabled = false;
-
+    
+    // We create a copy of the database handle here so that the sync node can operate on its handle and the plugin gets
+    // its own handle to operate on. This avoids conflicts where the sync thread and the plugin are trying to both run
+    // queries at the same time. This also avoids the need to create any share locking between the two.
+    pluginDB = new SQLite(_db);
     SINFO("[NOTIFY] setting commit count to: " << _db.getCommitCount());
     _localCommitNotifier.notifyThrough(_db.getCommitCount());
 
@@ -149,6 +153,10 @@ SQLiteNode::~SQLiteNode() {
 
     for (SQLitePeer* peer : _peerList) {
         delete peer;
+    }
+
+    if (pluginDB != nullptr) {
+        delete pluginDB;
     }
 }
 
@@ -1815,16 +1823,8 @@ void SQLiteNode::_changeState(SQLiteNodeState newState) {
     _localCommitNotifier.notifyThrough(_db.getCommitCount());
 
     if (newState != _state) {
-        {
-            // We get a new handle here so that the sync node can operate on its handle and the plugin gets
-            // its own handle to operate on. This avoids conflicts where the sync thread and the plugin are trying to
-            // both run queries at the same time. This also avoids the need to create any share locking between the two.
-            SQLiteScopedHandle dbScope(*_dbPool, _dbPool->getIndex());
-            SQLite& pluginDB = dbScope.db();
-
-            // First, we notify all plugins about the state change
-            _server.notifyStateChangeToPlugins(pluginDB, newState);
-        }
+        // First, we notify all plugins about the state change
+        _server.notifyStateChangeToPlugins(*pluginDB, newState);
 
         // If we were following, and now we're not, we give up an any replications.
         if (_state == SQLiteNodeState::FOLLOWING) {


### PR DESCRIPTION
Reverts Expensify/Bedrock#1551

This is broken when used with Auth, I'll try to figure out a fix, but for now let's just revert so we can deploy. The old code worked fine. 