### PR TITLE
Add group edge to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ notifications:
 script: ./travis.sh
 os: linux
 dist: focal
+group: edge
 os: linux
 language: cpp
 vm:


### PR DESCRIPTION
### Details
Applies to the same fix as we did in Auth with https://github.com/Expensify/Auth/pull/9483 - see https://expensify.enterprise.slack.com/archives/C06BHM7BWUQ

### Fixed Issues
Failed build https://app.travis-ci.com/github/Expensify/Bedrock/builds/267981383

### Tests
Be able to deploy Bedrock to production
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
