### PR TITLE
Add SData operator for <<

### DIFF
--- a/libstuff/SData.h
+++ b/libstuff/SData.h
@@ -111,3 +111,10 @@ struct SData {
     static SData create(const string& rhs);
     static const string placeholder;
 };
+
+// Support output stream operations.
+inline ostream& operator<<(ostream& output, const SData& val)
+{
+    output << val.serialize();
+    return output;
+}


### PR DESCRIPTION
### Details
@tylerkaraszewski please review. had this change sitting my in my working tree, it can be pretty helpful for debugging, potentially for logging too. Adds a `<<` operator for SData serialization.


### Fixed Issues
None, QOL

### Tests
used it in debugging, it worked. 
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
