### PR TITLE
Measure postProcess and prePeek time in blockingCommit

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -197,14 +197,12 @@ void BedrockCommand::finalizeTimingInfo() {
 
     // Build a map of the values we care about.
     map<string, uint64_t> valuePairs = {
-        {"prePeekTime",                  prePeekTotal},
-        {"peekTime",                     peekTotal},
-        {"processTime",                  processTotal},
-        {"postProcessTime",              postProcessTotal},
-        {"totalTime",                    totalTime},
-        {"unaccountedTime",              unaccountedTime},
-        {"blockingCommitThreadTime",     blockingCommitThreadTime},
-        {"exclusiveTransactionLockTime", exclusiveTransactionLockTime},
+        {"prePeekTime",     prePeekTotal},
+        {"peekTime",        peekTotal},
+        {"processTime",     processTotal},
+        {"postProcessTime", postProcessTotal},
+        {"totalTime",       totalTime},
+        {"unaccountedTime", unaccountedTime},
     };
 
     // We also want to know what leader did if we're on a follower.

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -272,6 +272,7 @@ void BedrockCommand::finalizeTimingInfo() {
           "escalation:" << escalationTimeUS/1000 <<
           ". Blocking: "
           "prePeek:" << blockingPrePeekTotal/1000 << ", "
+          "peek:" << blockingPeekTotal/1000 << ", "
           "process:" << blockingProcessTotal/1000 << ", "
           "postProcess:" << blockingPostProcessTotal/1000 << ", "
           "commit:" << blockingCommitWorkerTotal/1000 <<

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -192,8 +192,8 @@ void BedrockCommand::finalizeTimingInfo() {
     uint64_t unaccountedTime = totalTime - (prePeekTotal + peekTotal + processTotal + postProcessTotal + commitWorkerTotal + commitSyncTotal +
                                             escalationTimeUS + queueWorkerTotal + queueBlockingTotal + queueSyncTotal + queuePageLockTotal);
 
-    uint64_t blockingCommitThreadTime = blockingPrePeekTotal + blockingPeekTotal + blockingProcessTotal + blockingPostProcessTotal + blockingCommitWorkerTotal;
     uint64_t exclusiveTransactionLockTime = blockingPeekTotal + blockingProcessTotal + blockingCommitWorkerTotal;
+    uint64_t blockingCommitThreadTime = exclusiveTransactionLockTime + blockingPrePeekTotal + blockingPostProcessTotal;
 
     // Build a map of the values we care about.
     map<string, uint64_t> valuePairs = {

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -26,8 +26,12 @@ class BedrockCommand : public SQLiteCommand {
         QUEUE_SYNC,
         QUEUE_BLOCKING,
         QUEUE_PAGE_LOCK,
+
+        // Time spent in the blockingCommit thread (not the same as "commit lock time")
+        BLOCKING_PREPEEK,
         BLOCKING_PEEK,
         BLOCKING_PROCESS,
+        BLOCKING_POSTPROCESS,
         BLOCKING_COMMIT_WORKER,
     };
 

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -64,8 +64,8 @@ bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command) {
     return false;
 }
 
-void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command) {
-    AutoTimer timer(command, BedrockCommand::PREPEEK);
+void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool blockingCommitThread) {
+    AutoTimer timer(command, blockingCommitThread ? BedrockCommand::BLOCKING_PREPEEK : BedrockCommand::PREPEEK);
 
     // Convenience references to commonly used properties.
     const SData& request = command->request;
@@ -306,8 +306,8 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
     return needsCommit ? RESULT::NEEDS_COMMIT : RESULT::NO_COMMIT_REQUIRED;
 }
 
-void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command) {
-    AutoTimer timer(command, BedrockCommand::POSTPROCESS);
+void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool blockingCommitThread) {
+    AutoTimer timer(command, blockingCommitThread ? BedrockCommand::BLOCKING_POSTPROCESS : BedrockCommand::POSTPROCESS);
 
     // Convenience references to commonly used properties.
     const SData& request = command->request;

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -64,8 +64,8 @@ bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command) {
     return false;
 }
 
-void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool blockingCommitThread) {
-    AutoTimer timer(command, blockingCommitThread ? BedrockCommand::BLOCKING_PREPEEK : BedrockCommand::PREPEEK);
+void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlockingCommitThread) {
+    AutoTimer timer(command, isBlockingCommitThread ? BedrockCommand::BLOCKING_PREPEEK : BedrockCommand::PREPEEK);
 
     // Convenience references to commonly used properties.
     const SData& request = command->request;
@@ -306,8 +306,8 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
     return needsCommit ? RESULT::NEEDS_COMMIT : RESULT::NO_COMMIT_REQUIRED;
 }
 
-void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool blockingCommitThread) {
-    AutoTimer timer(command, blockingCommitThread ? BedrockCommand::BLOCKING_POSTPROCESS : BedrockCommand::POSTPROCESS);
+void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool isBlockingCommitThread) {
+    AutoTimer timer(command, isBlockingCommitThread ? BedrockCommand::BLOCKING_POSTPROCESS : BedrockCommand::POSTPROCESS);
 
     // Convenience references to commonly used properties.
     const SData& request = command->request;

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -36,7 +36,7 @@ class BedrockCore : public SQLiteCore {
     // the command hasn't timed out.
     bool isTimedOut(unique_ptr<BedrockCommand>& command);
 
-    void prePeekCommand(unique_ptr<BedrockCommand>& command, bool blockingCommitThread);
+    void prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlockingCommitThread);
 
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same
     // command, and it *may be called multiple times*. Preventing duplicate actions on calling peek multiple times is
@@ -59,7 +59,7 @@ class BedrockCore : public SQLiteCore {
     // this command *will be passed to process again in the future to retry*.
     RESULT processCommand(unique_ptr<BedrockCommand>& command, bool exclusive = false);
 
-    void postProcessCommand(unique_ptr<BedrockCommand>& command, bool blockingCommitThread);
+    void postProcessCommand(unique_ptr<BedrockCommand>& command, bool isBlockingCommitThread);
 
   private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -36,7 +36,7 @@ class BedrockCore : public SQLiteCore {
     // the command hasn't timed out.
     bool isTimedOut(unique_ptr<BedrockCommand>& command);
 
-    void prePeekCommand(unique_ptr<BedrockCommand>& command);
+    void prePeekCommand(unique_ptr<BedrockCommand>& command, bool blockingCommitThread);
 
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same
     // command, and it *may be called multiple times*. Preventing duplicate actions on calling peek multiple times is
@@ -59,7 +59,7 @@ class BedrockCore : public SQLiteCore {
     // this command *will be passed to process again in the future to retry*.
     RESULT processCommand(unique_ptr<BedrockCommand>& command, bool exclusive = false);
 
-    void postProcessCommand(unique_ptr<BedrockCommand>& command);
+    void postProcessCommand(unique_ptr<BedrockCommand>& command, bool blockingCommitThread);
 
   private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -380,7 +380,7 @@ void BedrockServer::sync()
 
             if (command->shouldPostProcess() && command->response.methodLine == "200 OK") {
                 // PostProcess if the command should run postProcess, and there have been no errors thrown thus far.
-                core.postProcessCommand(command);
+                core.postProcessCommand(command, false);
             }
 
             if (_syncNode->commitSucceeded()) {
@@ -478,7 +478,7 @@ void BedrockServer::sync()
                     // re-verify that any checks made in peek are still valid in process.
                     if (!command->httpsRequests.size()) {
                         if (command->shouldPrePeek() && !command->repeek) {
-                            core.prePeekCommand(command);
+                            core.prePeekCommand(command, false);
                         }
 
                         // This command finsihed in prePeek, which likely means it threw.
@@ -868,7 +868,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
 
             // If the command should run prePeek, do that now .
             if (!command->repeek && !command->httpsRequests.size() && command->shouldPrePeek()) {
-                core.prePeekCommand(command);
+                core.prePeekCommand(command, isBlocking);
 
                 if (command->complete) {
                     _reply(command);
@@ -1027,7 +1027,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
             if (command->complete) {
                 if (command->shouldPostProcess() && command->response.methodLine == "200 OK") {
                     // PostProcess if the command should run postProcess, and there have been no errors thrown thus far.
-                    core.postProcessCommand(command);
+                    core.postProcessCommand(command, isBlocking);
                 }
                 _reply(command);
 


### PR DESCRIPTION
### Details

Add the time spent in `blockingCommit` thread by `postProcess` and `prePeek`.
Added to aggregated variables to the timing info log too:

```
blockingCommitThreadTime =
    blockingPrePeekTotal +
    blockingPeekTotal +
    blockingProcessTotal +
    blockingPostProcessTotal +
    blockingCommitWorkerTotal;

```

```
exclusiveTransactionLockTime = blockingPeekTotal + blockingProcessTotal + blockingCommitWorkerTotal;
```


The Salt PR to parse the new timing line format: https://github.com/Expensify/Salt/pull/13502

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/393801

### Tests

Log lines should look like:

`2024-05-07T21:46:06.927236+00:00 expensidev2004 bedrock: Jhm0nE admin@500-members-15-reports-per-member.com (BedrockCommand.cpp:255) finalizeTimingInfo [blockingCommit] [info] command 'CreateAccount' timing info (ms): prePeek:4 (count: 5), peek:9 (count:5), process:92 (count:5), postProcess:3 (count:1), total:166, unaccounted:15, blockingCommitThreadTime:30, exclusiveTransactionLockTime:26. Commit: worker:39, sync:0. Queue: worker:0, sync:0, blocking:1, pageLock:0, escalation:0. Blocking: prePeek:0, peek:1, process:20, postProcess:3, commit:4. Upstream: peek:123, process:450, total:64, unaccounted:1.`
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
