### PR TITLE
Fast stand down, no timeouts.

### DIFF
--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -198,9 +198,6 @@ class BedrockCommand : public SQLiteCommand {
     // in `process` instead of peek, as it will always be escalated to leader
     const bool escalateImmediately;
 
-    // Record the state we were acting under in the last call to `peek` or `process`.
-    SQLiteNodeState lastPeekedOrProcessedInState = SQLiteNodeState::UNKNOWN;
-
     // If someone is waiting for this command to complete, this will be called in the destructor.
     function<void()>* destructionCallback;
 

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -125,8 +125,6 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command) {
 }
 
 BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command, bool exclusive) {
-    BedrockServer::ScopedStateSnapshot snapshot(_server);
-    command->lastPeekedOrProcessedInState = _server.getState();
 
     // Convenience references to commonly used properties.
     const SData& request = command->request;
@@ -220,16 +218,6 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
 
 BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& command, bool exclusive) {
     AutoTimer timer(command, exclusive ? BedrockCommand::BLOCKING_PROCESS : BedrockCommand::PROCESS);
-    BedrockServer::ScopedStateSnapshot snapshot(_server);
-
-    // We need to be leading (including standing down) and we need to have peeked this command in the same set of
-    // states, or we can't complete this command (we can't commit the command if we're not leading, and if we're
-    // leading but were following when we peeked, we may try to read HTTPS requests we never made).
-    if ((command->lastPeekedOrProcessedInState != SQLiteNodeState::LEADING && command->lastPeekedOrProcessedInState != SQLiteNodeState::STANDINGDOWN) ||
-        (_server.getState() != SQLiteNodeState::LEADING && _server.getState() != SQLiteNodeState::STANDINGDOWN)) {
-        return RESULT::SERVER_NOT_LEADING;
-    }
-    command->lastPeekedOrProcessedInState = _server.getState();
 
     // Convenience references to commonly used properties.
     const SData& request = command->request;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1005,7 +1005,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                                 auto state = _syncNode->getState();
                                 if (state != SQLiteNodeState::LEADING) {
                                     _replicationState.store(state);
-                                    SINFO("SHUTDOWN Stopped leading while trying to commit, will retry.");
+                                    SINFO("Stopped leading while trying to commit, will retry.");
 
                                     // Jump back to the top of the main loop but skip the check that would push these to the blocking commit queue.
                                     continue;
@@ -1446,9 +1446,8 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
         if (!_outstandingSocketThreads && !count) {
             _shutdownState.store(COMMANDS_FINISHED);
 
-            // This is when we should tell the sync thread to shut down.
-
             // This interrupts the sync thread's poll() loop so it doesn't wait for up to an extra second to finish.
+            // When it wakes up, it will begin its own shutdown.
             _syncNode->notifyCommit();
         }
     }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1062,7 +1062,13 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                 }
 
                 if (state == SQLiteNodeState::STANDINGDOWN) {
-                    SINFO("Starting process() while standing down.");
+                    if (command->httpsRequests.size()) {
+                        SINFO("Standing down but finishing `process()` because we have HTTPS requests.");
+                    } else {
+                        SINFO("Re-queueing command without HTTPS requests because standing down.");
+                        _standDownQueue.push(move(command));
+                        break;
+                    }
                 }
 
                 // In this case, there's nothing blocking us from processing this in a worker, so let's try it.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -668,6 +668,8 @@ void BedrockServer::sync()
         _blockingCommandQueue.clear();
     }
 
+    SINFO(_outstandingSocketThreads << " socket threads remaining.");
+
     // We clear this before the _syncNode that it references.
     _clusterMessenger.reset();
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1055,8 +1055,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                                 // So instead, we need to check node state after the commit lock is acquired, which is where db.prepare() is called in SQLiteCore::commit.
                                 //
                                 // I'm worried this is going to have severe performance repercussions by gating commits on `update()` and/or `postPoll()`.
-                                auto stateLock = _syncNode->getStateLock(); 
-                                commitSuccess = core.commit(SQLiteNode::stateName(_replicationState), transactionID, transactionHash, enableOnPrepareNotifications, onPrepareHandler);
+                                commitSuccess = core.commit(*_syncNode, transactionID, transactionHash, enableOnPrepareNotifications, onPrepareHandler);
                             }
                         }
                     }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -203,7 +203,7 @@ void BedrockServer::sync()
         // we're leading, then the next update() loop will set us to standing down, and then we won't accept any new
         // commands, and we'll shortly run through the existing queue.
         if (_shutdownState.load() == CLIENTS_RESPONDED) {
-            SINFO("SHUTDOWN All clients responded to, " << BedrockCommand::getCommandCount() << " remaining. Shutting down sync node.");
+            SINFO("All clients responded to, " << BedrockCommand::getCommandCount() << " commands remaining. Shutting down sync node.");
             _syncNode->beginShutdown();
 
             // This will cause us to skip the next `poll` iteration which avoids a 1 second wait.
@@ -264,15 +264,13 @@ void BedrockServer::sync()
         _leaderVersion.store(_syncNode->getLeaderVersion());
 
         // If we're not leading, move any commands from the blocking queue back to the main queue.
-        /* not currently working.
         if (nodeState != SQLiteNodeState::LEADING && nodeState != preUpdateState) {
             auto commands = _blockingCommandQueue.getAll();
+            SINFO("Moving " << commands.size() << " commands from blocking queue to main queue.");
             for (auto& cmd : commands) {
                 _commandQueue.push(move(cmd));
             }
-            SINFO("SHUTDOWN Moved " << commands.size() << " commands from blocking queue to main queue.");
         }
-        */
 
         // If we were LEADING, but we've transitioned, then something's gone wrong (perhaps we got disconnected
         // from the cluster). Reset some state and try again.
@@ -573,7 +571,7 @@ void BedrockServer::sync()
 
     // We've finished shutting down the sync node, tell the workers that it's finished.
     _shutdownState.store(DONE);
-    SINFO("SHUTDOWN Sync thread finished with commands.");
+    SINFO("Sync thread finished with commands.");
 
     // We just fell out of the loop where we were waiting for shutdown to complete. Update the state one last time when
     // the writing replication thread exits.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1439,13 +1439,14 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity) {
         // if we are detaching.
         unique_lock<shared_mutex> lock(_controlPortExclusionMutex);
 
-        // Notify how many sockets and commands are left. We're not done until they're gone.
         size_t count = BedrockCommand::getCommandCount();
         SINFO("SHUTDOWN Have " << _outstandingSocketThreads << " socket threads and " << count << " commands remaining.");
 
         // Don't tell the sync node to shut down while we still have commands or sockets left.
         if (!_outstandingSocketThreads && !count) {
             _shutdownState.store(COMMANDS_FINISHED);
+
+            // This is when we should tell the sync thread to shut down.
 
             // This interrupts the sync thread's poll() loop so it doesn't wait for up to an extra second to finish.
             _syncNode->notifyCommit();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2322,5 +2322,7 @@ SQLiteNodeState BedrockServer::getState() const {
         return _syncNodeCopy->getState();
     }
 
-    return SQLiteNodeState::UNKNOWN;
+    // For historical reasons, we return "SEARCHING" instead of "UNKNOWN" when the node is not available.
+    // Scripts and tests, as well as the status command, expect this result.
+    return SQLiteNodeState::SEARCHING;
 }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -293,7 +293,7 @@ void BedrockServer::sync()
         _leaderVersion.store(_syncNode->getLeaderVersion());
 
         // If anything was in the stand down queue, move it back to the main queue.
-        if (nodeState != SQLiteNodeState::STANDINGDOWN) {
+        if (nodeState == SQLiteNodeState::LEADING || nodeState == SQLiteNodeState::FOLLOWING) {
             while (_standDownQueue.size()) {
                 SINFO("Moving " <<  _standDownQueue.size() << " commands back to main queue from stand down queue");
                 _commandQueue.push(_standDownQueue.pop());

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -283,8 +283,6 @@ class BedrockServer : public SQLiteServer {
     // reference to this object is passed to the sync thread to allow this update.
     atomic<string> _leaderVersion;
 
-    atomic<size_t> _commandsWaitingOnNetwork = 0;
-
     // This is a synchronized queued that can wake up a `poll()` call if something is added to it. This contains the
     // list of commands that worker threads were unable to complete on their own that needed to be passed back to the
     // sync thread. A reference is passed to the sync thread.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -414,11 +414,6 @@ class BedrockServer : public SQLiteServer {
 
     mutex _httpsCommandMutex;
 
-    // When we're standing down, we temporarily dump newly received commands here (this lets all existing
-    // partially-completed commands, like commands with HTTPS requests) finish without risking getting caught in an
-    // endless loop of always having new unfinished commands.
-    BedrockTimeoutCommandQueue _standDownQueue;
-
     // The following variables all exist to to handle commands that seem to have caused crashes. This lets us broadcast
     // a command to all peer nodes with information about the crash-causing command, so they can refuse to process it if
     // it gets sent again (i.e., if an end-user clicks 'refresh' after crashing the first node). Because these can

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -147,7 +147,7 @@ class BedrockServer : public SQLiteServer {
     enum SHUTDOWN_STATE {
         RUNNING,
         START_SHUTDOWN,
-        CLIENTS_RESPONDED,
+        CLIENTS_RESPONDED, // TODO: Rename 'COMMANDS_FINISHED'
         DONE
     };
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -283,6 +283,8 @@ class BedrockServer : public SQLiteServer {
     // reference to this object is passed to the sync thread to allow this update.
     atomic<string> _leaderVersion;
 
+    atomic<size_t> _commandsWaitingOnNetwork = 0;
+
     // This is a synchronized queued that can wake up a `poll()` call if something is added to it. This contains the
     // list of commands that worker threads were unable to complete on their own that needed to be passed back to the
     // sync thread. A reference is passed to the sync thread.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -282,7 +282,11 @@ class BedrockServer : public SQLiteServer {
 
     // The actual thread object for the sync thread.
     thread _syncThread;
-    atomic<bool> _syncThreadComplete;
+
+    // This is true from when the sync thread *should* start, until it exits. It may become true again if it should run again
+    // (i.e., after a `Detach` and then `Attach`. It's used to indicate that the sync thread has finished during shutdown.
+    // Notably it's true *before* the sync thread start both at startup and when re-attaching.
+    atomic<bool> _syncLoopShouldBeRunning;
 
     // Give all of our plugins a chance to verify and/or modify the database schema. This will run every time this node
     // becomes leader. It will return true if the DB has changed and needs to be committed.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -210,10 +210,6 @@ class BedrockServer : public SQLiteServer {
     // Not atomic because it's only accessed with a lock on _portMutex.
     list<string> commandPortSuppressionReasons;
 
-    // This will return true if there's no outstanding writable activity that we're waiting on. It's called by an
-    // SQLiteNode in a STANDINGDOWN state to know that it can switch to searching.
-    virtual bool canStandDown();
-
     // Returns whether or not this server was configured to backup.
     bool shouldBackup();
 

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -15,13 +15,6 @@ SHTTPSManager::SHTTPSManager(BedrockPlugin& plugin_, const string& pem, const st
 {
 }
 
-void SHTTPSManager::validate() {
-    // These can only be created on a leader node.
-    if (plugin.server.getState() != SQLiteNodeState::LEADING && plugin.server.getState() != SQLiteNodeState::STANDINGDOWN) {
-        throw NotLeading();
-    }
-}
-
 SStandaloneHTTPSManager::SStandaloneHTTPSManager()
 {
 }

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -42,13 +42,6 @@ class SStandaloneHTTPSManager : public STCPManager {
 
     static int getHTTPResponseCode(const string& methodLine);
 
-    virtual void validate() {
-        // The constructor for a transaction needs to call this on it's manager. It can then throw in cases where this
-        // manager should not be allowed to create transactions. This lets us have different validation behavior for
-        // different managers without needing to subclass Transaction.
-        // The default implementation does nothing.
-    }
-
   protected: // Child API
 
     // Used to create the signing certificate.
@@ -73,8 +66,6 @@ class SHTTPSManager : public SStandaloneHTTPSManager {
             return "Can't create SHTTPSManager::Transaction when not leading";
         }
     };
-
-    virtual void validate() override;
 
     protected:
     // Reference to the plugin that owns this object.

--- a/libstuff/SScheduledPriorityQueue.h
+++ b/libstuff/SScheduledPriorityQueue.h
@@ -47,6 +47,9 @@ class SScheduledPriorityQueue {
     // Remove all items from the queue.
     void clear();
 
+    // Clears the queue, returning all the commands.
+    list<T> getAll();
+
     // Returns true if there are no queued commands.
     bool empty();
 
@@ -94,6 +97,7 @@ template<typename T>
 void SScheduledPriorityQueue<T>::clear()  {
     lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     _queue.clear();
+    _lookupByTimeout.clear();
 }
 
 template<typename T>
@@ -310,3 +314,20 @@ T SScheduledPriorityQueue<T>::_dequeue() {
     throw out_of_range("No item found.");
 }
 
+template<typename T>
+list<T> SScheduledPriorityQueue<T>::getAll() {
+    lock_guard<decltype(_queueMutex)> lock(_queueMutex);
+    list<T> items;
+
+    // Iterate across each map in each queue and pull out all the items.
+    for (auto& queue: _queue) {
+        for (auto& p : queue.second) {
+            items.emplace_back(move(p.second.item));
+        }
+    }
+
+    // Empty now.
+    clear();
+
+    return items;
+}

--- a/libstuff/SScheduledPriorityQueue.h
+++ b/libstuff/SScheduledPriorityQueue.h
@@ -326,8 +326,9 @@ list<T> SScheduledPriorityQueue<T>::getAll() {
         }
     }
 
-    // Empty now.
-    clear();
+    // Call the same thing that `clear()` does, but without locking recursively.
+    _queue.clear();
+    _lookupByTimeout.clear();
 
     return items;
 }

--- a/libstuff/SScheduledPriorityQueue.h
+++ b/libstuff/SScheduledPriorityQueue.h
@@ -58,10 +58,6 @@ class SScheduledPriorityQueue {
     // available.
     T get(uint64_t waitUS = 0, bool loggingEnabled = false);
 
-    // Immediately gets the first item in the queue, whether it's ready or not.
-    // It is an error to call this on an empty queue.
-    T getImmediate();
-
     // Add an item to the queue. The queue takes ownership of the item and the caller's copy is invalidated.
     void push(T&& item, Priority priority, Scheduled scheduled, Timeout timeout);
 
@@ -98,7 +94,6 @@ template<typename T>
 void SScheduledPriorityQueue<T>::clear()  {
     lock_guard<decltype(_queueMutex)> lock(_queueMutex);
     _queue.clear();
-    _lookupByTimeout.clear();
 }
 
 template<typename T>
@@ -179,56 +174,6 @@ T SScheduledPriorityQueue<T>::get(uint64_t waitUS, bool loggingEnabled) {
             }
         }
     }
-}
-
-template<typename T>
-T SScheduledPriorityQueue<T>::getImmediate()  {
-    lock_guard<decltype(_queueMutex)> lock(_queueMutex);
-    for (auto queueIt = _queue.rbegin(); queueIt != _queue.rend(); ++queueIt) {
-
-        // Record the priority of the queue we're currently looking at.
-        Priority queuePriority = queueIt->first;
-
-        // And look at the first item in this particular priority queue.
-        auto itemIt = queueIt->second.begin();
-
-        // Convenience names for legibility.
-        const Scheduled thisItemScheduled = itemIt->first;
-        ItemTimeoutPair& thisItemTimeoutPair = itemIt->second;
-        const Timeout thisItemTimeout = thisItemTimeoutPair.timeout;
-
-        // Pull out the item we want to return.
-        T item = move(thisItemTimeoutPair.item);
-
-        // Delete the entry in this queue.
-        queueIt->second.erase(itemIt);
-
-        // If the whole queue is empty, delete that too.
-        if (queueIt->second.empty()) {
-            // The odd syntax in the argument converts a reverse to forward iterator.
-            _queue.erase(next(queueIt).base());
-        }
-
-        // Remove from the timeout map, as well.
-        auto matchingTimeoutIterators = _lookupByTimeout.equal_range(thisItemTimeout);
-        for (auto it = matchingTimeoutIterators.first; it != matchingTimeoutIterators.second; it++) {
-
-            // Convenience names for legibility.
-            auto& timeoutPair = it->second;
-            Priority& thisTimeoutPriority = timeoutPair.first;
-            Scheduled& thisTimeoutScheduled = timeoutPair.second;
-
-            // If this timeout entry has the same queue that we're in, and the same scheduled time, we can remove it.
-            if (thisTimeoutPriority == queuePriority && thisTimeoutScheduled == thisItemScheduled) {
-                _lookupByTimeout.erase(it);
-                break;
-            }
-        }
-
-        return item;
-    }
-
-    throw out_of_range("No item found.");
 }
 
 template<typename T>

--- a/sqlitecluster/SQLiteClusterMessenger.h
+++ b/sqlitecluster/SQLiteClusterMessenger.h
@@ -44,10 +44,6 @@ class SQLiteClusterMessenger {
     // to handle the failure.
     bool runOnPeer(BedrockCommand& command, const string& peerName);
 
-    // Set a timestamp by which we should give up on any pending commands. Once set, this is permanent. You will need a
-    // new SQLiteClusterMessenger if you want to shutdown again.
-    void shutdownBy(uint64_t shutdownTimestamp);
-
   private:
     // This takes a pollfd with either POLLIN or POLLOUT set, and waits for the socket to be ready to read or write,
     // respectively. It returns true if ready, or false if error or timeout. The timeout is specified as a timestamp in
@@ -71,11 +67,6 @@ class SQLiteClusterMessenger {
     unique_ptr<SHTTPSManager::Socket> _getSocketForAddress(string address);
 
     const shared_ptr<const SQLiteNode> _node;
-
-    // This is set to a timestamp when the server is shutting down so that we can abandon any commands that would
-    // block that.
-    atomic<uint64_t> _shutDownBy = 0;
-    atomic_flag _shutdownSet = ATOMIC_FLAG_INIT;
 
     // For managing many connections to leader, we have a socket pool.
     SMultiHostSocketPool _socketPool;

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -8,7 +8,7 @@ SQLiteCore::SQLiteCore(SQLite& db) : _db(db)
 { }
 
 bool SQLiteCore::commit(const string& description, uint64_t& commitID, string& transactionHash,
-                        bool needsPluginNotification, void (*notificationHandler)(SQLite& _db, int64_t tableID)) {
+                        bool needsPluginNotification, void (*notificationHandler)(SQLite& _db, int64_t tableID)) noexcept {
     
     // This handler only needs to exist in prepare so we scope it here to automatically unset
     // the handler function once we are done with prepare.

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -17,6 +17,13 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
         SASSERT(_db.prepare(&commitID, &transactionHash));
     }
 
+    // Check for any state other than leading and refuse.
+    if (node.getState() != SQLiteNodeState::LEADING) {
+        SINFO("No longer leading, rolling back.");
+        _db.rollback();
+        return false;
+    }
+
     // If there's nothing to commit, we won't bother, but warn, as we should have noticed this already.
     if (_db.getUncommittedHash().empty()) {
         SWARN("Commit called with nothing to commit.");

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -7,8 +7,7 @@
 SQLiteCore::SQLiteCore(SQLite& db) : _db(db)
 { }
 
-bool SQLiteCore::commit(const string& description, uint64_t& commitID, string& transactionHash,
-                        bool needsPluginNotification, void (*notificationHandler)(SQLite& _db, int64_t tableID)) noexcept {
+bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, bool needsPluginNotification, void (*notificationHandler)(SQLite& _db, int64_t tableID)) noexcept {
     
     // This handler only needs to exist in prepare so we scope it here to automatically unset
     // the handler function once we are done with prepare.
@@ -25,7 +24,7 @@ bool SQLiteCore::commit(const string& description, uint64_t& commitID, string& t
     }
 
     // Perform the actual commit, rollback if it fails.
-    int errorCode = _db.commit(description);
+    int errorCode = _db.commit(SQLiteNode::stateName(node.getState()));
     if (errorCode == SQLITE_BUSY_SNAPSHOT) {
         SINFO("Commit conflict, rolling back.");
         _db.rollback();

--- a/sqlitecluster/SQLiteCore.h
+++ b/sqlitecluster/SQLiteCore.h
@@ -1,5 +1,6 @@
 #pragma once
 class SQLite;
+class SQLiteNode;
 
 class SQLiteCore {
   public:
@@ -8,8 +9,7 @@ class SQLiteCore {
 
     // Commit the outstanding transaction on the DB.
     // Returns true on successful commit, false on conflict.
-    bool commit(const string& description, uint64_t& commitID, string& transactionHash, bool needsPluginNotifiation, 
-                void (*notificationHandler)(SQLite& _db, int64_t tableID) = nullptr) noexcept;
+    bool commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, bool needsPluginNotifiation, void (*notificationHandler)(SQLite& _db, int64_t tableID) = nullptr) noexcept;
 
     // Roll back a transaction if we've decided not to commit it.
     void rollback();

--- a/sqlitecluster/SQLiteCore.h
+++ b/sqlitecluster/SQLiteCore.h
@@ -9,7 +9,7 @@ class SQLiteCore {
     // Commit the outstanding transaction on the DB.
     // Returns true on successful commit, false on conflict.
     bool commit(const string& description, uint64_t& commitID, string& transactionHash, bool needsPluginNotifiation, 
-                void (*notificationHandler)(SQLite& _db, int64_t tableID) = nullptr);
+                void (*notificationHandler)(SQLite& _db, int64_t tableID) = nullptr) noexcept;
 
     // Roll back a transaction if we've decided not to commit it.
     void rollback();

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -993,6 +993,7 @@ bool SQLiteNode::update() {
                 // Commit this distributed transaction. Either we have quorum, or we don't need it.
                 SDEBUG("Committing current transaction because consistentEnough: " << _db.getUncommittedQuery());
                 uint64_t beforeCommit = STimeNow();
+                // Only other intersting place we commit and would care about node state.
                 int result = _db.commit(stateName(_state));
                 SINFO("SQLite::commit in SQLiteNode took " << ((STimeNow() - beforeCommit)/1000) << "ms.");
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -571,6 +571,8 @@ bool SQLiteNode::update() {
 
         // If we're trying to shut down, just do nothing, especially don't jump directly to leading and get stuck in an endless loop.
         if (_isShuttingDown) {
+
+            // We need to exit here.
             return false; // Don't re-update
         }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1133,7 +1133,7 @@ bool SQLiteNode::update() {
                 SHMMM(standDownReason);
                 // Place 1 where we STAND DOWN
                 _changeState(SQLiteNodeState::STANDINGDOWN);
-                SINFO("Standing down: " << standDownReason);
+                SINFO("SHUTDOWN Standing down: " << standDownReason);
             }
         }
 
@@ -1437,7 +1437,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                                 PWARN("Higher-priority peer is trying to stand up while we are STANDINGUP, SEARCHING.");
                                 _changeState(SQLiteNodeState::SEARCHING);
                             } else if (_state == SQLiteNodeState::LEADING) {
-                                PWARN("Higher-priority peer is trying to stand up while we are LEADING, STANDINGDOWN.");
+                                PINFO("SHUTDOWN Higher-priority peer is trying to stand up while we are LEADING, STANDINGDOWN.");
                                 // Place 2 where we STAND DOWN
                                 _changeState(SQLiteNodeState::STANDINGDOWN);
                             } else {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1921,11 +1921,6 @@ void SQLiteNode::_changeState(SQLiteNodeState newState) {
     _localCommitNotifier.notifyThrough(_db.getCommitCount());
 
     if (newState != _state) {
-
-        // IMPORTANT: Don't return early or throw from this method.
-        // Note: _stateMutex is already locked here (by update, _replicate, or postPoll).
-        _db.exclusiveLockDB();
-
         // First, we notify all plugins about the state change
         _server.notifyStateChangeToPlugins(*pluginDB, newState);
 
@@ -2055,6 +2050,10 @@ void SQLiteNode::_changeState(SQLiteNodeState newState) {
                 _db.exclusiveUnlockDB();
             }
         }
+
+        // IMPORTANT: Don't return early or throw from this method after here.
+        // Note: _stateMutex is already locked here (by update, _replicate, or postPoll).
+        _db.exclusiveLockDB();
 
         // Send to everyone we're connected to, whether or not
         // we're "LoggedIn" (else we might change state after sending LOGIN,

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2753,16 +2753,3 @@ void SQLiteNode::kill() {
         peer->reset();
     }
 }
-
-SQLiteNode::StateLock::StateLock(SQLiteNode& node) : _node(node) {
-    // only shared locking not so much to prevent other SQLiteNode functions from running, but to prevent serializing all commits on this.
-    _node._stateMutex.lock_shared();
-}
-
-SQLiteNode::StateLock::~StateLock() {
-    _node._stateMutex.unlock_shared();
-}
-
-SQLiteNode::StateLock SQLiteNode::getStateLock() {
-    return StateLock(*this);
-}

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -76,19 +76,6 @@ class SQLiteNode : public STCPManager {
         NUM_CONSISTENCY_LEVELS
     };
 
-    // This exists as a RAII-protected lock on the node state.
-    // Creating one of these prevents the node from changing state until this completes.
-    class StateLock {
-      public:
-        StateLock(SQLiteNode& node);
-        ~StateLock();
-
-      private:
-        SQLiteNode& _node;
-    };
-
-    StateLock getStateLock();
-
     // This is a globally accessible pointer to some node instance. The intention here is to let signal handling code attempt to kill outstanding
     // peer connections on this node before shutting down.
     static SQLiteNode* KILLABLE_SQLITE_NODE;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -124,6 +124,10 @@ class SQLiteNode : public STCPManager {
     // Does not block.
     int getPriority() const;
 
+    // Sets the node priority to 1 and broadcasts STATE to the cluster.
+    // Can block.
+    void setShutdownPriority();
+
     // Returns our current state.
     // Does not block.
     SQLiteNodeState getState() const;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -76,6 +76,19 @@ class SQLiteNode : public STCPManager {
         NUM_CONSISTENCY_LEVELS
     };
 
+    // This exists as a RAII-protected lock on the node state.
+    // Creating one of these prevents the node from changing state until this completes.
+    class StateLock {
+      public:
+        StateLock(SQLiteNode& node);
+        ~StateLock();
+
+      private:
+        SQLiteNode& _node;
+    };
+
+    StateLock getStateLock();
+
     // This is a globally accessible pointer to some node instance. The intention here is to let signal handling code attempt to kill outstanding
     // peer connections on this node before shutting down.
     static SQLiteNode* KILLABLE_SQLITE_NODE;

--- a/sqlitecluster/SQLiteServer.h
+++ b/sqlitecluster/SQLiteServer.h
@@ -8,10 +8,6 @@ class SQLitePeer;
 // commands it receives.
 class SQLiteServer : public STCPManager {
   public:
-    // This will return true if there's no outstanding writable activity that we're waiting on. It's called by an
-    // SQLiteNode in a STANDINGDOWN state to know that it can switch to searching.
-    virtual bool canStandDown() = 0;
-
     // When a node connects to the cluster, this function will be called on the sync thread.
     virtual void onNodeLogin(SQLitePeer* peer) = 0;
 

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -199,7 +199,10 @@ ClusterTester<T>::~ClusterTester()
         // If we don't do this, then if the leader loses quorum, because the other nodes have all shut down,
         // it won't run remaining commands, and it will get stuck forever.
         // In tests, this can happen with commands that generate other commands that don't expect a response.
-        getTester(i).waitForStatusTerm("commandCount", "1");
+        // We can skip this if the node is already stopped, though.
+        if (getTester(i).getPID()) {
+            getTester(i).waitForStatusTerm("commandCount", "1");
+        }
     }
 
     for (int i = _size - 1; i > 0; i--) {

--- a/test/clustertest/BedrockClusterTester.h
+++ b/test/clustertest/BedrockClusterTester.h
@@ -193,6 +193,15 @@ ClusterTester<T>::~ClusterTester()
 
     // Shut down everything but the leader first.
     list<thread> threads;
+
+    for (int i = 0; i< _size; i++) {
+        // Wait for all the commands to be done before stopping.
+        // If we don't do this, then if the leader loses quorum, because the other nodes have all shut down,
+        // it won't run remaining commands, and it will get stuck forever.
+        // In tests, this can happen with commands that generate other commands that don't expect a response.
+        getTester(i).waitForStatusTerm("commandCount", "1");
+    }
+
     for (int i = _size - 1; i > 0; i--) {
         threads.emplace_back([&, i](){
             stopNode(i);

--- a/test/clustertest/tests/FastStandDownTest.cpp
+++ b/test/clustertest/tests/FastStandDownTest.cpp
@@ -1,0 +1,116 @@
+
+#include <iostream>
+
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
+
+/* This class currently tests two important cases for fast stand down, 1 that we can stand down with commands currently running (the HTTPS test does this)
+ * And 2, that we can stand down with commands queued (the future commands test does this).
+ * It does not exhaustively test every case because they're almost impossible to test, largely for timing reasons.
+ *
+ * Some cases that would be nice to test:
+ * * Commands in the blocking commit queue.
+ * * Commands in the middle of running `process()`.
+ * * Commands where the node state change in the call to `commit()`.
+ *
+ * Unfortunately these are very hard to do, and the expectation is that these cases work very similarly to the cases we DO have tests for.
+ */
+struct FastStandDownTest : tpunit::TestFixture {
+    FastStandDownTest()
+        : tpunit::TestFixture("FastStandDown",
+                              BEFORE_CLASS(FastStandDownTest::setup),
+                              AFTER_CLASS(FastStandDownTest::teardown),
+                              TEST(FastStandDownTest::testHTTPSRequests),
+                              TEST(FastStandDownTest::testFutureCommands)) { }
+
+    BedrockClusterTester* tester;
+
+    void setup() {
+        tester = new BedrockClusterTester();
+    }
+
+    void teardown() {
+        delete tester;
+    }
+
+    void testHTTPSRequests()
+    {
+        // Send a command that makes a slow HTTPS request.
+        SData httpsRequest("httpstimeout");
+        httpsRequest["waitFor"] = "5"; // Wait for 5 seconds before sending.
+        vector<SData> httpsResult;
+        thread t1([&]() {
+            httpsResult = tester->getTester(0).executeWaitMultipleData({httpsRequest}, 1);
+        });
+        uint64_t commandStartTime = STimeNow();
+
+        // Stop leader, but don't wait for it to finish yet.
+        thread t2([&]() {
+            // Allow for our command to have sent.
+            sleep(1);
+            tester->stopNode(0);
+        });
+
+        // Wait for secondary to be leading. We can't wait for the old leader to be following, because it will have closed its ports so we can't check its state.
+        ASSERT_TRUE(tester->getTester(1).waitForState("LEADING"));
+
+        // Check that the follower became leader while the command on the old leader should still have been stuck in its 5s slow HTTPS send.
+        ASSERT_LESS_THAN((STimeNow() - commandStartTime), 4'000'000);
+
+        // Wait for the response to the command.
+        t1.join();
+
+        // And for our leader to finish shutting down.
+        t2.join();
+
+        // verify the response was processed on `cluster_node_1`. It was sent to `cluster_node_0`, so this means it was escalated.
+        // For it to be escalated, node_0 would have needed to be FOLLOWING, which implies it ran through the correct: LEADING->FOLLOWING->OFF series of events.
+        ASSERT_EQUAL(httpsResult[0]["processingNode"], "cluster_node_1");
+    }
+
+    void testFutureCommands()
+    {
+        // Because we'd stopped this in the previous test, we need to start it again.
+        tester->startNode(0);
+
+        // Create a command that will run 5 seconds from now.
+        SData insertQuery("Query");
+        insertQuery["commandExecuteTime"] = to_string(STimeNow() + 5'000'000);
+        insertQuery["Query"] = "INSERT INTO test VALUES(" + insertQuery["commandExecuteTime"] + ", " + SQ("escalated_in_the_past") + ");";
+        vector<SData> httpsResult;
+        thread t1([&]() {
+            httpsResult = tester->getTester(0).executeWaitMultipleData({insertQuery}, 1);
+        });
+        uint64_t commandStartTime = STimeNow();
+
+        // Stop leader, but don't wait for it to finish yet.
+        uint64_t nodeStopStime = 0;
+        thread t2([&]() {
+            // Allow for all of our commands to have sent.
+            sleep(1);
+            tester->stopNode(0);
+            nodeStopStime = STimeNow();
+        });
+
+        // Wait for secondary to be leading. We can't wait for the old leader to be following, because it will have closed its ports and so we can't check its state.
+        ASSERT_TRUE(tester->getTester(1).waitForState("LEADING"));
+
+        // Check that the follower became leader while the command on the old leader should still have been stuck in its 5s wait.
+        ASSERT_LESS_THAN((STimeNow() - commandStartTime), 4'000'000);
+
+        // Wait for responses for our commands.
+        t1.join();
+
+        // And for our leader to finish shutting down.
+        t2.join();
+
+        // Verify that leader couldn't shut down until after the 5s delay we introduced.
+        ASSERT_GREATER_THAN(nodeStopStime, stoull(insertQuery["commandExecuteTime"]));
+
+        // Verify the DB on the new leader contains the commit.
+        SData lookupQuery("Query");
+        lookupQuery["Query"] = "SELECT COUNT(*) FROM test WHERE id = " + insertQuery["commandExecuteTime"] + " AND value = 'escalated_in_the_past';"; 
+        httpsResult = tester->getTester(1).executeWaitMultipleData({lookupQuery}, 1);
+        ASSERT_EQUAL(httpsResult[0].content, "COUNT(*)\n1\n");
+    }
+} __FastStandDownTest;

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -121,7 +121,6 @@ struct GracefulFailoverTest : tpunit::TestFixture {
         sleep(2);
 
         // Now our clients are spamming all our nodes. Shut down leader.
-        SINFO("SHUTDOWN Stopping leader");
         tester->stopNode(0);
 
         // Wait for node 1 to be leader.
@@ -133,7 +132,6 @@ struct GracefulFailoverTest : tpunit::TestFixture {
         // Bring leader back up.
         tester->getTester(0).startServer();
         ASSERT_TRUE(tester->getTester(0).waitForState("LEADING"));
-
         sleep(15);
 
         // Now let's  stop a follower and make sure everything keeps working.

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -133,6 +133,7 @@ struct GracefulFailoverTest : tpunit::TestFixture {
         // Bring leader back up.
         tester->getTester(0).startServer();
         ASSERT_TRUE(tester->getTester(0).waitForState("LEADING"));
+
         sleep(15);
 
         // Now let's  stop a follower and make sure everything keeps working.

--- a/test/clustertest/tests/GracefulFailoverTest.cpp
+++ b/test/clustertest/tests/GracefulFailoverTest.cpp
@@ -121,6 +121,7 @@ struct GracefulFailoverTest : tpunit::TestFixture {
         sleep(2);
 
         // Now our clients are spamming all our nodes. Shut down leader.
+        SINFO("SHUTDOWN Stopping leader");
         tester->stopNode(0);
 
         // Wait for node 1 to be leader.

--- a/test/clustertest/tests/VersionMismatchTest.cpp
+++ b/test/clustertest/tests/VersionMismatchTest.cpp
@@ -7,7 +7,7 @@ struct VersionMismatchTest : tpunit::TestFixture {
             BEFORE_CLASS(VersionMismatchTest::setup),
             TEST(VersionMismatchTest::testReadEscalation), 
             TEST(VersionMismatchTest::testWriteEscalation),
-            AFTER_CLASS(VersionMismatchTest::setup)) { }
+            AFTER_CLASS(VersionMismatchTest::destroy)) { }
 
     BedrockClusterTester* tester = nullptr;
 
@@ -23,9 +23,11 @@ struct VersionMismatchTest : tpunit::TestFixture {
         tester->getTester(4).updateArgs({{"-versionOverride", "ABCDE"}});
         tester->getTester(4).startServer();
     }
+
     void destroy() {
         delete tester;
     }
+
     void testReadEscalation()
     {
         // Send a query to all three and make sure the version-mismatched one escalates.

--- a/test/clustertest/tests/VersionMismatchTest.cpp
+++ b/test/clustertest/tests/VersionMismatchTest.cpp
@@ -7,7 +7,7 @@ struct VersionMismatchTest : tpunit::TestFixture {
             BEFORE_CLASS(VersionMismatchTest::setup),
             TEST(VersionMismatchTest::testReadEscalation), 
             TEST(VersionMismatchTest::testWriteEscalation),
-            AFTER_CLASS(VersionMismatchTest::destroy)) { }
+            AFTER_CLASS(VersionMismatchTest::teardown)) { }
 
     BedrockClusterTester* tester = nullptr;
 
@@ -24,7 +24,7 @@ struct VersionMismatchTest : tpunit::TestFixture {
         tester->getTester(4).startServer();
     }
 
-    void destroy() {
+    void teardown() {
         delete tester;
     }
 


### PR DESCRIPTION
### Details

Design for this:

### Step 0:
Make HTTPS on followers work for all commands. This largely should be finished when `auth.isLeading` is not checked by any commands (Exceptions: SavePolicy)

### Step 1: instant standdown
Instant stand down is a knife switch in `commit`. If the node is `LEADING` you can commit, and if the node is `STANDINGDOWN` then you cannot, *except for a single quorum commit if one is in progress*.

This means that `_changeState` in `SQLiteNode` needs to grab an exclusive lock on the commit mutex for the DB. This could potentially take a long time on an overloaded server, but it's still the best option we have, so we should log the timing (maybe only if it takes over 10ms or something).

Additionally, we want to check for the node state inside of the shared/exclusive lock inside `commit()` in BedrockServer, before we actually do anything. If we're STANDINGDOWN (or generally, not LEADING), we can simply throw out of here and handle that the same way we'd handle a commit conflict, but on the next try we'll escalate to the leader on the next commit.

On change to `STANDINGDOWN` we can move everything out of the blocking commit queue.

We can also remove the `_standDownQueue`, it's no longer required.

There is a potential loop where we start `STANDINGDOWN` while a command is running, but don't get a leader for a few seconds, where we run through all our potential retries. We need to essentially remove this line:
https://github.com/Expensify/Bedrock/blob/e1672edc974e427f054a8e63933b9d72dd6cbe8b/BedrockServer.cpp#L745
But we need to do that check inside the main `runCommand` loop.

With these changes, all `STANDINGDOWN` does is finish whatever commits already have the commit lock, and then delivers the outstanding commits to followers. Standing down is then complete. No incomplete commands are waited for.

### Step 2: change how shutdown works.
Details to come, but the new shutdown is essentially:

1. Close command port.
2. Change priority to 1 (or 0, or -1, whichever works best for this, possibly -1). If we are leading this will cause us to stand down, but importantly, come back up as following afterward. Notably, this has no effect for a single-node cluster such as used in tests.
3. Wait until there are no commands left, or we time out, and turn off.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/350259

### Tests
New tests added.

### Deploy notes:
I sort of expect hiccups with this, but I think the most likely issue is that after a node stands down it gets stuck without finally stopping. This is not that bad of an issue and we can kill the process.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
