### PR TITLE
Add `STIMESTAMP_MS`

### DIFF
--- a/libstuff/STime.cpp
+++ b/libstuff/STime.cpp
@@ -1,6 +1,8 @@
 #include "libstuff.h"
 
+#include <ctime>
 #include <sys/time.h>
+
 
 uint64_t STimeNow() {
     // Get the time = microseconds since 00:00:00 UTC, January 1, 1970
@@ -51,12 +53,7 @@ timeval SToTimeval(uint64_t when) {
 }
 
 string SCURRENT_TIMESTAMP_MS() {
-    uint64_t time = STimeNow();
-    uint64_t ms = (time % 1'000'000) / 1'000;
-    string timestamp = SUNQUOTED_TIMESTAMP(time);
-    char msString[5] = {0};
-    snprintf(msString, 5, "%03lu", ms);
-    return timestamp + "." + msString;
+    return STIMESTAMP_MS(STimeNow());
 }
 
 string SFirstOfMonth(const string& timeStamp, const int64_t& offset) {
@@ -96,4 +93,12 @@ string SFirstOfMonth(const string& timeStamp, const int64_t& offset) {
     char buf[256] = {};
     size_t length = strftime(buf, sizeof(buf), "%Y-%m-%d", &t);
     return string(buf, length);
+}
+
+uint64_t STimestampToEpoch(const string& timestamp, const string& format)
+{
+    tm tm = {};
+    istringstream ss(timestamp);
+    ss >> get_time(&tm, format);
+    const int64_t epoch = static_cast<int64_t>(mktime(&tm));
 }

--- a/libstuff/STime.cpp
+++ b/libstuff/STime.cpp
@@ -93,11 +93,3 @@ string SFirstOfMonth(const string& timeStamp, const int64_t& offset) {
     size_t length = strftime(buf, sizeof(buf), "%Y-%m-%d", &t);
     return string(buf, length);
 }
-
-uint64_t STimestampToEpoch(const string& timestamp, const string& format)
-{
-    tm tm = {};
-    istringstream ss(timestamp);
-    ss >> get_time(&tm, format);
-    const int64_t epoch = static_cast<int64_t>(mktime(&tm));
-}

--- a/libstuff/STime.cpp
+++ b/libstuff/STime.cpp
@@ -1,6 +1,5 @@
 #include "libstuff.h"
 
-#include <ctime>
 #include <sys/time.h>
 
 uint64_t STimeNow() {

--- a/libstuff/STime.cpp
+++ b/libstuff/STime.cpp
@@ -3,7 +3,6 @@
 #include <ctime>
 #include <sys/time.h>
 
-
 uint64_t STimeNow() {
     // Get the time = microseconds since 00:00:00 UTC, January 1, 1970
     timeval time;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -3075,6 +3075,14 @@ string STIMESTAMP(uint64_t when) {
     return SQ(SUNQUOTED_TIMESTAMP(when));
 }
 
+string STIMESTAMP_MS(uint64_t when) {
+    uint64_t ms = (time % 1'000'000) / 1'000;
+    string timestamp = SUNQUOTED_TIMESTAMP(when);
+    char msString[5] = {0};
+    snprintf(msString, 5, "%03lu", ms);
+    return timestamp + "." + msString;
+}
+
 string SUNQUOTED_CURRENT_TIMESTAMP() {
     return SUNQUOTED_TIMESTAMP(STimeNow());
 }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -3076,7 +3076,7 @@ string STIMESTAMP(uint64_t when) {
 }
 
 string STIMESTAMP_MS(uint64_t when) {
-    uint64_t ms = (time % 1'000'000) / 1'000;
+    uint64_t ms = (when % 1'000'000) / 1'000;
     string timestamp = SUNQUOTED_TIMESTAMP(when);
     char msString[5] = {0};
     snprintf(msString, 5, "%03lu", ms);

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -165,7 +165,6 @@ int SDaysInMonth(int year, int month);
 string SComposeTime(const string& format, uint64_t when);
 timeval SToTimeval(uint64_t when);
 string SFirstOfMonth(const string& timeStamp, const int64_t& offset = 0);
-uint64_t STimestampToEpoch();
 
 // Helpful class for timing
 struct SStopwatch {

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -165,6 +165,7 @@ int SDaysInMonth(int year, int month);
 string SComposeTime(const string& format, uint64_t when);
 timeval SToTimeval(uint64_t when);
 string SFirstOfMonth(const string& timeStamp, const int64_t& offset = 0);
+uint64_t STimestampToEpoch();
 
 // Helpful class for timing
 struct SStopwatch {
@@ -601,6 +602,7 @@ bool SQVerifyTableExists(sqlite3* db, const string& tableName);
 // --------------------------------------------------------------------------
 string SUNQUOTED_TIMESTAMP(uint64_t when);
 string STIMESTAMP(uint64_t when);
+string STIMESTAMP_MS(uint64_t when);
 string SUNQUOTED_CURRENT_TIMESTAMP();
 string SCURRENT_TIMESTAMP();
 string SCURRENT_TIMESTAMP_MS();


### PR DESCRIPTION
### Details
Adds a new utility function `STIMESTAMP_MS`. Used in https://github.com/Expensify/Auth/pull/10919

### Fixed Issues
N/A

### Tests
Tested with https://github.com/Expensify/Auth/pull/10919
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
