### PR TITLE
Revert "Enable HTTPS on followers"

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -141,6 +141,8 @@ SStandaloneHTTPSManager::Transaction::Transaction(SStandaloneHTTPSManager& manag
     sentTime(0),
     requestID(requestID.empty() ? SThreadLogPrefix : requestID)
 {
+    // TODO: Remove this block to to enable HTTPS on followers. Also the `validate` method can be removed entirely.
+    manager.validate();
 }
 
 SStandaloneHTTPSManager::Transaction::~Transaction() {


### PR DESCRIPTION
Reverts Expensify/Bedrock#1647

Voted on this here: https://expensify.slack.com/archives/C06KNCDSSBC/p1708424674574629?thread_ts=1708424167.505529&cid=C06KNCDSSBC

Caused #fireroom-2024-02-20-new-https-broken

In Slack, @tylerkaraszewski mentioned [here](https://expensify.slack.com/archives/C094TGUTZ/p1708380237776499) that if the original PR caused a problem, we would only have to revert this one & deploy to fix:

> The auth deploy for HTTPS requests on followers seems to have gone smoothly. If anyone notices any significant increase in failures on commands that make HTTPS requests (ScrapeCard, commands that talk to Marqeta or Stripe, etc), let me know. If it's a fire, roll back the deploy or revert this PR: https://github.com/Expensify/Bedrock/pull/1647. I'll continue you to monitor for the afternoon.