### PR TITLE
Use correct cancelAfter broadcast when resources are exhausted

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1719,7 +1719,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     // If the server is strugling and falling behind on replication, we might have too many threads
                     // causing a resource exhaustion. If that happens, all the transations that are already threaded
                     // and waiting for the transaction that failed will be stuck in an infinite loop. To prevent that
-                    // we're cancelling all threads that would need to wait on the transaction that is failing.
+                    // we're cancelling all threads that would need to wait on the transaction failed to be threaded.
                     uint64_t cancelAfter = message.calcU64("NewCount") - 1;
                     _localCommitNotifier.cancel(cancelAfter);
                     _leaderCommitNotifier.cancel(cancelAfter);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1721,9 +1721,8 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     // and waiting for the transaction that failed will be stuck in an infinite loop. To prevent that
                     // we're changing the state to SEARCHING and sending the cancelAfter property to drop all threads
                     // that depend on the transaction that failed to be threaded.
-                    uint64_t cancelAfter = message.calcU64("NewCount") - 1;
-                    _changeState(SQLiteNodeState::SEARCHING, cancelAfter);
-                    SWARN("Caught system_error starting _replicate thread with" << _replicationThreadCount.load() << " threads. cancelAfter="<< cancelAfter << " e.what()=" << e.what());
+                    _changeState(SQLiteNodeState::SEARCHING, message.calcU64("NewCount") - 1);
+                    SWARN("Caught system_error starting _replicate thread with " << _replicationThreadCount.load() << " threads. e.what()=" << e.what());
                     STHROW("Error starting replicate thread so giving up and reconnecting.");
                 }
                 SDEBUG("Done spawning concurrent replicate thread: " << threadID);
@@ -1939,7 +1938,7 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
         // If we were following, and now we're not, we give up an any replications.
         if (_state == SQLiteNodeState::FOLLOWING) {
             _replicationThreadsShouldExit = true;
-            uint64_t cancelAfter = commitIDToCancelAfter > 0 ? commitIDToCancelAfter : _leaderCommitNotifier.getValue();
+            uint64_t cancelAfter = commitIDToCancelAfter ? commitIDToCancelAfter : _leaderCommitNotifier.getValue();
             SINFO("Replication threads should exit, canceling commits after current leader commit " << cancelAfter);
             _localCommitNotifier.cancel(cancelAfter);
             _leaderCommitNotifier.cancel(cancelAfter);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1719,11 +1719,10 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     // If the server is strugling and falling behind on replication, we might have too many threads
                     // causing a resource exhaustion. If that happens, all the transations that are already threaded
                     // and waiting for the transaction that failed will be stuck in an infinite loop. To prevent that
-                    // we're cancelling all threads that would need to wait on the transaction failed to be threaded.
+                    // we're changing the state to SEARCHING and sending the cancelAfter property to drop all threads
+                    // that depend on the transaction that failed to be threaded.
                     uint64_t cancelAfter = message.calcU64("NewCount") - 1;
-                    _localCommitNotifier.cancel(cancelAfter);
-                    _leaderCommitNotifier.cancel(cancelAfter);
-                    _changeState(SQLiteNodeState::SEARCHING);
+                    _changeState(SQLiteNodeState::SEARCHING, cancelAfter);
                     SWARN("Caught system_error starting _replicate thread with" << _replicationThreadCount.load() << " threads. cancelAfter="<< cancelAfter << " e.what()=" << e.what());
                     STHROW("Error starting replicate thread so giving up and reconnecting.");
                 }
@@ -1929,7 +1928,7 @@ void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly) {
     }
 }
 
-void SQLiteNode::_changeState(SQLiteNodeState newState) {
+void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCancelAfter) {
     SINFO("[NOTIFY] setting commit count to: " << _db.getCommitCount());
     _localCommitNotifier.notifyThrough(_db.getCommitCount());
 
@@ -1940,7 +1939,7 @@ void SQLiteNode::_changeState(SQLiteNodeState newState) {
         // If we were following, and now we're not, we give up an any replications.
         if (_state == SQLiteNodeState::FOLLOWING) {
             _replicationThreadsShouldExit = true;
-            uint64_t cancelAfter = _leaderCommitNotifier.getValue();
+            uint64_t cancelAfter = commitIDToCancelAfter > 0 ? commitIDToCancelAfter : _leaderCommitNotifier.getValue();
             SINFO("Replication threads should exit, canceling commits after current leader commit " << cancelAfter);
             _localCommitNotifier.cancel(cancelAfter);
             _leaderCommitNotifier.cancel(cancelAfter);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1723,7 +1723,8 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     uint64_t cancelAfter = message.calcU64("NewCount") - 1;
                     _localCommitNotifier.cancel(cancelAfter);
                     _leaderCommitNotifier.cancel(cancelAfter);
-                    SWARN("Caught system_error starting _replicate thread with" << _replicationThreadCount.load() << " threads. cancelAfter=" << cancelAfter << " e.what()=" << e.what());
+                    _changeState(SQLiteNodeState::SEARCHING);
+                    SWARN("Caught system_error starting _replicate thread with" << _replicationThreadCount.load() << " threads. cancelAfter="<< cancelAfter << " e.what()=" << e.what());
                     STHROW("Error starting replicate thread so giving up and reconnecting.");
                 }
                 SDEBUG("Done spawning concurrent replicate thread: " << threadID);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1717,7 +1717,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     thread(&SQLiteNode::_replicate, this, peer, message, _dbPool->getIndex(false), threadAttemptStartTimestamp).detach();
                 } catch (const system_error& e) {
                     // If the server is strugling and falling behind on replication, we might have too many threads
-                    // causing a resource exhaustion. If that happens, all the transations that are already threaded
+                    // causing a resource exhaustion. If that happens, all the transactions that are already threaded
                     // and waiting for the transaction that failed will be stuck in an infinite loop. To prevent that
                     // we're changing the state to SEARCHING and sending the cancelAfter property to drop all threads
                     // that depend on the transaction that failed to be threaded.

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1723,7 +1723,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     uint64_t cancelAfter = message.calcU64("NewCount") - 1;
                     _localCommitNotifier.cancel(cancelAfter);
                     _leaderCommitNotifier.cancel(cancelAfter);
-                    SWARN(format("Caught system_error starting _replicate thread with {} threads. cancelAfter={} e.what()={}", _replicationThreadCount.load(), cancelAfter, e.what()));
+                    SWARN("Caught system_error starting _replicate thread with" << _replicationThreadCount.load() << " threads. cancelAfter=" << cancelAfter << " e.what()=" << e.what());
                     STHROW("Error starting replicate thread so giving up and reconnecting.");
                 }
                 SDEBUG("Done spawning concurrent replicate thread: " << threadID);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1716,7 +1716,11 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     uint64_t threadAttemptStartTimestamp = STimeNow();
                     thread(&SQLiteNode::_replicate, this, peer, message, _dbPool->getIndex(false), threadAttemptStartTimestamp).detach();
                 } catch (const system_error& e) {
-                    SWARN("Caught system_error starting _replicate thread with " << _replicationThreadCount.load() << " threads. e.what()=" << e.what());
+                    
+                    uint64_t cancelAfter = message.calcU64("NewCount") - 1;
+                    _localCommitNotifier.cancel(cancelAfter);
+                    _leaderCommitNotifier.cancel(cancelAfter);
+                    SWARN(format("Caught system_error starting _replicate thread with {} threads. cancelAfter={} e.what()={}", _replicationThreadCount.load(), cancelAfter, e.what()));
                     STHROW("Error starting replicate thread so giving up and reconnecting.");
                 }
                 SDEBUG("Done spawning concurrent replicate thread: " << threadID);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -226,7 +226,7 @@ class SQLiteNode : public STCPManager {
     // Add required headers for messages being sent to peers.
     SData _addPeerHeaders(SData message);
 
-    void _changeState(SQLiteNodeState newState);
+    void _changeState(SQLiteNodeState newState, uint64_t commitIDToCancelAfter = 0);
 
     // Handlers for transaction messages.
     void _handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SData& message, bool wasConflict);


### PR DESCRIPTION
### Details
Currently, we're facing issues with the replication timing. Because that's happening, the number of replication threads is growing too much, causing resource exhaustion. 

Considering that all replication messages can arrive in parallel and not necessarily in order, followers could get stuck in the following case:

- receives commit 1, creates thread 1
- receives commit 3, creates thread 2
- receive commit 2, tries to create thread 3 but resources are exhausted and it fails

Since no threads were created for commit 2, it is never applied. Thread 2, which depends on commit 2 to be completed, gets stuck in an infinite loop. The server then never goes back to a searching state, and can only go back to the pool after a restart.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
