### PR TITLE
Improve shutdown speed.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -254,7 +254,7 @@ void BedrockServer::sync()
         }
 
         // And set our next timeout for 1 second from now.
-         nextActivity = STimeNow() + (STIME_US_PER_MS * 100);
+        nextActivity = STimeNow() + (STIME_US_PER_MS * 100);
 
         // Process any network traffic that happened. Scope this so that we can change the log prefix and have it
         // auto-revert when we're finished.
@@ -648,14 +648,10 @@ void BedrockServer::sync()
     // Note: This is not an atomic operation but should not matter. Nothing should use this that can happen with no
     // sync thread.
     // If there are socket threads in existance, they can be looking at this through a syncThread copy.
-    SINFO("Deleting DB pool");
     _dbPool = nullptr;
-    SINFO("Deleted DB pool");
 
     // We're really done, store our flag so main() can be aware.
-    SINFO("Marking sync thread complete");
     _syncThreadComplete.store(true);
-    SINFO("Marked sync thread complete");
 }
 
 void BedrockServer::worker(int threadId)
@@ -1354,10 +1350,7 @@ BedrockServer::~BedrockServer() {
 
     // Delete our plugins.
     for (auto& p : plugins) {
-        string name = p.second->getName();
-        SINFO("Deleting " << name << "plugin.");
         delete p.second;
-        SINFO("Done deleting " << name << "plugin.");
     }
 }
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -489,4 +489,8 @@ class BedrockServer : public SQLiteServer {
 
     // We call this method whenever a node changes state
     void notifyStateChangeToPlugins(SQLite& db, SQLiteNodeState newState) override;
+
+    // This is just here to allow `poll` in main.cpp to get interrupted when the server shuts down.
+    // to wait up to a full second for them.
+    SSynchronizedQueue<bool> _notifyDone;
 };

--- a/libstuff/SSignal.cpp
+++ b/libstuff/SSignal.cpp
@@ -131,7 +131,7 @@ void _SSignal_signalHandlerThreadFunc() {
         siginfo_t siginfo = {0};
         struct timespec timeout;
         timeout.tv_sec = 0;
-        timeout.tv_nsec = 100'000;
+        timeout.tv_nsec = 100'000'000; // 100ms in ns.
         int result = -1;
         while (result == -1) {
             result = sigtimedwait(&signals, &siginfo, &timeout);

--- a/libstuff/SSignal.cpp
+++ b/libstuff/SSignal.cpp
@@ -130,8 +130,8 @@ void _SSignal_signalHandlerThreadFunc() {
         // Wait for a signal to appear.
         siginfo_t siginfo = {0};
         struct timespec timeout;
-        timeout.tv_sec = 1;
-        timeout.tv_nsec = 0;
+        timeout.tv_sec = 0;
+        timeout.tv_nsec = 100'000;
         int result = -1;
         while (result == -1) {
             result = sigtimedwait(&signals, &siginfo, &timeout);
@@ -159,7 +159,7 @@ void _SSignal_signalHandlerThreadFunc() {
 void SStopSignalThread() {
     _SSignal_threadStopFlag = true;
     if (_SSignal_threadInitialized.test_and_set()) {
-        // Send ourselves a singnal to interrupt our thread.
+        // Send ourselves a signal to interrupt our thread.
         SINFO("Joining signal thread.");
         _SSignal_signalThread.join();
         _SSignal_threadInitialized.clear();

--- a/main.cpp
+++ b/main.cpp
@@ -365,7 +365,7 @@ int main(int argc, char* argv[]) {
             const uint64_t now = STimeNow();
             auto timeBeforePoll = chrono::steady_clock::now();
             S_poll(fdm, max(nextActivity, now) - now);
-            nextActivity = STimeNow() + STIME_US_PER_S; // 0.1s max period
+            nextActivity = STimeNow() + STIME_US_PER_MS * 100; // 0.1s max period
             auto timeAfterPoll = chrono::steady_clock::now();
             server.postPoll(fdm, nextActivity);
             auto timeAfterPostPoll = chrono::steady_clock::now();

--- a/main.cpp
+++ b/main.cpp
@@ -365,7 +365,7 @@ int main(int argc, char* argv[]) {
             const uint64_t now = STimeNow();
             auto timeBeforePoll = chrono::steady_clock::now();
             S_poll(fdm, max(nextActivity, now) - now);
-            nextActivity = STimeNow() + STIME_US_PER_MS * 100; // 0.1s max period
+            nextActivity = STimeNow() + STIME_US_PER_S; // 1s max period
             auto timeAfterPoll = chrono::steady_clock::now();
             server.postPoll(fdm, nextActivity);
             auto timeAfterPostPoll = chrono::steady_clock::now();

--- a/main.cpp
+++ b/main.cpp
@@ -365,7 +365,7 @@ int main(int argc, char* argv[]) {
             const uint64_t now = STimeNow();
             auto timeBeforePoll = chrono::steady_clock::now();
             S_poll(fdm, max(nextActivity, now) - now);
-            nextActivity = STimeNow() + STIME_US_PER_S; // 1s max period
+            nextActivity = STimeNow() + STIME_US_PER_S; // 0.1s max period
             auto timeAfterPoll = chrono::steady_clock::now();
             server.postPoll(fdm, nextActivity);
             auto timeAfterPostPoll = chrono::steady_clock::now();

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -83,7 +83,7 @@ SQLitePeer::PeerPostPollStatus SQLitePeer::postPoll(fd_map& fdm, uint64_t& nextA
             }
             case STCPManager::Socket::CLOSED: {
                 // Done; clean up and try to reconnect
-                uint64_t delay = SRandom::rand64() % (STIME_US_PER_S * 5);
+                uint64_t delay = SRandom::rand64() % (STIME_US_PER_S * 1);
                 if (socket->connectFailure) {
                     SINFO("SQLitePeer connection failed after " << (STimeNow() - socket->openTime) / 1000 << "ms, reconnecting in " << delay / 1000 << "ms");
                 } else {

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -180,7 +180,9 @@ ClusterTester<T>::ClusterTester(ClusterSize size,
     }
     auto end = STimeNow();
 
-    cout << "Took " << ((end - start) / 1000) << "ms to start cluster." << endl;
+    if ((end - start) > 5000000) {
+        cout << "Took " << ((end - start) / 1000) << "ms to start cluster." << endl;
+    }
 }
 
 template <typename T>
@@ -190,10 +192,8 @@ ClusterTester<T>::~ClusterTester()
 
     // Shut down everything but the leader first.
     list<thread> threads;
-    cout << "Starting shutdown at " << SCURRENT_TIMESTAMP() << endl;
     for (int i = _size - 1; i > 0; i--) {
         threads.emplace_back([&, i](){
-            cout << "Stopping node " << i << " at " << SCURRENT_TIMESTAMP() << endl;
             stopNode(i);
         });
     }
@@ -202,12 +202,13 @@ ClusterTester<T>::~ClusterTester()
     }
 
     // Then do leader last. This is to avoid getting in a state where nodes try to stand up as leader shuts down.
-    cout << "Stopping node " << 0 << " at " << SCURRENT_TIMESTAMP() << endl;
     stopNode(0);
 
     auto end = STimeNow();
 
-    cout << "Took " << ((end - start) / 1000) << "ms to stop cluster." << endl;
+    if ((end - start) > 5000000) {
+        cout << "Took " << ((end - start) / 1000) << "ms to stop cluster." << endl;
+    }
     _cluster.clear();
 }
 

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -153,6 +153,7 @@ ClusterTester<T>::ClusterTester(ClusterSize size,
         threads.emplace_back([it](){
             it->startServer();
         });
+        usleep(100'000);
     }
     for (auto& i : threads) {
         i.join();


### PR DESCRIPTION
### Details
This shortens maximum timeouts from 1s to 0.1s, adds interrupts to existing `poll` loops, and shuts down followers in a cluster in parallel.

### Fixed Issues
Fixes GH_LINK

### Tests
```
vagrant@expensidev2004:/vagrant/Auth/test$ time ./authtest -only ConfigureExpensifyCard
✅ ConfigureExpensifyCardTest::testDomainAdmin (3752ms)
✅ ConfigureExpensifyCardTest::testGroupDefault (10093ms 🐌)
✅ ConfigureExpensifyCardTest::testGroupSharing (6061ms 🐌)
✅ ConfigureExpensifyCardTest::testNotifications (8941ms 🐌)
Took 33192ms to start cluster.
✅ ConfigureExpensifyCardTest::testUnvalidatedAccount (35541ms 🐌)
✅ ConfigureExpensifyCardTest::testLockedPaymentAccount (4935ms)
✅ ConfigureExpensifyCardTest::testMultipleCards (4827ms)
✅ ConfigureExpensifyCardTest::testMultipleFeeds (11017ms 🐌)
Took 35181ms to start cluster.
✅ ConfigureExpensifyCardTest::testThrowForDeactivatedCard (37591ms 🐌)
✅ ConfigureExpensifyCardTest::testThrowForDomainLimitSuspended (3730ms)
✅ ConfigureExpensifyCardTest::testThrowForDeprovisionedDomain (3667ms)
✅ ConfigureExpensifyCardTest::testVirtualCardSync (6733ms 🐌)
✅ ConfigureExpensifyCardTest::testSMSLogin (3907ms)
✅ ConfigureExpensifyCardTest::testPublicDomain (3961ms)
✅ ConfigureExpensifyCardTest::testSuspendingAndReactivatingCards (14160ms 🐌)
Took 12185ms to start cluster.
✅ ConfigureExpensifyCardTest::testReactivatingSuspendedCardsOnOldProgram (19030ms 🐌)
✅ ConfigureExpensifyCardTest::testMarqetaToken (6685ms 🐌)
✅ ConfigureExpensifyCardTest::testDomainLevelFraudInfo (8544ms 🐌)
✅ ConfigureExpensifyCardTest::testEditAdminIssuedVirtualCards (4659ms)

[ TEST RESULTS ] Passed: 19, Failed: 0

Slowest Test Classes:
197854ms: ConfigureExpensifyCard

real	3m18.116s
user	0m18.839s
sys	0m7.154s
vagrant@expensidev2004:/vagrant/Auth/test$
```

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
