### PR TITLE
Increase db pool limit from 25k to 100k

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -89,7 +89,7 @@ void BedrockServer::sync()
     int64_t mmapSizeGB = args.isSet("-mmapSizeGB") ? stoll(args["-mmapSizeGB"]) : 0;
 
     // We use fewer FDs on test machines that have other resource restrictions in place.
-    int fdLimit = args.isSet("-live") ? 25'000 : 250;
+    int fdLimit = args.isSet("-live") ? 100'000 : 250;
     SINFO("Setting dbPool size to: " << fdLimit);
     _dbPool = make_shared<SQLitePool>(fdLimit, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), workerThreads, args["-synchronous"], mmapSizeGB, args.isSet("-hctree"));
     SQLite& db = _dbPool->getBase();
@@ -703,7 +703,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
     }
 
     // If we're following, we will automatically escalate any command that's:
-    // 1. Not already complete (complete commands are likely already returned from leader with legacy escalation) 
+    // 1. Not already complete (complete commands are likely already returned from leader with legacy escalation)
     // and is marked as `escalateImmediately` (which lets them skip the queue, which is particularly useful if they're waiting
     // for a previous commit to be delivered to this follower);
     // 2. Any commands if the current version of the code is not the same one as leader is executing.
@@ -1915,7 +1915,7 @@ void BedrockServer::_beginShutdown(const string& reason, bool detach) {
             _portPluginMap.clear();
             _shutdownState.store(START_SHUTDOWN);
         }
-        SQLiteNodeState currentState = SQLiteNodeState::UNKNOWN; 
+        SQLiteNodeState currentState = SQLiteNodeState::UNKNOWN;
         auto syncNodeCopy = atomic_load(&_syncNode);
         if (syncNodeCopy) {
             currentState = syncNodeCopy->getState();


### PR DESCRIPTION
Context https://expensify.slack.com/archives/C0714QF3A1Z/p1715619862362019

### Details

Problem: The times for Get private_lastModified command go up when this should not happen as that's the most basic command of them all. If this gets slow it means all other commands get slow by that much too.
Solution: This is happening because bedrock has a db pool size of max 25k and in some cases (at least when site performance is degraded, but maybe in other scenarios) we hit that limit, which means incoming commands need to wait for another running command to finish before being able to run (https://github.com/Expensify/Bedrock/blob/6a064cb6af1905731d52287d460c3c8171fdf221/sqlitecluster/SQLitePool.cpp#L62). I don't think there's any reason why 25k is a good limit and we seem to have more than enough CPU and memory anyway, so let's increase that limit (I propose 100k but got that number from a :tophat: )

### Tests
No
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
