### PR TITLE
Fix incorrect log line

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1533,7 +1533,7 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
     const string& pluginName = command->request["plugin"];
 
     if (command->socket) {
-        SINFO("[performance] Command " << command->response.methodLine << " has a socket, going to try to reply.");
+        SINFO("[performance] Command " << command->request.methodLine << " has a socket, going to try to reply.");
         if (!pluginName.empty()) {
             // Let the plugin handle it
             SINFO("Plugin '" << pluginName << "' handling response '" << command->response.methodLine
@@ -1546,7 +1546,6 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
             }
         } else {
             // Otherwise we send the standard response.
-            SINFO("[performance] About to reply to command " << command->request.methodLine);
             if (!command->socket->send(command->response.serialize())) {
                 // If we can't send (client closed the socket?), alert our plugin it's response was never sent.
                 SINFO("No socket to reply for: '" << command->request.methodLine << "' #" << command->initiatingClientID);


### PR DESCRIPTION
### Details
I noticed this while investigating a different issue. The following logline:
```
2023-11-06T12:53:52.415800+00:00 db1.lax bedrock: 821d7b5989f46549-LHR mike.karim@turntide.com (BedrockServer.cpp:1536) _reply [socket32855895] [info] [performance] Command 406 Account Billing In Progress has a socket, going to try to reply.
```

Should be:
```
2023-11-06T12:53:52.415800+00:00 db1.lax bedrock: 821d7b5989f46549-LHR mike.karim@turntide.com (BedrockServer.cpp:1536) _reply [socket32855895] [info] [performance] Command BillSmartScanSubscription has a socket, going to try to reply.
```

The removed line is just redundant, we don't need both of these lines.


### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
