### PR TITLE
DOn't set the timeout in poll to zero

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -820,21 +820,20 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
             networkLoopCount++;
             fd_map fdm;
             command->prePoll(fdm);
-            const uint64_t now = STimeNow();
-            uint64_t nextActivity = 0;
-            S_poll(fdm, max(nextActivity, now) - now);
 
             // Timeout is five minutes unless we're shutting down or standing down, in which case it's 5 seconds.
             // Note that BedrockCommad::postPoll sets the timeout to the command's timeout if it's lower than this value anyway,
             // So this only has an effect if it will be shorter than the command's timeout.
-            uint64_t maxWaitMs = 5 * 60 * 1'000;
+            uint64_t maxWaitUs = 5 * 60 * 1'000'000;
             auto _syncNodeCopy = atomic_load(&_syncNode);
             if (_shutdownState.load() != RUNNING || (_syncNodeCopy && _syncNodeCopy->getState() == SQLiteNodeState::STANDINGDOWN)) {
-                maxWaitMs = 5'000;
+                maxWaitUs = 5'000'000;
             }
 
+            S_poll(fdm, maxWaitUs);
+
             auto start = STimeNow();
-            command->postPoll(fdm, nextActivity, maxWaitMs);
+            command->postPoll(fdm, maxWaitUs, maxWaitUs);
             postPollCumulativeTime += (STimeNow() - start);
         }
 


### PR DESCRIPTION
### Details
Fixes a bug in the newly deployed code to poll https commands in socket threads.

We had accidentally used a timeout of zero, causing poll to return immediately if there was no activity, which caused high CPU usage.

This waits up to 60 seconds (or five if we're shutting down), or the command's timeout value, whichever is shorter.

### Fixed Issues
Fixes GH_LINK

### Tests
Manually tested.