### PR TITLE
Add command count to Status response

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1691,10 +1691,11 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
             pluginList.push_back(SComposeJSONObject(pluginData));
         }
         content["isLeader"] = state == SQLiteNodeState::LEADING ? "true" : "false";
-        content["plugins"]  = SComposeJSONArray(pluginList);
-        content["state"]    = SQLiteNode::stateName(state);
-        content["version"]  = _version;
-        content["host"]     = args["-nodeHost"];
+        content["plugins"] = SComposeJSONArray(pluginList);
+        content["state"] = SQLiteNode::stateName(state);
+        content["version"] = _version;
+        content["host"] = args["-nodeHost"];
+        content["commandCount"] = BedrockCommand::getCommandCount();
 
         {
             // Make it known if anything is known to cause crashes.


### PR DESCRIPTION
### Details
Adds `commandCount` to `Status` response, i.e.:
```
{
"commandCount":1,
"commandPortBlockReasons":[],
"CommitCount":403,
"crashCommands":0,
"host":"0.0.0.0:4445",
"isLeader":true,
"multiWriteEnabled":true,
"multiWriteManualBlacklist":[],
"peerList":[],
"plugins":[{"name":"Auth","version":1},{"name":"DB"},{"name":"expensifyBackupManager","version":"cbeb484250"}],
"priority":-1,
"queuedCommandList":[],
"state":"LEADING",
"syncNodeAvailable":true,
"syncThreadQueuedCommandList":[],
"version":"Auth_1:b1502192f4:expensifyBackupManager_cbeb484250"
}
```

### Fixed Issues
Fixes GH_LINK

### Tests
While running bedrock, send a Status command:
```
> nc locahost 4444
Status

```

Verify it contains a command count.