### PR TITLE
Throw if parent of unique job is different than the one saved

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -296,7 +296,7 @@ bool BedrockJobsCommand::peek(SQLite& db) {
 
                 // If there's no job or the existing job doesn't match the data we've been passed, escalate to leader.
                 if (!result.empty()) {
-                    // If the parent passed does not much the parent the job already had, then it must mean we did something
+                    // If the parent passed does not match the parent the job already had, then it must mean we did something
                     // wrong or made a bad CQ, so we throw so we can investigate. Updating the parent here would be
                     // confusing, as it could leave the original parent in a bad state (like for example paused forever)
                     if (result[0][2] != "0" && result[0][2] != job["parentJobID"]) {

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -296,13 +296,15 @@ bool BedrockJobsCommand::peek(SQLite& db) {
 
                 // If there's no job or the existing job doesn't match the data we've been passed, escalate to leader.
                 if (!result.empty()) {
+                    // If the parent passed does not much the parent the job already had, then it must mean we did something
+                    // wrong or made a bad CQ, so we throw so we can investigate. Updating the parent here would be
+                    // confusing, as it could leave the original parent in a bad state (like for example paused forever)
                     if (result[0][2] != "0" && result[0][2] != job["parentJobID"]) {
                         STHROW("404 Trying to create a child that already exists, but it is tied to a different parent");
                     }
                     if (SIEquals(requestVerb, "CreateJob") && ((job["data"].empty() && result[0][1] == "{}") || (!job["data"].empty() && result[0][1] == job["data"]))) {
                         // Return early, no need to pass to leader, there are no more jobs to create.
-                        SINFO("Job already existed and unique flag was passed, reusing existing job " << result[0][0] << ", mocked? "
-                        << (mockRequest ? "true" : "false"));
+                        SINFO("Job already existed and unique flag was passed, reusing existing job " << result[0][0] << ", mocked? " << (mockRequest ? "true" : "false"));
                         jsonContent["jobID"] = result[0][0];
                         return true;
                     }


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/379036

### Tests
Have 2 jobs like so:
```
sqlite> select * from jobs;
created              jobID                state    name                nextRun              lastRun  repeat  data                                 priority  parentJobID  retryAfter
-------------------  -------------------  -------  ------------------  -------------------  -------  ------  -----------------------------------  --------  -----------  ----------
2024-03-21 18:36:37  8905654694324888019  RUNNING  www-prod/caca       2024-03-21 18:36:37                   {"_commitCounts":{"webrock":56468}}  500       0
2024-03-21 18:37:56  8956861316907429890  PAUSED   www-prod/cacaChild  2024-03-21 18:37:56                   {"_commitCounts":{"webrock":56470}}  500       1
```
Run in PHP: `Jobs::queueJob("www-prod/cacaChild", [], null, null, true, Jobs::PRIORITY_500, 8905654694324888019);`
Check it throws:
```
2024-03-21T18:40:20.824080+00:00 expensidev2004 bedrock: Jx4f5P we@dont.know (BedrockCore.cpp:403) _handleCommandException [socket0] [info] Error processing command 'CreateJob' (404 Trying to create a child that already exists, but it is tied to a different parent), ignoring.
```


_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
