### PR TITLE
Fix socket max and logging

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2018,13 +2018,6 @@ void BedrockServer::_acceptSockets() {
     // trying to diagnose exactly what's happening.
     static uint64_t lastLogged = 0;
     try {
-        uint64_t now = STimeNow();
-        if ((_outstandingSocketThreads >= _maxSocketThreads) && (lastLogged < now - 3'000'000)) {
-            SINFO("Not accepting any new socket threads as we already have " << _outstandingSocketThreads << " of " << _maxSocketThreads);
-            lastLogged = now;
-            return;
-        }
-
         // Make a list of ports to accept on.
         // We'll check the control port, command port, and any plugin ports for new connections.
         list<reference_wrapper<const unique_ptr<Port>>> portList = {_commandPortPublic, _commandPortPrivate, _controlPort};
@@ -2048,6 +2041,15 @@ void BedrockServer::_acceptSockets() {
 
             // Accept as many sockets as we can.
             while (true) {
+                uint64_t now = STimeNow();
+                if ((_outstandingSocketThreads >= _maxSocketThreads)) {
+                    if ((lastLogged < now - 3'000'000)) {
+                        SINFO("Not accepting any new socket threads as we already have " << _outstandingSocketThreads << " of " << _maxSocketThreads);
+                        lastLogged = now;
+                    }
+                    return;
+                }
+
                 sockaddr_in addr;
                 int s = S_accept(port->s, addr, true); // Note that this sets the newly accepted socket to be blocking.
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2020,7 +2020,7 @@ void BedrockServer::_acceptSockets() {
     try {
         // Make a list of ports to accept on.
         // We'll check the control port, command port, and any plugin ports for new connections.
-        list<reference_wrapper<const unique_ptr<Port>>> portList = {_controlPort, _commandPortPublic, _commandPortPrivate};
+        list<reference_wrapper<const unique_ptr<Port>>> portList = {_controlPort, _commandPortPrivate, _commandPortPublic};
 
         // Lock _portMutex so suppressing the port does not cause it to be null
         // in the middle of this function.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2020,7 +2020,7 @@ void BedrockServer::_acceptSockets() {
     try {
         // Make a list of ports to accept on.
         // We'll check the control port, command port, and any plugin ports for new connections.
-        list<reference_wrapper<const unique_ptr<Port>>> portList = {_commandPortPublic, _commandPortPrivate, _controlPort};
+        list<reference_wrapper<const unique_ptr<Port>>> portList = {_controlPort, _commandPortPublic, _commandPortPrivate};
 
         // Lock _portMutex so suppressing the port does not cause it to be null
         // in the middle of this function.
@@ -2042,7 +2042,7 @@ void BedrockServer::_acceptSockets() {
             // Accept as many sockets as we can.
             while (true) {
                 uint64_t now = STimeNow();
-                if ((_outstandingSocketThreads >= _maxSocketThreads)) {
+                if ((port != _controlPort) && (_outstandingSocketThreads >= _maxSocketThreads)) {
                     if ((lastLogged < now - 3'000'000)) {
                         SINFO("Not accepting any new socket threads as we already have " << _outstandingSocketThreads << " of " << _maxSocketThreads);
                         lastLogged = now;


### PR DESCRIPTION
### Details
Fixes bug introduced here:
https://github.com/Expensify/Bedrock/pull/1733

Also fixes where the limit is applied to the number of sockets, and exempts the control port from the limit.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
