### PR TITLE
Log a debug stack trace for STHROW

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -4,12 +4,12 @@
 // Global logging state shared between all threads
 atomic<int> _g_SLogMask(LOG_INFO);
 
-void SLogStackTrace() {
+void SLogStackTrace(int level) {
     // Output the symbols to the log
     void* callstack[100];
     int depth = backtrace(callstack, 100);
     vector<string> stack = SGetCallstack(depth, callstack);
     for (const auto& frame : stack) {
-        SWARN(frame);
+        SLogAtLevel(level, frame);
     }
 }

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -10,6 +10,27 @@ void SLogStackTrace(int level) {
     int depth = backtrace(callstack, 100);
     vector<string> stack = SGetCallstack(depth, callstack);
     for (const auto& frame : stack) {
-        SLogAtLevel(level, frame);
+        switch (level) {
+        case LOG_DEBUG:
+            SDEBUG(frame);
+            break;
+        case LOG_INFO:
+            SINFO(frame);
+            break;
+        case LOG_NOTICE:
+            SHMMM(frame);
+            break;
+        case LOG_WARNING:
+            SWARN(frame);
+            break;
+        case LOG_ALERT:
+            SALERT(frame);
+            break;
+        case LOG_ERR:
+            SERROR(frame);
+            break;
+        default:
+            break;
+        }
     }
 }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2844,6 +2844,31 @@ void SLogLevel(int level) {
     setlogmask(_g_SLogMask);
 }
 
+void SLogAtLevel(int level, const string& message) {
+    switch (level) {
+    case LOG_DEBUG:
+        SDEBUG(message);
+        break;
+    case LOG_INFO:
+        SINFO(message);
+        break;
+    case LOG_NOTICE:
+        SHMMM(message);
+        break;
+    case LOG_WARNING:
+        SWARN(message);
+        break;
+    case LOG_ALERT:
+        SALERT(message);
+        break;
+    case LOG_ERR:
+        SERROR(message);
+        break;
+    default:
+        break;
+    }
+}
+
 SAutoThreadPrefix::SAutoThreadPrefix(const SData& request) {
     // Retain the old prefix
     oldPrefix = SThreadLogPrefix;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -142,15 +142,14 @@ SException::SException(const string& file,
                        bool generateCallstack,
                        const string& _method,
                        const STable& _headers,
-                       const string& _body,
-                       bool logStackTrace)
+                       const string& _body)
   : _file(file), _line(line), method(_method), headers(_headers), body(_body) {
     // Build a callstack. We don't convert it to symbols unless someone asks for it later.
     if (generateCallstack) {
         _depth = backtrace(_callstack, CALLSTACK_LIMIT);
     }
     SINFO("Throwing exception with message: '" << _method << "' from " << file << ":" << line);
-    if (logStackTrace) {
+    if (_logStackTrace) {
         SLogStackTrace(LOG_DEBUG);
     }
 }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -140,6 +140,7 @@ void SLogSetThreadName(const string& logName) {
 SException::SException(const string& file,
                        int line,
                        bool generateCallstack,
+                       bool logStackTrace,
                        const string& _method,
                        const STable& _headers,
                        const string& _body)
@@ -149,6 +150,9 @@ SException::SException(const string& file,
         _depth = backtrace(_callstack, CALLSTACK_LIMIT);
     }
     SINFO("Throwing exception with message: '" << _method << "' from " << file << ":" << line);
+    if (logStackTrace) {
+        SLogStackTrace();
+    }
 }
 
 const char* SException::what() const noexcept {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -151,7 +151,7 @@ SException::SException(const string& file,
     }
     SINFO("Throwing exception with message: '" << _method << "' from " << file << ":" << line);
     if (logStackTrace) {
-        SLogStackTrace();
+        SLogStackTrace(LOG_DEBUG);
     }
 }
 

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -140,10 +140,10 @@ void SLogSetThreadName(const string& logName) {
 SException::SException(const string& file,
                        int line,
                        bool generateCallstack,
-                       bool logStackTrace,
                        const string& _method,
                        const STable& _headers,
-                       const string& _body)
+                       const string& _body,
+                       bool logStackTrace)
   : _file(file), _line(line), method(_method), headers(_headers), body(_body) {
     // Build a callstack. We don't convert it to symbols unless someone asks for it later.
     if (generateCallstack) {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2840,31 +2840,6 @@ void SLogLevel(int level) {
     setlogmask(_g_SLogMask);
 }
 
-void SLogAtLevel(int level, const string& message) {
-    switch (level) {
-    case LOG_DEBUG:
-        SDEBUG(message);
-        break;
-    case LOG_INFO:
-        SINFO(message);
-        break;
-    case LOG_NOTICE:
-        SHMMM(message);
-        break;
-    case LOG_WARNING:
-        SWARN(message);
-        break;
-    case LOG_ALERT:
-        SALERT(message);
-        break;
-    case LOG_ERR:
-        SERROR(message);
-        break;
-    default:
-        break;
-    }
-}
-
 SAutoThreadPrefix::SAutoThreadPrefix(const SData& request) {
     // Retain the old prefix
     oldPrefix = SThreadLogPrefix;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -149,9 +149,6 @@ SException::SException(const string& file,
         _depth = backtrace(_callstack, CALLSTACK_LIMIT);
     }
     SINFO("Throwing exception with message: '" << _method << "' from " << file << ":" << line);
-    if (_logStackTrace) {
-        SLogStackTrace(LOG_DEBUG);
-    }
 }
 
 const char* SException::what() const noexcept {

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -114,10 +114,12 @@ typedef map<string, SString, STableComp> STable;
 // body. The STHROW and STHROW_STACK macros will create an SException that logs it's file and line of creation, and
 // optionally, a stack trace at the same time. They can take, 1, 2, or all 3 of the components of an HTTP response
 // as arguments. logStackTrace is set outside the constructor to maintain the same API for the SException constructor.
-#define STHROW(...)                                                 \
-SException ex = SException(__FILE__, __LINE__, false, __VA_ARGS__); \
-ex.setLogStackTrace(true);                                          \
-throw ex;                                                           \
+#define STHROW(...)                                                     \
+do {                                                                    \
+    SException ex = SException(__FILE__, __LINE__, false, __VA_ARGS__); \
+    ex.setLogStackTrace(true);                                          \
+    throw ex;                                                           \
+} while (false)
 
 #define STHROW_STACK(...) throw SException(__FILE__, __LINE__, true, __VA_ARGS__)
 class SException : public exception {

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -113,11 +113,10 @@ typedef map<string, SString, STableComp> STable;
 // An SException is an exception class that can represent an HTTP-like response, with a method line, headers, and a
 // body. The STHROW and STHROW_STACK macros will create an SException that logs it's file, line of creation, and
 // a stack trace at the same time. They can take, 1, 2, or all 3 of the components of an HTTP response as arguments.
-#define STHROW(...)                                                     \
-do {                                                                    \
-    SException ex = SException(__FILE__, __LINE__, false, __VA_ARGS__); \
-    SLogStackTrace(LOG_DEBUG);                                          \
-    throw ex;                                                           \
+#define STHROW(...)                                           \
+do {                                                          \
+    SLogStackTrace(LOG_DEBUG);                                \
+    throw SException(__FILE__, __LINE__, false, __VA_ARGS__); \
 } while (false)
 
 #define STHROW_STACK(...) throw SException(__FILE__, __LINE__, true, __VA_ARGS__)

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -113,8 +113,12 @@ typedef map<string, SString, STableComp> STable;
 // An SException is an exception class that can represent an HTTP-like response, with a method line, headers, and a
 // body. The STHROW and STHROW_STACK macros will create an SException that logs it's file and line of creation, and
 // optionally, a stack trace at the same time. They can take, 1, 2, or all 3 of the components of an HTTP response
-// as arguments.
-#define STHROW(...) throw SException(__FILE__, __LINE__, false, __VA_ARGS__, "", {}, "", true)
+// as arguments. logStackTrace is set outside the constructor to maintain the same API for the SException constructor.
+#define STHROW(...)                                                 \
+SException ex = SException(__FILE__, __LINE__, false, __VA_ARGS__); \
+ex.setLogStackTrace(true);                                          \
+throw ex;                                                           \
+
 #define STHROW_STACK(...) throw SException(__FILE__, __LINE__, true, __VA_ARGS__)
 class SException : public exception {
   private:
@@ -123,6 +127,7 @@ class SException : public exception {
     const int _line;
     void* _callstack[CALLSTACK_LIMIT];
     int _depth = 0;
+    bool _logStackTrace = false;
 
   public:
     SException(const string& file = "unknown",
@@ -130,10 +135,13 @@ class SException : public exception {
                bool generateCallstack = false,
                const string& _method = "",
                const STable& _headers = {},
-               const string& _body = "",
-               bool logStackTrace = false);
+               const string& _body = "");
     const char* what() const noexcept;
     vector<string> details() const noexcept;
+    void setLogStackTrace(bool value)
+    {
+        _logStackTrace = value;
+    }
 
     const string method;
     const STable headers;

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -114,8 +114,8 @@ typedef map<string, SString, STableComp> STable;
 // body. The STHROW and STHROW_STACK macros will create an SException that logs it's file and line of creation, and
 // optionally, a stack trace at the same time. They can take, 1, 2, or all 3 of the components of an HTTP response
 // as arguments.
-#define STHROW(...) throw SException(__FILE__, __LINE__, false, true, __VA_ARGS__)
-#define STHROW_STACK(...) throw SException(__FILE__, __LINE__, true, false, __VA_ARGS__)
+#define STHROW(...) throw SException(__FILE__, __LINE__, false, __VA_ARGS__, "", {}, "", true)
+#define STHROW_STACK(...) throw SException(__FILE__, __LINE__, true, __VA_ARGS__)
 class SException : public exception {
   private:
     static const int CALLSTACK_LIMIT = 100;
@@ -128,10 +128,10 @@ class SException : public exception {
     SException(const string& file = "unknown",
                int line = 0,
                bool generateCallstack = false,
-               bool logStackTrace = false,
                const string& _method = "",
                const STable& _headers = {},
-               const string& _body = "");
+               const string& _body = "",
+               bool logStackTrace = false);
     const char* what() const noexcept;
     vector<string> details() const noexcept;
 

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -223,8 +223,6 @@ void SLogLevel(int level);
 // Stack trace logging
 void SLogStackTrace(int level = LOG_WARNING);
 
-void SLogAtLevel(int level, const string& message);
-
 // This is a drop-in replacement for syslog that directly logs to `/run/systemd/journal/syslog` bypassing journald.
 void SSyslogSocketDirect(int priority, const char* format, ...);
 

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -114,8 +114,8 @@ typedef map<string, SString, STableComp> STable;
 // body. The STHROW and STHROW_STACK macros will create an SException that logs it's file and line of creation, and
 // optionally, a stack trace at the same time. They can take, 1, 2, or all 3 of the components of an HTTP response
 // as arguments.
-#define STHROW(...) throw SException(__FILE__, __LINE__, true, __VA_ARGS__)
-#define STHROW_STACK(...) throw SException(__FILE__, __LINE__, true, __VA_ARGS__)
+#define STHROW(...) throw SException(__FILE__, __LINE__, false, true, __VA_ARGS__)
+#define STHROW_STACK(...) throw SException(__FILE__, __LINE__, true, false, __VA_ARGS__)
 class SException : public exception {
   private:
     static const int CALLSTACK_LIMIT = 100;
@@ -128,6 +128,7 @@ class SException : public exception {
     SException(const string& file = "unknown",
                int line = 0,
                bool generateCallstack = false,
+               bool logStackTrace = false,
                const string& _method = "",
                const STable& _headers = {},
                const string& _body = "");

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -220,6 +220,8 @@ void SLogLevel(int level);
 // Stack trace logging
 void SLogStackTrace();
 
+void SLogAtLevel(int level, const string& message);
+
 // This is a drop-in replacement for syslog that directly logs to `/run/systemd/journal/syslog` bypassing journald.
 void SSyslogSocketDirect(int priority, const char* format, ...);
 

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -111,13 +111,12 @@ class SString : public string {
 typedef map<string, SString, STableComp> STable;
 
 // An SException is an exception class that can represent an HTTP-like response, with a method line, headers, and a
-// body. The STHROW and STHROW_STACK macros will create an SException that logs it's file and line of creation, and
-// optionally, a stack trace at the same time. They can take, 1, 2, or all 3 of the components of an HTTP response
-// as arguments. logStackTrace is set outside the constructor to maintain the same API for the SException constructor.
+// body. The STHROW and STHROW_STACK macros will create an SException that logs it's file, line of creation, and
+// a stack trace at the same time. They can take, 1, 2, or all 3 of the components of an HTTP response as arguments.
 #define STHROW(...)                                                     \
 do {                                                                    \
     SException ex = SException(__FILE__, __LINE__, false, __VA_ARGS__); \
-    ex.setLogStackTrace(true);                                          \
+    SLogStackTrace(LOG_DEBUG);                                          \
     throw ex;                                                           \
 } while (false)
 
@@ -129,7 +128,6 @@ class SException : public exception {
     const int _line;
     void* _callstack[CALLSTACK_LIMIT];
     int _depth = 0;
-    bool _logStackTrace = false;
 
   public:
     SException(const string& file = "unknown",
@@ -140,10 +138,6 @@ class SException : public exception {
                const string& _body = "");
     const char* what() const noexcept;
     vector<string> details() const noexcept;
-    void setLogStackTrace(bool value)
-    {
-        _logStackTrace = value;
-    }
 
     const string method;
     const STable headers;

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -114,7 +114,7 @@ typedef map<string, SString, STableComp> STable;
 // body. The STHROW and STHROW_STACK macros will create an SException that logs it's file and line of creation, and
 // optionally, a stack trace at the same time. They can take, 1, 2, or all 3 of the components of an HTTP response
 // as arguments.
-#define STHROW(...) throw SException(__FILE__, __LINE__, false, __VA_ARGS__)
+#define STHROW(...) throw SException(__FILE__, __LINE__, true, __VA_ARGS__)
 #define STHROW_STACK(...) throw SException(__FILE__, __LINE__, true, __VA_ARGS__)
 class SException : public exception {
   private:
@@ -368,7 +368,7 @@ template <class A> inline bool SContains(const set<A>& valueList, const A& value
 
 bool SContains(const list<string>& valueList, const char* value);
 bool SContains(const string& haystack, const string& needle);
-bool SContains(const string& haystack, char needle); 
+bool SContains(const string& haystack, char needle);
 bool SContains(const STable& nameValueMap, const string& name);
 
 bool SIsValidSQLiteDateModifier(const string& modifier);
@@ -378,7 +378,7 @@ bool SIEquals(const string& lhs, const string& rhs);
 bool SIContains(const string& haystack, const string& needle);
 bool SStartsWith(const string& haystack, const string& needle);
 bool SStartsWith(const char* haystack, size_t haystackSize, const char* needle, size_t needleSize);
-bool SEndsWith(const string& haystack, const string& needle); 
+bool SEndsWith(const string& haystack, const string& needle);
 bool SConstantTimeEquals(const string& secret, const string& userInput);
 bool SConstantTimeIEquals(const string& secret, const string& userInput);
 

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -218,7 +218,7 @@ extern atomic<int> _g_SLogMask;
 void SLogLevel(int level);
 
 // Stack trace logging
-void SLogStackTrace();
+void SLogStackTrace(int level = LOG_WARNING);
 
 void SLogAtLevel(int level, const string& message);
 


### PR DESCRIPTION
### Details
Update STHROW to automatically log a debug stack trace to make it easier to debug Auth and track down where problems are coming from. Since the logs are debug lines, they won't be logged on production. To implement this, SLogStackTrace now takes a level param, which defaults to the currently used level of WARN. Then the trace is logged at that level with a new util function SLogAtLevel.

The STHROW macro was modified to create the exception, then separately log the debug trace. Logging the stack trace within SException was an option but a param would need to be added to the constructor to toggle it, which would break existing uses dues to the variadic arguments.

### Related Issues
https://github.com/Expensify/Expensify/issues/387500

### Tests

1. Make bedrock and restart it
2. Check out this Auth commit `git checkout ff56a0013a08e6730484e03fe6fbb3d5b6a60b44` where I have a failing test due to an STHROW in a function a few layers down
3. Make auth, restart it(?), and make auth tests
4. Run `./test/authtest -only TransactionLib`
5. Open the logs and search for the STHROW line `Throwing exception with message: '401 Unauthorized report NVP.' from auth/lib/Report.cpp:2347`
6. Verify that there's a helpful stack trace shown above
7. Verify that the lines are tagged [debug]


<details>
<summary>Test results</summary>

Before
```
2024-04-24T23:13:04.479290+00:00 expensidev2004 bedrock: 6PR1Xm (libstuff.cpp:151) SException [socket259] [info] Throwing exception with message: '401 Unauthorized report NVP.' from auth/lib/Report.cpp:2347
2024-04-24T23:13:04.479345+00:00 expensidev2004 bedrock: 6PR1Xm (BedrockCore.cpp:393) _handleCommandException [socket259] [info] Error processing command 'CreateMoneyRequest' (401 Unauthorized report NVP.), ignoring.
```

After
```
2024-04-24T23:31:09.002439+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug]
2024-04-24T23:31:09.002495+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] SLogStackTrace(int) [0xaaaac4490078]
2024-04-24T23:31:09.002648+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] Report::setNameValuePair(SQLite&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<long>, std::allocator<std::pair<long const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) [0xffffaa8c94ac]
2024-04-24T23:31:09.002694+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] Report::setNameValuePair(SQLite&, long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) [0xffffaa8cb064]
2024-04-24T23:31:09.002735+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] Report::getOrCreateIOUReport(SQLite&, long, long, long, bool, long, long) [0xffffaa902d5c]
2024-04-24T23:31:09.002792+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] Transaction::createMoneyRequest(SQLite&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, long, long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, long, long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, long, long, long, long const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, long, JSON::Value, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Transaction::states, long, long, long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, JSON::Value const&) [0xffffaac79050]
2024-04-24T23:31:09.002838+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] CreateMoneyRequest::process() [0xffffab02e9dc]
2024-04-24T23:31:09.002857+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] AuthCommand::processCommand() [0xffffaa762a84]
2024-04-24T23:31:09.002873+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] AuthCommand::process(SQLite&) [0xffffaa75a548]
2024-04-24T23:31:09.002891+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] BedrockCore::processCommand(std::unique_ptr<BedrockCommand, std::default_delete<BedrockCommand> >&, bool) [0xaaaac4471808]
2024-04-24T23:31:09.002907+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] BedrockServer::runCommand(std::unique_ptr<BedrockCommand, std::default_delete<BedrockCommand> >&&, bool, bool) [0xaaaac432d75c]
2024-04-24T23:31:09.002946+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] BedrockServer::handleSocket(STCPManager::Socket&&, bool, bool, bool) [0xaaaac4347aa4]
2024-04-24T23:31:09.002972+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] void std::__invoke_impl<void, void (BedrockServer::*)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*, STCPManager::Socket, bool, bool, bool>(std::__invoke_memfun_deref, void (BedrockServer::*&&)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*&&, STCPManager::Socket&&, bool&&, bool&&, bool&&) [0xaaaac4374d40]
2024-04-24T23:31:09.002990+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] std::__invoke_result<void (BedrockServer::*)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*, STCPManager::Socket, bool, bool, bool>::type std::__invoke<void (BedrockServer::*)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*, STCPManager::Socket, bool, bool, bool>(void (BedrockServer::*&&)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*&&, STCPManager::Socket&&, bool&&, bool&&, bool&&) [0xaaaac437492c]
2024-04-24T23:31:09.003007+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] void std::thread::_Invoker<std::tuple<void (BedrockServer::*)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*, STCPManager::Socket, bool, bool, bool> >::_M_invoke<0ul, 1ul, 2ul, 3ul, 4ul, 5ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul, 4ul, 5ul>) [0xaaaac437438c]
2024-04-24T23:31:09.003026+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] std::thread::_Invoker<std::tuple<void (BedrockServer::*)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*, STCPManager::Socket, bool, bool, bool> >::operator()() [0xaaaac4372f74]
2024-04-24T23:31:09.003043+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (BedrockServer::*)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*, STCPManager::Socket, bool, bool, bool> > >::_M_run() [0xaaaac4372474]
2024-04-24T23:31:09.003059+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] /lib/aarch64-linux-gnu/libstdc++.so.6(+0xdbc6c) [0xffffb1dedc6c]
2024-04-24T23:31:09.003195+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] /lib/aarch64-linux-gnu/libpthread.so.0(+0x7624) [0xffffb1faa624]
2024-04-24T23:31:09.003217+00:00 expensidev2004 bedrock: fenkGS (libstuff.cpp:2846) SLogAtLevel [socket259] [dbug] /lib/aarch64-linux-gnu/libc.so.6(+0xd149c) [0xffffb1b9c49c]
2024-04-24T23:31:09.003249+00:00 expensidev2004 bedrock: fenkGS (BedrockCore.cpp:393) _handleCommandException [socket259] [info] Error processing command 'CreateMoneyRequest' (401 Unauthorized report NVP.), ignoring.
```

It's much easier to trace through the code and find the root of the problem after these changes.

</details>


_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
