### PR TITLE
Only create a stack trace for STHROW on debug

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -112,10 +112,12 @@ typedef map<string, SString, STableComp> STable;
 
 // An SException is an exception class that can represent an HTTP-like response, with a method line, headers, and a
 // body. The STHROW and STHROW_STACK macros will create an SException that logs it's file, line of creation, and
-// a stack trace at the same time. They can take, 1, 2, or all 3 of the components of an HTTP response as arguments.
+// (for DEBUG) a stack trace at the same time. They can take, 1, 2, or all 3 of the components of an HTTP response as arguments.
 #define STHROW(...)                                           \
 do {                                                          \
-    SLogStackTrace(LOG_DEBUG);                                \
+    if (_g_SLogMask & (1 << LOG_DEBUG)) {                     \
+        SLogStackTrace(LOG_DEBUG);                            \
+    }                                                         \
     throw SException(__FILE__, __LINE__, false, __VA_ARGS__); \
 } while (false)
 


### PR DESCRIPTION
### Details
Whenever there's an STHROW, bedrock generates a stack trace and logs it only for debug. However Flo pointed out that generating the stack trace is a waste on prod if we're never going to log anything. Now, only generate and log the stack trace if the log level is set to DEBUG.

### Fixed Issues
See the problem described by @flodnv [in Slack here](https://expensify.slack.com/archives/C0714QF3A1Z/p1716296875772719?thread_ts=1716223415.768539&cid=C0714QF3A1Z).

### Tests
1. Comment out [these lines](https://github.com/Expensify/Bedrock/blob/267895ee89867d35dd1db7a4b08e48bbd337266c/main.cpp#L276-L283) which set debug logging on dev. Now Bedrock should log only at the SINFO level.
2. Add an SINFO log line at the top of SLogStackTrace to show when the stack trace is generated
3. Build and restart Bedrock
4. Add an STHROW to an Auth command
5. Rebuild and restart Auth
6. Run the Auth command
7. Search logs for the STHROW
8. Verify there is not a log line for generating the stack trace
9. Uncomment the lines to set the Bedrock log level to debug
10. Rebuild Bedrock and restart all
11. Run the Auth command again
12. Search logs for the STHROW
13. Verify there is a stack trace


<details>
<summary>Auth command with STHROW doesn't generate stack trace at the SINFO log level</summary>

```
2024-05-21T17:26:40.917511+00:00 expensidev2004 php-fpm: IxCXRz /api.php split@distance.com !ecash1.4.74-1! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'OpenReport' clusterName: 'auth' headers: '[authToken: '<REDACTED>' loginList: '' reportID: '3775338456560574' createdReportActionID: '0' anonymousEmail: '' personalPolicyValue: '' parentReportActionID: '0' ipAddress: '10.2.2.1' chatType: '' reportName: '' avatarUrl: '' groupChatAdminLogins: '' logParam: 'split@distance.com' urlToNewDot: 'https://dev.new.expensify.com:8082/' maxNumberOfUpdates: '500' requestID: 'IxCXRz' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '110000']'
2024-05-21T17:26:40.917876+00:00 expensidev2004 php-fpm: IxCXRz /api.php split@distance.com !ecash1.4.74-1! ?api? [info] Bedrock\Client - APC fetch host configs ~~ 0: 'auth'
2024-05-21T17:26:40.917936+00:00 expensidev2004 php-fpm: IxCXRz /api.php split@distance.com !ecash1.4.74-1! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'auth']'
2024-05-21T17:26:40.917987+00:00 expensidev2004 php-fpm: IxCXRz /api.php split@distance.com !ecash1.4.74-1! ?api? [info] Bedrock\Client - Reusing socket ~~ host: 'auth' cluster: 'auth' pid: '1055'
2024-05-21T17:26:40.919811+00:00 expensidev2004 bedrock: IxCXRz split@distance.com (AuthToken.cpp:930) checkRevoked [socket4] [info] Checking authToken validity for accountID=1760 / partnerID=83 / partnerUserID=expensify.cash-6951e274-848c-5181-eb77-a2a7ccdcdf3e / isValidated=true / expiresAt=1716313595065544 / isPasswordless=true
2024-05-21T17:26:40.920248+00:00 expensidev2004 bedrock: IxCXRz split@distance.com (libstuff.cpp:151) SException [socket4] [info] Throwing exception with message: 'Open report fails' from auth/command/OpenReport.cpp:70
2024-05-21T17:26:40.922208+00:00 expensidev2004 bedrock: IxCXRz split@distance.com (BedrockCore.cpp:378) _handleCommandException [socket4] [info] Error processing command 'OpenReport' (Open report fails), ignoring.
2024-05-21T17:26:40.922280+00:00 expensidev2004 bedrock: IxCXRz split@distance.com (BedrockCommand.cpp:253) finalizeTimingInfo [socket4] [info] command 'OpenReport' timing info (ms): prePeek:0 (count: 0), peek:2 (count:1), process:0 (count:0), postProcess:0 (count:0), total:4, unaccounted:1, blockingCommitThreadTime:0, exclusiveTransactionLockTime:0. Commit: worker:0, sync:0. Queue: worker:0, sync:0, blocking:0, pageLock:0, escalation:0. Blocking: prePeek:0, peek:0, process:0, postProcess:0, commit:0. Upstream: peek:0, process:0, total:0, unaccounted:0.
```
</details> 

The stack trace was not generated either. Searching for the log line in vim results in `E486: Pattern not found: Generating a stack trace`




<details>
<summary>Now with the SDEBUG log level we see the stack trace is generated and logged</summary>

```
2024-05-21T17:32:57.659344+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:8) SLogStackTrace [socket0] [info] Generating a stack trace
2024-05-21T17:32:57.662813+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug]
2024-05-21T17:32:57.662881+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] SLogStackTrace(int) [0xaaaad393d5cc]
2024-05-21T17:32:57.662912+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] OpenReport::peek() [0xffffb6eab788]
2024-05-21T17:32:57.662932+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] AuthCommand::peekCommand() [0xffffb65088d4]
2024-05-21T17:32:57.662953+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] AuthCommand::peek(SQLite&) [0xffffb65027d4]
2024-05-21T17:32:57.662977+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] BedrockCore::peekCommand(std::unique_ptr<BedrockCommand, std::default_delete<BedrockCommand> >&, bool) [0xaaaad391cfc0]
2024-05-21T17:32:57.663000+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] BedrockServer::runCommand(std::unique_ptr<BedrockCommand, std::default_delete<BedrockCommand> >&&, bool, bool) [0xaaaad37d5fbc]
2024-05-21T17:32:57.663015+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] BedrockServer::handleSocket(STCPManager::Socket&&, bool, bool, bool) [0xaaaad37f2320]
2024-05-21T17:32:57.663038+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] void std::__invoke_impl<void, void (BedrockServer::*)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*, STCPManager::Socket, bool, bool, bool>(std::__invoke_memfun_deref, void (BedrockServer::*&&)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*&&, STCPManager::Socket&&, bool&&, bool&&, bool&&) [0xaaaad381ee08]
2024-05-21T17:32:57.663089+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] std::__invoke_result<void (BedrockServer::*)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*, STCPManager::Socket, bool, bool, bool>::type std::__invoke<void (BedrockServer::*)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*, STCPManager::Socket, bool, bool, bool>(void (BedrockServer::*&&)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*&&, STCPManager::Socket&&, bool&&, bool&&, bool&&) [0xaaaad381e9f4]
2024-05-21T17:32:57.663116+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] void std::thread::_Invoker<std::tuple<void (BedrockServer::*)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*, STCPManager::Socket, bool, bool, bool> >::_M_invoke<0ul, 1ul, 2ul, 3ul, 4ul, 5ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul, 4ul, 5ul>) [0xaaaad381e454]
2024-05-21T17:32:57.663155+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] std::thread::_Invoker<std::tuple<void (BedrockServer::*)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*, STCPManager::Socket, bool, bool, bool> >::operator()() [0xaaaad381e040]
2024-05-21T17:32:57.663182+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (BedrockServer::*)(STCPManager::Socket&&, bool, bool, bool), BedrockServer*, STCPManager::Socket, bool, bool, bool> > >::_M_run() [0xaaaad381d540]
2024-05-21T17:32:57.663283+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] /lib/aarch64-linux-gnu/libstdc++.so.6(+0xdbc6c) [0xffffbe644c6c]
2024-05-21T17:32:57.663335+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] /lib/aarch64-linux-gnu/libpthread.so.0(+0x7624) [0xffffbe801624]
2024-05-21T17:32:57.663399+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (SLog.cpp:16) SLogStackTrace [socket0] [dbug] /lib/aarch64-linux-gnu/libc.so.6(+0xd149c) [0xffffbe3f349c]
2024-05-21T17:32:57.663436+00:00 expensidev2004 bedrock: AO4jrZ split@distance.com (libstuff.cpp:151) SException [socket0] [info] Throwing exception with message: 'Open report fails' from auth/command/OpenReport.cpp:70
```
</details>

