### PR TITLE
Allow retrieving value by name

### DIFF
--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -1,6 +1,29 @@
 #include <libstuff/libstuff.h>
 #include "SQResult.h"
 
+SQResultRow::SQResultRow(SQResult& result, size_t count) : vector<string>(count), result(&result) {
+}
+
+SQResultRow::SQResultRow() : vector<string>(), result(nullptr) {
+}
+
+void SQResultRow::push_back(const string& s) {
+    vector<string>::push_back(s);
+}
+
+string& SQResultRow::operator[](const size_t& key) {
+    return vector<string>::operator[](key);
+}
+const string& SQResultRow::operator[](const size_t& key) const {
+    return vector<string>::operator[](key);
+}
+
+SQResultRow& SQResultRow::operator=(const SQResultRow& other) {
+    vector<string>::operator=(other);
+    result = other.result;
+    return *this;
+}
+
 string SQResult::serializeToJSON() const {
     // Just output as a simple object
     // **NOTE: This probably isn't super fast, but could be easily optimized
@@ -90,7 +113,7 @@ void SQResult::clear() {
     rows.clear();
 }
 
-vector<string>& SQResult::operator[](size_t rowNum) {
+SQResultRow& SQResult::operator[](size_t rowNum) {
     try {
         return rows.at(rowNum);
     } catch (const out_of_range& e) {
@@ -98,7 +121,7 @@ vector<string>& SQResult::operator[](size_t rowNum) {
     }
 }
 
-const vector<string>& SQResult::operator[](size_t rowNum) const {
+const SQResultRow& SQResult::operator[](size_t rowNum) const {
     try {
         return rows.at(rowNum);
     } catch (const out_of_range& e) {

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -105,3 +105,21 @@ const vector<string>& SQResult::operator[](size_t rowNum) const {
         STHROW("Out of range");
     }
 }
+
+string& SQResult::cell(size_t row, const string& cellKey) {
+    for (size_t i = 0; i < headers.size(); i++) {
+        if (headers[i] == cellKey) {
+            return rows[row][i];
+        }
+    }
+    throw out_of_range("No column named " + cellKey);
+}
+
+const string& SQResult::cell(size_t row, const string& cellKey) const {
+    for (size_t i = 0; i < headers.size(); i++) {
+        if (headers[i] == cellKey) {
+            return rows[row][i];
+        }
+    }
+    throw out_of_range("No column named " + cellKey);
+}

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -24,6 +24,40 @@ SQResultRow& SQResultRow::operator=(const SQResultRow& other) {
     return *this;
 }
 
+string& SQResultRow::operator[](const string& key) {
+    if (result) {
+        for (size_t i = 0; i < result->headers.size(); i++) {
+
+            // If the headers have more entries than the row (they really shouldn't), break early instead of segfaulting.
+            if (i >= size()) {
+                break;
+            }
+
+            if (result->headers[i] == key) {
+                return (*this)[i];
+            }
+        }
+    }
+    throw out_of_range("No column named " + key);
+}
+
+const string& SQResultRow::operator[](const string& key) const {
+    if (result) {
+        for (size_t i = 0; i < result->headers.size(); i++) {
+
+            // If the headers have more entries than the row (they really shouldn't), break early instead of segfaulting.
+            if (i >= size()) {
+                break;
+            }
+
+            if (result->headers[i] == key) {
+                return (*this)[i];
+            }
+        }
+    }
+    throw out_of_range("No column named " + key);
+}
+
 string SQResult::serializeToJSON() const {
     // Just output as a simple object
     // **NOTE: This probably isn't super fast, but could be easily optimized
@@ -127,22 +161,4 @@ const SQResultRow& SQResult::operator[](size_t rowNum) const {
     } catch (const out_of_range& e) {
         STHROW("Out of range");
     }
-}
-
-string& SQResult::cell(size_t row, const string& cellKey) {
-    for (size_t i = 0; i < headers.size(); i++) {
-        if (headers[i] == cellKey) {
-            return rows[row][i];
-        }
-    }
-    throw out_of_range("No column named " + cellKey);
-}
-
-const string& SQResult::cell(size_t row, const string& cellKey) const {
-    for (size_t i = 0; i < headers.size(); i++) {
-        if (headers[i] == cellKey) {
-            return rows[row][i];
-        }
-    }
-    throw out_of_range("No column named " + cellKey);
 }

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -3,12 +3,28 @@
 #include <string>
 #include <vector>
 using namespace std;
+class SQResult;
+
+class SQResultRow : public vector<string> {
+  public:
+    SQResultRow();
+    SQResultRow(SQResult& result, size_t count = 0);
+    void push_back(const string& s);
+    string& operator[](const size_t& key);
+    const string& operator[](const size_t& key) const;
+    string& operator[](const string& key);
+    const string& operator[](const string& key) const;
+    SQResultRow& operator=(const SQResultRow& other);
+
+  private:
+    SQResult* result = nullptr;
+};
 
 class SQResult {
   public:
     // Attributes
     vector<string> headers;
-    vector<vector<string>> rows;
+    vector<SQResultRow> rows;
 
     // Accessors
     bool empty() const;
@@ -18,8 +34,8 @@ class SQResult {
     void clear();
 
     // Operators
-    vector<string>& operator[](size_t rowNum);
-    const vector<string>& operator[](size_t rowNum) const;
+    SQResultRow& operator[](size_t rowNum);
+    const SQResultRow& operator[](size_t rowNum) const;
 
     string& cell(size_t row, const string& cellKey);
     const string& cell(size_t row, const string& cellKey) const;

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -21,6 +21,9 @@ class SQResult {
     vector<string>& operator[](size_t rowNum);
     const vector<string>& operator[](size_t rowNum) const;
 
+    string& cell(size_t row, const string& cellKey);
+    const string& cell(size_t row, const string& cellKey) const;
+
     // Serializers
     string serializeToJSON() const;
     string serializeToText() const;

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -37,9 +37,6 @@ class SQResult {
     SQResultRow& operator[](size_t rowNum);
     const SQResultRow& operator[](size_t rowNum) const;
 
-    string& cell(size_t row, const string& cellKey);
-    const string& cell(size_t row, const string& cellKey) const;
-
     // Serializers
     string serializeToJSON() const;
     string serializeToText() const;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2592,7 +2592,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
                 }
 
                 if (error == SQLITE_ROW) {
-                    result.rows.emplace_back(vector<string>(numColumns));
+                    result.rows.emplace_back(SQResultRow(result, numColumns));
                     for (int i = 0; i < numColumns; i++) {
                         int colType = sqlite3_column_type(preparedStatement, i);
                         switch (colType) {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -721,7 +721,7 @@ int SQLite::commit(const string& description, function<void()>* preCheckpointCal
         sqlite3_file *pWal = 0;
         sqlite3_int64 sz = 0;
         sqlite3_file_control(_db, "main", SQLITE_FCNTL_JOURNAL_POINTER, &pWal);
-        if (pWal) {
+        if (pWal && pWal->pMethods) {
             // This is not set for HC-tree DBs.
             pWal->pMethods->xFileSize(pWal, &sz);
         }

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -568,7 +568,7 @@ bool BedrockTester::readDB(const string& query, SQResult& result, bool online)
         list<string> rows = SParseJSONArray(row0);
         for (const string& rowStr : rows) {
             list<string> vals = SParseJSONArray(rowStr);
-            vector<string> row;
+            SQResultRow row(result);
             for (auto& v : vals) {
                 row.push_back(v);
             }

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -654,22 +654,29 @@ struct LibStuff : tpunit::TestFixture {
         db.rollback();
 
         // All our names make sense?
-        ASSERT_EQUAL(result.cell(0, "name"), "name1");
-        ASSERT_EQUAL(result.cell(1, "name"), "name2");
-        ASSERT_EQUAL(result.cell(2, "name"), "name3");
+        ASSERT_EQUAL(result[0]["name"], "name1");
+        ASSERT_EQUAL(result[1]["name"], "name2");
+        ASSERT_EQUAL(result[2]["name"], "name3");
 
         // All our values make sense?
-        ASSERT_EQUAL(result.cell(0, "value"), "value1");
-        ASSERT_EQUAL(result.cell(1, "value"), "value2");
-        ASSERT_EQUAL(result.cell(2, "value"), "value3");
+        ASSERT_EQUAL(result[0]["value"], "value1");
+        ASSERT_EQUAL(result[1]["value"], "value2");
+        ASSERT_EQUAL(result[2]["value"], "value3");
 
         // Validate our exception handling.
         bool threw = false;
         try {
-            string s = result.cell(0, "notacolumn");
+            string s = result[0]["notacolumn"];
         } catch (const out_of_range& e) {
             threw = true;
         }
         ASSERT_TRUE(threw);
+
+        // Test aliased names.
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED);
+        result.clear();
+        db.read("SELECT name as caca, value FROM testTable ORDER BY id;", result);
+        db.rollback();
+        ASSERT_EQUAL(result[0]["caca"], "name1");
     }
 } __LibStuff;

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -675,8 +675,8 @@ struct LibStuff : tpunit::TestFixture {
         // Test aliased names.
         db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED);
         result.clear();
-        db.read("SELECT name as caca, value FROM testTable ORDER BY id;", result);
+        db.read("SELECT name as coco, value FROM testTable ORDER BY id;", result);
         db.rollback();
-        ASSERT_EQUAL(result[0]["caca"], "name1");
+        ASSERT_EQUAL(result[0]["coco"], "name1");
     }
 } __LibStuff;


### PR DESCRIPTION
### Details
This allows retrieving a row/column value from an SQResult by name instead of just numeric index.

~Hold for: https://github.com/Expensify/Auth/pull/9505~

### Fixed Issues
Fixes https://github.com/Expensify/Auth/pull/9469#discussion_r1430510490

### Tests
Added

Auth tests passed in VM.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
