### PR TITLE
Unbreak sequential notifier infinite loop

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -184,6 +184,10 @@ SQLiteNode::~SQLiteNode() {
 void SQLiteNode::_replicate(SQLitePeer* peer, SData command, size_t sqlitePoolIndex, uint64_t threadAttemptStartTimestamp) {
     // Initialize each new thread with a new number.
     SInitialize("replicate" + to_string(currentReplicateThreadID.fetch_add(1)));
+    
+    // Weirdly , we have logs that at some point only have even-numbered replicate threads?
+    // Never mind, half of them are for `BEGIN_TRANSACTION`
+    // No, those are all even as well?
 
     // Actual thread startup time.
     uint64_t threadStartTime = STimeNow();

--- a/sqlitecluster/SQLiteSequentialNotifier.cpp
+++ b/sqlitecluster/SQLiteSequentialNotifier.cpp
@@ -5,6 +5,7 @@ SQLiteSequentialNotifier::RESULT SQLiteSequentialNotifier::waitFor(uint64_t valu
     shared_ptr<WaitState> state(nullptr);
     {
         lock_guard<mutex> lock(_internalStateMutex);
+        SINFO("Waiting for " << value << ", in transaction? " << insideTransaction);
         if (value <= _value) {
             return RESULT::COMPLETED;
         }
@@ -60,6 +61,7 @@ SQLiteSequentialNotifier::RESULT SQLiteSequentialNotifier::waitFor(uint64_t valu
             if (_globalResult == RESULT::CANCELED || state->result == RESULT::CANCELED) {
                 // It's possible that we hit the timeout here after `cancel()` has set the global value, but before we received the notification.
                 // This isn't a problem, and we can jump back to the top of the loop and check again. If there's some problem, we'll see it there.
+                SINFO("Hit 1s timeout while global cancel " << (_globalResult == RESULT::CANCELED) << " or " << " specific cancel " << (state->result == RESULT::CANCELED));
                 cancelAttempts++;
                 continue;
             }
@@ -80,9 +82,11 @@ void SQLiteSequentialNotifier::notifyThrough(uint64_t value) {
     for (auto valueThreadMapPtr : {&_valueToPendingThreadMap, &_valueToPendingThreadMapNoCurrentTransaction}) {
         auto& valueThreadMap = *valueThreadMapPtr;
         auto lastToDelete = valueThreadMap.begin();
+        SINFO("Notifying " << valueThreadMap.size() << " waiting threads for value: " << value);
         for (auto it = valueThreadMap.begin(); it != valueThreadMap.end(); it++) {
             if (it->first > value)  {
                 // If we've passed our value, there's nothing else to erase, so we can stop.
+                SINFO("Breaking out of thread notifications because " <<  it->first << " > " << value);
                 break;
             }
 
@@ -92,6 +96,7 @@ void SQLiteSequentialNotifier::notifyThrough(uint64_t value) {
             // Make the changes to the state object - mark it complete and notify anyone waiting.
             lock_guard<mutex> lock(it->second->waitingThreadMutex);
             it->second->result = RESULT::COMPLETED;
+            SINFO("Notifying thread waiting on value: " << it->first);
             it->second->waitingThreadConditionVariable.notify_all();
         }
 
@@ -102,6 +107,7 @@ void SQLiteSequentialNotifier::notifyThrough(uint64_t value) {
         //
         // I think it's reasonable to assume this is the intention for multimap as well, and in my testing, that was the
         // case.
+        SINFO("Deleting from thread map through value: " << lastToDelete->first);
         valueThreadMap.erase(valueThreadMap.begin(), lastToDelete);
     }
 }
@@ -119,6 +125,7 @@ void SQLiteSequentialNotifier::cancel(uint64_t cancelAfter) {
         auto& valueThreadMap = *valueThreadMapPtr;
         // If cancelAfter is specified, start from that value. Otherwise, we start from the beginning.
         auto start = _cancelAfter ? valueThreadMap.upper_bound(_cancelAfter) : valueThreadMap.begin();
+        SINFO("Next value to cancel after " << cancelAfter << " is " << start->first);
         if (start == valueThreadMap.end()) {
             // There's nothing to remove.
             return;
@@ -127,10 +134,12 @@ void SQLiteSequentialNotifier::cancel(uint64_t cancelAfter) {
         // Now iterate across whatever's remaining and mark it canceled.
         auto current = start;
         while(current != valueThreadMap.end()) {
+            SINFO("Setting canceled for thread waiting on " << current->first);
             lock_guard<mutex> lock(current->second->waitingThreadMutex);
             current->second->result = RESULT::CANCELED;
             current->second->waitingThreadConditionVariable.notify_all();
             current++;
+            SINFO("Canceled for thread waiting on " << current->first);
         }
 
         // And remove these items entirely.

--- a/sqlitecluster/SQLiteSequentialNotifier.cpp
+++ b/sqlitecluster/SQLiteSequentialNotifier.cpp
@@ -52,6 +52,7 @@ SQLiteSequentialNotifier::RESULT SQLiteSequentialNotifier::waitFor(uint64_t valu
             // cancellation) or if the log line is delayed by up to a second (indicating a problem).
             if (_globalResult == RESULT::CANCELED || state->result == RESULT::CANCELED) {
                 SWARN("Got timeout in wait_for but state has changed! Was waiting for " << value);
+                return RESULT::CANCELED;
             }
         }
     }


### PR DESCRIPTION
### Details
This makes two material changes (besides logging):

1. It changes the commit after which we'll cancel incomplete replicated transactions when changing state away from FOLLOWING. Previously, we would wait for all completely *received* but not *applied* transactions to complete. The new behavior is to cancel all transactions with commit numbers higher than the current highest in the DB. This effectively abandons all in-flight commits when we stop following. They will need to be synchronized later.

2. It limits the amount of time we will spend waiting for a commit, even one *below* the cancel threshold, once any cancellation attempt has been made for replication threads. These will now cancel after 10 attempts, even if they are for commits *before* the value of `cancelAfter`. This has essentially the same effect as the above, to abandon in-flight commits when stopping FOLLOWING.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
