### PR TITLE
Fix bug where rows would reference wrong SQResult after copy

### DIFF
--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -162,3 +162,12 @@ const SQResultRow& SQResult::operator[](size_t rowNum) const {
         STHROW("Out of range");
     }
 }
+
+SQResult& SQResult::operator=(const SQResult& other) {
+    headers = other.headers;
+    rows = other.rows;
+    for (auto& row : rows) {
+        row.result = this;
+    }
+    return *this;
+}

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -6,6 +6,7 @@ using namespace std;
 class SQResult;
 
 class SQResultRow : public vector<string> {
+    friend class SQResult;
   public:
     SQResultRow();
     SQResultRow(SQResult& result, size_t count = 0);
@@ -36,6 +37,7 @@ class SQResult {
     // Operators
     SQResultRow& operator[](size_t rowNum);
     const SQResultRow& operator[](size_t rowNum) const;
+    SQResult& operator=(const SQResult& other);
 
     // Serializers
     string serializeToJSON() const;


### PR DESCRIPTION
### Details
When copying an SQResult, we would copy the rows, but the rows would continue to refer to the original SQResult object. This updates the rows to point to the new object.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
