### PR TITLE
SLogStackTrace only if the log level is set

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -5,6 +5,10 @@
 atomic<int> _g_SLogMask(LOG_INFO);
 
 void SLogStackTrace(int level) {
+    // If the level isn't set in the log mask, nothing more to do
+    if (!(_g_SLogMask & (1 << level))) {
+        return;
+    }
     // Output the symbols to the log
     void* callstack[100];
     int depth = backtrace(callstack, 100);

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -115,9 +115,7 @@ typedef map<string, SString, STableComp> STable;
 // (for DEBUG) a stack trace at the same time. They can take, 1, 2, or all 3 of the components of an HTTP response as arguments.
 #define STHROW(...)                                           \
 do {                                                          \
-    if (_g_SLogMask & (1 << LOG_DEBUG)) {                     \
-        SLogStackTrace(LOG_DEBUG);                            \
-    }                                                         \
+    SLogStackTrace(LOG_DEBUG);                                \
     throw SException(__FILE__, __LINE__, false, __VA_ARGS__); \
 } while (false)
 


### PR DESCRIPTION
### Details
In a previous PR I made it so that Bedrock only generates a stack traces for STHROW at the debug level. That was a good improvement, but it would be better to put that check inside the SLogStackTrace function instead. I want to log some debug stack traces in an [Auth PR](https://github.com/Expensify/Auth/pull/11021) without causing any extra work for the productions server, so I'm moving the check into the function.

### Related Issues
https://github.com/Expensify/Expensify/issues/387500

### Tests
1. Add a SINFO log line at the top of the function, [after the early return](https://github.com/Expensify/Bedrock/blob/38e8038620643a4e8d215e5b70d1f7646f338a18/libstuff/SLog.cpp#L11) `SINFO("Creating stack trace and logging it");`
2. Rebuild and restart Bedrock
3. Modify test/main.cpp to throw an error with this diff
```diff
diff --git a/test/main.cpp b/test/main.cpp
index ec723eae88..008c699451 100644
--- a/test/main.cpp
+++ b/test/main.cpp
@@ -65,6 +65,15 @@ void sigclean(int sig)
 
 int main(int argc, char* argv[])
 {
+
+    // Temporary tests for stack traces in JSON::Value
+    SLogSetThreadName("");
+    SLogSetThreadPrefix("");
+    SLogLevel(LOG_INFO);
+    SINFO("Throwing test exception");
+    STHROW("Test exception");
+    return 0;
+
     SData args = SParseCommandLine(argc, argv);
```
5. Make auth tests
6. Run them `./test/authtest`
7. Search the logs and verify that the log line for creating the stack trace does not show, but the error does appear.
```
2024-05-30T00:41:51.640856+00:00 expensidev2004 bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread escalate loop): 0/10009 ms timed, 0.00%
2024-05-30T00:41:52.511816+00:00 expensidev2004 systemd[1]: Started Session 11091 of user vagrant.
2024-05-30T00:41:53.268573+00:00 expensidev2004 authtest: (main.cpp:73) main [] [info] Throwing test exception
2024-05-30T00:41:53.271511+00:00 expensidev2004 authtest: (libstuff.cpp:151) SException [] [info] Throwing exception with message: 'Test exception' from test/main.cpp:74
2024-05-30T00:41:53.274974+00:00 expensidev2004 systemd[1]: session-11091.scope: Succeeded.
2024-05-30T00:41:53.633697+00:00 expensidev2004 bedrock: xxxxxx (main.cpp:378) main [main] [info] [performance] main poll loop timing: 10007 ms elapsed. 10006 ms in poll. 0 ms in postPoll.
2024-05-30T00:41:53.810413+00:00 expensidev2004 bedrock: xxxxxx (AutoTimer.cpp:22) stop [sync] [info] {} [performance] AutoTimer (sync thread poll): 10004/10005 ms timed, 99.99%
```

`E486: Pattern not found: Creating stack trace`
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
