### PR TITLE
Add diagnostivs for db2.rno

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -61,6 +61,8 @@
 
 SQLiteNode* SQLiteNode::KILLABLE_SQLITE_NODE{0};
 
+bool SQLiteNode::IS_DB2_RNO = false;
+
 // Initializations for static vars.
 const uint64_t SQLiteNode::RECV_TIMEOUT{STIME_US_PER_S * 30};
 
@@ -147,6 +149,10 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, cons
       _stateTimeout(STimeNow() + firstTimeout),
       _syncPeer(nullptr)
 {
+    if (_name == "auth.db2.rno") {
+        IS_DB2_RNO = true;
+    }
+
     KILLABLE_SQLITE_NODE = this;
     SASSERT(_originalPriority >= 0);
     onPrepareHandlerEnabled = false;
@@ -2625,10 +2631,19 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
             break;
             case SQLitePeer::PeerPostPollStatus::OK:
             {
+                auto now = STimeNow();
+                if (IS_DB2_RNO && peer->state != SQLiteNodeState::LEADING) {
+                    SINFO("Peer " << peer->name << " lastSent: " << (now - peer->lastSendTime()) << "us ago, lastRecv'ed: " << (now - peer->lastRecvTime()) << "us ago. (raw lastRecvTime: "
+                          << peer->lastSendTime() << ", raw lastSendTime: " << peer->lastRecvTime() << ")");
+                }
                 auto lastActivityTime = max(peer->lastSendTime(), peer->lastRecvTime());
-                if (lastActivityTime && STimeNow() - lastActivityTime > SQLiteNode::RECV_TIMEOUT - 5 * STIME_US_PER_S) {
-                    SINFO("Close to timeout (" << (STimeNow() - lastActivityTime) << "us since last activity), sending PING to peer '" << peer->name << "'");
+                if (lastActivityTime && now - lastActivityTime > SQLiteNode::RECV_TIMEOUT - 5 * STIME_US_PER_S) {
+                    SINFO("Close to timeout (" << (now - lastActivityTime) << "us since last activity), sending PING to peer '" << peer->name << "'");
                     _sendPING(peer);
+                } else {
+                    if (IS_DB2_RNO && peer->state != SQLiteNodeState::LEADING) {
+                        SINFO("Not close to timeout for peer " << peer->name << ", lastActivityTime: " << lastActivityTime << ", now: " << now);
+                    }
                 }
                 try {
                     size_t messagesDeqeued = 0;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -68,6 +68,8 @@ class SQLiteNode : public STCPManager {
         FAILED
     };
 
+    static bool IS_DB2_RNO;
+
     // Write consistencies available
     enum ConsistencyLevel {
         ASYNC,  // Fully asynchronous write, no follower approval required.

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -60,6 +60,7 @@ void SQLitePeer::prePoll(fd_map& fdm) const {
     lock_guard<decltype(peerMutex)> lock(peerMutex);
     if (socket) {
         STCPManager::prePoll(fdm, *socket);
+        _lastRecvTime = socket->lastRecvTime;
     }
 }
 
@@ -71,6 +72,9 @@ SQLitePeer::PeerPostPollStatus SQLitePeer::postPoll(fd_map& fdm, uint64_t& nextA
         // We have a socket; process based on its state
         switch (socket->state.load()) {
             case STCPManager::Socket::CONNECTED: {
+                if (SQLiteNode::IS_DB2_RNO && state != SQLiteNodeState::LEADING && _lastRecvTime != socket->lastRecvTime) {
+                    SINFO("Updated last recv time from peer " << name);
+                }
                 // socket->lastRecvTime is always set, it's initialized to STimeNow() at creation.
                 if (socket->lastRecvTime + SQLiteNode::RECV_TIMEOUT < STimeNow()) {
                     SHMMM("Connection with peer '" << name << "' timed out.");
@@ -233,11 +237,15 @@ bool SQLitePeer::isPermafollower(const STable& params) {
 void SQLitePeer::sendMessage(const SData& message) {
     lock_guard<decltype(peerMutex)> lock(peerMutex);
     if (socket) {
+        uint64_t lastSendTime = socket->lastSendTime;
         size_t bytesSent = 0;
         if (socket->send(message.serialize(), &bytesSent)) {
             SINFO("No error sending " << message.methodLine << " to peer " << name << " (" << bytesSent << " bytes actually sent).");
         } else {
             SHMMM("Error sending " << message.methodLine << " to peer " << name << ".");
+        }
+        if (SQLiteNode::IS_DB2_RNO && state != SQLiteNodeState::LEADING && lastSendTime != socket->lastSendTime) {
+            SINFO("Updated last send time to peer " << name);
         }
     } else {
         SINFO("Tried to send " << message.methodLine << " to peer " << name << ", but not available.");

--- a/sqlitecluster/SQLitePeer.h
+++ b/sqlitecluster/SQLitePeer.h
@@ -99,6 +99,8 @@ class SQLitePeer {
 
     // Not named with an underscore because it's only sort-of private (see friend class declaration above).
     STCPManager::Socket* socket = nullptr;
+
+    mutable uint64_t _lastRecvTime = 0;
 };
 
 // serialization for Responses.


### PR DESCRIPTION
### Details
Attempts to diagnose connection failures specifically on db2.rno, and only to nodes that are *not* leading, to keep noise down.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
