### PR TITLE
Add `SParseSet`

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -702,7 +702,7 @@ bool SParseList(const char* ptr, list<string>& valueList, char separator) {
 }
 
 // --------------------------------------------------------------------------
-set<int64_t> SParseSet(const string& value, char separator) {
+set<string> SParseSet(const string& value, char separator) {
     set<string> valueSet;
     list<string> strings = SParseList(value, separator);
     for (const string& str : strings) {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -701,6 +701,16 @@ bool SParseList(const char* ptr, list<string>& valueList, char separator) {
     return (!component.empty());
 }
 
+// --------------------------------------------------------------------------
+set<int64_t> SParseSet(const string& value, char separator) {
+    set<string> valueSet;
+    list<string> strings = SParseList(value, separator);
+    for (const string& str : strings) {
+        valueSet.insert(str);
+    }
+    return valueSet;
+}
+
 STable SParseCommandLine(int argc, char* argv[]) {
     // Just walk across and find the pairs, then put the remainder on a list in the method
     STable results;

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -444,6 +444,7 @@ list<int64_t> SParseIntegerList(const string& value, char separator = ',');
 set<int64_t> SParseIntegerSet(const string& value, char separator = ',');
 bool SParseList(const char* value, list<string>& valueList, char separator = ',');
 bool SParseList(const string& value, list<string>& valueList, char separator = ',');
+set<string> SParseSet(const string& value, char separator = ',');
 list<string> SParseList(const string& value, char separator = ',');
 
 // Concatenates things into a string. "Things" can mean essentially any


### PR DESCRIPTION
SParseSet parses a comma separated string into a set of strings.

i.e. `"a", "b", "c"` becomes `<set<string>>{"a", "b", "c"}`

### Details
Needed for https://github.com/Expensify/Auth/pull/10560

### Fixed Issues
Related to https://github.com/Expensify/App/issues/35240

### Tests
Tested with https://github.com/Expensify/Auth/pull/10560, I compiled it against my changes, and the automated tests in that PR call the new code added here.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
