### PR TITLE
Add a log when generating CRASH_COMMAND command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1972,6 +1972,7 @@ bool BedrockServer::shouldBackup() {
 }
 
 SData BedrockServer::_generateCrashMessage(const unique_ptr<BedrockCommand>& command) {
+    SHMMM("Generating CRASH_COMMAND command for " << command->request.methodLine);
     SData message("CRASH_COMMAND");
     SData subMessage(command->request.methodLine);
     for (auto& pair : command->crashIdentifyingValues) {


### PR DESCRIPTION
### Details

### Fixed Issues
Fixes https://expensify.slack.com/archives/C0714QF3A1Z/p1717696155865759?thread_ts=1717694266.106479&cid=C0714QF3A1Z

### Tests
no
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
