### PR TITLE
Shorten timeout when no sockets to poll

### DIFF
--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -33,6 +33,8 @@ class SStandaloneHTTPSManager : public STCPManager {
     void prePoll(fd_map& fdm, Transaction& transaction);
 
     // Default timeout for HTTPS requests is 5 minutes.This can be changed on any call to postPoll.
+    // This is a total amount of milliseconds of idle activity since the last send on a socket before killing it.
+    // The purpose of this is to be able to shut down when no activity is happening.
     void postPoll(fd_map& fdm, Transaction& transaction, uint64_t& nextActivity, uint64_t timeoutMS = (5 * 60 * 1000));
 
     // Close a transaction and remove it from our internal lists.


### PR DESCRIPTION
### Details
This fixes the issue we ran into in auth tests [here]. The comment in the code explains it, but Stripe creates HTTPS transaction objects with no sockets, and they would end up timing out because the sockets would get attached to the commands in the middle of a long `poll` cycle.

This didn't happen before because we'd poll on *all* of the Stripe sockets in the same loop, so if any Stripe socket had activity, it would interrupt waiting on the others, and their sockets could get attached.

There may be a more ideal fix for this, but I think this is OK right now.

### Fixed Issues
Fixes GH_LINK

### Tests

Auth:
```
[ TEST RESULTS ] Passed: 2354, Failed: 0
```
