### PR TITLE
Add support for `START OF HOUR` date/time modifier for job repeat

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1391,12 +1391,18 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
     }
 
     for (const string& part : parts) {
+        // This isn't supported natively by SQLite, so do it manually here instead.
         if (SToUpper(part) == "START OF HOUR") {
-            // Transform to strftime.
+            SQResult result;
+            if (!db.read("SELECT STRFTIME('%Y-%m-%d %H:00:00', " + base + ");", result) || result.empty()) {
+                SWARN("Syntax error, failed parsing repeat "+part);
+                return "";
+            }
 
+            base = SQ(result[0][0]);
         } else if (!SIsValidSQLiteDateModifier(part)){
             // Validate the sqlite date modifiers
-            SWARN("Syntax error, failed parsing repeat "+part);
+            SWARN("Syntax error, failed parsing repeat " + part);
             return "";
         } else {
             SQResult result;

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1377,16 +1377,16 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
     }
 
     // Make sure the first part indicates the base (eg, what we are modifying)
-    string base = parts.front();
+    string nextRun = parts.front();
     parts.pop_front();
-    if (base == "SCHEDULED") {
-        base = SQ(lastScheduled);
-    } else if (base == "STARTED") {
-        base = SQ(lastRun);
-    } else if (base == "FINISHED") {
-        base = SCURRENT_TIMESTAMP();
+    if (nextRun == "SCHEDULED") {
+        nextRun = SQ(lastScheduled);
+    } else if (nextRun == "STARTED") {
+        nextRun = SQ(lastRun);
+    } else if (nextRun == "FINISHED") {
+        nextRun = SCURRENT_TIMESTAMP();
     } else {
-        SWARN("Syntax error, failed parsing repeat '" << repeat << "': missing base (" << base << ")");
+        SWARN("Syntax error, failed parsing repeat '" << repeat << "': missing base (" << nextRun << ")");
         return "";
     }
 
@@ -1394,28 +1394,28 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
         // This isn't supported natively by SQLite, so do it manually here instead.
         if (SToUpper(part) == "START OF HOUR") {
             SQResult result;
-            if (!db.read("SELECT STRFTIME('%Y-%m-%d %H:00:00', " + base + ");", result) || result.empty()) {
+            if (!db.read("SELECT STRFTIME('%Y-%m-%d %H:00:00', " + nextRun + ");", result) || result.empty()) {
                 SWARN("Syntax error, failed parsing repeat "+part);
                 return "";
             }
 
-            base = SQ(result[0][0]);
+            nextRun = SQ(result[0][0]);
         } else if (!SIsValidSQLiteDateModifier(part)){
             // Validate the sqlite date modifiers
             SWARN("Syntax error, failed parsing repeat " + part);
             return "";
         } else {
             SQResult result;
-            if (!db.read("SELECT DATETIME(" + base + ", " + SQ(part) + ");", result) || result.empty()) {
+            if (!db.read("SELECT DATETIME(" + nextRun + ", " + SQ(part) + ");", result) || result.empty()) {
                 SWARN("Syntax error, failed parsing repeat "+part);
                 return "";
             }
 
-            base = SQ(result[0][0]);
+            nextRun = SQ(result[0][0]);
         }
     }
 
-    return "DATETIME(" + base + ")";
+    return "DATETIME(" + nextRun + ")";
 }
 
 // ==========================================================================

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1395,7 +1395,7 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
         if (SToUpper(part) == "START OF HOUR") {
             SQResult result;
             if (!db.read("SELECT STRFTIME('%Y-%m-%d %H:00:00', " + nextRun + ");", result) || result.empty()) {
-                SWARN("Syntax error, failed parsing repeat "+part);
+                SWARN("Syntax error, failed parsing repeat " + part);
                 return "";
             }
 
@@ -1407,7 +1407,7 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
         } else {
             SQResult result;
             if (!db.read("SELECT DATETIME(" + nextRun + ", " + SQ(part) + ");", result) || result.empty()) {
-                SWARN("Syntax error, failed parsing repeat "+part);
+                SWARN("Syntax error, failed parsing repeat " + part);
                 return "";
             }
 

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1415,7 +1415,7 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
         }
     }
 
-    return base;
+    return "DATETIME(" + base + ")";
 }
 
 // ==========================================================================

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -33,8 +33,8 @@ class BedrockJobsCommand : public BedrockCommand {
 
   private:
     // Helper functions
-    string _constructNextRunDATETIME(const string& lastScheduled, const string& lastRun, const string& repeat);
-    bool _validateRepeat(const string& repeat) { return !_constructNextRunDATETIME("", "", repeat).empty(); }
+    string _constructNextRunDATETIME(SQLite& db, const string& lastScheduled, const string& lastRun, const string& repeat);
+    bool _validateRepeat(SQLite& db, const string& repeat) { return !_constructNextRunDATETIME(db, "", "", repeat).empty(); }
     bool _hasPendingChildJobs(SQLite& db, int64_t jobID);
     void _validatePriority(const int64_t priority);
 

--- a/test/tests/jobs/RetryJobTest.cpp
+++ b/test/tests/jobs/RetryJobTest.cpp
@@ -344,7 +344,7 @@ struct RetryJobTest : tpunit::TestFixture {
         SData command("CreateJob");
         command["name"] = "job";
         command["repeat"] = "SCHEDULED, START OF DAY, +5 MINUTES, START OF HOUR";
-        command["nextRun"] = now;
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", now);
         STable response = tester->executeWaitVerifyContentTable(command);
         string jobID = response["jobID"];
 
@@ -375,7 +375,7 @@ struct RetryJobTest : tpunit::TestFixture {
         SData command("CreateJob");
         command["name"] = "job";
         command["repeat"] = "SCHEDULED, START OF DAY, +30 MINUTES, START OF HOUR, +5 MINUTES";
-        command["nextRun"] = now;
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", now);
         STable response = tester->executeWaitVerifyContentTable(command);
         string jobID = response["jobID"];
 

--- a/test/tests/jobs/RetryJobTest.cpp
+++ b/test/tests/jobs/RetryJobTest.cpp
@@ -17,6 +17,7 @@ struct RetryJobTest : tpunit::TestFixture {
                               TEST(RetryJobTest::delayError),
                               TEST(RetryJobTest::hasRepeat),
                               TEST(RetryJobTest::hasRepeatStartOfHour),
+                              TEST(RetryJobTest::hasRepeatStartOfHourNotLast),
                               TEST(RetryJobTest::inRunqueuedState),
                               TEST(RetryJobTest::simplyRetryWithNextRun),
                               TEST(RetryJobTest::changeNameAndPriority),
@@ -364,6 +365,37 @@ struct RetryJobTest : tpunit::TestFixture {
         tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
         ASSERT_EQUAL(result.size(), 1);
         ASSERT_EQUAL(result[0][0], SComposeTime("%Y-%m-%d 00:00:00", now));
+    }
+
+    // Same as hasRepeatStartOfHour but "START OF HOUR" is not last, to confirm it works when not last.
+    void hasRepeatStartOfHourNotLast() {
+        uint64_t now = STimeNow();
+
+        // Create the job
+        SData command("CreateJob");
+        command["name"] = "job";
+        command["repeat"] = "STARTED, START OF DAY, +30 MINUTES, START OF HOUR, +5 MINUTES";
+        command["nextRun"] = now;
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Retry it
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm nextRun is at the beginning of the day and not 5 minutes after
+        SQResult result;
+        tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
+        ASSERT_EQUAL(result.size(), 1);
+        ASSERT_EQUAL(result[0][0], SComposeTime("%Y-%m-%d 00:05:00", now));
     }
 
     // Retry job in RUNQUEUED state

--- a/test/tests/jobs/RetryJobTest.cpp
+++ b/test/tests/jobs/RetryJobTest.cpp
@@ -343,7 +343,7 @@ struct RetryJobTest : tpunit::TestFixture {
         // Create the job
         SData command("CreateJob");
         command["name"] = "job";
-        command["repeat"] = "STARTED, START OF DAY, +5 MINUTES, START OF HOUR";
+        command["repeat"] = "SCHEDULED, START OF DAY, +5 MINUTES, START OF HOUR";
         command["nextRun"] = now;
         STable response = tester->executeWaitVerifyContentTable(command);
         string jobID = response["jobID"];
@@ -374,7 +374,7 @@ struct RetryJobTest : tpunit::TestFixture {
         // Create the job
         SData command("CreateJob");
         command["name"] = "job";
-        command["repeat"] = "STARTED, START OF DAY, +30 MINUTES, START OF HOUR, +5 MINUTES";
+        command["repeat"] = "SCHEDULED, START OF DAY, +30 MINUTES, START OF HOUR, +5 MINUTES";
         command["nextRun"] = now;
         STable response = tester->executeWaitVerifyContentTable(command);
         string jobID = response["jobID"];

--- a/test/tests/jobs/RetryJobTest.cpp
+++ b/test/tests/jobs/RetryJobTest.cpp
@@ -16,6 +16,7 @@ struct RetryJobTest : tpunit::TestFixture {
                               TEST(RetryJobTest::positiveDelay),
                               TEST(RetryJobTest::delayError),
                               TEST(RetryJobTest::hasRepeat),
+                              TEST(RetryJobTest::hasRepeatStartOfHour),
                               TEST(RetryJobTest::inRunqueuedState),
                               TEST(RetryJobTest::simplyRetryWithNextRun),
                               TEST(RetryJobTest::changeNameAndPriority),
@@ -332,6 +333,37 @@ struct RetryJobTest : tpunit::TestFixture {
         time_t createdTime = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
         time_t nextRunTime = JobTestHelper::getTimestampForDateTimeString(result[0][1]);
         ASSERT_EQUAL(difftime(nextRunTime, createdTime), 3600);
+    }
+
+    // Retry a job with a repeat that uses the custom "START OF HOUR" modifier
+    void hasRepeatStartOfHour() {
+        uint64_t now = STimeNow();
+
+        // Create the job
+        SData command("CreateJob");
+        command["name"] = "job";
+        command["repeat"] = "STARTED, START OF DAY, +5 MINUTES, START OF HOUR";
+        command["nextRun"] = now;
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Retry it
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // Confirm nextRun is at the beginning of the day and not 5 minutes after
+        SQResult result;
+        tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
+        ASSERT_EQUAL(result.size(), 1);
+        ASSERT_EQUAL(result[0][0], SComposeTime("%Y-%m-%d 00:00:00", now));
     }
 
     // Retry job in RUNQUEUED state


### PR DESCRIPTION
### Details

Add support for `START OF HOUR` date/time modifier for job repeat

### Fixed Issues
Partial fix for https://github.com/Expensify/Expensify/issues/335314

### Tests
Added a unit tests, plus existing unit tests cover this flow
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
