### PR TITLE
Save logline at shutdown

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 ///
 #include <dlfcn.h>
 #include <iostream>
+#include <fstream>
 #include <signal.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
@@ -399,5 +400,14 @@ int main(int argc, char* argv[]) {
 
     // All done
     SINFO("Graceful process shutdown complete");
+
+    // Save that we're shutting down.
+    pid_t pid = getpid();
+    ofstream file("/var/log/bedrock_shutdown", std::ios::app);
+    if (file) {
+        file << "shutdown " << pid << " " << SComposeTime("%Y-%m-%dT%H:%M:%S", STimeNow()) << endl;
+        file.close();
+    }
+
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -402,10 +402,9 @@ int main(int argc, char* argv[]) {
     SINFO("Graceful process shutdown complete");
 
     // Save that we're shutting down.
-    pid_t pid = getpid();
     ofstream file("/var/log/bedrock_shutdown", std::ios::app);
     if (file) {
-        file << "shutdown " << pid << " " << SComposeTime("%Y-%m-%dT%H:%M:%S", STimeNow()) << endl;
+        file << "shutdown " << getpid() << " " << SComposeTime("%Y-%m-%dT%H:%M:%S", STimeNow()) << endl;
         file.close();
     }
 


### PR DESCRIPTION
### Details
Adds a logline in `/var/log/bedrock_shutdown` when bedrock shuts down.

Format:
```
shutdown $PID $TIMESTAMP
```

Example:
```
shutdown 1685177 2024-06-05T22:51:02
shutdown 1686170 2024-06-05T22:54:15
```

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/171333

### Tests
Build bedrock/auth in the VM.

run:
```
sudo service auth start
sudo service auth stop
```

inspect the contents of `/var/log/bedrock_shutdown`
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
