### PR TITLE
Revert "Update SQLite3 to v3.46 and to fix conflict logs"

### DIFF
--- a/libstuff/sqlite3.h
+++ b/libstuff/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.46.0"
-#define SQLITE_VERSION_NUMBER 3046000
-#define SQLITE_SOURCE_ID      "2024-05-28 18:41:32 19d5fd8a483d23262c98524386d39bb7f4fb9ed79343c574abe51b57eb8296ec"
+#define SQLITE_VERSION        "3.45.0"
+#define SQLITE_VERSION_NUMBER 3045000
+#define SQLITE_SOURCE_ID      "2024-02-16 11:05:35 11a4178f0e6cd760303a5874b5a3529ccd78a2398b59700e878c7e6b1251de91"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -420,8 +420,6 @@ typedef int (*sqlite3_callback)(void*,int,char**, char**);
 **      the 1st parameter to sqlite3_exec() while sqlite3_exec() is running.
 ** <li> The application must not modify the SQL statement text passed into
 **      the 2nd parameter of sqlite3_exec() while sqlite3_exec() is running.
-** <li> The application must not dereference the arrays or string pointers
-**       passed as the 3rd and 4th callback parameters after it returns.
 ** </ul>
 */
 SQLITE_API int sqlite3_exec(
@@ -764,11 +762,11 @@ struct sqlite3_file {
 ** </ul>
 ** xLock() upgrades the database file lock.  In other words, xLock() moves the
 ** database file lock in the direction NONE toward EXCLUSIVE. The argument to
-** xLock() is always one of SHARED, RESERVED, PENDING, or EXCLUSIVE, never
+** xLock() is always on of SHARED, RESERVED, PENDING, or EXCLUSIVE, never
 ** SQLITE_LOCK_NONE.  If the database file lock is already at or above the
 ** requested lock, then the call to xLock() is a no-op.
 ** xUnlock() downgrades the database file lock to either SHARED or NONE.
-** If the lock is already at or below the requested lock state, then the call
+*  If the lock is already at or below the requested lock state, then the call
 ** to xUnlock() is a no-op.
 ** The xCheckReservedLock() method checks whether any database connection,
 ** either in this process or in some other process, is holding a RESERVED,
@@ -2143,22 +2141,6 @@ struct sqlite3_mem_methods {
 ** configuration setting is never used, then the default maximum is determined
 ** by the [SQLITE_MEMDB_DEFAULT_MAXSIZE] compile-time option.  If that
 ** compile-time option is not set, then the default maximum is 1073741824.
-**
-** [[SQLITE_CONFIG_ROWID_IN_VIEW]]
-** <dt>SQLITE_CONFIG_ROWID_IN_VIEW
-** <dd>The SQLITE_CONFIG_ROWID_IN_VIEW option enables or disables the ability
-** for VIEWs to have a ROWID.  The capability can only be enabled if SQLite is
-** compiled with -DSQLITE_ALLOW_ROWID_IN_VIEW, in which case the capability
-** defaults to on.  This configuration option queries the current setting or
-** changes the setting to off or on.  The argument is a pointer to an integer.
-** If that integer initially holds a value of 1, then the ability for VIEWs to
-** have ROWIDs is activated.  If the integer initially holds zero, then the
-** ability is deactivated.  Any other initial value for the integer leaves the
-** setting unchanged.  After changes, if any, the integer is written with
-** a 1 or 0, if the ability for VIEWs to have ROWIDs is on or off.  If SQLite
-** is compiled without -DSQLITE_ALLOW_ROWID_IN_VIEW (which is the usual and
-** recommended case) then the integer is always filled with zero, regardless
-** if its initial value.
 ** </dl>
 */
 #define SQLITE_CONFIG_SINGLETHREAD         1  /* nil */
@@ -2190,7 +2172,6 @@ struct sqlite3_mem_methods {
 #define SQLITE_CONFIG_SMALL_MALLOC        27  /* boolean */
 #define SQLITE_CONFIG_SORTERREF_SIZE      28  /* int nByte */
 #define SQLITE_CONFIG_MEMDB_MAXSIZE       29  /* sqlite3_int64 */
-#define SQLITE_CONFIG_ROWID_IN_VIEW       30  /* int* */
 
 /*
 ** CAPI3REF: Database Connection Configuration Options
@@ -3305,8 +3286,8 @@ SQLITE_API int sqlite3_set_authorizer(
 #define SQLITE_RECURSIVE            33   /* NULL            NULL            */
 
 /*
-** CAPI3REF: Deprecated Tracing And Profiling Functions
-** DEPRECATED
+** CAPI3REF: Tracing And Profiling Functions
+** METHOD: sqlite3
 **
 ** These routines are deprecated. Use the [sqlite3_trace_v2()] interface
 ** instead of the routines described here.
@@ -6887,12 +6868,6 @@ SQLITE_API int sqlite3_autovacuum_pages(
 ** The exceptions defined in this paragraph might change in a future
 ** release of SQLite.
 **
-** Whether the update hook is invoked before or after the
-** corresponding change is currently unspecified and may differ
-** depending on the type of change. Do not rely on the order of the
-** hook call with regards to the final result of the operation which
-** triggers the hook.
-**
 ** The update hook implementation must not do anything that will modify
 ** the database connection that invoked the update hook.  Any actions
 ** to modify the database connection must be deferred until after the
@@ -8363,7 +8338,7 @@ SQLITE_API int sqlite3_test_control(int op, ...);
 ** The sqlite3_keyword_count() interface returns the number of distinct
 ** keywords understood by SQLite.
 **
-** The sqlite3_keyword_name(N,Z,L) interface finds the 0-based N-th keyword and
+** The sqlite3_keyword_name(N,Z,L) interface finds the N-th keyword and
 ** makes *Z point to that keyword expressed as UTF8 and writes the number
 ** of bytes in the keyword into *L.  The string that *Z points to is not
 ** zero-terminated.  The sqlite3_keyword_name(N,Z,L) routine returns
@@ -9942,44 +9917,23 @@ SQLITE_API const char *sqlite3_vtab_collation(sqlite3_index_info*,int);
 ** <li value="2"><p>
 ** ^(If the sqlite3_vtab_distinct() interface returns 2, that means
 ** that the query planner does not need the rows returned in any particular
-** order, as long as rows with the same values in all columns identified
-** by "aOrderBy" are adjacent.)^  ^(Furthermore, when two or more rows
-** contain the same values for all columns identified by "colUsed", all but
-** one such row may optionally be omitted from the result.)^
-** The virtual table is not required to omit rows that are duplicates
-** over the "colUsed" columns, but if the virtual table can do that without
-** too much extra effort, it could potentially help the query to run faster.
+** order, as long as rows with the same values in all "aOrderBy" columns
+** are adjacent.)^  ^(Furthermore, only a single row for each particular
+** combination of values in the columns identified by the "aOrderBy" field
+** needs to be returned.)^  ^It is always ok for two or more rows with the same
+** values in all "aOrderBy" columns to be returned, as long as all such rows
+** are adjacent.  ^The virtual table may, if it chooses, omit extra rows
+** that have the same value for all columns identified by "aOrderBy".
+** ^However omitting the extra rows is optional.
 ** This mode is used for a DISTINCT query.
 ** <li value="3"><p>
-** ^(If the sqlite3_vtab_distinct() interface returns 3, that means the
-** virtual table must return rows in the order defined by "aOrderBy" as
-** if the sqlite3_vtab_distinct() interface had returned 0.  However if
-** two or more rows in the result have the same values for all columns
-** identified by "colUsed", then all but one such row may optionally be
-** omitted.)^  Like when the return value is 2, the virtual table
-** is not required to omit rows that are duplicates over the "colUsed"
-** columns, but if the virtual table can do that without
-** too much extra effort, it could potentially help the query to run faster.
-** This mode is used for queries
+** ^(If the sqlite3_vtab_distinct() interface returns 3, that means
+** that the query planner needs only distinct rows but it does need the
+** rows to be sorted.)^ ^The virtual table implementation is free to omit
+** rows that are identical in all aOrderBy columns, if it wants to, but
+** it is not required to omit any rows.  This mode is used for queries
 ** that have both DISTINCT and ORDER BY clauses.
 ** </ol>
-**
-** <p>The following table summarizes the conditions under which the
-** virtual table is allowed to set the "orderByConsumed" flag based on
-** the value returned by sqlite3_vtab_distinct().  This table is a
-** restatement of the previous four paragraphs:
-**
-** <table border=1 cellspacing=0 cellpadding=10 width="90%">
-** <tr>
-** <td valign="top">sqlite3_vtab_distinct() return value
-** <td valign="top">Rows are returned in aOrderBy order
-** <td valign="top">Rows with the same value in all aOrderBy columns are adjacent
-** <td valign="top">Duplicates over all colUsed columns may be omitted
-** <tr><td>0<td>yes<td>yes<td>no
-** <tr><td>1<td>no<td>yes<td>no
-** <tr><td>2<td>no<td>yes<td>yes
-** <tr><td>3<td>yes<td>yes<td>yes
-** </table>
 **
 ** ^For the purposes of comparing virtual table output values to see if the
 ** values are same value for sorting purposes, two NULL values are considered
@@ -12173,30 +12127,6 @@ SQLITE_API int sqlite3changegroup_schema(sqlite3_changegroup*, sqlite3*, const c
 SQLITE_API int sqlite3changegroup_add(sqlite3_changegroup*, int nData, void *pData);
 
 /*
-** CAPI3REF: Add A Single Change To A Changegroup
-** METHOD: sqlite3_changegroup
-**
-** This function adds the single change currently indicated by the iterator
-** passed as the second argument to the changegroup object. The rules for
-** adding the change are just as described for [sqlite3changegroup_add()].
-**
-** If the change is successfully added to the changegroup, SQLITE_OK is
-** returned. Otherwise, an SQLite error code is returned.
-**
-** The iterator must point to a valid entry when this function is called.
-** If it does not, SQLITE_ERROR is returned and no change is added to the
-** changegroup. Additionally, the iterator must not have been opened with
-** the SQLITE_CHANGESETAPPLY_INVERT flag. In this case SQLITE_ERROR is also
-** returned.
-*/
-SQLITE_API int sqlite3changegroup_add_change(
-  sqlite3_changegroup*,
-  sqlite3_changeset_iter*
-);
-
-
-
-/*
 ** CAPI3REF: Obtain A Composite Changeset From A Changegroup
 ** METHOD: sqlite3_changegroup
 **
@@ -13000,8 +12930,8 @@ struct Fts5PhraseIter {
 ** EXTENSION API FUNCTIONS
 **
 ** xUserData(pFts):
-**   Return a copy of the pUserData pointer passed to the xCreateFunction()
-**   API when the extension function was registered.
+**   Return a copy of the context pointer the extension function was
+**   registered with.
 **
 ** xColumnTotalSize(pFts, iCol, pnToken):
 **   If parameter iCol is less than zero, set output variable *pnToken

--- a/libstuff/sqlite3ext.h
+++ b/libstuff/sqlite3ext.h
@@ -363,9 +363,6 @@ struct sqlite3_api_routines {
   int (*is_interrupted)(sqlite3*);
   /* Version 3.43.0 and later */
   int (*stmt_explain)(sqlite3_stmt*,int);
-  /* Version 3.44.0 and later */
-  void *(*get_clientdata)(sqlite3*,const char*);
-  int (*set_clientdata)(sqlite3*, const char*, void*, void(*)(void*));
 };
 
 /*
@@ -696,9 +693,6 @@ typedef int (*sqlite3_loadext_entry)(
 #define sqlite3_is_interrupted         sqlite3_api->is_interrupted
 /* Version 3.43.0 and later */
 #define sqlite3_stmt_explain           sqlite3_api->stmt_explain
-/* Version 3.44.0 and later */
-#define sqlite3_get_clientdata         sqlite3_api->get_clientdata
-#define sqlite3_set_clientdata         sqlite3_api->set_clientdata
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)


### PR DESCRIPTION
Reverts Expensify/Bedrock#1748

Context https://expensify.slack.com/archives/C0714QF3A1Z/p1717078837927219
We think this update might have made things worse performance wise.