### PR TITLE
[HOLD] Move prepeek out of a db transaction

### DIFF
--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -49,10 +49,10 @@ class BedrockCommand : public SQLiteCommand {
     // Destructor.
     virtual ~BedrockCommand();
 
-    // Optionally called to execute read-only operations for a command in a separate transaction than the transaction
-    // that can execute write operations for a command (i.e. the transaction that runs peek and process). This must be
+    // Optionally called to execute read-only operations for a command separately
+    // than the execution of write operations for a command (i.e. the transaction that runs peek and process). This must be
     // called before the transaction that executes write operations.
-    virtual void prePeek(SQLite& db) { STHROW("500 Base class prePeek called"); }
+    virtual bool prePeek(SQLite& db) { STHROW("500 Base class prePeek called"); }
 
     // Called to attempt to handle a command in a read-only fashion. Should return true if the command has been
     // completely handled and a response has been written into `command.response`, which can be returned to the client.
@@ -88,7 +88,7 @@ class BedrockCommand : public SQLiteCommand {
     }
 
     // Bedrock will call this before writing to the database after it has prepared a transaction for each plugin to allow it to
-    // enable a handler function for prepare If a plugin would like to perform operations after prepare but before commit, this should 
+    // enable a handler function for prepare If a plugin would like to perform operations after prepare but before commit, this should
     // return true, and it should set the prepareHandler it would like to use.
     virtual bool shouldEnableOnPrepareNotification(const SQLite& db, void (**onPrepareHandler)(SQLite& _db, int64_t tableID)) {
         return false;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -757,7 +757,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
     SQLiteNodeState state = _replicationState.load();
 
     // If we're following, we will automatically escalate any command that's:
-    // 1. Not already complete (complete commands are likely already returned from leader with legacy escalation) 
+    // 1. Not already complete (complete commands are likely already returned from leader with legacy escalation)
     // and is marked as `escalateImmediately` (which lets them skip the queue, which is particularly useful if they're waiting
     // for a previous commit to be delivered to this follower);
     // 2. Any commands if the current version of the code is not the same one as leader is executing.

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -171,7 +171,7 @@ bool BedrockPlugin_TestPlugin::preventAttach() {
     return shouldPreventAttach;
 }
 
-void TestPluginCommand::prePeek(SQLite& db) {
+bool TestPluginCommand::prePeek(SQLite& db) {
     if (request.methodLine == "prepeekcommand" || request.methodLine == "prepeekpostprocesscommand") {
         if (request["shouldThrow"] == "true") {
             STHROW("501 ERROR");
@@ -180,6 +180,8 @@ void TestPluginCommand::prePeek(SQLite& db) {
     } else {
         STHROW("500 no prePeek defined, shouldPrePeek should be false");
     }
+
+    return false;
 }
 bool TestPluginCommand::peek(SQLite& db) {
     // Always blacklist on userID.
@@ -368,7 +370,7 @@ void TestPluginCommand::process(SQLite& db) {
     // upgradeDatabase and the thread running in `stateChanged`, it is possible the sync thread
     // tries to accept a command on a loop before `stateChanged` queries and gets a value for _maxID.
     // Also note this really doesn't matter in production, because we don't use `upgradeDatabase` this
-    // truly only exists for dev and testing to function properly. 
+    // truly only exists for dev and testing to function properly.
     while (plugin()._maxID < 0) {
         SINFO("Waiting for _maxID " << plugin()._maxID);
         usleep(50'000);

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -44,7 +44,7 @@ class TestPluginCommand : public BedrockCommand {
   public:
     TestPluginCommand(SQLiteCommand&& baseCommand, BedrockPlugin_TestPlugin* plugin);
     ~TestPluginCommand();
-    virtual void prePeek(SQLite& db);
+    virtual bool prePeek(SQLite& db);
     virtual bool peek(SQLite& db);
     virtual void process(SQLite& db);
     virtual void postProcess(SQLite& db);


### PR DESCRIPTION
### Details
See this thread for details: https://expensify.slack.com/archives/C094TGUTZ/p1701196803575909?thread_ts=1700652975.334579&cid=C094TGUTZ

### Fixed Issues
N/A

### Tests
Ongoing
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
