### PR TITLE
Notice when leader dies.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -712,7 +712,6 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
     // signals, like SIGSEGV, this function will be called.
     SSetSignalHandlerDieFunc([&](){
         _clusterMessenger->runOnAll(_generateCrashMessage(command));
-        _syncNode->kill();
     });
 
     // If we dequeue a status or control command, handle it immediately.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -712,6 +712,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
     // signals, like SIGSEGV, this function will be called.
     SSetSignalHandlerDieFunc([&](){
         _clusterMessenger->runOnAll(_generateCrashMessage(command));
+        _syncNode->kill();
     });
 
     // If we dequeue a status or control command, handle it immediately.

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -76,6 +76,10 @@ class SQLiteNode : public STCPManager {
         NUM_CONSISTENCY_LEVELS
     };
 
+    // This is a globally accessible pointer to some node instance. The intention here is to let signal handling code attempt to kill outstanding
+    // peer connections on this node before shutting down.
+    static SQLiteNode* KILLABLE_SQLITE_NODE;
+
     // Receive timeout for cluster messages.
     static const uint64_t RECV_TIMEOUT;
 
@@ -151,6 +155,9 @@ class SQLiteNode : public STCPManager {
 
     // Call this if you want to shut down the node.
     void beginShutdown();
+
+    // kill all peer connections on this node.
+    void kill();
 
     // Handle any read/write events that occurred.
     void postPoll(fd_map& fdm, uint64_t& nextActivity);

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -72,8 +72,7 @@ SQLitePeer::PeerPostPollStatus SQLitePeer::postPoll(fd_map& fdm, uint64_t& nextA
         switch (socket->state.load()) {
             case STCPManager::Socket::CONNECTED: {
                 // socket->lastRecvTime is always set, it's initialized to STimeNow() at creation.
-                auto lastActivityTime = max(socket->lastSendTime, socket->lastRecvTime);
-                if (lastActivityTime + SQLiteNode::RECV_TIMEOUT < STimeNow()) {
+                if (socket->lastRecvTime + SQLiteNode::RECV_TIMEOUT < STimeNow()) {
                     SHMMM("Connection with peer '" << name << "' timed out.");
                     return PeerPostPollStatus::SOCKET_ERROR;
                 }


### PR DESCRIPTION
### Details
I think this fixes the issue we've seen where it takes a long time for the cluster to reform after leader crashing. It seems we're not noticing that the connection has dropped, because the other side has not responded with anything (including `RST`) and so we think the connection is still alive.

Here are some logs showing db1.sjc dying, and db1.lax happily thinking it wasn't dead for 10 minutes.
```
2024-02-22T09:46:12.646580+00:00 db1.sjc bedrock: 859649a0dde77da0-TLV rotem.hurvitz@cellebrite.com (SLog.cpp:13) SLogStackTrace [socket20539844] [warn] SQLiteCore::commit(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool, void (*)(SQLite&, long)) [0x564b5b23fdd8]
2024-02-22T09:46:38.678778+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25996204us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:47:03.694610+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25015756us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:47:28.709603+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25014903us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:47:53.725934+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25016186us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:48:18.741376+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25015359us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:48:43.757050+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25015589us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:49:08.772374+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25015270us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:49:33.782543+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25010114us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:49:58.808348+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25025718us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:50:23.832161+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25023747us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:50:48.859136+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25026824us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:51:13.874909+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25015585us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:51:38.899266+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25024295us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:52:03.918268+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25018901us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:52:28.931697+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25013305us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:52:53.943144+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25011390us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:53:18.955975+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25012770us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:53:43.983347+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25027312us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:54:08.986850+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25003420us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:54:34.009108+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25022212us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:54:59.032139+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25022988us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:55:24.066306+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25034126us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:55:49.085520+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25019167us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:56:14.100314+00:00 db1.lax bedrock: xxxxxx (SQLiteNode.cpp:2627) postPoll [sync] [info] {auth.db1.lax/FOLLOWING} Close to timeout (25014726us since last activity), sending PING to peer 'auth.db1.sjc'
2024-02-22T09:56:39.018209+00:00 db1.lax bedrock: xxxxxx (SQLitePeer.cpp:89) postPoll [sync] [hmmm] {auth.db1.sjc} Lost peer connection after 117832697ms, reconnecting in 3231ms
```

We're counting sending a message as the connection being alive, but in these cases, those sent messages are just going into a black hole on the other end, and sometimes it takes the remote OS many minutes to tell us the process (and thus the socket) has died. This seems like an obvious bug, except that we added this on purpose here: https://github.com/Expensify/Bedrock/pull/1578. I think that was probably overzealous, and it did avoid us timing out, but to the point where we end up with this other problem. I also don't think we're likely to hit the same case we used to hit there anyway, as HTTPS requests are no longer being done in the sync thread.

So the change to `sqlitecluster/SQLitePeer.cpp` will hopefully notice that we haven't heard anything from a dead remote process in 30s.

The remainder of this change is to get the dying leader to close all its peer sockets in the same place we log the stack trace. Hopefully this notifies peer *immediately* that this connection has closed, and so they can start picking a new leader right away, instead of waiting 30s to notice that they're talking to a black hole.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
