### PR TITLE
Revert "Notice timeout faster"

### DIFF
--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -72,7 +72,8 @@ SQLitePeer::PeerPostPollStatus SQLitePeer::postPoll(fd_map& fdm, uint64_t& nextA
         switch (socket->state.load()) {
             case STCPManager::Socket::CONNECTED: {
                 // socket->lastRecvTime is always set, it's initialized to STimeNow() at creation.
-                if (socket->lastRecvTime + SQLiteNode::RECV_TIMEOUT < STimeNow()) {
+                auto lastActivityTime = max(socket->lastSendTime, socket->lastRecvTime);
+                if (lastActivityTime + SQLiteNode::RECV_TIMEOUT < STimeNow()) {
                     SHMMM("Connection with peer '" << name << "' timed out.");
                     return PeerPostPollStatus::SOCKET_ERROR;
                 }


### PR DESCRIPTION
This reverts commit 26a652972371bec8b704301575e0a030c3492bbc.

See: https://expensify.slack.com/archives/C06N57HEGAY/p1709677652715349


### Details
Related to: [#fireroom-2024-03-06-bedrock-awol](https://expensify.slack.com/archives/C06N57HEGAY/p1709677652715349)

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
