### PR TITLE
Fix constraints warning

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2686,7 +2686,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
         // We don't warn for constraints errors because sometimes they're allowed, and BedrockCore.cpp will warn for the ones that aren't.
         // This prevents creating bugbot issues for the allowed cases. We still log as INFO though so we can diagnose the query with the problem.
         if (error == SQLITE_CONSTRAINT) {
-            INFO("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
+            SINFO("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
         } else {
             SWARN("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
         }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2683,7 +2683,13 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
         string sqlToLog = sql.substr(0, 20000);
         SRedactSensitiveValues(sqlToLog);
 
-        SWARN("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
+        // We don't warn for constraints errors because sometimes they're allowed, and BedrockCore.cpp will warn for the ones that aren't.
+        // This prevents creating bugbot issues for the allowed cases. We still log as INFO though so we can diagnose the query with the problem.
+        if (error == SQLITE_CONSTRAINT) {
+            INFO("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
+        } else {
+            SWARN("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
+        }
     }
 
     // But we log for commit conflicts as well, to keep track of how often this happens with this experimental feature.


### PR DESCRIPTION
### Details
Demote warning for CONSTRAINTS error.

Explanation for why this is not an issue is here:
https://github.com/Expensify/Bedrock/blob/4a474df3aba260b44d0eed658f84fea2150ee260/sqlitecluster/SQLite.h#L19-L38

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/192271

### Tests
N/A
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
