### PR TITLE
Move AutoTimer after transaction

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -145,7 +145,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
                 STHROW("501 Failed to begin " + (exclusive ? "exclusive"s : "shared"s) + " transaction");
             }
 
-            // We start the timer here to avoid including the time spent acquiring the the lock _sharedData.commitLock
+            // We start the timer here to avoid including the time spent acquiring the lock _sharedData.commitLock
             AutoTimer timer(command, exclusive ? BedrockCommand::BLOCKING_PEEK : BedrockCommand::PEEK);
 
             // Make sure no writes happen while in peek command


### PR DESCRIPTION
### Details

If a command is going to run `peek` in blocking commit, and it has to wait for other commands that are already running in blocking commit, that wait time was being added to the `peek` time, which makes it look like this command used more time than it really used in the blocking commit thread.

See https://expensify.slack.com/archives/C05CBC62HGW/p1712357941670379
Another examples found here: https://github.com/Expensify/Expensify/issues/387423#issuecomment-2057690158


I want to fix this because this error in our performance measuring tools makes us focus on things that are not really a problem.

### Fixed Issues
Fixes https://expensify.slack.com/archives/C05CBC62HGW/p1712357941670379


### Tests

N/A

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
