### PR TITLE
Add some logging around cache invalidation

### DIFF
--- a/plugins/Cache.cpp
+++ b/plugins/Cache.cpp
@@ -190,6 +190,7 @@ bool BedrockCacheCommand::peek(SQLite& db) {
             SASSERT(result[0].size() == 2);
             response["name"] = result[0][0];
             response.content = result[0][1];
+            SINFO("Pushing " << response["name"] << " to LRU cache");
 
             // Update the LRU Map
             plugin()._lruMap.pushMRU(response["name"]);
@@ -261,6 +262,7 @@ void BedrockCacheCommand::process(SQLite& db) {
             auto popResult = plugin()._lruMap.popLRU();
             const string& name = (popResult.second ? popResult.first : db.read("SELECT name FROM cache LIMIT 1"));
             SASSERT(!name.empty());
+            SINFO("Deleting " << response["name"] << " from the cache");
 
             // Delete it
             if (!db.write("DELETE FROM cache WHERE name=" + SQ(name) + ";")) {


### PR DESCRIPTION
### Details
Just adding more logging so we get some info on this.

### Fixed Issues
Related to https://github.com/Expensify/Expensify/issues/327164

### Tests
```
> $cache = new Expensify\Bedrock\Cache(Expensify\Bedrock\Client::getInstance());
= Expensify\Bedrock\Cache {#2814}

> $cache->readWithDefault('algo', [])
= []

> $cache->write('algo', '1234')
= null

> $cache->readWithDefault('algo', [])
= "1234"

```
> 2023-10-18T16:42:01.987478+00:00 expensidev2004 bedrock: JtGw9b we@dont.know (Cache.cpp:193) peek [socket11] [info] {Cache} Pushing algo/ to LRU cache
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
