### PR TITLE
Attempt to recover after error starting replciate thread

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1657,7 +1657,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     thread(&SQLiteNode::_replicate, this, peer, message, _dbPool->getIndex(false), threadAttemptStartTimestamp).detach();
                 } catch (const system_error& e) {
                     SWARN("Caught system_error starting _replicate thread with " << _replicationThreadCount.load() << " threads. e.what()=" << e.what());
-                    throw;
+                    STHROW("Error starting replicate thread so giving up and reconnecting.");
                 }
                 SDEBUG("Done spawning concurrent replicate thread: " << threadID);
             }


### PR DESCRIPTION
### Details
Previously if we hit this error case, we would crash, as `system_error` is not handled anywhere. With this change, we throw `SException` instead, which will be caught here:
https://github.com/Expensify/Bedrock/blob/cf9e098967dd99bb81322ae462567de1ec34db70/sqlitecluster/SQLiteNode.cpp#L1717-L1722

This will cause us to reconnect to this peer, which is LEADER, so we should stop following and go SEARCHING at this point. This should run this code:
https://github.com/Expensify/Bedrock/blob/cf9e098967dd99bb81322ae462567de1ec34db70/sqlitecluster/SQLiteNode.cpp#L1863-L1868

Which should wait for existing replicate threads to finish, and then we should re-SYNCHRONIZE.

I don't guarantee there are no issues with this new path, but the existing path just crashes so it can't really be worse.

### Fixed Issues
Fixes GH_LINK

### Tests
Existing tests.