### PR TITLE
Reset '_upgradeCompleted' when we stop leading.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -316,12 +316,14 @@ void BedrockServer::sync()
             // If we bailed out while doing a upgradeDB, clear state
             if (_upgradeInProgress) {
                 _upgradeInProgress = false;
-                _upgradeCompleted = false;
                 if (committingCommand) {
                     db.rollback();
                     committingCommand = false;
                 }
             }
+
+            // If we're not leading, we're not upgrading, but we will need to check for upgrades again next time we go leading, so be ready for that.
+            _upgradeCompleted = false;
 
             // We should give up an any commands, and let them be re-escalated. If commands were initiated locally,
             // we can just re-queue them, they will get re-checked once things clear up, and then they'll get

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -316,6 +316,7 @@ void BedrockServer::sync()
             // If we bailed out while doing a upgradeDB, clear state
             if (_upgradeInProgress) {
                 _upgradeInProgress = false;
+                _upgradeCompleted = false;
                 if (committingCommand) {
                     db.rollback();
                     committingCommand = false;


### PR DESCRIPTION
### Details
https://expensify.slack.com/archives/C05QUDDG4LQ/p1693350528605589

When the server stops leading, reset `_upgradeCompleted` so it can go from `false` to `true` again the next time the server starts to lead.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
