### PR TITLE
Check for forked nodes in WAITING to allow standup even if forked peer is fresher.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -690,13 +690,13 @@ bool SQLiteNode::update() {
         SQLitePeer* currentLeader = nullptr;
         for (auto peer : _peerList) {
             if (peer->permaFollower) {
-                // Permafollowers are none of the things we care about.
+                // Permafollowers are treated as ineligible for leader, etc.
                 continue;
             }
 
             if (_forkedFrom.count(peer->name)) {
-                SHMMM("Not counting forked peer " << peer->name << " for freshest, highestPriority, or currentLeader"); 
-                // Forked nodes are treated as ineligible as leader, etc.
+                // Forked nodes are treated as ineligible for leader, etc.
+                SHMMM("Not counting forked peer " << peer->name << " for freshest, highestPriority, or currentLeader.");
                 continue;
             }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -689,28 +689,38 @@ bool SQLiteNode::update() {
         SQLitePeer* freshestPeer = nullptr;
         SQLitePeer* currentLeader = nullptr;
         for (auto peer : _peerList) {
-            // Make sure we're a full peer
-            if (!peer->permaFollower) {
-                // Verify we're logged in
-                ++numFullPeers;
-                if (peer->loggedIn) {
-                    // Verify we're still fresh
-                    ++numLoggedInFullPeers;
-                    if (!freshestPeer || peer->commitCount > freshestPeer->commitCount)
-                        freshestPeer = peer;
+            if (peer->permaFollower) {
+                // Permafollowers are none of the things we care about.
+                continue;
+            }
 
-                    // See if it's the highest priority
-                    if (!highestPriorityPeer || peer->priority > highestPriorityPeer->priority)
-                        highestPriorityPeer = peer;
+            if (_forkedFrom.count(peer->name)) {
+                SHMMM("Not counting forked peer " << peer->name << " for freshest, highestPriority, or currentLeader"); 
+                // Forked nodes are treated as ineligible as leader, etc.
+                continue;
+            }
 
-                    // See if it is currently the leader (or standing up/down)
-                    if (peer->state == SQLiteNodeState::STANDINGUP || peer->state == SQLiteNodeState::LEADING || peer->state == SQLiteNodeState::STANDINGDOWN) {
-                        // Found the current leader
-                        if (currentLeader)
-                            PHMMM("Multiple peers trying to stand up (also '" << currentLeader->name
-                                                                              << "'), let's hope they sort it out.");
-                        currentLeader = peer;
+            // Verify we're logged in
+            ++numFullPeers;
+            if (peer->loggedIn) {
+                // Verify we're still fresh
+                ++numLoggedInFullPeers;
+                if (!freshestPeer || peer->commitCount > freshestPeer->commitCount) {
+                    freshestPeer = peer;
+                }
+
+                // See if it's the highest priority
+                if (!highestPriorityPeer || peer->priority > highestPriorityPeer->priority) {
+                    highestPriorityPeer = peer;
+                }
+
+                // See if it is currently the leader (or standing up/down)
+                if (peer->state == SQLiteNodeState::STANDINGUP || peer->state == SQLiteNodeState::LEADING || peer->state == SQLiteNodeState::STANDINGDOWN) {
+                    // Found the current leader
+                    if (currentLeader) {
+                        PHMMM("Multiple peers trying to stand up (also '" << currentLeader->name << "'), let's hope they sort it out.");
                     }
+                    currentLeader = peer;
                 }
             }
         }


### PR DESCRIPTION
### Details
I believe that this resolves a potential issue where we could refuse to stand up if we are connected to a forked leader.

Imagine node A is the highest priority, node B is second priority, etc.

Node A forks from the cluster.
Node B should become LEADER.

Node B is synchronized and ready to go, it changes state to WAITING, and returns from `update`.

On the next call to update, we run the `WAITING` case and find that there is a fresher peer than us (Node A) and so we do not attempt to stand up.

We will only go to WAITING after SYNCHRONIZING, but when synchronizing, we will only synchronize from [peers we are not forked from](https://github.com/Expensify/Bedrock/blob/d55f2177edf863a13fdb791661b92a629f2f9323/sqlitecluster/SQLiteNode.cpp#L2118-L2121).

After coming out of SYNCHRONIZING, if we are connected to the forked leader, and it still has newer commits than the rest of the cluster, [this line](https://github.com/Expensify/Bedrock/blob/d55f2177edf863a13fdb791661b92a629f2f9323/sqlitecluster/SQLiteNode.cpp#L699) will cause us not to attempt to stand up.

This is not a common case, as normally leader forks when it is disconnected, and we only realize we've forked from it much later, when it's highest commit (which may be a few dozen to a few hundred commits past the fork) is well behind the new leader's new highest commit, but the following is feasible:

Primary leader: commit 10,000
Secondary leader: commit 9,990
Primary leader disconnects.
Secondary leader takes over and commits 9,991-9,995.
Primary leader comes back up.
It is forked, and the cluster can not include it, but it is also freshest.

I believe if the above scenario occurs, secondary leader will not stand up so long as primary leader is connected.
There are a variety of cases where we'll cause a reconnect from a forked peer, so the above situation should be transient, but I still think this change is more correct.


### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
