### PR TITLE
Block the CURRENT_TIMESTAMP function in writes.

### DIFF
--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -506,4 +506,7 @@ class SQLite {
 
     // This is a string (which may be empty) containing the most recent logged error by SQLite in this thread.
     static thread_local string _mostRecentSQLiteErrorLog;
+
+    // Set to true inside of a write query.
+    bool _currentlyWriting{false};
 };


### PR DESCRIPTION
### Details
~[HOLD] https://github.com/Expensify/Auth/pull/9182~

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/335499

### Tests

Auth:

Two tests fail, PR created.

With the linked auth PR:
```
[ TEST RESULTS ] Passed: 2438, Failed: 0
```
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
