### PR TITLE
Maintain cluster syncronization without quorum commands

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1937,7 +1937,7 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
 
         uint64_t newValue = command->request.calcU64("value");
         if (newValue < SQLiteNode::MIN_APPROVE_FREQUENCY) {
-            // We won't break everything in purpose. This can be used to check the existing value without changing anything by passing `0`.
+            // We won't break everything on purpose. This can be used to check the existing value without changing anything by passing `0`.
             response.methodLine = "400 Refusing to set peer fall behind below " + to_string(SQLiteNode::MIN_APPROVE_FREQUENCY);
         } else {
             // Set the new value and return 200 OK.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1936,9 +1936,9 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
         response["previousValue"] = to_string(existingValue);
 
         uint64_t newValue = command->request.calcU64("value");
-        if (newValue < 50) {
+        if (newValue < SQLiteNode::MIN_APPROVE_FREQUENCY) {
             // We won't break everything in purpose. This can be used to check the existing value without changing anything by passing `0`.
-            response.methodLine = "400 Refusing to set peer fall behind below 50";
+            response.methodLine = "400 Refusing to set peer fall behind below " + to_string(SQLiteNode::MIN_APPROVE_FREQUENCY);
         } else {
             // Set the new value and return 200 OK.
             SQLiteNode::MAX_PEER_FALL_BEHIND = newValue;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1801,6 +1801,7 @@ bool BedrockServer::_isControlCommand(const unique_ptr<BedrockCommand>& command)
         SIEquals(command->request.methodLine, "EnableSQLTracing")       ||
         SIEquals(command->request.methodLine, "BlockWrites")            ||
         SIEquals(command->request.methodLine, "UnblockWrites")          ||
+        SIEquals(command->request.methodLine, "SetMaxPeerFallBehind")   ||
         SIEquals(command->request.methodLine, "CRASH_COMMAND")
         ) {
         return true;
@@ -1933,6 +1934,20 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
             delete __quiesceThread;
             __quiesceThread = nullptr;
             response.methodLine = "200 Unblocked";
+        }
+    } else if (SIEquals(command->request.methodLine, "SetMaxPeerFallBehind")) {
+        // Look up the existing value so we can report what it was.
+        uint64_t existingValue = SQLiteNode::MAX_PEER_FALL_BEHIND;
+        response["previousValue"] = to_string(existingValue);
+
+        uint64_t newValue = command->request.calcU64("value");
+        if (newValue < 50) {
+            // We won't break everything in purpose. This can be used to check the existing value without changing anything by passing `0`.
+            response.methodLine = "400 Refusing to set peer fall behind below 50";
+        } else {
+            // Set the new value and return 200 OK.
+            SQLiteNode::MAX_PEER_FALL_BEHIND = newValue;
+            response["previousValue"] = to_string(existingValue);
         }
     }
 }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -323,13 +323,14 @@ SQLite::~SQLite() {
 }
 
 void SQLite::exclusiveLockDB() {
-    _sharedData.writeLock.lock();
+    // This is buggy, writeLock does not always get locked first. For exclusive transactions (sync thread, blockingCommit thread) commitLock is locked before anything is written.
+    // _sharedData.writeLock.lock();
     _sharedData.commitLock.lock();
 }
 
 void SQLite::exclusiveUnlockDB() {
     _sharedData.commitLock.unlock();
-    _sharedData.writeLock.unlock();
+    // _sharedData.writeLock.unlock();
 }
 
 bool SQLite::beginTransaction(TRANSACTION_TYPE type) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -64,7 +64,7 @@ const uint64_t SQLiteNode::RECV_TIMEOUT{STIME_US_PER_S * 30};
 
 // Setting this to 10 or lower may deadlock the server, as followers are only guaranteed to respond to every 10th message.
 // If the threshold for blocking commits is less than 10, we may block, but never receive a message indicating that we should unblock.
-atomic<uint64_t> SQLiteNode::MAX_PEER_FALL_BEHIND{20};
+atomic<uint64_t> SQLiteNode::MAX_PEER_FALL_BEHIND{500};
 
 const string SQLiteNode::CONSISTENCY_LEVEL_NAMES[] = {"ASYNC",
                                                     "ONE",
@@ -182,8 +182,6 @@ void SQLiteNode::_replicate(SQLitePeer* peer, SData command, size_t sqlitePoolIn
 
     // Actual thread startup time.
     uint64_t threadStartTime = STimeNow();
-
-    usleep(50'000);
 
     // Allow the DB handle to be returned regardless of how this function exits.
     SQLiteScopedHandle dbScope(*_dbPool, sqlitePoolIndex);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -64,7 +64,7 @@ const uint64_t SQLiteNode::RECV_TIMEOUT{STIME_US_PER_S * 30};
 
 // Setting this to 10 or lower may deadlock the server, as followers are only guaranteed to respond to every 10th message.
 // If the threshold for blocking commits is less than 10, we may block, but never receive a message indicating that we should unblock.
-atomic<uint64_t> SQLiteNode::MAX_PEER_FALL_BEHIND{20};
+atomic<uint64_t> SQLiteNode::MAX_PEER_FALL_BEHIND{500};
 
 const string SQLiteNode::CONSISTENCY_LEVEL_NAMES[] = {"ASYNC",
                                                     "ONE",
@@ -179,8 +179,6 @@ SQLiteNode::~SQLiteNode() {
 void SQLiteNode::_replicate(SQLitePeer* peer, SData command, size_t sqlitePoolIndex, uint64_t threadAttemptStartTimestamp) {
     // Initialize each new thread with a new number.
     SInitialize("replicate" + to_string(currentReplicateThreadID.fetch_add(1)));
-
-    usleep(50'000);
 
     // Actual thread startup time.
     uint64_t threadStartTime = STimeNow();

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1749,11 +1749,6 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                         }
                         PINFO("Peer " << response << " transaction #" << message["NewCount"] << " (" << message["NewHash"] << ")");
                         peer->transactionResponse = response;
-                    } else {
-                        // Old command.  Nothing to do.  We already sent a commit or rollback.
-                        // Shut this up.
-                        PINFO("Peer '" << message.methodLine << "' transaction #" << message["NewCount"]
-                              << " (" << message["NewHash"] << ") after " << (hashMatch ? "commit" : "rollback") << ".");
                     }
                 } catch (const SException& e) {
                     // Doesn't correspond to the outstanding transaction not necessarily fatal. This can happen if, for

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -61,7 +61,7 @@
 
 // Initializations for static vars.
 const uint64_t SQLiteNode::RECV_TIMEOUT{STIME_US_PER_S * 30};
-const uint64_t SQLiteNode::MAX_PEER_FALL_BEHIND{500};
+atomic<uint64_t> SQLiteNode::MAX_PEER_FALL_BEHIND{500};
 
 const string SQLiteNode::CONSISTENCY_LEVEL_NAMES[] = {"ASYNC",
                                                     "ONE",

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2348,7 +2348,7 @@ void SQLiteNode::_handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const S
 
     // Are we participating in quorum?
     if (_priority) {
-        // If the ID is /ASYNC_\d+/, leader will keep going regardless, but we send every 10th response anyway, jsut so leader keeps relatively current with our commit count.
+        // If the ID is /ASYNC_\d+/, leader will keep going regardless, but we send every 10th response anyway, just so leader keeps relatively current with our commit count.
         string verb = success ? "APPROVE_TRANSACTION" : "DENY_TRANSACTION";
         uint64_t currentCommitCount = db.getCommitCount();
         bool isAsync = SStartsWith(message["ID"], "ASYNC_");

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1273,7 +1273,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                 _commitsBlocked = false;
                 SWARN("[clustersync] Cluster is no longer behind by over " << MAX_PEER_FALL_BEHIND << " commits. Unblocking new commits.");
                 _db.exclusiveUnlockDB();
-            } else if (!quorumUpToDate && !_commitsBlocked) {
+            } else if (!quorumUpToDate && !_commitsBlocked && !_db.insideTransaction()) {
                 _commitsBlocked = true;
                 uint64_t myCommitCount = getCommitCount();
                 SWARN("[clustersync] Cluster is behind by over " << MAX_PEER_FALL_BEHIND << " commits. New commits blocked until the cluster catches up.");

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -64,7 +64,7 @@ const uint64_t SQLiteNode::RECV_TIMEOUT{STIME_US_PER_S * 30};
 
 // Setting this to 10 or lower may deadlock the server, as followers are only guaranteed to respond to every 10th message.
 // If the threshold for blocking commits is less than 10, we may block, but never receive a message indicating that we should unblock.
-atomic<uint64_t> SQLiteNode::MAX_PEER_FALL_BEHIND{500};
+atomic<uint64_t> SQLiteNode::MAX_PEER_FALL_BEHIND{20};
 
 const string SQLiteNode::CONSISTENCY_LEVEL_NAMES[] = {"ASYNC",
                                                     "ONE",
@@ -182,6 +182,8 @@ void SQLiteNode::_replicate(SQLitePeer* peer, SData command, size_t sqlitePoolIn
 
     // Actual thread startup time.
     uint64_t threadStartTime = STimeNow();
+
+    usleep(50'000);
 
     // Allow the DB handle to be returned regardless of how this function exits.
     SQLiteScopedHandle dbScope(*_dbPool, sqlitePoolIndex);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1252,7 +1252,8 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
         peer->setCommit(message.calcU64("CommitCount"), message["Hash"]);
 
         // If we're leading, see if this peer meets the definition of "up-to-date", which is to say, it's close enough to in-sync with us.
-        if (_state == SQLiteNodeState::LEADING) {
+        // We can skip checking if the peer is a permafollower, because we don't care about his state.
+        if (!peer->permaFollower && _state == SQLiteNodeState::LEADING) {
             if (peer->commitCount + MAX_PEER_FALL_BEHIND > getCommitCount()) {
                 _upToDatePeers.insert(peer);
             } else {
@@ -2008,7 +2009,7 @@ void SQLiteNode::_changeState(SQLiteNodeState newState) {
             // Mark peers that are up-to-date so we have a valid starting state.
             _upToDatePeers.clear();
             for (const auto& peer : _peerList) {
-                if (peer->commitCount + MAX_PEER_FALL_BEHIND > getCommitCount()) {
+                if (!peer->permaFollower && (peer->commitCount + MAX_PEER_FALL_BEHIND > getCommitCount())) {
                     _upToDatePeers.insert(peer);
                 }
             }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1719,7 +1719,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
             // is ready to commit. Note that this peer approves the transaction for use in the LEADING and STANDINGDOWN
             // update loop.
 
-            // If it's DENY or AsyncNotification is set means that it's not just a simple notification that the follower has some commit number.
+            // If it's DENY, or AsyncNotification isn't set, this means that it's not just a simple notification that the follower has some commit number.
             // It's either a real DENY, or a real APPROVE of a quorum transaction.
             if (SIEquals(message.methodLine, "DENY_TRANSACTION") || !message.isSet("AsyncNotification")) {
                 if (!message.isSet("ID")) {

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -79,6 +79,10 @@ class SQLiteNode : public STCPManager {
     // Receive timeout for cluster messages.
     static const uint64_t RECV_TIMEOUT;
 
+    // The minimum frequency of APPROVE_TRANSACTION messages we'll send when following, back to leader, to indicate our own current synchronization state.
+    // This is expressed as "every Nth message", where e.g., if MIN_APPROVE_FREQUENCY is 10, we will respond to at least every 10th BEGIN_TRANSACTION message.
+    static const size_t MIN_APPROVE_FREQUENCY;
+
     // The maximum number of commits behind we'll allow a quorum number of peers to be before we block commits on leader.
     static atomic<uint64_t> MAX_PEER_FALL_BEHIND;
 

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -80,7 +80,7 @@ class SQLiteNode : public STCPManager {
     static const uint64_t RECV_TIMEOUT;
 
     // The maximum number of commits behind we'll allow a quorum number of peers to be before we block commits on leader.
-    static const uint64_t MAX_PEER_FALL_BEHIND;
+    static atomic<uint64_t> MAX_PEER_FALL_BEHIND;
 
     // Get and SQLiteNode State from it's name.
     static SQLiteNodeState stateFromName(const string& name);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -79,6 +79,9 @@ class SQLiteNode : public STCPManager {
     // Receive timeout for cluster messages.
     static const uint64_t RECV_TIMEOUT;
 
+    // The maximum number of commits behind we'll allow a quorum number of peers to be before we block commits on leader.
+    static const uint64_t MAX_PEER_FALL_BEHIND;
+
     // Get and SQLiteNode State from it's name.
     static SQLiteNodeState stateFromName(const string& name);
 
@@ -193,6 +196,7 @@ class SQLiteNode : public STCPManager {
     static atomic<int64_t> currentReplicateThreadID;
 
     static const vector<SQLitePeer*> _initPeers(const string& peerList);
+    static size_t _initQuorumSize(const vector<SQLitePeer*>& _peerList, const int priority);
 
     // Queue a SYNCHRONIZE message based on the current state of the node, thread-safe, but you need to pass the
     // *correct* DB for the thread that's making the call (i.e., you can't use the node's internal DB from a worker
@@ -261,6 +265,11 @@ class SQLiteNode : public STCPManager {
     // When the node starts, it is not ready to serve requests without first connecting to the other nodes, and checking
     // to make sure it's up-to-date. Store the configured priority here and use "-1" until we're ready to fully join the cluster.
     const int _originalPriority;
+
+    // If we're leading and we're too far ahead of the rest of the cluster, we block new commits. This prevents us from forking too far ahead of everyone else.
+    const size_t _quorumSize;
+    bool _commitsBlocked{false};
+    set<SQLitePeer*> _upToDatePeers;
 
     // A string representing an address (i.e., `127.0.0.1:80`) where this server accepts commands. I.e., "the command port".
     const unique_ptr<Port> _port;


### PR DESCRIPTION
### Details
This simply prevents leader from committing if it's too far ahead of the rest of the cluster. It's essentially a speed brake if leader is running ahead, but the real effect is that it's a limiter on how much data can be lost in a fork.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/321149

### Tests
Using commit [71b5fa9](https://github.com/Expensify/Bedrock/pull/1577/commits/71b5fa998c606452383aa2a734aa629d089e53ac) to run the `ConflictSpam` test, we get the following logs:
```
2023-10-09T22:43:54.214565+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:1284) _onMESSAGE [sync] [warn] {cluster_node_0/LEADING} [clustersync] Cluster is behind by over 20 commits. New commits blocked until the cluster catches up.
2023-10-09T22:43:54.215883+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:1287) _onMESSAGE [sync] [warn] {cluster_node_0/LEADING} [clustersync] Took 1905us to block commits. Dumping cluster commit state. I have commit: 91
2023-10-09T22:43:54.215910+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:1289) _onMESSAGE [sync] [warn] {cluster_node_0/LEADING} [clustersync] Peer cluster_node_1 has commit 70, behind by: 21
2023-10-09T22:43:54.215928+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:1289) _onMESSAGE [sync] [warn] {cluster_node_0/LEADING} [clustersync] Peer cluster_node_2 has commit 70, behind by: 21
2023-10-09T22:43:54.248143+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:1279) _onMESSAGE [sync] [warn] {cluster_node_0/LEADING} [clustersync] Cluster is no longer behind by over 20 commits. Unblocking new commits.
```

And it repeats until the test does eventually complete.