### PR TITLE
[HOLD] Migrate compiler to GCC13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - CXX=g++-9 CC=gcc-9
+    - CXX=g++-13 CC=gcc-13
     - secure: gIOAWHsP6BaQgQc/IBEqdcyzMepMQFoKL4BzFwysbTcX3yIT3k5iSHpoCH/+RuHOB8XZl+xOwbOyuV+ujgbb70WB1ycYiQRhYZiX1kdmjodbbqgh9ZbGYajN62sI0JrTin4mGFnTwNJ0g1nuneuqIh0z5bszu+fcbfrqmaYkxO3cKUhyPp1jl7iAFmqkhnnLmXsi0N7d3yn1rLYfEfya9e4LOAC4pKPJUJzrs7vcavRVuFOAL3Lg+DyDsbBHy330SZEERUyX5Jb44nVJ3j9XGrujnPhlwan8wye9vrCrtRhC1lo2cllV9m0oSboJsV9A+bMQ2kgFqjZTMyZyjsQrflYNYhLpiFp3qVCTHpGH7jS6pUOXzRn/T+BUns4/4RJE5EsDzgBOg90oBVNGU++zJjCGMRaOp2LJt7uSCSc8kHEzfgvbcaGI9CPSlZLILVcrifUCNzktbEtQXEJ7SAtsSDI8sbxtBKvL0wExxx8FpKSY4yvRU7xfMhumzU4Ngufz3521MyZkYsOJVE02N/D+jzHRTjGRypatm9QfHeQmRuawT+aZ/Vra9jVTBelFkibshXAiVAm8kkAq4xz9Pml31+nsNUIo9rwfzyPdLAx8qV31EFmf55zggHu0LuEO1mp46y82oPakO6BxVdRtAUnZogagMWflant/KqRlzRsQt/M=
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 # to be set, but for the time being we need to override the defaults so that our existing dev environment works. This
 # can be removed when that is resolved.
 ifeq ($(CC),cc)
-CC = gcc-9
+CC = gcc-13
 endif
 ifeq ($(CXX),g++)
-CXX = g++-9
+CXX = g++-13
 endif
 
 # Set the optimization level from the environment, or default to -O2.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ You can build from scratch as follows:
     # Install some dependencies
     sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     sudo apt-get update
-    sudo apt-get install build-essential gcc-9 g++-9 libpcre++-dev zlib1g-dev
+    sudo apt-get install build-essential gcc-13 g++-13 libpcre++-dev zlib1g-dev
 
     # Build it
     cd Bedrock
@@ -73,7 +73,7 @@ You can build from scratch as follows:
 
     # Install some dependencies with Brew (see: https://brew.sh/)
     brew update
-    brew install gcc@6
+    brew install gcc@13
 
     # Configure PCRE to use C++17 and compile from source
     brew uninstall --ignore-dependencies pcre
@@ -81,7 +81,7 @@ You can build from scratch as follows:
     # Add these to the end of the `system "./configure"` command:
     #     "--enable-cpp",
     #     "--enable-pcre64",
-    #     "CXX=/usr/local/bin/g++-9",
+    #     "CXX=/usr/local/bin/g++-13",
     #     "CXXFLAGS=--std=gnu++14"
     brew install --build-from-source pcre
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -147,7 +147,7 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, cons
 {
     SASSERT(_originalPriority >= 0);
     onPrepareHandlerEnabled = false;
-    
+
     // We create a copy of the database handle here so that the sync node can operate on its handle and the plugin gets
     // its own handle to operate on. This avoids conflicts where the sync thread and the plugin are trying to both run
     // queries at the same time. This also avoids the need to create any share locking between the two.
@@ -567,7 +567,7 @@ bool SQLiteNode::update() {
         size_t numFullPeers = 0;
         size_t numLoggedInFullPeers = 0;
         SQLitePeer* freshestPeer = nullptr;
-        for (const auto peer : _peerList) {
+        for (const auto& peer : _peerList) {
             // Count how many full peers (non-permafollowers) we have, and how many are logged in.
             // Note that the `permaFollower` property is const and this value will always be the same for a given peer.
             if (!peer->permaFollower) {

--- a/test/clustertest/tests/ClusterUpgradeTest.cpp
+++ b/test/clustertest/tests/ClusterUpgradeTest.cpp
@@ -69,7 +69,7 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
             ASSERT_FALSE(system(("cd " + brReleaseDir + " && cd Bedrock && git checkout " + bedrockTagName + "  > /dev/null").c_str()));
 
             // Build the release.
-            ASSERT_FALSE(system(("cd " + brReleaseDir + " && cd Bedrock && make -j8 > /dev/null").c_str()));
+            ASSERT_FALSE(system(("cd " + brReleaseDir + " && cd Bedrock && CXX=g++-9 CC=gcc-9 make -j8 > /dev/null").c_str()));
 
             // Save the final product.
             mkdir(prodBedrockDirName.c_str(), 0755);

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -103,8 +103,8 @@ using namespace std;
  */
 #define ASSERT_FLOAT_EQUAL(lhs, rhs) if(tpunit_detail_fp_equal(lhs, rhs, 4)) { PASS(); } else { PrintEquality(lhs, rhs, false); ABORT(); }
 #define EXPECT_FLOAT_EQUAL(lhs, rhs) if(tpunit_detail_fp_equal(lhs, rhs, 4)) { PASS(); } else { PrintEquality(lhs, rhs, false); FAIL(); }
-#define ASSERT_FLOAT_NEAR(lhs, rhs, abs_error) if((((lhs) > (rhs)) ? (lhs) - (rhs) : (rhs) - (lhs)) <= (abs_error)) { PASS(); } else { "incorrectly asserted " + SToStr(lhs) + " near " + SToStr(rhs); ABORT(); }
-#define EXPECT_FLOAT_NEAR(lhs, rhs, abs_error) if((((lhs) > (rhs)) ? (lhs) - (rhs) : (rhs) - (lhs)) <= (abs_error)) { PASS(); } else { "incorrectly expected " + SToStr(lhs) + " near " + SToStr(rhs); FAIL(); }
+#define ASSERT_FLOAT_NEAR(lhs, rhs, abs_error) if((((lhs) > (rhs)) ? (lhs) - (rhs) : (rhs) - (lhs)) <= (abs_error)) { PASS(); } else { TESTINFO("incorrectly asserted " + SToStr(lhs) + " near " + SToStr(rhs)); ABORT(); }
+#define EXPECT_FLOAT_NEAR(lhs, rhs, abs_error) if((((lhs) > (rhs)) ? (lhs) - (rhs) : (rhs) - (lhs)) <= (abs_error)) { PASS(); } else { TESTINFO("incorrectly expected " + SToStr(lhs) + " near " + SToStr(rhs)); FAIL(); }
 
 /**
  * The set of macros for checking whether a statement will throw or not

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -101,8 +101,8 @@ using namespace std;
  * ASSERT|EXPECT_FLOAT_NEAR(lhs, rhs, abs_error); generates a failure if
  * the given floating-point values exceed the absolute error.
  */
-#define ASSERT_FLOAT_EQUAL(lhs, rhs) if(tpunit_detail_fp_equal(lhs, rhs, 4)) { PASS(); } else { "incorrectly asserted " + SToStr(lhs) + " = " + SToStr(rhs); ABORT(); }
-#define EXPECT_FLOAT_EQUAL(lhs, rhs) if(tpunit_detail_fp_equal(lhs, rhs, 4)) { PASS(); } else { "incorrectly expected " + SToStr(lhs) + " = " + SToStr(rhs); FAIL(); }
+#define ASSERT_FLOAT_EQUAL(lhs, rhs) if(tpunit_detail_fp_equal(lhs, rhs, 4)) { PASS(); } else { PrintEquality(lhs, rhs, false); ABORT(); }
+#define EXPECT_FLOAT_EQUAL(lhs, rhs) if(tpunit_detail_fp_equal(lhs, rhs, 4)) { PASS(); } else { PrintEquality(lhs, rhs, false); FAIL(); }
 #define ASSERT_FLOAT_NEAR(lhs, rhs, abs_error) if((((lhs) > (rhs)) ? (lhs) - (rhs) : (rhs) - (lhs)) <= (abs_error)) { PASS(); } else { "incorrectly asserted " + SToStr(lhs) + " near " + SToStr(rhs); ABORT(); }
 #define EXPECT_FLOAT_NEAR(lhs, rhs, abs_error) if((((lhs) > (rhs)) ? (lhs) - (rhs) : (rhs) - (lhs)) <= (abs_error)) { PASS(); } else { "incorrectly expected " + SToStr(lhs) + " near " + SToStr(rhs); FAIL(); }
 

--- a/travis.sh
+++ b/travis.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-export CXX=g++-9
-export CC=gcc-9
+export CXX=g++-13
+export CC=gcc-13
 
 # Add the current working directory to $PATH so that tests can find bedrock.
 export PATH=$PATH:`pwd`
@@ -72,7 +72,7 @@ else
 fi
 
 sudo apt-get update -y
-sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install gcc-9 g++-9
+sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install gcc-13 g++-13
 
 travis_time_finish
 travis_fold end build_bedrock


### PR DESCRIPTION
### Details
Follow up of https://github.com/Expensify/Bedrock/pull/1606, actually migrates the compiler in this repo to GCC 13. 

### Fixed Issues
https://github.com/Expensify/Expensify/issues/334261

### Tests
Existing.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
