### PR TITLE
[WIP] Allow testing a single test method from a test fixture

### DIFF
--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -347,7 +347,7 @@ namespace tpunit {
 
          static int tpunit_detail_do_run(const std::set<std::string>& include, const std::set<std::string>& exclude,
                                          const std::list<std::string>& before, const std::list<std::string>& after, int threads,
-                                         std::function<void()> threadInitFunction);
+                                         std::function<void()> threadInitFunction, const std::set<std::string>& includeMethods);
 
          /**
           * This method writes to a temporary buffer and formats the message nicely for debugging
@@ -385,13 +385,13 @@ namespace tpunit {
 
       private:
 
-         static void tpunit_run_test_class(TestFixture*);
+         static void tpunit_run_test_class(TestFixture*, const std::set<std::string>& includeMethods);
 
          static void tpunit_detail_do_method(method* m);
 
          static void tpunit_detail_do_methods(method* m);
 
-         static void tpunit_detail_do_tests(TestFixture* f);
+         static void tpunit_detail_do_tests(TestFixture* f, const std::set<std::string>& includeMethods);
 
          static stats& tpunit_detail_stats();
 
@@ -434,6 +434,6 @@ namespace tpunit {
        */
       static int run(const std::set<std::string>& include, const std::set<std::string>& exclude,
                      const std::list<std::string>& before, const std::list<std::string>& after, int threads = 1,
-                     std::function<void()> threadInitFunction = [](){});
+                     std::function<void()> threadInitFunction = [](){}, const std::set<string>& includeTestCase = {});
    };
 }


### PR DESCRIPTION
### Details

- This gives us a way to test a specific method in a test case.
- Pretty rough PoC for now just to prove it works to see if we might want this
- I am assuming we are gonna be perpetually maintaining our fork of tpunit in this repo and this is a reasonable place to raise this change.

cc @youssef-lr

### Fixed Issues

Related [convo](https://expensify.slack.com/archives/C03TQ48KC/p1715964660816439)

### Tests

1. Build Auth 
2. Run a test like `./test/authtest -only RemoveFromGroupChat -includeMethods testCommand`

Verify only the one test method runs:

![2024-05-17_12-11-33](https://github.com/Expensify/Bedrock/assets/32969087/ad24c7f2-d59a-4588-978b-305db199733c)

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
