### PR TITLE
Actually run tests over the 50th

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -59,6 +59,8 @@ tpunit::TestFixture::TestFixture(method* m0,  method* m1,  method* m2,  method* 
 {
     tpunit_detail_fixture_list()->push_back(this);
 
+    // DO NOT modify this over 70, you're holding it wrong if you do.
+    // Split your test suites/files if you need to!
     method* methods[70] = { m0,  m1,  m2,  m3,  m4,  m5,  m6,  m7,  m8,  m9,
                             m10, m11, m12, m13, m14, m15, m16, m17, m18, m19,
                             m20, m21, m22, m23, m24, m25, m26, m27, m28, m29,

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -59,13 +59,15 @@ tpunit::TestFixture::TestFixture(method* m0,  method* m1,  method* m2,  method* 
 {
     tpunit_detail_fixture_list()->push_back(this);
 
-    method* methods[50] = { m0,  m1,  m2,  m3,  m4,  m5,  m6,  m7,  m8,  m9,
+    method* methods[70] = { m0,  m1,  m2,  m3,  m4,  m5,  m6,  m7,  m8,  m9,
                             m10, m11, m12, m13, m14, m15, m16, m17, m18, m19,
                             m20, m21, m22, m23, m24, m25, m26, m27, m28, m29,
                             m30, m31, m32, m33, m34, m35, m36, m37, m38, m39,
-                            m40, m41, m42, m43, m44, m45, m46, m47, m48, m49 };
+                            m40, m41, m42, m43, m44, m45, m46, m47, m48, m49,
+                            m50, m51, m52, m53, m54, m55, m56, m57, m58, m59,
+                            m60, m61, m62, m63, m64, m65, m66, m67, m68, m69 };
 
-    for(int i = 0; i < 50; i++) {
+    for(int i = 0; i < 70; i++) {
        if(methods[i]) {
           method** m = 0;
           switch(methods[i]->_type) {

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -258,6 +258,8 @@ namespace tpunit {
          // Use constructor delegation to add an optional default 'name' parameter that works as a first argument.
          // This lets us keep backwards compatibility with existing tests, and add a name to new tests without having
          // to add 70 '0's for a bunch of unused methods.
+         // DO NOT ADD MORE THAN 70 METHODS TO A TEST FIXTURE. If you need more, split the test file into multiple files
+         // so that you can run these tests more efficiently in parallel.
          TestFixture(const char* name,
                      method* m0,      method* m1  = 0, method* m2  = 0, method* m3  = 0, method* m4  = 0,
                      method* m5  = 0, method* m6  = 0, method* m7  = 0, method* m8  = 0, method* m9  = 0,
@@ -306,7 +308,9 @@ namespace tpunit {
 
          /**
           * Base constructor to register methods with the test fixture. A test
-          * fixture can register up to 70 methods.
+          * fixture can register up to 70 methods. DO NOT expand this beyond 70 tests.
+          * Split your tests into more files/suites if you need more than 70 tests
+          * so that you can run these tests more efficiently in parallel.
           *
           * @param[in] m0..m49 The methods to register with the test fixture.
           */


### PR DESCRIPTION
### Details
This was missed by https://github.com/Expensify/Bedrock/pull/1694


### Fixed Issues
Fixes https://expensify.slack.com/archives/C03TQ48KC/p1713205627453889

### Tests
See tests run on Auth locally. cc @arosiclair 

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
