### PR TITLE
This should allow tpunit assertions to be used from functions that ar…

### DIFF
--- a/test/clustertest/tests/PrePeekPostProcessTest.cpp
+++ b/test/clustertest/tests/PrePeekPostProcessTest.cpp
@@ -2,6 +2,10 @@
 #include <libstuff/SData.h>
 #include <test/clustertest/BedrockClusterTester.h>
 
+void checkWithoutThis() {
+    ASSERT_EQUAL(1, 1);
+}
+
 struct PrePeekPostProcessTest : tpunit::TestFixture {
     PrePeekPostProcessTest() : tpunit::TestFixture("PrePeekPostProcess", BEFORE_CLASS(PrePeekPostProcessTest::setup),
                                                                          AFTER_CLASS(PrePeekPostProcessTest::teardown),
@@ -22,6 +26,8 @@ struct PrePeekPostProcessTest : tpunit::TestFixture {
 
     void prePeek()
     {
+        checkWithoutThis();
+
         BedrockTester& brtester = tester->getTester(1);
         SData cmd("prepeekcommand");
         STable response = SParseJSONObject(brtester.executeWaitMultipleData({cmd})[0].content);

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -6,6 +6,7 @@ using namespace tpunit;
 
 bool tpunit::TestFixture::exitFlag = false;
 thread_local string tpunit::currentTestName;
+thread_local tpunit::TestFixture* tpunit::currentTestPtr = nullptr;
 thread_local mutex tpunit::currentTestNameMutex;
 
 thread_local int tpunit::TestFixture::perFixtureStats::_assertions = 0;
@@ -239,6 +240,7 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
                    }
                    {
                        lock_guard<mutex> lock(currentTestNameMutex);
+                       currentTestPtr = f;
                        if (f->_name) {
                            currentTestName = f->_name;
                        } else {
@@ -412,6 +414,7 @@ void tpunit::TestFixture::tpunit_detail_do_tests(TestFixture* f) {
         testThreads.push_back(thread([t, f]() {
             recursive_mutex& m = *(f->_mutex);
             currentTestName = f->_name;
+            currentTestPtr = f;
             f->_stats._assertions = 0;
             f->_stats._exceptions = 0;
             f->testOutputBuffer = "";

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -60,10 +60,10 @@ using namespace std;
  * TRACE(message); adds a trace to the test output with a user
  * specified string message.
  */
-#define ABORT() tpunit_detail_assert(this, __FILE__, __LINE__); return;
-#define FAIL()  tpunit_detail_assert(this, __FILE__, __LINE__);
+#define ABORT() tpunit::TestFixture::tpunit_detail_assert(tpunit::currentTestPtr, __FILE__, __LINE__); return;
+#define FAIL()  tpunit::TestFixture::tpunit_detail_assert(tpunit::currentTestPtr, __FILE__, __LINE__);
 #define PASS()  /* do nothing */
-#define TRACE(message) tpunit_detail_trace(this, __FILE__, __LINE__, message);
+#define TRACE(message) tpunit::TestFixture::tpunit_detail_trace(tpunit::currentTestPtr, __FILE__, __LINE__, message);
 
 /**
  * The set of core macros for basic predicate testing of boolean
@@ -353,12 +353,14 @@ namespace tpunit {
           */
          static bool tpunit_detail_fp_equal(double lhs, double rhs, unsigned char ulps);
 
+       public:
          static void tpunit_detail_assert(TestFixture* f, const char* _file, int _line);
 
          static void tpunit_detail_exception(TestFixture* f, method* _method, const char* _message);
 
          static void tpunit_detail_trace(TestFixture* f, const char* _file, int _line, const char* _message);
 
+       protected:
          const char* _name;
 
          bool _parallel = false;
@@ -391,6 +393,8 @@ namespace tpunit {
          // True if running multithreaded.
          bool _multiThreaded;
    };
+
+   extern thread_local tpunit::TestFixture* currentTestPtr;
 
    /**
     * Convenience class containing the entry point to run all registered tests.

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -359,7 +359,6 @@ namespace tpunit {
           */
          static bool tpunit_detail_fp_equal(double lhs, double rhs, unsigned char ulps);
 
-       protected:
          const char* _name;
 
          bool _parallel = false;

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -335,6 +335,12 @@ namespace tpunit {
           */
          void TESTINFO(const string& newLog);
 
+         static void tpunit_detail_assert(TestFixture* f, const char* _file, int _line);
+
+         static void tpunit_detail_exception(TestFixture* f, method* _method, const char* _message);
+
+         static void tpunit_detail_trace(TestFixture* f, const char* _file, int _line, const char* _message);
+
       protected:
 
          /**
@@ -352,13 +358,6 @@ namespace tpunit {
           * http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
           */
          static bool tpunit_detail_fp_equal(double lhs, double rhs, unsigned char ulps);
-
-       public:
-         static void tpunit_detail_assert(TestFixture* f, const char* _file, int _line);
-
-         static void tpunit_detail_exception(TestFixture* f, method* _method, const char* _message);
-
-         static void tpunit_detail_trace(TestFixture* f, const char* _file, int _line, const char* _message);
 
        protected:
          const char* _name;


### PR DESCRIPTION
…e not part of a test so long as a test is currently running

### Details

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/332746

### Tests
Auth tests all pass:
```
[ TEST RESULTS ] Passed: 2429, Failed: 0
```
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
