### PR TITLE
Make DB reads logically const - and fix timeout crash.

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -445,7 +445,7 @@ bool SQLite::addColumn(const string& tableName, const string& column, const stri
     return false;
 }
 
-string SQLite::read(const string& query) {
+string SQLite::read(const string& query) const {
     // Execute the read-only query
     SQResult result;
     if (!read(query, result)) {
@@ -457,7 +457,7 @@ string SQLite::read(const string& query) {
     return result[0][0];
 }
 
-bool SQLite::read(const string& query, SQResult& result) {
+bool SQLite::read(const string& query, SQResult& result) const {
     uint64_t before = STimeNow();
     bool queryResult = false;
     _queryCount++;
@@ -478,7 +478,7 @@ bool SQLite::read(const string& query, SQResult& result) {
     return queryResult;
 }
 
-void SQLite::_checkInterruptErrors(const string& error) {
+void SQLite::_checkInterruptErrors(const string& error) const {
 
     // Local error code.
     int errorCode = 0;
@@ -1011,7 +1011,7 @@ void SQLite::startTiming(uint64_t timeLimitUS) {
     _timeoutError = 0;
 }
 
-void SQLite::resetTiming() {
+void SQLite::resetTiming() const {
     _timeoutLimit = 0;
     _timeoutStart = 0;
     _timeoutError = 0;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -492,7 +492,6 @@ void SQLite::_checkInterruptErrors(const string& error) const {
         }
         if (_timeoutError) {
             time = _timeoutError;
-            resetTiming();
             errorCode = 1;
         }
     }
@@ -1005,13 +1004,13 @@ int SQLite::_authorize(int actionCode, const char* detail1, const char* detail2,
     return SQLITE_DENY;
 }
 
-void SQLite::startTiming(uint64_t timeLimitUS) {
+void SQLite::setTimeout(uint64_t timeLimitUS) {
     _timeoutStart = STimeNow();
     _timeoutLimit = _timeoutStart + timeLimitUS;
     _timeoutError = 0;
 }
 
-void SQLite::resetTiming() const {
+void SQLite::clearTimeout() {
     _timeoutLimit = 0;
     _timeoutStart = 0;
     _timeoutError = 0;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -223,11 +223,11 @@ class SQLite {
     // Looks up a range of commits.
     bool getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result);
 
-    // Start a timing operation, that will time out after the given number of microseconds.
-    void startTiming(uint64_t timeLimitUS);
+    // Set a time limit for this transaction, in US from the current time.
+    void setTimeout(uint64_t timeLimitUS);
 
-    // Reset timing after finishing a timed operation.
-    void resetTiming() const;
+    // Reset all timeout information to 0, to be ready for the next operation.
+    void clearTimeout();
 
     // This atomically removes and returns committed transactions from our internal list. SQLiteNode can call this, and
     // it will return a map of transaction IDs to tuples of (query, hash, dbCountAtTransactionStart), so that those

--- a/test/clustertest/tests/TimeoutTest.cpp
+++ b/test/clustertest/tests/TimeoutTest.cpp
@@ -10,6 +10,7 @@ struct TimeoutTest : tpunit::TestFixture {
                               TEST(TimeoutTest::test),
                               TEST(TimeoutTest::longerThanDefaultProcess),
                               TEST(TimeoutTest::testprocess),
+                              TEST(TimeoutTest::testPostProcess),
                               TEST(TimeoutTest::totalTimeout),
                               TEST(TimeoutTest::quorumHTTPS),
                               TEST(TimeoutTest::futureCommitTimeout)) { }
@@ -78,6 +79,13 @@ struct TimeoutTest : tpunit::TestFixture {
         slow["size"] = "100";
         slow["count"] = "10000";
         brtester.executeWaitVerifyContent(slow, "555 Timeout processing command");
+    }
+
+    void testPostProcess() {
+        BedrockTester& brtester = tester->getTester(0);
+        SData slow("testPostProcessTimeout");
+        slow["timeout"] = "500"; // 0.5s
+        brtester.executeWaitVerifyContent(slow, "555 Timeout postProcessing command");
     }
 
     void totalTimeout() {


### PR DESCRIPTION
### Details
I was doing a minor refactor to `SQLite` to make the read methods `const` so that eventually auth library functions can also be `const`.

This changed the signature on a couple of `SQLite` methods to add `const`, and changed some internal state variables to be `mutable` allowing them to change even in const methods. This is because we do store state for the query cache and timeout info that needs to change as we do reads. However, a caller (like auth) doing `db.read()` should be able to logically treat this as not changing the state of the DB object, so we allow this.

While doing this, I noticed that the way the `try/catch` blocks in `postProcess` would not correctly catch and re-throw a `SQLite::timeout_error` the same way that (for example) `peekCommand` and `processCommand` do. I have fixed the `try/catch` here as well and added a test case for it.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/318225

### Tests
Added a new test for the timeout case. Without the modified try/catch block, bedrock crashes and the test fails.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
```
[ TEST RESULTS ] Passed: 2319, Failed: 0
```