### PR TITLE
[HOLD] Close command port when not leading/following/standing down

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -324,7 +324,7 @@ void BedrockServer::sync()
             }
             continue;
         } else {
-            if (preUpdateState == SQLiteNodeState::LEADING || preUpdateState == SQLiteNodeState::FOLLOWING || preUpdateState == SQLiteNodeState::STANDINGDOWN) {
+            if (preUpdateState != SQLiteNodeState::LEADING && preUpdateState != SQLiteNodeState::FOLLOWING && preUpdateState != SQLiteNodeState::STANDINGDOWN) {
                 unblockCommandPort("INVALID_SERVER_STATE", true);
             }
         }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -319,7 +319,7 @@ void BedrockServer::sync()
         if ((getState() == SQLiteNodeState::SEARCHING || getState() == SQLiteNodeState::SYNCHRONIZING) &&
             (preUpdateState != SQLiteNodeState::SEARCHING && preUpdateState != SQLiteNodeState::SYNCHRONIZING)) {
             if (_commandPortPublic) {
-                SINFO("Closing command port because "<< SQLiteNode::stateName(geState()));
+                SINFO("Closing command port because " << SQLiteNode::stateName(getState()));
                 _commandPortPublic = nullptr;
             }
         }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -320,12 +320,12 @@ void BedrockServer::sync()
         // until we're either leading or following.
         if (getState() != SQLiteNodeState::LEADING && getState() != SQLiteNodeState::FOLLOWING && getState() != SQLiteNodeState::STANDINGDOWN) {
             if (preUpdateState == SQLiteNodeState::LEADING || preUpdateState == SQLiteNodeState::FOLLOWING || preUpdateState == SQLiteNodeState::STANDINGDOWN) {
-                blockCommandPort("INVALID_SERVER_STATE", true);
+                blockCommandPort("INVALID_SERVER_STATE", false);
             }
             continue;
         } else {
             if (preUpdateState != SQLiteNodeState::LEADING && preUpdateState != SQLiteNodeState::FOLLOWING && preUpdateState != SQLiteNodeState::STANDINGDOWN) {
-                unblockCommandPort("INVALID_SERVER_STATE", true);
+                unblockCommandPort("INVALID_SERVER_STATE", false);
             }
         }
 
@@ -1543,6 +1543,8 @@ void BedrockServer::unblockCommandPort(const string& reason, bool repeatable) {
         if (repeatable) {
             // We don't warn in this case for unrepeatable blocks. This lets callers call block and then unblock multiple times in a row for these cases.
             SWARN("Tried to remove command port block because: " << reason << ", but it wasn't blocked for that reason!");
+        } else {
+            SINFO("Command port not blocked for : " << reason);
         }
     } else {
         _commandPortBlockReasons.erase(it);

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -182,11 +182,8 @@ class BedrockServer : public SQLiteServer {
     void onNodeLogin(SQLitePeer* peer) override;
 
     // You must block and unblock the command port with *identical strings*.
-    void blockCommandPort(const string& reason);
-    void unblockCommandPort(const string& reason);
-
-    // Legacy version of above.
-    void suppressCommandPort(const string& reason, bool suppress, bool manualOverride = false);
+    void blockCommandPort(const string& reason, bool repeatable = true);
+    void unblockCommandPort(const string& reason, bool repeatable = true);
 
     // Reasons for each request to close the command port mapped to the instance of commandPortSuppressionCount that
     // created them.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -182,8 +182,8 @@ class BedrockServer : public SQLiteServer {
     void onNodeLogin(SQLitePeer* peer) override;
 
     // You must block and unblock the command port with *identical strings*.
-    void blockCommandPort(const string& reason, bool repeatable = true);
-    void unblockCommandPort(const string& reason, bool repeatable = true);
+    void blockCommandPort(const string& reason);
+    void unblockCommandPort(const string& reason);
 
     // Reasons for each request to close the command port mapped to the instance of commandPortSuppressionCount that
     // created them.


### PR DESCRIPTION
### Details
I think this works but it's untested so far. The test is difficult because we generally won't go synchronizing very often except when starting up from off, but the command port isn't open then. We need to lose synchronization without going offline to trigger this.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/395959

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
