### PR TITLE
Fix initing queries on dbs

### DIFF
--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -107,13 +107,13 @@ BedrockTester::BedrockTester(const map<string, string>& args,
     if (!SFileExists(_args["-db"])) {
         SFileSave(_args["-db"], "");
     }
-    
+
     // Run any supplied queries on the DB.
     // We don't use SQLite here, because we specifically want to avoid dealing with journal tables.
     if (queries.size()) {
         sqlite3* db;
         sqlite3_initialize();
-        string completeFilename = dbFileName;
+        string completeFilename = _args["-db"];
         if (ENABLE_HCTREE) {
             completeFilename = "file://" + completeFilename + "?hctree=1";
         }
@@ -378,7 +378,7 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
                         usleep(100'000);
                         continue;
                     }
-                    
+
                     // Socket is successfully created. We can exit this loop.
                     break;
                 }


### PR DESCRIPTION
### Details
When we added hctree we broke init queries on non-standard databases names, which breaks EBM tests. They are currently broken, not actually uploading anything but a blank file. 


### Fixed Issues
Broken tests

### Tests
Ran tests in EBM and confirmed data was added to the correct database.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
