### PR TITLE
Update tester to allow forcing ordered commands.

### DIFF
--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -35,6 +35,8 @@ class ClusterTester {
     // Stops a given node.
     void stopNode(size_t index);
 
+    atomic<uint64_t> groupCommitCount{0};
+
   private:
 
     // The number of nodes in the cluster.
@@ -140,7 +142,7 @@ ClusterTester<T>::ClusterTester(ClusterSize size,
         }
 
         // And add the new entry in the map.
-        _cluster.emplace_back(args, queries, serverPort, nodePort, controlPort, false, processPath);
+        _cluster.emplace_back(args, queries, serverPort, nodePort, controlPort, false, processPath, &groupCommitCount);
     }
 
     // Now start them all.

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -40,11 +40,13 @@ BedrockTester::BedrockTester(const map<string, string>& args,
                              uint16_t nodePort,
                              uint16_t controlPort,
                              bool startImmediately,
-                             const string& bedrockBinary) :
+                             const string& bedrockBinary,
+                             atomic<uint64_t>* alternateCounter) :
     _serverPort(serverPort ?: ports.getPort()),
     _nodePort(nodePort ?: ports.getPort()),
     _controlPort(controlPort ?: ports.getPort()),
-    _commandPortPrivate(ports.getPort())
+    _commandPortPrivate(ports.getPort()),
+    _commitCount(alternateCounter ? *alternateCounter : _commitCountBase)
 {
     {
         lock_guard<decltype(_testersMutex)> lock(_testersMutex);
@@ -396,6 +398,9 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
                         break;
                     } else {
                         myRequest = requests[myIndex];
+                        if (_enforceCommandOrder) {
+                            myRequest["commitCount"] = to_string(_commitCount);
+                        }
                     }
 
                     // Reset this for the next request that might need it.
@@ -490,6 +495,12 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
                     } else if (!timedOut) {
                         // Ok, done, let's lock again and insert this in the results.
                         SData responseData;
+                        if (headers.find("commitCount") != headers.end()) {
+                            uint64_t newCommitCount = SToUInt64(headers["commitCount"]);
+                            if (newCommitCount > _commitCount) {
+                                _commitCount = newCommitCount;
+                            }
+                        }
                         responseData.nameValueMap = headers;
                         responseData.methodLine = methodLine;
                         responseData.content = content;
@@ -610,4 +621,8 @@ bool BedrockTester::waitForState(const string& state, uint64_t timeoutUS)
 int BedrockTester::getPID() const
 {
     return _serverPID;
+}
+
+void BedrockTester::setEnforceCommandOrder(bool enforce) {
+    _enforceCommandOrder = enforce;
 }

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -32,7 +32,8 @@ class BedrockTester {
                   uint16_t nodePort = 0,
                   uint16_t controlPort = 0,
                   bool startImmediately = true,
-                  const string& bedrockBinary = "");
+                  const string& bedrockBinary = "",
+                  atomic<uint64_t>* alternateCounter = nullptr);
 
     // Destructor.
     ~BedrockTester();
@@ -46,6 +47,10 @@ class BedrockTester {
 
     // Shuts down all bedrock servers associated with any existing testers.
     static void stopAll();
+
+    // If enabled, commands will send the most recent `commitCount` received back from this BedrockTester with each new request,
+    // enforcing that prior commands finish before later commands.
+    void setEnforceCommandOrder(bool enforce);
 
     // Generate a temporary filename with an optional prefix. Used particularly to create new DB files for each server,
     // but can generally be used for any temporary file required.
@@ -120,5 +125,9 @@ class BedrockTester {
     uint16_t _nodePort;
     uint16_t _controlPort;
     uint16_t _commandPortPrivate;
+
+    bool _enforceCommandOrder = false;
+    atomic<uint64_t> _commitCountBase = 0;
+    atomic<uint64_t>& _commitCount;
 };
 


### PR DESCRIPTION
### Details

This code adds a new `BedrockTester` API called `setEnforceCommandOrder` that allows the caller to cause a tester to always set the `CommitCount` parameter on every request made to its Bedrock instance, and update it on every response.

This means that if `setEnforceCommandOrder` is true and multiple threads are making requests simultaneously, each request will wait until the bedrock node it's talking to has the latest commit before servicing it. I.e., if you make a request to leader to "UPDATE xyz" and get back commitCount 101, you can then *immediately* make a request to a follower and you will be guaranteed that the follower will have that commit.

The default method of using this for a single `BedrockTester` isn't very useful, so there's a parameter to use an external counter, which `BedrockClusterTester` does. This means that each tester in the cluster will update the same counter, and so when a request to leader sets a higher commit count, any requests to followers made after that will wait for that commit.

This isn't particularly useful currently in the Bedrock tests, but it's going to be very important in an [upcoming auth change](https://github.com/Expensify/Auth/pull/9815). Auth has always assumed that any node it talks to has the latest data, because it only ever talks to leader. This will allow auth to mix requests between leaders and followers and still guarantee consistency.

This PR and this one: https://github.com/Expensify/Auth/pull/9881
Are prerequisites to this big change: https://github.com/Expensify/Bedrock/pull/1640

Instructions:
1. Merge this PR.
2. Immediately re-test https://github.com/Expensify/Auth/pull/9881
3. Merge that Auth PR.

These are changes *only* to the test frameworks, and so can't break anything but tests. If all the tests are passing, these are low risk.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
