### PR TITLE
Optimize `setCommitEnabled`

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1114,7 +1114,7 @@ _commitLockTimer("commit lock timer", {
 { }
 
 void SQLite::SharedData::setCommitEnabled(bool enable) {
-    if (commitEnabled == enable) {
+    if (_commitEnabled == enable) {
         // Exit early without grabbing the lock. It's possible during highly congested times for getting the lock to take long enough to time out the cluster.
         return;
     }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -701,7 +701,16 @@ int SQLite::commit(const string& description, function<void()>* preCheckpointCal
     _conflictPage = 0;
     uint64_t before = STimeNow();
     uint64_t beforeCommit = STimeNow();
+
+    // This is a last-second check in case we hit the exceptional case where we were unable to acquire the lock when disabling commits.
+    // If we get here, things are not going well but this minimizes the chance that we'll commit a transaction that won't get broadcast to peers.
+    if (!_sharedData._commitEnabled) {
+        return COMMIT_DISABLED;
+    }
     result = SQuery(_db, "committing db transaction", "COMMIT");
+    if (!_sharedData._commitEnabled) {
+        SALERT("This transaction was committed while commits were disabled, it may or may not get sent to peers.");
+    }
     _lastConflictPage = _conflictPage;
     if (_lastConflictPage) {
         SINFO("part of last conflcit page: " << _lastConflictPage);
@@ -1114,8 +1123,28 @@ _commitLockTimer("commit lock timer", {
 { }
 
 void SQLite::SharedData::setCommitEnabled(bool enable) {
-    lock_guard<decltype(commitLock)> lock(commitLock);
-    _commitEnabled = enable;
+    if (enable) {
+        lock_guard<decltype(commitLock)> lock(commitLock);
+        _commitEnabled = true;
+    } else {
+        // If we are disabling commits, we are standing down, and we don't want to be stuck in the back of a giant queue of commands to be able to do this,
+        // because it blocks the sync thread and prevents the server from standing down at all.
+        unique_lock<decltype(commitLock)> lock(commitLock, defer_lock);
+        bool locked = lock.try_lock_for(3s);
+        if (!locked) {
+            // This may result in a commit that happens after we've stood down, and thus a forked node.
+            // However, waiting indefinitely on this may result in a timeout on the whole cluster, and then a forked node anyway.
+            SALERT("Could not acquire commit lock to disable commits. Doing it anyway!");
+        }
+
+        _commitEnabled = false;
+
+        // This is even hackier, but the idea is that if we set this value in the middle of a commit happening, that commit can finish even though
+        // commits are off. When we return from this function, we're going to want to send all outstanding commits to followers, so we block here for a
+        // couple seconds just to allow a final commit to finish. This doesn't guarantee anything, but it's really just trying to reduce the surface area for failure.
+        sleep(3);
+        SINFO("Done sleeping after failing to acquire commit lock.");
+    }
 }
 
 void SQLite::SharedData::incrementCommit(const string& commitHash) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1153,7 +1153,6 @@ bool SQLiteNode::update() {
 
             // We're no longer waiting on responses from peers, we can re-update immediately and start becoming a
             // follower node instead.
-            // If we get here in our `while(update)` loop, what happens?
             return true;
         }
         break;
@@ -1976,12 +1975,10 @@ void SQLiteNode::_changeState(SQLiteNodeState newState) {
 
             // Turn off commits. This prevents late commits coming in right after we call `_sendOutstandingTransactions`
             // below, which otherwise could get committed on leader and not replicated to followers.
-            // This blocks on the commit lock. That could hurt.
             _db.setCommitEnabled(false);
 
             // We send any unsent transactions here before we finish switching states, we need to make sure these are
             // all sent to the new leader before we complete the transition.
-            // It seems like we would have done something here, but we didn't log anything. Maybe there weren't any transactions?
             _sendOutstandingTransactions();
         }
 
@@ -1998,7 +1995,6 @@ void SQLiteNode::_changeState(SQLiteNodeState newState) {
 
         // Re-enable commits if they were disabled during a previous stand-down.
         if (newState != SQLiteNodeState::SEARCHING) {
-            // Could have hit this.
             _db.setCommitEnabled(true);
         }
 


### PR DESCRIPTION
### Details

This aims to avoid the situation we ran across in `#fireroom-2024-02-27-site-down` where it seems it took 2:23 for db2.sjc to acquire the commit lock.

Here's what we had for logs. They've been truncated a bit for readability:
```
19:48:21 db2.sjc [sync] [hmmm] {auth.db2.sjc/LEADING} Found higher priority WAITING peer (auth.db1.sjc) while LEADING, STANDINGDOWN
19:48:21 db2.sjc [sync] [info] {auth.db2.sjc/LEADING} [NOTIFY] setting commit count to: 22467242460
19:48:21 db2.sjc [sync] [info] {auth.db2.sjc/LEADING} Switching from 'LEADING' to 'STANDINGDOWN'
19:50:44 db2.sjc [sync] [info] {auth.db1.lax} No error sending STATE to peer auth.db1.lax (196 bytes actually sent).
19:50:44 db2.sjc [sync] [info] {auth.db1.rno} No error sending STATE to peer auth.db1.rno (196 bytes actually sent).
19:50:44 db2.sjc [sync] [info] {auth.db1.sjc} No error sending STATE to peer auth.db1.sjc (196 bytes actually sent).
19:50:44 db2.sjc [sync] [info] {auth.db2.lax} No error sending STATE to peer auth.db2.lax (196 bytes actually sent).
19:50:44 db2.sjc [sync] [hmmm] send((errno#107)) failed with response 'Connection timed out' (#110), clo sing.
19:50:44 db2.sjc [sync] [hmmm] {auth.db2.rno} Error sending STATE to peer auth.db2.rno.
19:50:44 db2.sjc [sync] [info] {auth.db2.sjc/STANDINGDOWN} Standing down: Found higher priority WAITING peer (auth.db1 .sjc) while LEADING, STANDINGDOWN
```

You can see the 2:23 gap between the 3rd and 4th lines.

This all happens between these three lines of code, you can see the loglines for the first and last line are the first and last loglines above:
https://github.com/Expensify/Bedrock/blob/543a65619db8e0f17a97b49b7b5046269cade018/sqlitecluster/SQLiteNode.cpp#L1132-L1134

So the delay needs to happen in `_changeState`.

You can see `_changeState` gets at least this far before the delay:
https://github.com/Expensify/Bedrock/blob/main/sqlitecluster/SQLiteNode.cpp#L1950

But not this far until after the delay:
https://github.com/Expensify/Bedrock/blob/main/sqlitecluster/SQLiteNode.cpp#L2054

That gives us about 100 lines of code to look through, but we know that we're changing from `LEADING` to `STANDINGDOWN` which means we skip most of it.

The code that actually runs in here for these states is:
```
uint64_t timeout = 0;
timeout = 0;
SDEBUG("Setting state timeout of " << timeout / 1000 << "ms");
_stateTimeout = STimeNow() + timeout;
_leadPeer = nullptr;
_forkedFrom.clear();
_db.setCommitEnabled(true);
_standDownTimeout.alarmDuration = STIME_US_PER_S * 30;
_standDownTimeout.start();
```

Most of this is trivial and effectively can't block, but `_db.setCommitEnabled(true);` acquires the commit lock:
https://github.com/Expensify/Bedrock/blob/543a65619db8e0f17a97b49b7b5046269cade018/sqlitecluster/SQLite.cpp#L1117-L1118

The node was *super* overloaded at this time, and the commit lock was very busy:

Here's some logs showing the commit lock was held over 99% of the time during this period (also truncated for readabilty):
```
19:48:23 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10001.63ms (99.58%) in 10043ms total.
19:48:33 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10022.56ms (99.05%) in 10118ms total.
19:48:43 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 9945.18ms (99.29%) in 10016ms total.
19:48:53 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10315.87ms (99.37%) in 10380ms total.
19:49:03 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10222.02ms (99.50%) in 10273ms total.
19:49:13 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10058.19ms (99.54%) in 10104ms total.
19:49:24 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10046.35ms (99.88%) in 10058ms total.
19:49:34 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10392.25ms (99.74%) in 10419ms total.
19:49:44 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10244.98ms (99.65%) in 10280ms total.
19:49:54 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10223.53ms (99.91%) in 10232ms total.
19:50:05 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10111.11ms (99.85%) in 10126ms total.
19:50:15 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10188.79ms (98.22%) in 10373ms total.
19:50:25 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10029.50ms (99.88%) in 10041ms total.
19:50:35 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10035.97ms (99.88%) in 10047ms total.
19:50:45 db2.sjc [info] commit lock timer: EXCLUSIVE 0.00ms (0.00%), SHARED 10024.59ms (99.04%) in 10121ms total.
```

It seems reasonable then, that it just took ~2.5 minutes to acquire this lock, waiting on all the other threads that also wanted it.

However, this whole thing is unnecessary We are trying to set `_commitEnabled` to `true`, when it is already `true`. It is only set to `false` once we drop out of `LEADING` or `STANDINGDOWN`, but we are still currently `LEADING`.

The fix I've made here is to just skip changing `_commitEnabled` if the requested value is the current value. This also allows to skip the locking on the busy mutex.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
