### PR TITLE
Allow farther fall behind

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -64,7 +64,7 @@ const uint64_t SQLiteNode::RECV_TIMEOUT{STIME_US_PER_S * 30};
 
 // Setting this to 10 or lower may deadlock the server, as followers are only guaranteed to respond to every 10th message.
 // If the threshold for blocking commits is less than 10, we may block, but never receive a message indicating that we should unblock.
-atomic<uint64_t> SQLiteNode::MAX_PEER_FALL_BEHIND{500};
+atomic<uint64_t> SQLiteNode::MAX_PEER_FALL_BEHIND{1000};
 
 const string SQLiteNode::CONSISTENCY_LEVEL_NAMES[] = {"ASYNC",
                                                     "ONE",


### PR DESCRIPTION
### Details
Hopefully this is enough to mostly get rid of the warnings we're seeing in the linked issue. We can adjust further if needed.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/331202

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
