### PR TITLE
Move shutdown logging to just before deleting the SQLitePool, which is where unmapping happens

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,7 +4,6 @@
 ///
 #include <dlfcn.h>
 #include <iostream>
-#include <fstream>
 #include <signal.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
@@ -401,12 +400,6 @@ int main(int argc, char* argv[]) {
     // All done
     SINFO("Graceful process shutdown complete");
 
-    // Save that we're shutting down.
-    ofstream file("/var/log/bedrock_shutdown", std::ios::app);
-    if (file) {
-        file << "shutdown " << getpid() << " " << SComposeTime("%Y-%m-%dT%H:%M:%S", STimeNow()) << endl;
-        file.close();
-    }
 
     return 0;
 }


### PR DESCRIPTION
This was happening too late before, we are moving it to just before deleting the SQLitePool, which triggers unmapping.
### Details

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/171333

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
