### PR TITLE
Don't keep checking https requests that are completed.

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -303,7 +303,6 @@ void BedrockCommand::postPoll(fd_map& fdm, uint64_t nextActivity, uint64_t maxWa
         transaction->manager.postPoll(fdm, *transaction, nextActivity, maxWaitMS);
         requestIt++;
     }
-
 }
 
 void BedrockCommand::setTimeout(uint64_t timeoutDurationMS) {

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -23,7 +23,7 @@ BedrockCommand::BedrockCommand(SQLiteCommand&& baseCommand, BedrockPlugin* plugi
     _commitEmptyTransactions(false),
     _inProgressTiming(INVALID, 0, 0),
     _timeout(_getTimeout(request, scheduledTime)),
-    _lastContiguousCompletedTransaction(httpsRequests.begin())
+    _lastContiguousCompletedTransaction(httpsRequests.end())
 {
     // Initialize the priority, if supplied.
     if (request.isSet("priority")) {
@@ -108,7 +108,7 @@ void BedrockCommand::stopTiming(TIMING_INFO type) {
 }
 
 bool BedrockCommand::areHttpsRequestsComplete() const {
-    list<SHTTPSManager::Transaction*>::iterator requestIt = _lastContiguousCompletedTransaction;
+    auto requestIt = (_lastContiguousCompletedTransaction == httpsRequests.end()) ? httpsRequests.begin() : _lastContiguousCompletedTransaction;
     while (requestIt != httpsRequests.end()) {
         if (!(*requestIt)->response) {
             return false;
@@ -279,7 +279,7 @@ void BedrockCommand::finalizeTimingInfo() {
 
 void BedrockCommand::prePoll(fd_map& fdm)
 {
-    list<SHTTPSManager::Transaction*>::iterator requestIt = _lastContiguousCompletedTransaction;
+    auto requestIt = (_lastContiguousCompletedTransaction == httpsRequests.end()) ? httpsRequests.begin() : _lastContiguousCompletedTransaction;
     while (requestIt != httpsRequests.end()) {
         SHTTPSManager::Transaction* transaction = *requestIt;
         transaction->manager.prePoll(fdm, *transaction);
@@ -289,7 +289,7 @@ void BedrockCommand::prePoll(fd_map& fdm)
 
 void BedrockCommand::postPoll(fd_map& fdm, uint64_t nextActivity, uint64_t maxWaitMS)
 {
-    list<SHTTPSManager::Transaction*>::iterator requestIt = _lastContiguousCompletedTransaction;
+    auto requestIt = (_lastContiguousCompletedTransaction == httpsRequests.end()) ? httpsRequests.begin() : _lastContiguousCompletedTransaction;
     while (requestIt != httpsRequests.end()) {
         SHTTPSManager::Transaction* transaction = *requestIt;
 

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -232,4 +232,6 @@ class BedrockCommand : public SQLiteCommand {
     static atomic<size_t> _commandCount;
 
     static const string defaultPluginName;
+
+    mutable list<SHTTPSManager::Transaction*>::iterator _lastContiguousCompletedTransaction;
 };

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -233,5 +233,15 @@ class BedrockCommand : public SQLiteCommand {
 
     static const string defaultPluginName;
 
+    // This refers to the last request in httpsRequests for which all previous requests (including the one referred to) are known to be complete.
+    // For instance, if there are 10 requests (0-9) in httpsRequests, and 0, 1, 2, 5, and 8 are complete, this can refer to request 2, the last one completed
+    // for which all previous requests are also completed.
+    // This is only updated when `areHttpsRequestsComplete()` is called, hence "known to be complete". Requests may have completed that are not yet known, but no
+    // requests can exist before this iterator that are incomplete.
+    // This is used as an optimization. For some operations (areHttpsRequestsComplete, prePoll, postPoll) we iterate across httpsReqeusts, but only actually need to iterate
+    // across httpsRequests that have not yet finished. This allows us to skip known finished requests. If a command has 1,000 attached requests, and on the previous loop
+    // it was known that 990 of them had completed, then on the next loop we can use this to check only the remaining 10 requests rather than all 1,000.
+    //
+    // The default value of this is httpsRequests.end(), which is treated as "no requests completed".
     mutable list<SHTTPSManager::Transaction*>::const_iterator _lastContiguousCompletedTransaction;
 };

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -233,5 +233,5 @@ class BedrockCommand : public SQLiteCommand {
 
     static const string defaultPluginName;
 
-    mutable list<SHTTPSManager::Transaction*>::iterator _lastContiguousCompletedTransaction;
+    mutable list<SHTTPSManager::Transaction*>::const_iterator _lastContiguousCompletedTransaction;
 };


### PR DESCRIPTION
### Details
This change adds `_lastContiguousCompletedTransaction` to keep track of which https requests are already complete on a command.

We call `areHttpsRequestsComplete` repeatedly in a loop until all https requests finish. For each call to `areHttpsRequestsComplete`, we check every https request on the command. This is not really a problem with commands that make a handful of requests, but we are now developing commands that make dozens, hundreds, or thousands of requests. If a command makes 10,000 https requests, then each call to `areHttpsRequestsComplete` looks at 10,000 requests, even if 9,999 of them were already completed on the last loop.

This change just keeps track of the last contiguous request that was completed. "Contiguous" here means that all https requests from the first one through this one are completed. I.e., if a command has 10 https requests, and requests, 0, 1, 2, 3, 5, 7, and 8 are complete, the last contiguous completed request is number 3, because request 4 is not completed. Because `areHttpsRequestsComplete` exits as soon as it finds an incomplete request, this means that it will exit on the first item checked until request 4 completes, after which it will increment `_lastContiguousCompletedTransaction` through request 5 (which has already completed) until request 6 completes.

This is especially useful for commands that make large number of https requests in batches. If a command makes 10 requests at a time, and uses `repeek` to send 100 of these batches, then by the last batch we will be examining only the last 10 requests instead of all 1000 requests.

`prePoll` and `postPoll` are also updated with the same logic, these requests no longer need polling once complete.

### Fixed Issues
Related to https://github.com/Expensify/Expensify/issues/368959

### Tests
Existing HTTPS test and auth tests.
