### PR TITLE
Remove obsolete API

### DIFF
--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -140,10 +140,6 @@ class BedrockCommand : public SQLiteCommand {
     // A list of timing sets, with an info type, start, and end.
     list<tuple<TIMING_INFO, uint64_t, uint64_t>> timingInfo;
 
-    // This defaults to false, but a specific plugin can set it to 'true' to force this command to be passed
-    // to the sync thread for processing, thus guaranteeing that process() will not result in a conflict.
-    virtual bool onlyProcessOnSyncThread() { return false; }
-
     // Add any sockets that this command has opened (not the socket the client sent it on, but any outgoing sockets
     // it's opened itself) to a fd_map so that they can be polled for activity.
     void prePoll(fd_map& fdm);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -983,10 +983,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                 }
 
                 // Peek wasn't enough to handle this command. See if we think it should be writable in parallel.
-                // We check `onlyProcessOnSyncThread` here, rather than before processing the command, because it's
-                // not set at creation time, it's set in `peek`, so we need to wait at least until after peek is
-                // called to check it.
-                if (command->onlyProcessOnSyncThread() || !canWriteParallel) {
+                if (!canWriteParallel) {
                     // Roll back the transaction, it'll get re-run in the sync thread.
                     core.rollback();
                     auto _clusterMessengerCopy = _clusterMessenger;


### PR DESCRIPTION
### Details
`onlyProcessOnSyncThread` causes performance issues and is no longer used. This removes it.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/320681

### Tests
Auth:
```
[ TEST RESULTS ] Passed: 2358, Failed: 0
```