### PR TITLE
Updated logging for diagnosing journal conflicts.

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -371,7 +371,7 @@ bool SQLite::beginTransaction(TRANSACTION_TYPE type) {
     // Reset before the query, as it's possible the query sets these.
     _autoRolledBack = false;
 
-    SDEBUG("[concurrent] Beginning transaction");
+    SINFO("[concurrent] Beginning transaction");
     uint64_t before = STimeNow();
     _insideTransaction = !SQuery(_db, "starting db transaction", "BEGIN CONCURRENT");
 
@@ -719,7 +719,7 @@ int SQLite::commit(const string& description, function<void()>* preCheckpointCal
     result = SQuery(_db, "committing db transaction", "COMMIT");
     _lastConflictPage = _conflictPage;
     if (_lastConflictPage) {
-        SINFO("part of last conflcit page: " << _lastConflictPage);
+        SINFO("part of last conflict page: " << _lastConflictPage);
     }
 
     // If there were conflicting commits, will return SQLITE_BUSY_SNAPSHOT
@@ -772,7 +772,7 @@ int SQLite::commit(const string& description, function<void()>* preCheckpointCal
         }
         SINFO(description << " COMMIT complete in " << time << ". Wrote " << (endPages - startPages)
               << " pages. WAL file size is " << sz << " bytes. " << _queryCount << " queries attempted, " << _cacheHits
-              << " served from cache.");
+              << " served from cache. Used journal " << _journalName);
         _queryCount = 0;
         _cacheHits = 0;
         _dbCountAtStart = 0;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -362,7 +362,7 @@ class SQLite {
     // Pointer to our SharedData object, which is shared between all SQLite DB objects for the same file.
     SharedData& _sharedData;
 
-    // The name of the journal table that this particular DB handle with write to.
+    // The name of the journal table that this particular DB handle will write to.
     string _journalName;
 
     // The current size of the journal, in rows. TODO: Why isn't this in SharedData?


### PR DESCRIPTION
### Details

This updates two typos, updates one logline, and adds one new logline.

We are experiencing a suspiciously high number of conflicts in journals.

This change aims to make the following possible:

When we see a conflict in a journal table, i.e.:
```
2024-05-29T17:05:00.405786+00:00 db1.sjc bedrock: 88b8110c2fc281ee-IAD cwikstrom@devotedcity.com (SQLite.cpp:280) _sqliteLogCallback [socket4356405] [info] {SQLITE} Code: 0, Message: cannot commit CONCURRENT transaction - conflict at page 1200081400 (read/write page; part of db table journal0116; content=050000010806B800...)
```

We will be able to go back through the logs to the previous:
```
SINFO("[concurrent] Beginning transaction");
```

Then, examining all the logs between those two lines for the updated:
```
2024-05-29T17:06:50.725543+00:00 db1.sjc bedrock: 88b8110c2fc281ee-IAD cwikstrom@devotedcity.com (SQLite.cpp:773) commit [socket4356741] [info] LEADING COMMIT complete in 0.18ms. Wrote 4 pages. WAL file size is 2998816192 bytes. 16 queries attempted, 3 served from cache. Used journal _journalName
```

We should be able to see what commands used what journals in this timeframe. If there are only a few journals used in between, then it seems we should be able to hand out journals in a less-conflicty manner.

However, if there are hundreds of commits during the lifetime of a single transaction, then it's unlikely we'll find a journal we haven't written to in that timeframe. We'll need to explore some other options.

### Fixed Issues
https://expensify.slack.com/archives/C0714QF3A1Z/p1717017142682389?thread_ts=1717004253.340359&cid=C0714QF3A1Z

### Tests
None, only logging.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
