### PR TITLE
Check for valid crash command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1839,6 +1839,10 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
     } else if (SIEquals(command->request.methodLine, "CRASH_COMMAND")) {
         SData request;
         request.deserialize(command->request.content);
+        if (request.empty()) {
+            SINFO("Got CRASH_COMMAND with malformed command body. Is someone running this by hand? Nothing to blacklist.");
+            return;
+        }
 
         // Take a unique lock so nobody else can read from this table while we update it.
         unique_lock<decltype(_crashCommandMutex)> lock(_crashCommandMutex);


### PR DESCRIPTION
### Details
On further inspection, I think all our confusion here was around @flodnv trying to send these by hand, and the incorrect commands don't log anything useful.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/320365

### Tests
N/A