### PR TITLE
Undo change to discard last replicated commands

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2432,7 +2432,9 @@ int SQLiteNode::_handleCommitTransaction(SQLite& db, SQLitePeer* peer, const uin
 
     // Let the commit handler notify any other waiting threads that our commit is complete before it starts a checkpoint.
     function<void()> notifyIfCommitted = [&]() {
-        _localCommitNotifier.notifyThrough(db.getCommitCount());
+        auto commitCount = db.getCommitCount();
+        SINFO("Notifying waiting threads that we've locally committed " << commitCount);
+        _localCommitNotifier.notifyThrough(commitCount);
     };
 
     int result = db.commit(stateName(_state), &notifyIfCommitted);

--- a/sqlitecluster/SQLiteSequentialNotifier.cpp
+++ b/sqlitecluster/SQLiteSequentialNotifier.cpp
@@ -75,7 +75,6 @@ void SQLiteSequentialNotifier::notifyThrough(uint64_t value) {
     for (auto valueThreadMapPtr : {&_valueToPendingThreadMap, &_valueToPendingThreadMapNoCurrentTransaction}) {
         auto& valueThreadMap = *valueThreadMapPtr;
         auto lastToDelete = valueThreadMap.begin();
-        SINFO("Notifying " << valueThreadMap.size() << " waiting threads for value: " << value);
         for (auto it = valueThreadMap.begin(); it != valueThreadMap.end(); it++) {
             if (it->first > value)  {
                 // If we've passed our value, there's nothing else to erase, so we can stop.
@@ -100,7 +99,6 @@ void SQLiteSequentialNotifier::notifyThrough(uint64_t value) {
         //
         // I think it's reasonable to assume this is the intention for multimap as well, and in my testing, that was the
         // case.
-        SINFO("Deleting from thread map through value: " << lastToDelete->first);
         valueThreadMap.erase(valueThreadMap.begin(), lastToDelete);
     }
 }


### PR DESCRIPTION
### Details
This removes two hacks that hope to avoid getting stuck canceling commits by failing out earlier.

1. One stopped committing some "in flight" transactions from leader. This potentially lost these transactions if leader was crashing, which could result in a fork.
2. The other gave up after 10 attempts, which had the same effect, to potentially lose transactions in the case of a fork.

This also adds more logging to hopefully diagnose what's happening if/when we do see this stuck state again. Note that these logs are fairly verbose, and add six loglines to every replicated transaction.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
