### PR TITLE
Elevate "lost our leader" message from hmmm to warn

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1818,7 +1818,7 @@ void SQLiteNode::_onDisconnect(SQLitePeer* peer) {
     if (peer == _leadPeer) {
         // We've lost our leader: make sure we aren't waiting for
         // transaction response and re-SEARCH
-        PHMMM("Lost our LEADER, re-SEARCHING.");
+        PWARN("Lost our LEADER, re-SEARCHING.");
         SASSERTWARN(_state == SQLiteNodeState::SUBSCRIBING || _state == SQLiteNodeState::FOLLOWING);
         {
             _leadPeer = nullptr;


### PR DESCRIPTION
### Details

If a node loses it's leader, we want to highlight that in the logs to aid debugging.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/373569

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
