### PR TITLE
Simplify this

### DIFF
--- a/test/lib/PrintEquality.h
+++ b/test/lib/PrintEquality.h
@@ -2,55 +2,39 @@
 
 #include <iostream>
 #include <string>
+#include <set>
+#include <map>
+#include <list>
 #include <cxxabi.h>
 
 using namespace std;
 
+template<typename T>
+ostream& operator<<(ostream& output, const list<T>& val)
+{
+    return output << "[LIST]";
+}
+
+template<typename T>
+ostream& operator<<(ostream& output, const set<T>& val)
+{
+    return output << "[SET]";
+}
+
+template<typename T, typename U>
+ostream& operator<<(ostream& output, const map<T, U>& val)
+{
+    return output << "[MAP]";
+}
+
 class PrintEquality {
     public:
-        template <typename T, enable_if_t<is_integral<T>::value, bool> = true, typename U>
-        PrintEquality(T a, U b, bool isEqual)
-        {
-            // Integral case.
+        template <typename U, typename V>
+        PrintEquality(U a, V b, bool isEqual) {
             if (!isEqual) {
-                cout << "(Integral): " << a << " != " << b << "\n";
+                cout << "Not equal " << a << ", " << b << "\n";
             } else {
-                cout << "(Integral): " << a << " == " << b << "\n";
-            }
-        }
-
-        template <typename T, enable_if_t<!is_integral<T>::value, bool> = true, typename U>
-        PrintEquality(T a, U b, bool isEqual)
-        {
-            // Non-integral base case.
-            char buffer[1000];
-            size_t length = 1000;
-            int status;
-            abi::__cxa_demangle(typeid(a).name(), buffer, &length, &status);
-
-            if (!isEqual) {
-                cout << "Not equal (unhandled type: " << buffer << ")" << "\n";
-            } else {
-                cout << "equal (unhandled type: " << buffer << ")" << "\n";
-            }
-        }
-
-        template <typename U>
-        PrintEquality(string a, U b, bool isEqual)
-        {
-            if (!isEqual) {
-                cout << "(string): \"" << a << "\" != \"" << b << "\"" << "\n";
-            } else {
-                cout << "(string): \"" << a << "\" == \"" << b << "\"" << "\n";
-            }
-        }
-
-        template <typename U>
-        PrintEquality(const char* a, U b, bool isEqual) {
-            if (!isEqual) {
-                cout << "(const char*): \"" << a << "\" != \"" << b << "\"" << "\n";
-            } else {
-                cout << "(const char*): \"" << a << "\" == \"" << b << "\"" << "\n";
+                cout << "equal " << a << ", " << b << "\n";
             }
         }
 };


### PR DESCRIPTION
### Details
Simplifies PrintEquality to not need a million specializations,
Adds (basic) overloads for `list`, `set`, and `map` types so they can print to `ostream`.

Will break auth until this is merged, so do both together:
https://github.com/Expensify/Auth/pull/9992

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
