### PR TITLE
Improve cluster forming speed

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -98,8 +98,8 @@ const vector<SQLitePeer*> SQLiteNode::_initPeers(const string& peerListString) {
         SINFO("Adding peer #" << peerList.size() << ": " << name << " (" << host << "), " << SComposeJSONObject(params));
         SQLitePeer* peer = new SQLitePeer(name, host, params, peerList.size() + 1);
 
-        // Wait up to 2s before trying the first time
-        peer->nextReconnect = STimeNow() + SRandom::rand64() % (STIME_US_PER_S * 2);
+        // Wait up to 1s before trying the first time
+        peer->nextReconnect = STimeNow() + SRandom::rand64() % STIME_US_PER_S;
         peerList.push_back(peer);
     }
 
@@ -867,8 +867,7 @@ bool SQLiteNode::update() {
         // See if we're taking too long
         if (STimeNow() > _stateTimeout) {
             // Timed out
-            SHMMM("Timed out waiting for STANDUP approval; reconnect all and re-SEARCHING.");
-            _reconnectAll();
+            SHMMM("Timed out waiting for STANDUP approval; re-SEARCHING.");
             _changeState(SQLiteNodeState::SEARCHING);
             return true; // Re-update
         }
@@ -1791,6 +1790,16 @@ void SQLiteNode::_onConnect(SQLitePeer* peer) {
     login["Version"] = _version;
     login["Permafollower"] = _originalPriority ? "false" : "true";
     _sendToPeer(peer, login);
+
+    // If we're STANDINGUP when a peer connects, send them a STATE message so they know they need to APPROVE or DENY the standup.
+    // Otherwise we will wait for their response that's not coming,and can eventually time out the standup.
+    if (_state == SQLiteNodeState::STANDINGUP) {
+        SData state("STATE");
+        state["StateChangeCount"] = to_string(_stateChangeCount);
+        state["State"] = stateName(_state);
+        state["Priority"] = SToStr(_priority);
+        _sendToPeer(peer, state);
+    }
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
### Details
This change speeds up cluster formation. This is most obvious in tests, but happens in production as well. This adds a `STATE` message sent on connection. This makes peers that connect *after* leader has started standing up actually respond, rather than waiting until the eventual timeout, and then trying again.

It also removes re-connection in this case, which starts the whole process over and can result in the exact same situation, where a node is standing up, but another node connects to it after that begins, and thus does not respond quickly.

I have benchmarked the auth tests below with and without the change, you will notice that there are both significantly fewer loglines about slow cluster startup, and they are not nearly as slow, after the change.

This also speeds up the auth tests overall, but they are still currently limited by the `PayViaStripeConnect` test.

### Fixed Issues
Fixes slownesss

### Before this change
"Took XXXms to start cluster." lines:
```
Took 17039ms to start cluster.
Took 27104ms to start cluster.
Took 48031ms to start cluster.
Took 9136ms to start cluster.
Took 11229ms to start cluster.
Took 8229ms to start cluster.
Took 11134ms to start cluster.
Took 16164ms to start cluster.
Took 11035ms to start cluster.
Took 12052ms to start cluster.
Took 18065ms to start cluster.
Took 9221ms to start cluster.
Took 10226ms to start cluster.
Took 18039ms to start cluster.
Took 11235ms to start cluster.
Took 37190ms to start cluster.
```

Slowest classes and total timing:
```
Slowest Test Classes:
283453ms: PayViaStripeConnect
231664ms: WalletPayment
231223ms: ProcessStripeConnectWebhook
231063ms: WalletMTLFile
226257ms: WalletTransferBalance
224039ms: WalletCustomerMasterFile
223644ms: WalletReimbursement
223326ms: ValidateBankAccount
223267ms: UpgradeSharedBankAccounts
223199ms: ValidateBillingFund

real	4m43.796s
user	4m22.245s
sys	0m56.564s
```

### After this change
"Took XXXms to start cluster." lines:
```
Took 8042ms to start cluster.
Took 7121ms to start cluster.
Took 9133ms to start cluster.
Took 10229ms to start cluster.
Took 7123ms to start cluster.
Took 10229ms to start cluster.
Took 8221ms to start cluster.
Took 11240ms to start cluster.
Took 9119ms to start cluster.
Took 7215ms to start cluster.
Took 11228ms to start cluster.
Took 8127ms to start cluster.
```

Slowest classes and total timing:
```
Slowest Test Classes:
267888ms: PayViaStripeConnect
222401ms: WalletPayment
221798ms: WalletMTLFile
216937ms: RequestReplacementExpensifyCard
216585ms: WalletTransferBalance
214798ms: WalletCustomerMasterFile
214428ms: WalletReimbursement
214087ms: ValidateBillingFund
213996ms: UpgradeSharedBankAccounts
213985ms: ValidateBankAccount

real	4m28.098s
user	4m12.145s
sys	0m54.118s
```


### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
