### PR TITLE
Ping more reliably

### DIFF
--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -22,6 +22,7 @@ SQLitePeer::SQLitePeer(const string& name_, const string& host_, const STable& p
     subscribed(false),
     transactionResponse(Response::NONE),
     version(),
+    lastPingTime(0),
     hash()
 { }
 
@@ -46,6 +47,7 @@ void SQLitePeer::reset() {
     subscribed = false;
     transactionResponse = Response::NONE;
     version = "";
+    lastPingTime = 0,
     setCommit(0, "");
 }
 

--- a/sqlitecluster/SQLitePeer.h
+++ b/sqlitecluster/SQLitePeer.h
@@ -86,6 +86,7 @@ class SQLitePeer {
     atomic<bool> subscribed;
     atomic<Response> transactionResponse;
     atomic<string> version;
+    atomic<uint64_t> lastPingTime;
 
   private:
     // For initializing the permafollower value from the params list.


### PR DESCRIPTION
### Details
Send a ping when we haven't heard from a remote peer in over 25 seconds, *even* if we have sent to it recently. Remote servers do no reply to all messages. Also prevents spamming more than one PING per second.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
