### PR TITLE
Add flag to allow running 'prepare' with no writes

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -20,6 +20,7 @@ BedrockCommand::BedrockCommand(SQLiteCommand&& baseCommand, BedrockPlugin* plugi
     socket(nullptr),
     scheduledTime(request.isSet("commandExecuteTime") ? request.calc64("commandExecuteTime") : STimeNow()),
     _plugin(plugin),
+    _commitEmptyTransactions(false),
     _inProgressTiming(INVALID, 0, 0),
     _timeout(_getTimeout(request, scheduledTime))
 {
@@ -297,4 +298,8 @@ void BedrockCommand::setTimeout(uint64_t timeoutDurationMS) {
     timeoutDurationMS *= 1'000;
     timeoutDurationMS += STimeNow();
     _timeout = timeoutDurationMS;
+}
+
+bool BedrockCommand::shouldCommitEmptyTransactions() const {
+    return _commitEmptyTransactions;
 }

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -207,9 +207,16 @@ class BedrockCommand : public SQLiteCommand {
     // Time at which this command was initially scheduled (typically the time of creation).
     const uint64_t scheduledTime;
 
+    // Returns _commitEmptyTransactions.
+    bool shouldCommitEmptyTransactions() const;
+
   protected:
     // The plugin that owns this command.
     BedrockPlugin* _plugin;
+
+    // Commands can set this flag to indicate they want the commit process to be run even though it doesn't appear that any writes have occurred.
+    // The main use of this is to cause commands that use SQLite::onPrepareHandler to do additional writing to run these final writes.
+    bool _commitEmptyTransactions;
 
   private:
     // Set certain initial state on construction. Common functionality to several constructors.

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -278,7 +278,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
         }
 
         // If we have no uncommitted query, just rollback the empty transaction. Otherwise, we need to commit.
-        if (_db.getUncommittedQuery().empty()) {
+        if (_db.getUncommittedQuery().empty() && !command->shouldCommitEmptyTransactions()) {
             _db.rollback();
         } else {
             needsCommit = true;


### PR DESCRIPTION
### Details

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/302454

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
