### PR TITLE
[HOLD] Update to new clock function

### DIFF
--- a/libstuff/STime.cpp
+++ b/libstuff/STime.cpp
@@ -4,9 +4,16 @@
 
 uint64_t STimeNow() {
     // Get the time = microseconds since 00:00:00 UTC, January 1, 1970
-    timeval time;
-    gettimeofday(&time, 0);
-    return ((uint64_t)time.tv_sec * 1000000 + (uint64_t)time.tv_usec);
+    if (true) {
+        // Experimental usage of clock_gettime to explicitly use CLOCK_REALTIME.
+        struct timespec time{0};
+        clock_gettime(CLOCK_REALTIME, &time);
+        return ((uint64_t)time.tv_sec * 1000000 + (uint64_t)time.tv_nsec / 1000);
+    } else {
+        timeval time;
+        gettimeofday(&time, 0);
+        return ((uint64_t)time.tv_sec * 1000000 + (uint64_t)time.tv_usec);
+    }
 }
 
 string SComposeTime(const string& format, uint64_t when) {


### PR DESCRIPTION
### Details
This is an attempt to fix difficult timing issues seen in tests, particularly, in `UpdateBillingSubscriptionTest`.

We do the following:

1. Generate a timestamp in `authtest`.
2. Send a command to the `auth` server that the test is running, which generates it's own timestamp.
3. Query the auth server for its generated timestamp.
4. Compare the queried timestamp to the generated timestamp, and assert that the queried timestamp is *not before* (i.e., equal to or after) the generated timestamp.

This almost always works but occasionally fails. What seems to be the issue (which I haven't 100% proven) is that [gettimeofday()](https://man7.org/linux/man-pages/man2/gettimeofday.2.html) uses processor-specific clocks (such as TSC clocks, [see here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/7/html/reference_guide/chap-timestamping)) that are not guaranteed to be 100% in sync across different processor cores for various reasons. This means that if the tests are running on a different core than the auth server, the test can have its time skewed slightly ahead, such that it looks like it was generated after the timestamp generated by `auth`.

We might be able to make this change more conclusive by using millisecond timestamps in this test instead of second resolution. 

The conversation about various clocks on linux is long and I read way too many linux clock documents and discussions already, but ultimately I want to replace [gettimeofday()](https://man7.org/linux/man-pages/man2/gettimeofday.2.html) (note the docs mark this function as obsolete) with [clock_gettime()](https://man7.org/linux/man-pages/man2/clock_gettime.2.html), which is it's replacement. We use the `CLOCK_REALTIME` clock for wall-clock time here.

Note that this is still possibly to break if the system time moves backwards (i.e., if the clock is reset by an administrator).

[This GNU page](https://www.gnu.org/software/libc/manual/html_node/Getting-the-Time.html) says:
>  The clock of `gettimeofday` is close to, but not necessarily in lock-step with, the clocks of `time` and of `‘clock_gettime (CLOCK_REALTIME)’` (see above). 

That's not super conclusive, but implies this newer function might do something slightly better.

[This stackoverflow post](https://stackoverflow.com/questions/6498972/faster-equivalent-of-gettimeofday) implies `gettimeofday()` and `clock_gettime(CLOCK_REALTIME)` are equivalent from a performance perspective.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/379456

### Tests
For testing, before this change I ran `UpdateBillingSubscriptionTest` 1000 times in a row, or until failure. This failed 4x is a row, never reaching 1000 successes (it failed on anywhere from about the35th to 700th iteration).

After this change, I ran the same test 1000x again, and it passed 1000 times in a row:
```
[ TEST RESULTS ] Passed: 12000, Failed: 0
```

Also I ran the entire auth test suite:
```
IN PROGRESS
```


_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
