### PR TITLE
Add better logging if locking fails

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -339,7 +339,7 @@ void SQLite::exclusiveLockDB() {
     }
     try {
         _sharedData.writeLock.lock(const system_error& e);
-    } catch() {
+    } catch(const system_error& e) {
         SWARN("Caught system_error calling _sharedData.writeLock, code: " << e.code() << ", message: " << e.what());
         throw;
     }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -338,7 +338,7 @@ void SQLite::exclusiveLockDB() {
         throw;
     }
     try {
-        _sharedData.writeLock.lock(const system_error& e);
+        _sharedData.writeLock.lock();
     } catch(const system_error& e) {
         SWARN("Caught system_error calling _sharedData.writeLock, code: " << e.code() << ", message: " << e.what());
         throw;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -331,8 +331,18 @@ void SQLite::exclusiveLockDB() {
     // of the transaction. So in these instances, we lock commitLock first, and then writeLock, but the critical difference is we hold the commitLock through the entire duration of all
     // writes in this case.
     // So when these are both locked by the same thread at the same time, `commitLock` is always locked first, and we do it the same way here to avoid deadlocks.
-    _sharedData.commitLock.lock();
-    _sharedData.writeLock.lock();
+    try {
+        _sharedData.commitLock.lock();
+    } catch (const system_error& e) {
+        SWARN("Caught system_error calling _sharedData.commitLock, code: " << e.code() << ", message: " << e.what());
+        throw;
+    }
+    try {
+        _sharedData.writeLock.lock(const system_error& e);
+    } catch() {
+        SWARN("Caught system_error calling _sharedData.writeLock, code: " << e.code() << ", message: " << e.what());
+        throw;
+    }
 }
 
 void SQLite::exclusiveUnlockDB() {


### PR DESCRIPTION
### Details

### Fixed Issues
Adds logging if a crash seen in [#fireroom-2024-04-29-siteslows](https://expensify.enterprise.slack.com/archives/C0714QF3A1Z) recurrs.

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
