### PR TITLE
[WIP] Conflict free journal

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -162,6 +162,17 @@ vector<string> SQLite::initializeJournal(sqlite3* db, int minJournalTables) {
     return journalNames;
 }
 
+// Assumes that initializeJournal has already run.
+list<int64_t> initializeJournalNumbers() {
+    int64_t i = 0;
+    list<int64_t> result;
+    for (auto & j : journalNames) {
+        result.push_back(i);
+        ++i;
+    }
+    return result;
+}
+
 uint64_t SQLite::initializeJournalSize(sqlite3* db, const vector<string>& journalNames) {
     // We keep track of the number of rows in the journal, so that we can delete old entries when we're over our size
     // limit.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -404,6 +404,7 @@ class SQLite {
 
     atomic<int64_t> _lastConflictPage = 0;
     static thread_local int64_t _conflictPage;
+    static thread_local bool _journalConflict;
 
     bool _writeIdempotent(const string& query, bool alwaysKeepQueries = false);
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -300,29 +300,8 @@ class SQLite {
         mutex availableJournalsMutex;
         list<size_t> availableJournalNumbers;
         condition_variable availableJournalCV;
-
-        size_t reserveJournalNumber() {
-            unique_lock<mutex> lock(availableJournalsMutex);
-            size_t number{0};
-            while (true) {
-                if (availableJournalNumbers.size()) {
-                    number = availableJournalNumbers.front();
-                    availableJournalNumbers.pop_front();
-                    return number;
-                } else {
-                    // Wait until a journal is added.
-                    SINFO("All journals are reserved, waiting.");
-                    availableJournalCV.wait(lock);
-                    SINFO("Notified that journal is available, trying again.");
-                }
-            }
-        }
-
-        void returnJournalNumber(size_t journalNumber) {
-            lock_guard<mutex> lock(availableJournalsMutex);
-            availableJournalNumbers.push_back(journalNumber);
-            availableJournalCV.notify_one();
-        }
+        size_t reserveJournalNumber();
+        void returnJournalNumber(size_t journalNumber);
 
         // When `SQLite::prepare` is called, we need to save a set of info that will be broadcast to peers when the
         // transaction is ultimately committed. This should be cleared out if the transaction is rolled back.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -297,6 +297,7 @@ class SQLite {
         // This is the last committed hash by *any* thread for this file.
         atomic<string> lastCommittedHash;
 
+        // Data structures and methods required for letting threads reserve specific journal tables.
         mutex availableJournalsMutex;
         list<size_t> availableJournalNumbers;
         condition_variable availableJournalCV;

--- a/test/clustertest/tests/ConflictSpamTest.cpp
+++ b/test/clustertest/tests/ConflictSpamTest.cpp
@@ -81,7 +81,7 @@ struct ConflictSpamTest : tpunit::TestFixture {
 
                 // Let's make ourselves 20 commands to spam at each node.
                 vector<SData> requests;
-                int numCommands = 200;
+                int numCommands = 20000;
                 for (int j = 0; j < numCommands; j++) {
                     SData query("idcollision b2");
                     query["writeConsistency"] = "ASYNC";
@@ -91,7 +91,7 @@ struct ConflictSpamTest : tpunit::TestFixture {
                 }
 
                 // Ok, send them all!
-                auto results = brtester.executeWaitMultipleData(requests);
+                auto results = brtester.executeWaitMultipleData(requests, 50);
 
                 int failures = 0;
                 for (auto row : results) {


### PR DESCRIPTION
### Details
Currently ([6aa3d6f](https://github.com/Expensify/Bedrock/pull/1597/commits/6aa3d6fdad43163ca398d80086d244035ef23910)) This will reserve journal tables even if we have a different conflict on subsequent attempts after a single conflict on a journal table It seems to deadlock or something. Not sure if those are related.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
