### PR TITLE
Adding version mismatch handling

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1503,12 +1503,6 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
 
     command->response["nodeName"] = args["-nodeName"];
 
-    // This line will generate the node list that processed the command. 
-    // If the current node is on the right version of the cluster, then it will return the node itself
-    // If it's not on the right version, it will escalate to another follower
-    // The names will be generated in a way the the left-most node name is the last escalation step
-    command->response["nodesPath"] = string(command->response["nodesPath"]).empty() ? args["-nodeName"] : args["-nodeName"] +  "," + command->response["nodesPath"];
-
     // If we're shutting down, tell the caller to close the connection.
     // Also, if the caller wanted us to close the connection, we'll parrot that back.
     if (_shutdownState.load() != RUNNING || command->request["Connection"] == "close") {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1510,8 +1510,13 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
         command->handleFailedReply();
         return;
     }
+    
+    // This line will generate the node list that processed the command. 
+    // If the current node is on the right version of the cluster, then it will return the node itself
+    // If it's not on the right version, it will escalate to another follower
+    // The names will be generated in a way the the left-most node name is the last escalation step
 
-    command->response["nodeName"] = args["-nodeName"];
+    command->response["nodeNames"] = string(command->response["nodeNames"]).empty() ? args["-nodeName"] : args["-nodeName"] +  "," + command->response["nodeNames"];
 
     // If we're shutting down, tell the caller to close the connection.
     // Also, if the caller wanted us to close the connection, we'll parrot that back.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1510,13 +1510,14 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
         command->handleFailedReply();
         return;
     }
-    
+
+    command->response["nodeName"] = args["-nodeName"];
     // This line will generate the node list that processed the command. 
     // If the current node is on the right version of the cluster, then it will return the node itself
     // If it's not on the right version, it will escalate to another follower
     // The names will be generated in a way the the left-most node name is the last escalation step
 
-    command->response["nodeNames"] = string(command->response["nodeNames"]).empty() ? args["-nodeName"] : args["-nodeName"] +  "," + command->response["nodeNames"];
+    command->response["nodesPath"] = string(command->response["nodesPath"]).empty() ? args["-nodeName"] : args["-nodeName"] +  "," + command->response["nodesPath"];
 
     // If we're shutting down, tell the caller to close the connection.
     // Also, if the caller wanted us to close the connection, we'll parrot that back.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -783,12 +783,10 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
         if (command->escalateImmediately && _clusterMessengerCopy && _clusterMessengerCopy->runOnPeer(*command, true)) {
             // command->complete is now true for this command. It will get handled a few lines below.
             SINFO("Immediately escalated " << command->request.methodLine << " to leader.");
-            escalatedTo = "leader";
         } else if (_version != _leaderVersion.load() && _clusterMessengerCopy && _clusterMessengerCopy->runOnPeer(*command, false)) {
             SINFO("Escalated " << command->request.methodLine << " to follower peer.");
-            escalatedTo = "follower peer";
         } else {
-            SINFO("Couldn't escalate command " << command->request.methodLine << " to " << escalatedTo << ", queuing it again.");
+            SINFO("Couldn't escalate command " << command->request.methodLine << " to " << (command->escalateImmediately ? "leader" : "follower peer") << ", queuing it again.");
             _commandQueue.push(move(command));
             return;
         }

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -241,6 +241,13 @@ unique_ptr<SHTTPSManager::Socket> SQLiteClusterMessenger::_getSocketForAddress(s
     return s;
 }
 
+bool SQLiteClusterMessenger::runOnValidFollowerPeer(BedrockCommand& command) {
+    
+    const string peer = _node->getEligibleFollowerForForwarding();
+    
+    return false;
+}
+
 bool SQLiteClusterMessenger::runOnLeader(BedrockCommand& command) {
     auto start = chrono::steady_clock::now();
     bool sent = false;

--- a/sqlitecluster/SQLiteClusterMessenger.h
+++ b/sqlitecluster/SQLiteClusterMessenger.h
@@ -20,14 +20,12 @@ class SQLiteClusterMessenger {
 
     SQLiteClusterMessenger(const shared_ptr<const SQLiteNode> node);
 
-    // Attempts to make a TCP connection to the leader, and run the given command there, setting the appropriate
-    // response from leader in the command, and marking it as complete if possible.
+    // Attempts to make a TCP connection to a peer, that could be the leader or not, and run the given command there,
+    //  setting the appropriate response from the pear in the command, and marking it as complete if possible.
     // Returns command->complete at the end of the function, this is true if the command was successfully completed on
-    // leader, or if a fatal error occurred. This will be false if the command can be re-tried later (for instance, if
+    // the peer, or if a fatal error occurred. This will be false if the command can be re-tried later (for instance, if
     // no connection to leader could be made).
-    bool runOnLeader(BedrockCommand& command);
-
-    bool runOnValidFollowerPeer(BedrockCommand& command);
+    bool runOnPeer(BedrockCommand& command, bool runOnLeader);
 
     // Attempts to run command on every peer. This is done in threads, so the
     // order in which the peers run the command is not deterministic. Returns a

--- a/sqlitecluster/SQLiteClusterMessenger.h
+++ b/sqlitecluster/SQLiteClusterMessenger.h
@@ -27,6 +27,8 @@ class SQLiteClusterMessenger {
     // no connection to leader could be made).
     bool runOnLeader(BedrockCommand& command);
 
+    bool runOnValidFollowerPeer(BedrockCommand& command);
+
     // Attempts to run command on every peer. This is done in threads, so the
     // order in which the peers run the command is not deterministic. Returns a
     // vector of response objects from each command after they are run. It is

--- a/sqlitecluster/SQLiteClusterMessenger.h
+++ b/sqlitecluster/SQLiteClusterMessenger.h
@@ -21,7 +21,7 @@ class SQLiteClusterMessenger {
     SQLiteClusterMessenger(const shared_ptr<const SQLiteNode> node);
 
     // Attempts to make a TCP connection to a peer, that could be the leader or not, and run the given command there,
-    //  setting the appropriate response from the pear in the command, and marking it as complete if possible.
+    //  setting the appropriate response from the peer in the command, and marking it as complete if possible.
     // Returns command->complete at the end of the function, this is true if the command was successfully completed on
     // the peer, or if a fatal error occurred. This will be false if the command can be re-tried later (for instance, if
     // no connection to leader could be made).

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -458,9 +458,12 @@ list<STable> SQLiteNode::getPeerInfo() const {
     return peerData;
 }
 
-string SQLiteNode::getEligibleFollowerForForwarding() const {
+string SQLiteNode::getEligibleFollowerForForwardingAddress() const {
     vector<string> validPeers;
     const string leaderVersion = getLeaderVersion();
+    if (leaderVersion.empty()) {
+        return "";
+    }
     for (SQLitePeer* peer : _peerList) {
         // We want only nodes that are using the same version as leader and are currently followers
         if (peer->version.load() != leaderVersion || peer->state.load() != SQLiteNodeState::FOLLOWING) {
@@ -471,7 +474,7 @@ string SQLiteNode::getEligibleFollowerForForwarding() const {
     if (validPeers.empty()) {
         return "";
     }
-    return validPeers[rand() % validPeers.size()];
+    return getPeerByName(validPeers[rand() % validPeers.size()])->commandAddress.load();
 }
 
 // --------------------------------------------------------------------------

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -447,6 +447,22 @@ list<STable> SQLiteNode::getPeerInfo() const {
     return peerData;
 }
 
+string SQLiteNode::getEligibleFollowerForForwarding() const {
+    vector<string> validPeers;
+    const string leaderVersion = getLeaderVersion();
+    for (SQLitePeer* peer : _peerList) {
+        // We want only nodes that are using the same version as leader and are currently followers
+        if (peer->version.load() != leaderVersion || peer->state.load() != SQLiteNodeState::FOLLOWING) {
+            continue;
+        }
+        validPeers.push_back(peer->name);
+    }
+    if (validPeers.empty()) {
+        return "";
+    }
+    return validPeers[rand() % validPeers.size()];
+}
+
 // --------------------------------------------------------------------------
 // State Machine
 // --------------------------------------------------------------------------

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -106,6 +106,9 @@ class SQLiteNode : public STCPManager {
     // Can block.
     list<STable> getPeerInfo() const;
 
+    // Gets a random follower peer that is in the same version as leader.
+    string getEligibleFollowerForForwarding() const;
+
     // Returns our current priority.
     // Does not block.
     int getPriority() const;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -107,7 +107,7 @@ class SQLiteNode : public STCPManager {
     list<STable> getPeerInfo() const;
 
     // Gets a random follower peer that is in the same version as leader.
-    string getEligibleFollowerForForwarding() const;
+    string getEligibleFollowerForForwardingAddress() const;
 
     // Returns our current priority.
     // Does not block.

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -85,7 +85,6 @@ ClusterTester<T>::ClusterTester(ClusterSize size,
         STHROW("Couldn't get CWD");
     }
     if (SFileExists(string(cwd) + "/testplugin/testplugin.so") && !SContains(pluginsToLoad, "testplugin")) {
-        SINFO("LOADING TESTPLUGIN");
         pluginsToLoad += pluginsToLoad.size() ? "," : "";
         pluginsToLoad += string(cwd) + "/testplugin/testplugin.so";
     }

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -85,6 +85,7 @@ ClusterTester<T>::ClusterTester(ClusterSize size,
         STHROW("Couldn't get CWD");
     }
     if (SFileExists(string(cwd) + "/testplugin/testplugin.so") && !SContains(pluginsToLoad, "testplugin")) {
+        SINFO("LOADING TESTPLUGIN");
         pluginsToLoad += pluginsToLoad.size() ? "," : "";
         pluginsToLoad += string(cwd) + "/testplugin/testplugin.so";
     }

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -117,12 +117,6 @@ TestPluginCommand::TestPluginCommand(SQLiteCommand&& baseCommand, BedrockPlugin_
 
 TestPluginCommand::~TestPluginCommand()
 {
-    // This line will generate the node list that processed the command. 
-    // If the current node is on the right version of the cluster, then it will return the node itself
-    // If it's not on the right version, it will escalate to another follower
-    // The names will be generated in a way the the left-most node name is the last escalation step
-    response["nodesPath"] = string(response["nodesPath"]).empty() ? args["-nodeName"] : args["-nodeName"] +  "," + response["nodesPath"];
-
     if (request.methodLine == "testescalate") {
         string serverState = SQLiteNode::stateName(plugin().server.getState());
         string statString = "Destroying testescalate (" + serverState + ")\n";

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -103,7 +103,6 @@ unique_ptr<BedrockCommand> BedrockPlugin_TestPlugin::getCommand(SQLiteCommand&& 
     };
     for (auto& cmdName : supportedCommands) {
         if (SStartsWith(baseCommand.request.methodLine, cmdName)) {
-            SINFO("Called test plugin method " + baseCommand.request.methodLine);
             return make_unique<TestPluginCommand>(move(baseCommand), this);
         }
     }
@@ -345,15 +344,8 @@ bool TestPluginCommand::peek(SQLite& db) {
         fileAppend(request["tempFile"], statString);
         return false;
     } else if (request.methodLine == "testquery") {
-        const string nodeName = plugin().server.args["-nodeName"];
-        
-        // This line will generate the node list that processed the command. 
-        // If the current node is on the right version of the cluster, then it will return the node itself
-        // If it's not on the right version, it will escalate to another follower
-        // The names will be generated in a way the the left-most node name is the last escalation step
-        response["nodesPath"] = string(response["nodesPath"]).empty() ? nodeName : nodeName +  "," + response["nodesPath"];
-
-        if (SStartsWith(request["Query"], "select")) {
+        response["nodeRequestWasExecuted"] = plugin().server.args["-nodeName"];
+        if (SStartsWith(request["Query"], "SELECT")) {
             db.read(request["Query"]);
             return true;
         }

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -117,6 +117,12 @@ TestPluginCommand::TestPluginCommand(SQLiteCommand&& baseCommand, BedrockPlugin_
 
 TestPluginCommand::~TestPluginCommand()
 {
+    // This line will generate the node list that processed the command. 
+    // If the current node is on the right version of the cluster, then it will return the node itself
+    // If it's not on the right version, it will escalate to another follower
+    // The names will be generated in a way the the left-most node name is the last escalation step
+    response["nodesPath"] = string(response["nodesPath"]).empty() ? args["-nodeName"] : args["-nodeName"] +  "," + response["nodesPath"];
+
     if (request.methodLine == "testescalate") {
         string serverState = SQLiteNode::stateName(plugin().server.getState());
         string statString = "Destroying testescalate (" + serverState + ")\n";

--- a/test/clustertest/tests/VersionMismatchTest.cpp
+++ b/test/clustertest/tests/VersionMismatchTest.cpp
@@ -12,7 +12,7 @@ struct VersionMismatchTest : tpunit::TestFixture {
     BedrockClusterTester* tester = nullptr;
 
     void setup() { 
-        tester = new BedrockClusterTester(ClusterSize::SIX_NODE_CLUSTER, {"CREATE TABLE test (id INTEGER NOT NULL PRIMARY KEY, value TEXT NOT NULL)"});
+        tester = new BedrockClusterTester(ClusterSize::FIVE_NODE_CLUSTER, {"CREATE TABLE test (id INTEGER NOT NULL PRIMARY KEY, value TEXT NOT NULL)"});
         // Restart one of the followers on a new version.
         tester->getTester(2).stopServer();
         tester->getTester(2).updateArgs({{"-versionOverride", "ABCDE"}});
@@ -37,11 +37,11 @@ struct VersionMismatchTest : tpunit::TestFixture {
             // For read commands sent directly to leader, or to a follower on the same version as leader, there
             // should be no upstream times. However, on a follower on a different version to leader, it should
             // escalates even read commands.
-            if (i == 2){
+            if (i == 2) {
                 ASSERT_TRUE(SStartsWith(result["nodesPath"], "cluster_node_2"));
                 ASSERT_EQUAL(result["nodesPath"].length(), 29);
             }
-            if (i == 4){
+            if (i == 4) {
                 ASSERT_TRUE(SStartsWith(result["nodesPath"], "cluster_node_4"));
                 ASSERT_EQUAL(result["nodesPath"].length(), 29);
             }
@@ -62,13 +62,13 @@ struct VersionMismatchTest : tpunit::TestFixture {
             // For read commands sent directly to leader, or to a follower on the same version as leader, there
             // should be no upstream times. However, on a follower on a different version to leader, it should
             // escalates even read commands.
-            if (i == 0){
+            if (i == 0) {
                 ASSERT_EQUAL(result["nodesPath"], "cluster_node_0");
             }
-            if (i == 1){
+            if (i == 1) {
                 ASSERT_EQUAL(result["nodesPath"], "cluster_node_1,cluster_node_0");
             }
-            if (i == 2){
+            if (i == 2) {
                 ASSERT_TRUE(SEndsWith(result["nodesPath"], "cluster_node_0"));
 
                 // Since the follower selection is ramdon, there's no way to guarantee which server will
@@ -77,7 +77,7 @@ struct VersionMismatchTest : tpunit::TestFixture {
                 // length: cluster_node_2,cluster_node_3,cluster_node_0 = 44
                 ASSERT_EQUAL(result["nodesPath"].length(), 44);
             }
-            if (i == 3){
+            if (i == 3) {
                 ASSERT_EQUAL(result["nodesPath"], "cluster_node_3,cluster_node_0");
             }
             if (i == 4) {
@@ -87,9 +87,6 @@ struct VersionMismatchTest : tpunit::TestFixture {
                 // only 3 servers in the path.
                 // length: cluster_node_4,cluster_node_3,cluster_node_0 = 44
                 ASSERT_EQUAL(result["nodesPath"].length(), 44);
-            }
-            if (i == 5){
-                ASSERT_EQUAL(result["nodesPath"], "cluster_node_5,cluster_node_0");
             }
         }
     }

--- a/test/clustertest/tests/VersionMismatchTest.cpp
+++ b/test/clustertest/tests/VersionMismatchTest.cpp
@@ -38,12 +38,12 @@ struct VersionMismatchTest : tpunit::TestFixture {
             // should be no upstream times. However, on a follower on a different version to leader, it should
             // escalates even read commands.
             if (i == 2){
-                ASSERT_TRUE(SStartsWith(result["nodeNames"], "cluster_node_2"));
-                ASSERT_EQUAL(result["nodeNames"].length(), 29);
+                ASSERT_TRUE(SStartsWith(result["nodesPath"], "cluster_node_2"));
+                ASSERT_EQUAL(result["nodesPath"].length(), 29);
             }
             if (i == 4){
-                ASSERT_TRUE(SStartsWith(result["nodeNames"], "cluster_node_4"));
-                ASSERT_EQUAL(result["nodeNames"].length(), 29);
+                ASSERT_TRUE(SStartsWith(result["nodesPath"], "cluster_node_4"));
+                ASSERT_EQUAL(result["nodesPath"].length(), 29);
             }
         }
     }
@@ -63,33 +63,33 @@ struct VersionMismatchTest : tpunit::TestFixture {
             // should be no upstream times. However, on a follower on a different version to leader, it should
             // escalates even read commands.
             if (i == 0){
-                ASSERT_EQUAL(result["nodeNames"], "cluster_node_0");
+                ASSERT_EQUAL(result["nodesPath"], "cluster_node_0");
             }
             if (i == 1){
-                ASSERT_EQUAL(result["nodeNames"], "cluster_node_1,cluster_node_0");
+                ASSERT_EQUAL(result["nodesPath"], "cluster_node_1,cluster_node_0");
             }
             if (i == 2){
-                ASSERT_TRUE(SEndsWith(result["nodeNames"], "cluster_node_0"));
+                ASSERT_TRUE(SEndsWith(result["nodesPath"], "cluster_node_0"));
 
                 // Since the follower selection is ramdon, there's no way to guarantee which server will
                 // be the one in the middle. So let's just confirm that the string size is enough to do
                 // only 3 servers in the path.
                 // length: cluster_node_2,cluster_node_3,cluster_node_0 = 44
-                ASSERT_EQUAL(result["nodeNames"].length(), 44);
+                ASSERT_EQUAL(result["nodesPath"].length(), 44);
             }
             if (i == 3){
-                ASSERT_EQUAL(result["nodeNames"], "cluster_node_3,cluster_node_0");
+                ASSERT_EQUAL(result["nodesPath"], "cluster_node_3,cluster_node_0");
             }
             if (i == 4) {
-                ASSERT_TRUE(SEndsWith(result["nodeNames"], "cluster_node_0"));
+                ASSERT_TRUE(SEndsWith(result["nodesPath"], "cluster_node_0"));
                 // Since the follower selection is ramdon, there's no way to guarantee which server will
                 // be the one in the middle. So let's just confirm that the string size is enough to do
                 // only 3 servers in the path.
                 // length: cluster_node_4,cluster_node_3,cluster_node_0 = 44
-                ASSERT_EQUAL(result["nodeNames"].length(), 44);
+                ASSERT_EQUAL(result["nodesPath"].length(), 44);
             }
             if (i == 5){
-                ASSERT_EQUAL(result["nodeNames"], "cluster_node_5,cluster_node_0");
+                ASSERT_EQUAL(result["nodesPath"], "cluster_node_5,cluster_node_0");
             }
         }
     }

--- a/test/clustertest/tests/VersionMismatchTest.cpp
+++ b/test/clustertest/tests/VersionMismatchTest.cpp
@@ -4,37 +4,42 @@
 struct VersionMismatchTest : tpunit::TestFixture {
     VersionMismatchTest()
         : tpunit::TestFixture("VersionMismatch", 
+            BEFORE_CLASS(VersionMismatchTest::setup),
             TEST(VersionMismatchTest::testReadEscalation), 
-            TEST(VersionMismatchTest::testWriteEscalation)) { }
+            TEST(VersionMismatchTest::testWriteEscalation),
+            AFTER_CLASS(VersionMismatchTest::setup)) { }
 
+    BedrockClusterTester* tester = nullptr;
+
+    void setup() { 
+        tester = new BedrockClusterTester(ClusterSize::THREE_NODE_CLUSTER, {"CREATE TABLE test (id INTEGER NOT NULL PRIMARY KEY, value TEXT NOT NULL)"});
+    }
+    void destroy() {
+        delete tester;
+    }
     void testReadEscalation()
     {
-        // Create a cluster.
-        BedrockClusterTester tester;
-
         // Restart one of the followers on a new version.
-        tester.getTester(2).stopServer();
-        tester.getTester(2).updateArgs({{"-versionOverride", "ABCDE"}});
-        tester.getTester(2).startServer();
+        tester->getTester(2).stopServer();
+        tester->getTester(2).updateArgs({{"-versionOverride", "ABCDE"}});
+        tester->getTester(2).startServer();
 
         // Send a query to all three and make sure the version-mismatched one escalates.
         // Can do them all in parallel so might as well.
         list<thread> threads;
         for (size_t i = 0; i < 3; i++) {
-            threads.emplace_back([this, i, &tester](){
-                SData command("Query");
-                command["Query"] = "SELECT 1;";
-                auto result = tester.getTester(i).executeWaitMultipleData({command})[0];
+            SData command("Query");
+            command["Query"] = "SELECT 1;";
+            auto result = tester->getTester(i).executeWaitMultipleData({command})[0];
 
-                // For read commands sent directly to leader, or to a follower on the same version as leader, there
-                // should be no upstream times. However, on a follower on a different version to leader, it should
-                // escalates even read commands.
-                if (i == 2){
-                    ASSERT_TRUE(SContains(result["nodeNames"], ","));
-                    // Since this is a read query, let's confirm it's being escalated to another follower first
-                    ASSERT_EQUAL(result["nodeNames"], "cluster_node_2,cluster_node_1");
-                }
-            });
+            // For read commands sent directly to leader, or to a follower on the same version as leader, there
+            // should be no upstream times. However, on a follower on a different version to leader, it should
+            // escalates even read commands.
+            if (i == 2){
+                ASSERT_TRUE(SContains(result["nodeNames"], ","));
+                // Since this is a read query, let's confirm it's being escalated to another follower first
+                ASSERT_EQUAL(result["nodeNames"], "cluster_node_2,cluster_node_1");
+            }
         }
         for (auto& t : threads) {
             t.join();
@@ -42,36 +47,31 @@ struct VersionMismatchTest : tpunit::TestFixture {
     }
     void testWriteEscalation()
     {
-        // Create a cluster.
-        BedrockClusterTester tester;
-
         // Restart one of the followers on a new version.
-        tester.getTester(2).stopServer();
-        tester.getTester(2).updateArgs({{"-versionOverride", "ABCDE"}});
-        tester.getTester(2).startServer();
+        tester->getTester(2).stopServer();
+        tester->getTester(2).updateArgs({{"-versionOverride", "ABCDE"}});
+        tester->getTester(2).startServer();
 
         // Send a query to all three and make sure the version-mismatched one escalates.
         // Can do them all in parallel so might as well.
         list<thread> threads;
         for (int64_t i = 0; i < 3; i++) {
-            threads.emplace_back([this, i, &tester](){
-                SData command("Query");
-                command["Query"] = "INSERT INTO test VALUES(" + SQ(i) + ", " + SQ("val") + ");";
-                auto result = tester.getTester(i).executeWaitMultipleData({command})[0];
+            SData command("Query");
+            command["Query"] = "INSERT INTO test VALUES(" + SQ(i) + ", " + SQ("val") + ");";
+            auto result = tester->getTester(i).executeWaitMultipleData({command})[0];
 
-                // For read commands sent directly to leader, or to a follower on the same version as leader, there
-                // should be no upstream times. However, on a follower on a different version to leader, it should
-                // escalates even read commands.
-                if (i == 0){
-                    ASSERT_EQUAL(result["nodeNames"], "cluster_node_0");
-                }
-                if (i == 1){
-                    ASSERT_EQUAL(result["nodeNames"], "cluster_node_1,cluster_node_0");
-                }
-                if (i == 2){
-                    ASSERT_EQUAL(result["nodeNames"], "cluster_node_2,cluster_node_1,cluster_node_0");
-                }
-            });
+            // For read commands sent directly to leader, or to a follower on the same version as leader, there
+            // should be no upstream times. However, on a follower on a different version to leader, it should
+            // escalates even read commands.
+            if (i == 0){
+                ASSERT_EQUAL(result["nodeNames"], "cluster_node_0");
+            }
+            if (i == 1){
+                ASSERT_EQUAL(result["nodeNames"], "cluster_node_1,cluster_node_0");
+            }
+            if (i == 2){
+                ASSERT_EQUAL(result["nodeNames"], "cluster_node_2,cluster_node_1,cluster_node_0");
+            }
         }
 
         for (auto& t : threads) {

--- a/test/clustertest/tests/VersionMismatchTest.cpp
+++ b/test/clustertest/tests/VersionMismatchTest.cpp
@@ -3,9 +3,11 @@
 
 struct VersionMismatchTest : tpunit::TestFixture {
     VersionMismatchTest()
-        : tpunit::TestFixture("VersionMismatch", TEST(VersionMismatchTest::test)) { }
+        : tpunit::TestFixture("VersionMismatch", 
+            TEST(VersionMismatchTest::testReadEscalation), 
+            TEST(VersionMismatchTest::testWriteEscalation)) { }
 
-    void test()
+    void testReadEscalation()
     {
         // Create a cluster.
         BedrockClusterTester tester;
@@ -27,9 +29,51 @@ struct VersionMismatchTest : tpunit::TestFixture {
                 // For read commands sent directly to leader, or to a follower on the same version as leader, there
                 // should be no upstream times. However, on a follower on a different version to leader, it should
                 // escalates even read commands.
-                ASSERT_EQUAL(result.isSet("upstreamPeekTime"), i == 2);
+                if (i == 2){
+                    ASSERT_TRUE(SContains(result["nodeNames"], ","));
+                    // Since this is a read query, let's confirm it's being escalated to another follower first
+                    ASSERT_EQUAL(result["nodeNames"], "cluster_node_2,cluster_node_1");
+                }
             });
         }
+        for (auto& t : threads) {
+            t.join();
+        }
+    }
+    void testWriteEscalation()
+    {
+        // Create a cluster.
+        BedrockClusterTester tester;
+
+        // Restart one of the followers on a new version.
+        tester.getTester(2).stopServer();
+        tester.getTester(2).updateArgs({{"-versionOverride", "ABCDE"}});
+        tester.getTester(2).startServer();
+
+        // Send a query to all three and make sure the version-mismatched one escalates.
+        // Can do them all in parallel so might as well.
+        list<thread> threads;
+        for (int64_t i = 0; i < 3; i++) {
+            threads.emplace_back([this, i, &tester](){
+                SData command("Query");
+                command["Query"] = "INSERT INTO test VALUES(" + SQ(i) + ", " + SQ("val") + ");";
+                auto result = tester.getTester(i).executeWaitMultipleData({command})[0];
+
+                // For read commands sent directly to leader, or to a follower on the same version as leader, there
+                // should be no upstream times. However, on a follower on a different version to leader, it should
+                // escalates even read commands.
+                if (i == 0){
+                    ASSERT_EQUAL(result["nodeNames"], "cluster_node_0");
+                }
+                if (i == 1){
+                    ASSERT_EQUAL(result["nodeNames"], "cluster_node_1,cluster_node_0");
+                }
+                if (i == 2){
+                    ASSERT_EQUAL(result["nodeNames"], "cluster_node_2,cluster_node_1,cluster_node_0");
+                }
+            });
+        }
+
         for (auto& t : threads) {
             t.join();
         }

--- a/test/clustertest/tests/VersionMismatchTest.cpp
+++ b/test/clustertest/tests/VersionMismatchTest.cpp
@@ -42,7 +42,7 @@ struct VersionMismatchTest : tpunit::TestFixture {
                 ASSERT_EQUAL(result["nodeNames"].length(), 29);
             }
             if (i == 4){
-                ASSERT_TRUE(SStartsWith(result["nodeNames"], "cluster_node_4");
+                ASSERT_TRUE(SStartsWith(result["nodeNames"], "cluster_node_4"));
                 ASSERT_EQUAL(result["nodeNames"].length(), 29);
             }
         }

--- a/test/clustertest/tests/VersionMismatchTest.cpp
+++ b/test/clustertest/tests/VersionMismatchTest.cpp
@@ -38,11 +38,12 @@ struct VersionMismatchTest : tpunit::TestFixture {
             // should be no upstream times. However, on a follower on a different version to leader, it should
             // escalates even read commands.
             if (i == 2){
-                ASSERT_EQUAL(result["nodeNames"], "cluster_node_2,cluster_node_1");
+                ASSERT_TRUE(SStartsWith(result["nodeNames"], "cluster_node_2"));
+                ASSERT_EQUAL(result["nodeNames"].length(), 29);
             }
-            if (i == 5){
-                
-                ASSERT_EQUAL(result["nodeNames"], "cluster_node_5,cluster_node_1");
+            if (i == 4){
+                ASSERT_TRUE(SStartsWith(result["nodeNames"], "cluster_node_4");
+                ASSERT_EQUAL(result["nodeNames"].length(), 29);
             }
         }
     }

--- a/test/clustertest/tests/VersionMismatchTest.cpp
+++ b/test/clustertest/tests/VersionMismatchTest.cpp
@@ -12,7 +12,7 @@ struct VersionMismatchTest : tpunit::TestFixture {
     BedrockClusterTester* tester = nullptr;
 
     void setup() { 
-        tester = new BedrockClusterTester(ClusterSize::FIVE_NODE_CLUSTER, {"CREATE TABLE test (id INTEGER NOT NULL PRIMARY KEY, value TEXT NOT NULL)"});
+        tester = new BedrockClusterTester(ClusterSize::FIVE_NODE_CLUSTER, {"CREATE TABLE test (id INTEGER NOT NULL PRIMARY KEY, value TEXT NOT NULL)"}, {}, {}, "testplugin");
         // Restart one of the followers on a new version.
         tester->getTester(2).stopServer();
         tester->getTester(2).updateArgs({{"-versionOverride", "ABCDE"}});
@@ -30,7 +30,7 @@ struct VersionMismatchTest : tpunit::TestFixture {
     {
         // Send a query to all three and make sure the version-mismatched one escalates.
         for (size_t i = 0; i < 5; i++) {
-            SData command("Query");
+            SData command("testquery");
             command["Query"] = "SELECT 1;";
             auto result = tester->getTester(i).executeWaitMultipleData({command})[0];
 
@@ -55,7 +55,7 @@ struct VersionMismatchTest : tpunit::TestFixture {
         tester->getTester(2).startServer();
 
         for (int64_t i = 0; i < 5; i++) {
-            SData command("Query");
+            SData command("testquery");
             command["Query"] = "INSERT INTO test VALUES(" + SQ(i) + ", " + SQ("val") + ");";
             auto result = tester->getTester(i).executeWaitMultipleData({command})[0];
 


### PR DESCRIPTION
### Details

Now when there's a version mismatch, instead of escalating to the leader, we'll escalate to another follower. This will prevent a high CPU usage on leader during deploys.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/170599

### Tests
- Added tests to VersionMismatch
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
