### PR TITLE
Crash immediately when detecting corruption.

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2641,6 +2641,10 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
         }
     }
 
+    if (error == SQLITE_CORRUPT) {
+        SERROR("Database corruption was detected, cannot continue, bedrock will exit immediately.");
+    }
+
     uint64_t elapsed = STimeNow() - startTime;
     if ((int64_t)elapsed > warnThreshold || (int64_t)elapsed > 10000) {
         // Avoid logging queries so long that we need dozens of lines to log them.


### PR DESCRIPTION
### Details
This patch causes bedrock to crash and immediately exit when it detects corruption.

Good for review, but hold this until we have a mechanism to prevent systemd from automatically restarting it

### Related Issue
Related to https://github.com/Expensify/Expensify/issues/351242

### Tests
Tested by starting up bedrock with a working database, then flipped 1% of the bits in the database file to simulate corruption, then ran a query.

```
2024-03-14T04:16:36.599670+00:00 expensidev2004 bedrock: nOzuPj dan@expensify.com (SQLite.cpp:280) _sqliteLogCallback [socket11] [info] {SQLITE} Code: 11, Message: database corruption at line 90635 of [11a4178f0e]
2024-03-14T04:16:36.599723+00:00 expensidev2004 bedrock: nOzuPj dan@expensify.com (SQLite.cpp:280) _sqliteLogCallback [socket11] [info] {SQLITE} Code: 11, Message: statement aborts at 8: [SELECT value FROM nameValuePairs WHERE accountID=17 AND name='private_temporaryPasswordlessLogins';] database disk image is malformed
2024-03-14T04:16:36.599787+00:00 expensidev2004 bedrock: nOzuPj dan@expensify.com (libstuff.cpp:2645) SQuery [socket11] [eror] Database corruption was detected, cannot continue, bedrock will exit immediately.
```

<summary>
Bitflip Script
<details>

```
#!/usr/bin/python

import os
import random
import struct

file_name = '/var/auth/main.db'
flip_perc = 0.01

def flipbit(f, bit):
    print('Flipping bit: ' + str(bit))
    byte = bit / 8
    print('in byte: ' + str(byte))
    index = bit % 8

    mask = 1 << index

    f.seek(byte)
    original = struct.unpack('B', f.read(1))[0]

    new = struct.pack('B', original ^ mask)

    f.seek(byte)
    f.write(new)


with open(file_name, 'r+b') as f:
    # Get file size
    f.seek(0, os.SEEK_END)
    sz = f.tell() * 8

    print(sz)

    flip_count = int(sz * flip_perc) + 1

    flips = [random.randrange(0, sz, 1) for i in range(flip_count)]

    print("Flipping: " + repr(flips))

    for flip in flips:
        flipbit(f, flip)

```

</details>
</summary>

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
