### PR TITLE
Revert "Allocate RNG when called, not at startup"

### DIFF
--- a/libstuff/SRandom.cpp
+++ b/libstuff/SRandom.cpp
@@ -1,25 +1,20 @@
 #include "SRandom.h"
 
+#ifdef VALGRIND
+// random_device breaks valgrind.
+mt19937_64 SRandom::_generator = mt19937_64();
+#else
+mt19937_64 SRandom::_generator = mt19937_64(random_device()());
+#endif
+
 uniform_int_distribution<uint64_t> SRandom::_distribution64 = uniform_int_distribution<uint64_t>();
 
 uint64_t SRandom::limitedRand64(uint64_t minNum, uint64_t maxNum) {
      uniform_int_distribution<uint64_t> limitedRandom(minNum, maxNum);
-#ifdef VALGRIND
-    // random_device breaks valgrind.
-    mt19937_64 _generator = mt19937_64();
-#else
-    mt19937_64 _generator = mt19937_64(random_device()());
-#endif
      return limitedRandom(_generator);
 }
 
 uint64_t SRandom::rand64() {
-#ifdef VALGRIND
-    // random_device breaks valgrind.
-    mt19937_64 _generator = mt19937_64();
-#else
-    mt19937_64 _generator = mt19937_64(random_device()());
-#endif
     return _distribution64(_generator);
 }
 

--- a/libstuff/SRandom.h
+++ b/libstuff/SRandom.h
@@ -13,5 +13,6 @@ class SRandom {
     static string randStr(uint& length);
 
   private:
+    static mt19937_64 _generator;
     static uniform_int_distribution<uint64_t> _distribution64;
 };


### PR DESCRIPTION
Reverts Expensify/Bedrock#1624

Auth tests are working tested against this branch.