### PR TITLE
Upgrade 2 bottleneck logs to warns

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2044,7 +2044,7 @@ void BedrockServer::_acceptSockets() {
                 uint64_t now = STimeNow();
                 if ((port != _controlPort) && (_outstandingSocketThreads >= _maxSocketThreads)) {
                     if ((lastLogged < now - 3'000'000)) {
-                        SINFO("Not accepting any new socket threads as we already have " << _outstandingSocketThreads << " of " << _maxSocketThreads);
+                        SWARN("Not accepting any new socket threads as we already have " << _outstandingSocketThreads << " of " << _maxSocketThreads);
                         lastLogged = now;
                     }
                     return;

--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -60,7 +60,7 @@ size_t SQLitePool::getIndex(bool createHandle) {
             return index;
         } else {
             // Wait for a handle.
-            SINFO("Waiting for DB handle");
+            SWARN("Waiting for DB handle");
             _wait.wait(lock);
         }
     }
@@ -88,7 +88,7 @@ void SQLitePool::returnToPool(size_t index) {
 }
 
 SQLiteScopedHandle::SQLiteScopedHandle(SQLitePool& pool, size_t index) : _pool(pool), _index(index)
-{} 
+{}
 
 SQLiteScopedHandle::~SQLiteScopedHandle() {
     _pool.returnToPool(_index);


### PR DESCRIPTION
These logs should not occur in normal operation (they have not happened in the last five days outside of a wonky deploy on June 7th). I'd like to upgrade them to warns so that they are very obvious when they happen.