### PR TITLE
This command is buggy (particularly, SQLitePool::setMaxDBs) so removing

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1735,7 +1735,6 @@ bool BedrockServer::_isControlCommand(const unique_ptr<BedrockCommand>& command)
         SIEquals(command->request.methodLine, "UnblockWrites")          ||
         SIEquals(command->request.methodLine, "SetMaxPeerFallBehind")   ||
         SIEquals(command->request.methodLine, "SetMaxSocketThreads")    ||
-        SIEquals(command->request.methodLine, "SetMaxDBHandles")       ||
         SIEquals(command->request.methodLine, "CRASH_COMMAND")
         ) {
         return true;
@@ -1877,20 +1876,6 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
             _maxSocketThreads = newMax;
         } else {
             response.methodLine = "401 Don't Use Zero";
-        }
-    } else if (SIEquals(command->request.methodLine, "SetMaxDBHandles")) {
-        shared_ptr<SQLitePool> dbPoolHandle = _dbPool;
-        if (dbPoolHandle) {
-            size_t newMax = command->request.calcU64("handlesCount");
-            if (newMax) {
-                SINFO("Setting _dbPoolSize to " << newMax << " from " << _dbPoolSize);
-            } else {
-                response.methodLine = "401 Don't Use Zero";
-            }
-            _dbPoolSize = newMax;
-            dbPoolHandle->setMaxDBs(_dbPoolSize);
-        } else {
-            response.methodLine = "404 No DB Pool";
         }
     } else if (SIEquals(command->request.methodLine, "SetMaxPeerFallBehind")) {
         // Look up the existing value so we can report what it was.

--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -35,12 +35,6 @@ SQLite& SQLitePool::getBase() {
     return _baseDB;
 }
 
-void SQLitePool::setMaxDBs(size_t newMax) {
-    unique_lock<mutex> lock(_sync);
-    SINFO("Resetting max DB filehandles to " << newMax << " from " << _maxDBs);
-    _maxDBs = newMax;
-}
-
 size_t SQLitePool::getIndex(bool createHandle) {
     while (true) {
         unique_lock<mutex> lock(_sync);

--- a/sqlitecluster/SQLitePool.h
+++ b/sqlitecluster/SQLitePool.h
@@ -25,8 +25,6 @@ class SQLitePool {
     // Takes an allocated index and creates the appropriate DB handle if required.
     SQLite& initializeIndex(size_t index);
 
-    void setMaxDBs(size_t newMax);
-
     // Return an object to the pool.
     void returnToPool(size_t index);
 


### PR DESCRIPTION
### Details
`SQLitePool::setMaxDBs` doesn't work correctly because there's a fixed-size vector in SQLitePool called `_objects` that we neglected to resize when we added this.

However, just resizing it now isn't straightforward, as it would add a new mutex to lock that we were specifically avoiding before, so for now let's just take this out.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
