### PR TITLE
Fix sync thread timing out post polling HTTPS commands.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1944,6 +1944,7 @@ void BedrockServer::_postPollCommands(fd_map& fdm, uint64_t nextActivity) {
     auto it = _outstandingHTTPSCommands.begin();
     while (it != _outstandingHTTPSCommands.end()) {
         auto& command = *it;
+        SAUTOPREFIX(command->request);
 
         // By default, we can poll up to 5 min.
         uint64_t maxWaitMs = 5 * 60 * 1'000;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -236,9 +236,6 @@ void BedrockServer::sync()
         // activity. Once any of them has activity (or the timeout ends), poll will return.
         fd_map fdm;
 
-        // Prepare our commands for `poll` (for instance, in case they're making HTTP requests).
-        _prePollCommands(fdm);
-
         // Pre-process any sockets the sync node is managing (i.e., communication with peer nodes).
         _syncNode->prePoll(fdm);
 
@@ -263,7 +260,6 @@ void BedrockServer::sync()
 
             // Process any activity in our plugins.
             AutoTimerTime postPollTime(postPollTimer);
-            _postPollCommands(fdm, nextActivity);
             _syncNode->postPoll(fdm, nextActivity);
             _syncNodeQueuedCommands.postPoll(fdm);
         }
@@ -531,18 +527,13 @@ void BedrockServer::sync()
                             SERROR("peekCommand (" << command->request.getVerb() << ") returned invalid result code: " << (int)result);
                         }
 
-                        // If we just started a new HTTPS request, save it for later.
+                        // If this command attempted an HTTP request, kill it.
                         if (command->httpsRequests.size()) {
-                            waitForHTTPS(move(command));
-                            // TODO:
-                            // Move the HTTPS loop into the worker, so that the worker can poll on its own requests.
-                            // This is the first step toward linear workers that run start->finish without being
-                            // interrupted and bounced back and forth between a bunch of queues.
-                            //
-                            // The follow-up to that is to allow direct escalations from workers to leader, which can
-                            // be done as a simple HTTPS request for the exact same command.
-
-                            // Move on to the next command until this one finishes.
+                            SWARN("Killing command " << command->request.methodLine << " that attempted HTTPS request in sync thread.");
+                            command->response.clear();
+                            command->response.methodLine = "500 Refused";
+                            command->complete = true;
+                            _reply(command);
                             core.rollback();
                             break;
                         }
@@ -1927,54 +1918,6 @@ bool BedrockServer::_upgradeDB(SQLite& db) {
     return !db.getUncommittedQuery().empty();
 }
 
-void BedrockServer::_prePollCommands(fd_map& fdm) {
-    lock_guard<decltype(_httpsCommandMutex)> lock(_httpsCommandMutex);
-    for (auto& command : _outstandingHTTPSCommands) {
-        command->prePoll(fdm);
-    }
-
-    // Make sure that waiting for an HTTPS command interrupts the current `poll` in the sync thread.
-    _newCommandsWaiting.prePoll(fdm);
-}
-
-void BedrockServer::_postPollCommands(fd_map& fdm, uint64_t nextActivity) {
-    lock_guard<decltype(_httpsCommandMutex)> lock(_httpsCommandMutex);
-
-    // Just clear this, it doesn't matter what the contents are.
-    _newCommandsWaiting.postPoll(fdm);
-    _newCommandsWaiting.clear();
-
-    // Because we modify this list as we walk across it, we use an iterator to our current position.
-    auto it = _outstandingHTTPSCommands.begin();
-    while (it != _outstandingHTTPSCommands.end()) {
-        auto& command = *it;
-        SAUTOPREFIX(command->request);
-
-        // By default, we can poll up to 5 min.
-        uint64_t maxWaitMs = 5 * 60 * 1'000;
-        auto _syncNodeCopy = atomic_load(&_syncNode);
-        if (_shutdownState.load() != RUNNING || (_syncNodeCopy && _syncNodeCopy->getState() == SQLiteNodeState::STANDINGDOWN)) {
-            // But if we're trying to shut down, we give up after 5 seconds.
-            maxWaitMs = 5'000;
-        }
-        command->postPoll(fdm, nextActivity, maxWaitMs);
-
-        // If it finished all it's requests, put it back in the main queue.
-        if (command->areHttpsRequestsComplete()) {
-            SINFO("All HTTPS requests complete, returning to main queue.");
-
-            // Because sets contain only `const` data, they can't be moved-from without these weird `extract`
-            // semantics. This invalidates our iterator, so we save the one we want before we break it.
-            auto nextIt = next(it);
-            _commandQueue.push(move(_outstandingHTTPSCommands.extract(it).value()));
-            it = nextIt;
-        } else {
-            // otherwise just move on to the next command.
-            it++;
-        }
-    }
-}
-
 void BedrockServer::_beginShutdown(const string& reason, bool detach) {
     if (_shutdownState.load() == RUNNING) {
         _detach = detach;
@@ -2383,15 +2326,6 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
             unblockCommandPort("NOT_ENOUGH_THREADS");
         }
     }
-}
-
-void BedrockServer::waitForHTTPS(unique_ptr<BedrockCommand>&& command) {
-    SAUTOPREFIX(command->request);
-    lock_guard<mutex> lock(_httpsCommandMutex);
-    _outstandingHTTPSCommands.insert(move(command));
-
-    // Interrupt `poll` in the sync thread.
-    _newCommandsWaiting.push(true);
 }
 
 const atomic<SQLiteNodeState>& BedrockServer::getState() const {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2495,9 +2495,6 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                             // interrupt that chain in a way that will cause the remote end to think you've had an
                             // error, and start over. So, once a connection is established, we should just use that one
                             // for all communication until it breaks.
-                            peer->reset();
-                            // This line is broken.
-                            _onDisconnect(peer);
                             STHROW("Peer " + peer->name + " seems already connected.");
                         }
                     } else {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1810,7 +1810,10 @@ void SQLiteNode::_onDisconnect(SQLitePeer* peer) {
             //
             // It works for the sync thread as well, as there's handling in _changeState to rollback a commit when
             // dropping out of leading or standing down (and there can't be commits in progress in other states).
-            SWARN("We were " << stateName(_state) << " but lost quorum. Going to SEARCHING.");
+            SWARN("[clustersync] We were " << stateName(_state) << " but lost quorum (Disconnected from " << peer->name << "). Going to SEARCHING.");
+            for (const auto* p : _peerList) {
+                SWARN("[clustersync] Peer " << p->name << " logged in? " << (p->loggedIn ? "TRUE" : "FALSE") << (p->permaFollower ? " (permaFollower)" : ""));
+            }
             _changeState(SQLiteNodeState::SEARCHING);
         }
     }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2548,9 +2548,9 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
             break;
             case SQLitePeer::PeerPostPollStatus::OK:
             {
-                auto lastSendTime = peer->lastSendTime();
-                if (lastSendTime && STimeNow() - lastSendTime > SQLiteNode::RECV_TIMEOUT - 5 * STIME_US_PER_S) {
-                    SINFO("Close to timeout, sending PING to peer '" << peer->name << "'");
+                auto lastActivityTime = max(peer->lastSendTime(), peer->lastRecvTime());
+                if (lastActivityTime && STimeNow() - lastActivityTime > SQLiteNode::RECV_TIMEOUT - 5 * STIME_US_PER_S) {
+                    SINFO("Close to timeout (" << (STimeNow() - lastActivityTime) << "us since last activity), sending PING to peer '" << peer->name << "'");
                     _sendPING(peer);
                 }
                 try {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2496,6 +2496,7 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                             // error, and start over. So, once a connection is established, we should just use that one
                             // for all communication until it breaks.
                             peer->reset();
+                            // This line is broken.
                             _onDisconnect(peer);
                             STHROW("Peer " + peer->name + " seems already connected.");
                         }

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -72,7 +72,8 @@ SQLitePeer::PeerPostPollStatus SQLitePeer::postPoll(fd_map& fdm, uint64_t& nextA
         switch (socket->state.load()) {
             case STCPManager::Socket::CONNECTED: {
                 // socket->lastRecvTime is always set, it's initialized to STimeNow() at creation.
-                if (socket->lastRecvTime + SQLiteNode::RECV_TIMEOUT < STimeNow()) {
+                auto lastActivityTime = max(socket->lastSendTime, socket->lastRecvTime);
+                if (lastActivityTime + SQLiteNode::RECV_TIMEOUT < STimeNow()) {
                     SHMMM("Connection with peer '" << name << "' timed out.");
                     return PeerPostPollStatus::SOCKET_ERROR;
                 }


### PR DESCRIPTION
### Details (Very Long)

So here's what the sync thread was doing on 1.sjc when it forked and died most recently:
```
2023-09-29T13:35:47.663264+00:00 db1.sjc bedrock: xxxxxx (SQLitePeer.cpp:238) sendMessage [sync] [info] {auth.db2.sjc} No error sending COMMIT_TRANSACTION to peer auth.db2.sjc (247 bytes actually sent).
2023-09-29T13:35:47.676014+00:00 db1.sjc bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread escalate loop): 4/12157 ms timed, 0.03%
2023-09-29T13:35:47.701788+00:00 db1.sjc bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread poll): 0/12182 ms timed, 0.00%
2023-09-29T13:35:47.702038+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:48.930777+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:48.938225+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:50.002517+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:50.918473+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:50.957446+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:50.975480+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:51.820577+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:51.835996+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:51.836112+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:51.836163+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:51.836221+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:51.837346+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:51.874070+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:52.757888+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:53.579492+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:53.579633+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:53.593192+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:54.403455+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:54.416821+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:55.267485+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:56.127042+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:56.134609+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:56.954437+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:57.764537+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:58.532617+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:35:59.364905+00:00 db1.sjc bedrock: xxxxxx (BedrockServer.cpp:1959) _postPollCommands [sync] [info] All HTTPS requests complete, returning to main queue.
2023-09-29T13:36:00.147159+00:00 db1.sjc bedrock: xxxxxx (SQLitePeer.cpp:76) postPoll [sync] [hmmm] {auth.db1.rno} Connection with peer 'auth.db1.rno' timed out.
2023-09-29T13:36:00.147197+00:00 db1.sjc bedrock: xxxxxx (SQLitePeer.cpp:238) sendMessage [sync] [info] {auth.db1.rno} No error sending RECONNECT to peer auth.db1.rno (54 bytes actually sent).
2023-09-29T13:36:00.147215+00:00 db1.sjc bedrock: xxxxxx (SQLitePeer.cpp:76) postPoll [sync] [hmmm] {auth.db2.lax} Connection with peer 'auth.db2.lax' timed out.
2023-09-29T13:36:00.147238+00:00 db1.sjc bedrock: xxxxxx (SQLitePeer.cpp:238) sendMessage [sync] [info] {auth.db2.lax} No error sending RECONNECT to peer auth.db2.lax (54 bytes actually sent).
2023-09-29T13:36:00.151886+00:00 db1.sjc bedrock: xxxxxx (SQLitePeer.cpp:76) postPoll [sync] [hmmm] {auth.db2.sjc} Connection with peer 'auth.db2.sjc' timed out.
2023-09-29T13:36:00.151912+00:00 db1.sjc bedrock: xxxxxx (SQLitePeer.cpp:238) sendMessage [sync] [info] {auth.db2.sjc} No error sending RECONNECT to peer auth.db2.sjc (54 bytes actually sent).
```

So, you can see it gets stuck running `_postPollCommands` for about 12 seconds. There are two questions to answer here.

1. Why was it stuck in `_postPollCommands` for 12 seconds?
2. Why did this make it die?

Let's start with the first, but this one is more cursory because (spoiler alert) we're changing it to not do this anymore anyway.

We don't have a tom of info on exactly what's going on here, but this is the code that's running:
https://github.com/Expensify/Bedrock/blob/85dbfb1d6586528eeb153afae512ad3c4c832f50/BedrockServer.cpp#L1945-L1959

I specifically highlighted the first line there on purpose. My guess is that there are a whole lot of commands in `_outstandingHTTPSCommands` at this point, and not very many of them are completing.

We have a few examples during this time period of external network requests failing:
```
2023-09-29T13:35:48.179028+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (BedrockServer.cpp:2204) buildCommandFromRequest [socket3196218] [info] Waiting for 'AuthenticateGoogle' to complete.
2023-09-29T13:35:48.179093+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (AuthenticateGoogle.cpp:95) peek [socket3196218] [info] Attempting authenticate for partnerUserID=guanlop72@gmail.com
2023-09-29T13:35:48.179286+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (AuthenticateGoogle.cpp:141) peek [socket3196218] [info] User exists in the logins table. Using existing account details for checks.
2023-09-29T13:35:48.181993+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (libstuff.cpp:1745) S_socket [socket3196218] [info] DNS lookup took 0ms for 'www.googleapis.com'.
2023-09-29T13:35:48.182001+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (libstuff.cpp:1757) S_socket [socket3196218] [info] Resolved www.googleapis.com to ip: 10.6.102.1.
2023-09-29T13:36:06.180590+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com  (SSSLState.cpp:103) SSSLRecv [sync] [info] SSL reports recv error #-29312 (SSL - The connection indicated an EOF)
2023-09-29T13:36:06.180604+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com  (SSSLState.cpp:68) SSSLSend [sync] [info] SSL reports send error #-29312 (SSL - The connection indicated an EOF)
2023-09-29T13:36:06.180615+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com  (SHTTPSManager.cpp:125) postPoll [sync] [warn] Connection died prematurely
2023-09-29T13:36:06.873332+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (BedrockServer.cpp:693) worker [worker51] [info] Dequeued command AuthenticateGoogle (auth.db2.sjc#19448732) in worker, 0 commands in  queue.
2023-09-29T13:36:06.874945+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (libstuff.cpp:151) SException [worker51] [info] Throwing exception with message: '407 Unable to parse JSON' from auth/command/AuthenticateGoogle.cpp:171
2023-09-29T13:36:06.894116+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (BedrockCore.cpp:403) _handleCommandException [worker51] [info] Error processing command 'AuthenticateGoogle' (407 Unable to parse JSON), ignoring.
2023-09-29T13:36:06.894148+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (BedrockCommand.cpp:234) finalizeTimingInfo [worker51] [info] command 'AuthenticateGoogle' timing info (ms): prePeek: 0 (count: 0), peek:3 (count:1), process:20 (count:1), postProcess:0 (count:0), total:18715, unaccounted:18689. Commit: worker:0, sync:0. Queue: worker:1, sync:0, blocking:0, pageLock:0, escalation:0. Blocking: peek:0, process:0, commit:0. Upstream: peek:0, process:0, total:0, unaccounted:0.
2023-09-29T13:36:06.894162+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (BedrockServer.cpp:1514) _reply [worker51] [info] [performance] Command 407 Unable to parse JSON has a socket, going to try to reply.
2023-09-29T13:36:06.894169+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (BedrockServer.cpp:1527) _reply [worker51] [info] [performance] About to reply to command AuthenticateGoogle
2023-09-29T13:36:06.894198+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (BedrockServer.cpp:1533) _reply [worker51] [info] [performance] Replied
2023-09-29T13:36:06.894205+00:00 db1.sjc bedrock: 80e49c85cc1be599-DFW guanlop72@gmail.com (BedrockServer.cpp:1549) _reply [worker51] [info] [performance] Finished replying to command AuthenticateGoogle moving on to the next command.
```

You can see that request fails to authenticate with google becaue of an SSL send or recv error (both?). Anyway, that individual command isn't important, because my theory is we develop a backlog of commands in `_outstandingHTTPSCommands` due to slow external networking for a few seconds.

As that backlog gets bigger, our postPoll loop gets slower each time. This is corroborated by these log lines from this time period:
```
2023-09-29T13:35:10.638542+00:00 db1.sjc bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread PostPoll): 13194/14602 ms timed, 90.36%
2023-09-29T13:35:20.647417+00:00 db1.sjc bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread PostPoll): 7717/10008 ms timed, 77.11%
2023-09-29T13:35:34.987851+00:00 db1.sjc bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread PostPoll): 11202/14340 ms timed, 78.12%
2023-09-29T13:35:46.968170+00:00 db1.sjc bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread PostPoll): 11449/11980 ms timed, 95.57%
2023-09-29T13:36:00.156410+00:00 db1.sjc bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread PostPoll): 12454/13188 ms timed, 94.43%
2023-09-29T13:36:14.401442+00:00 db1.sjc bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread PostPoll): 13494/14245 ms timed, 94.73%
2023-09-29T13:36:24.802656+00:00 db1.sjc bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread PostPoll): 9853/10401 ms timed, 94.73%
2023-09-29T13:36:35.353525+00:00 db1.sjc bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread PostPoll): 9087/10550 ms timed, 86.13%
2023-09-29T13:36:50.695737+00:00 db1.sjc bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread PostPoll): 14917/15342 ms timed, 97.23%
```

We're spending almost all of our time in `postPoll`.

## Ok, so we've determined we're blocked in postPollCommands for 12 seconds. Why does this kill the cluster?

We have logic in place for nodes to ping one another periodically as a keep-alive. We have the timeout set at 30 seconds for this, and we will send a `PING` message when we get close to that timeout -- specifically, we send it 5s before we expect the timeout.

The way we check for the timeout is flawed. We send a `PING` if we have not *sent* anything to another node in 25+ seconds:
https://github.com/Expensify/Bedrock/blob/85dbfb1d6586528eeb153afae512ad3c4c832f50/sqlitecluster/SQLiteNode.cpp#L2548-L2551

There's nothing particularly wrong with this, except that it means we're ignoring receiving data as counting toward keeping the cluster alive. In a steady state where all nodes are online and connected, followers can hit this state every 25 seconds. This used to not be the case - but since we have HTTP escalation now, peers send very little data to the leader.

What's worse is the other end of this:
https://github.com/Expensify/Bedrock/blob/85dbfb1d6586528eeb153afae512ad3c4c832f50/sqlitecluster/SQLitePeer.cpp#L75-L77

`SQLitePeer` only checks `recv` times for the purpose of timeout. This means that it's 100% reliant on the opposite end of the connection to send that `PING` every 25 seconds. If it doesn't get the `PING` it'll time out, even if it's leader and it's been sending a steady stream of data to another node.

### So here's the problem
When we block leader's sync thread for 12 seconds, if this happens to overlap with the 5 second window in which a follower is trying to send a ping, then when leader finally finishes with `_postPollCommands` it times out the follower, because it's been over 30s since it last received any data from that follower.

If this happens to 3 followers at once, the entire cluster blows up.

### Let's do math.

Let's assume that we block the sync thread for 10 seconds at a random point in time.

For any peer, there is a 5 second window in any 30 second period where, if we block that entire window, we will not get our `PING` in time.

Assume each character is 1s
```
30 second window:
WWWWWWWWWWWWWWWWWWWWWWWWWWWWWW

Five second PING area:
                    PPPPP     

10 second blockage:
BBBBBBBBBB
```

Line these all up, and you can see that this example timing doesn't case a missed `PING`:
```
WWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
                    PPPPP     
BBBBBBBBBB
```

Let's treat this discreetly, and say there are 30 intervals to consider.

The first one that blocks the entire ping window is:
```
WWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
                    PPPPP     
               BBBBBBBBBB
```

And the last one that blocks the entire ping window is:
```
WWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
                    PPPPP     
                    BBBBBBBBBB
```

In fact, any of the following blockage windows will break the ping:
```
WWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
                    PPPPP     
               BBBBBBBBBB
                BBBBBBBBBB
                 BBBBBBBBBB
                  BBBBBBBBBB
                   BBBBBBBBBB
                    BBBBBBBBBB
```

I hope that diagram notation makes sense. There's probably an integral to do this as a continuous function, but I'm not going to bother figuring it out. In any case, that's 6 of 30 discreet windows that cause the ping on this peer to be missed. 

So in a 10 second blockage, we have a 20% change of timing out any peer.

That is to say we have a 0.2 * 0.2 * 0.2 = 0.8% chance that a 10 second blockage of the sync thread causes the whole cluster to fall apart.

If one quorum node is already down, then we only need to disconnect from two nodes to break the cluster, in which case we have a 4% chance of breaking the cluster with a 10 second sync thread blockage.

## Great? How are we going to fix it?

Two things.

*First*, don't time out connections based only on send or recv. Assume that if we've successfully sent, or successfully received, the connection is good. This gets rid of the ping timing issue regardless, as leader sending transactions to followers will keep the connection alive regardless. But in this case, if the sync thread is blocked in _postPollCommands  for 30 seconds, we'll still time out, because we won't have sent any transactions in that time either.

So what we really want to do is *not do command networking in the sync thread*. We already knew we didn't want to do this:
https://github.com/Expensify/Bedrock/blob/85dbfb1d6586528eeb153afae512ad3c4c832f50/BedrockServer.cpp#L542-L554

So let's go ahead and do that. The sync thread can't be blocked if socket threads are doing their own networking. This actually makes the code overall much *simpler* too. I will comment inline with more details on some of this change.

I think this is a high-risk deploy, and we should do it when we're prepared to roll back.

### Fixed Issues
Fixes ALL THE THINGS (#fireroom-2023-09-21-cluster-issues)

### Tests
Existing tests.

Auth at ef44bf0:
```
[ TEST RESULTS ] Passed: 2354, Failed: 0
```