### PR TITLE
Turn off annoying log line

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -671,7 +671,7 @@ void BedrockServer::worker(int threadId)
             });
 
             // Get the next one.
-            command = commandQueue.get(1000000, !threadId);
+            command = commandQueue.get(1000000);
 
             SAUTOPREFIX(command->request);
             SINFO("Dequeued command " << command->request.methodLine << " (" << command->id << ") in worker, "


### PR DESCRIPTION
### Details
Turns off these annoying log lines:
```
2023-10-10T16:38:38.685410+00:00 expensidev2004 bedrock10004: xxxxxx (SScheduledPriorityQueue.h:146) get [blockingCommit] [info] [performance] Notified or timed out, trying to return work.
2023-10-10T16:38:38.686287+00:00 expensidev2004 bedrock10004: xxxxxx (SScheduledPriorityQueue.h:158) get [blockingCommit] [info] [performance] Timed out and there was no work to be done.
2023-10-10T16:38:38.686495+00:00 expensidev2004 bedrock10004: xxxxxx (SScheduledPriorityQueue.h:141) get [blockingCommit] [info] [performance] Waiting for internal notify or timeout.
```

### Fixed Issues
Fixes N/A

### Tests
N/A

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
