### PR TITLE
Fix MassiveQueryTest

### DIFF
--- a/test/clustertest/tests/MassiveQueryTest.cpp
+++ b/test/clustertest/tests/MassiveQueryTest.cpp
@@ -14,13 +14,31 @@ struct MassiveQueryTest : tpunit::TestFixture {
         cmd["processTimeout"] = "290000";
         cmd["writeConsistency"] = "ASYNC";
         auto r1 = brtester.executeWaitMultipleData({cmd})[0];
-        uint64_t commitCount = stoull(r1["CommitCount"]);
+        uint64_t commitCount = 0;
+        try {
+            commitCount = stoull(r1["CommitCount"]);
+        } catch (const invalid_argument& e) {
+            cout << "invalid_argument parsing commitCount from: " << r1["CommitCount"] << endl;
+        } catch (const out_of_range& e) {
+            cout << "out_of_range parsing commitCount from: " << r1["CommitCount"] << endl;
+        }
         uint64_t commitCount2 = 0;
+
+        // Make sure the commit count is actually set.
+        ASSERT_TRUE(commitCount);
 
         SData status("Status");
         for (size_t i = 0; i < 500; i++) {
             auto r2 = tester.getTester(2).executeWaitMultipleData({status})[0];
-            commitCount2 = stoull(SParseJSONObject(r2.content)["CommitCount"]);
+            try {
+                commitCount2 = stoull(r1["CommitCount"]);
+            } catch (const invalid_argument& e) {
+                cout << "invalid_argument parsing commitCount2 from: " << SParseJSONObject(r2.content)["CommitCount"] << endl;
+                cout << r2.content << endl;
+            } catch (const out_of_range& e) {
+                cout << "out_of_range parsing commitCount2 from: " << SParseJSONObject(r2.content)["CommitCount"] << endl;
+                cout << r2.content << endl;
+            }
             if (commitCount2 == commitCount) {
                 break;
             }

--- a/test/clustertest/tests/MassiveQueryTest.cpp
+++ b/test/clustertest/tests/MassiveQueryTest.cpp
@@ -31,7 +31,7 @@ struct MassiveQueryTest : tpunit::TestFixture {
         for (size_t i = 0; i < 500; i++) {
             auto r2 = tester.getTester(2).executeWaitMultipleData({status})[0];
             try {
-                commitCount2 = stoull(r1["CommitCount"]);
+                commitCount2 = stoull(r2["CommitCount"]);
             } catch (const invalid_argument& e) {
                 cout << "invalid_argument parsing commitCount2 from: " << SParseJSONObject(r2.content)["CommitCount"] << endl;
                 cout << r2.content << endl;

--- a/test/clustertest/tests/MassiveQueryTest.cpp
+++ b/test/clustertest/tests/MassiveQueryTest.cpp
@@ -29,15 +29,17 @@ struct MassiveQueryTest : tpunit::TestFixture {
 
         SData status("Status");
         for (size_t i = 0; i < 500; i++) {
-            auto r2 = tester.getTester(2).executeWaitMultipleData({status})[0];
+            auto responseList = tester.getTester(2).executeWaitMultipleData({status});
+            auto r2 = responseList[0];
+            auto json = SParseJSONObject(r2.content);
             try {
-                commitCount2 = stoull(r2["CommitCount"]);
+                commitCount2 = stoull(json["CommitCount"]);
             } catch (const invalid_argument& e) {
-                cout << "invalid_argument parsing commitCount2 from: " << SParseJSONObject(r2.content)["CommitCount"] << endl;
-                cout << r2.content << endl;
+                cout << "invalid_argument parsing commitCount2." << endl;
+                cout << r2.serialize() << endl;
             } catch (const out_of_range& e) {
-                cout << "out_of_range parsing commitCount2 from: " << SParseJSONObject(r2.content)["CommitCount"] << endl;
-                cout << r2.content << endl;
+                cout << "out_of_range parsing commitCount2." << endl;
+                cout << r2.serialize() << endl;
             }
             if (commitCount2 == commitCount) {
                 break;


### PR DESCRIPTION
### Details
`MassiveQueryTest` sometimes fails with an `stoull` exception. This change jsut attempts to catch and diagnose that issue. It seems to nearly never happen in dev, so we'll get the logging in Travis.

### Fixed Issues
Fixes flaky test

### Tests
is test
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
