### PR TITLE
Show leader version when reporting mismatch in /status/handlingCommands

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1605,7 +1605,7 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         // This is similar to the above check, and is used for letting HAProxy load-balance commands.
 
         if (_version != _leaderVersion.load()) {
-            response.methodLine = "HTTP/1.1 500 Mismatched version. Version=" + _version;
+            response.methodLine = "HTTP/1.1 500 Mismatched version. Version=" + _version + ", LeaderVersion=" + _leaderVersion.load();
         } else {
             string method = "HTTP/1.1 ";
 


### PR DESCRIPTION
### Details

We are currently seeing a node running in a detached state. It is reporting a 500 error version mismatch in response to `/status/handlingCommands` but the version printed out there and in `/status` exactly matches leader. So likely, it is unable to load `_leaderVersion`. This adds the leader version to the output so we can verify the bug. 

### Fixed Issues
N/A, discussion from [here](https://expensify.slack.com/archives/C094TGUTZ/p1718332418132129?thread_ts=1718317822.557889&cid=C094TGUTZ)

### Tests
Not sure how to reproduce on dev, open to suggestions

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
