### PR TITLE
Save responses as not-chunked after de-chunking

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -823,6 +823,9 @@ int SParseHTTP(const char* buffer, size_t length, string& methodLine, STable& na
                     int numEOLs = 2;
                     while (parseEnd < inputEnd && (*parseEnd == '\r' || *parseEnd == '\n') && numEOLs--)
                         ++parseEnd;
+
+                    // The SData object we've generated is not chunked, we remove this header as it does not describe the state of this request.
+                    nameValueMap.erase("Transfer-Encoding");
                     return (int)(parseEnd - buffer);
                 }
 


### PR DESCRIPTION
### Details
So, here's the wierdness this addresses:

`SData` represents a fairly simple HTTP message, with a method line, headers, and a body.

`SParseHTTP` can accept responses with `Transfer-Encoding: chunked`. When it receives this, it reads each chunk into the `SData`'s `content` field, and when it finishes all the chunks, it has a single body with a regular `content-length`.

What this looks like is:
```
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Content-Length: 2

OK
```

This is [wrong](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding). For `Transfer-Encoding: chunked` responses, `Content-Length` should be omitted, and we should use chunked encoding, but what we have for the response body is not chunked.

What happens here is if we call `serialize()` on this data, we get the above (wrong) HTTP message, and if we attempt to `deserialize()` that (wrong) HTTP message, it fails, because it tries to interpret it as `chunked` encoding, but it isn't.

This fix removes the `Transfer-Encoding: chunked` when finishing a chunked request, so that the final request is valid.


### Fixed Issues
Fixes #fireroom-2024-02-20-new-https-broken

### Tests
Auth `AuthenticateGoogle` test.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
