### PR TITLE
Time out SUBSCRIBE query instead of forking.

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -882,10 +882,10 @@ int SQLite::getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result, u
     SDEBUG("Getting commits #" << fromIndex << "-" << toIndex);
     query = "SELECT hash, query FROM (" + query  + ") ORDER BY id";
     if (timeoutLimitUS) {
-        _timeoutLimit = STimeNow() + timeoutLimitUS;
+        setTimeout(timeoutLimitUS);
     }
     int queryResult = SQuery(_db, "getting commits", query, result);
-    _timeoutLimit = 0;
+    clearTimeout();
     return queryResult;
 }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -881,7 +881,13 @@ bool SQLite::getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result) 
                                     (toIndex ? " AND id <= " + SQ(toIndex) : "")});
     SDEBUG("Getting commits #" << fromIndex << "-" << toIndex);
     query = "SELECT hash, query FROM (" + query  + ") ORDER BY id";
-    return !SQuery(_db, "getting commits", query, result);
+
+    // Set timeout to 10 seconds.
+    _timeoutLimit = STimeNow() + 10'000'000;
+    int queryResult = SQuery(_db, "getting commits", query, result);
+    _timeoutLimit = 0;
+
+    return !queryResult;
 }
 
 int64_t SQLite::getLastInsertRowID() {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -211,7 +211,7 @@ void SQLite::commonConstructorInitialization(bool hctree) {
 
     // I tested and found that we could set about 10,000,000 and the number of steps to run and get a callback once a
     // second. This is set to be a bit more granular than that, which is probably adequate.
-    sqlite3_progress_handler(_db, 100, _progressHandlerCallback, this);
+    sqlite3_progress_handler(_db, 1'000'000, _progressHandlerCallback, this);
 
     // Setting a wal hook prevents auto-checkpointing.
     sqlite3_wal_hook(_db, _walHookCallback, this);

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -221,7 +221,7 @@ class SQLite {
     static bool getCommit(sqlite3* db, const vector<string> journalNames, uint64_t index, string& query, string& hash);
 
     // Looks up a range of commits.
-    bool getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result);
+    int getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result, uint64_t timeoutLimitUS = 0);
 
     // Set a time limit for this transaction, in US from the current time.
     void setTimeout(uint64_t timeLimitUS);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2132,12 +2132,17 @@ void SQLiteNode::_queueSynchronize(const SQLiteNode* const node, SQLitePeer* pee
         // Figure out how much to send it
         uint64_t fromIndex = peerCommitCount + 1;
         uint64_t toIndex = targetCommit;
-        if (!sendAll)
+        if (sendAll) {
+            SINFO("Sending all commits with synchronize message, from " << fromIndex << " to " << toIndex); 
+        } else {
             toIndex = min(toIndex, fromIndex + 100); // 100 transactions at a time
-        if (!db.getCommits(fromIndex, toIndex, result))
+        }
+        if (!db.getCommits(fromIndex, toIndex, result)) {
             STHROW("error getting commits");
-        if ((uint64_t)result.size() != toIndex - fromIndex + 1)
+        }
+        if ((uint64_t)result.size() != toIndex - fromIndex + 1) {
             STHROW("mismatched commit count");
+        }
 
         // Wrap everything into one huge message
         PINFO("Synchronizing commits from " << peerCommitCount + 1 << "-" << targetCommit);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2083,6 +2083,8 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
     }
 }
 
+static int __ATTEMPTS = 0;
+
 void SQLiteNode::_queueSynchronize(const SQLiteNode* const node, SQLitePeer* peer, SQLite& db, SData& response, bool sendAll) {
     // We need this to check the state of the node, and we also need `name` to make the logging macros work in a static
     // function. However, if you pass a null pointer here, we can't set these, so we'll fail. We also can't log that,
@@ -2139,7 +2141,12 @@ void SQLiteNode::_queueSynchronize(const SQLiteNode* const node, SQLitePeer* pee
             // We set this for all commits because this only gets all commits in response to SUBSCRIBE, which is done synchronously, and blocks the commit thread.
             // For asynchronous queries, there's nothing being blocked, so it doesn't much matter how long these take.
             // This is really not the correct encapsulation for this, but we can improve that later.
-            timeoutLimitUS = 100;
+            if (__ATTEMPTS) {
+                timeoutLimitUS = 10'000;
+            } else {
+                timeoutLimitUS = 100;
+            }
+            __ATTEMPTS++;
         } else {
             toIndex = min(toIndex, fromIndex + 100); // 100 transactions at a time
         }

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -216,7 +216,8 @@ class SQLiteNode : public STCPManager {
     // Queue a SYNCHRONIZE message based on the current state of the node, thread-safe, but you need to pass the
     // *correct* DB for the thread that's making the call (i.e., you can't use the node's internal DB from a worker
     // thread with a different DB object) - which is why this is static.
-    static void _queueSynchronize(const SQLiteNode* const node, SQLitePeer* peer, SQLite& db, SData& response, bool sendAll);
+    // Returns true on success, false on failure.
+    static bool _queueSynchronize(const SQLiteNode* const node, SQLitePeer* peer, SQLite& db, SData& response, bool sendAll);
 
     bool _isNothingBlockingShutdown() const;
     bool _majoritySubscribed() const;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -216,7 +216,7 @@ class SQLiteNode : public STCPManager {
     // Queue a SYNCHRONIZE message based on the current state of the node, thread-safe, but you need to pass the
     // *correct* DB for the thread that's making the call (i.e., you can't use the node's internal DB from a worker
     // thread with a different DB object) - which is why this is static.
-    static void _queueSynchronize(const SQLiteNode* const node, SQLitePeer* peer, SQLite& db, SData& response, bool sendAll);
+    static void _queueSynchronize(const SQLiteNode* const node, SQLitePeer* peer, SQLite& db, SData& response, bool sendAll, uint64_t timeoutAfterUS = 0);
 
     bool _isNothingBlockingShutdown() const;
     bool _majoritySubscribed() const;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -216,8 +216,7 @@ class SQLiteNode : public STCPManager {
     // Queue a SYNCHRONIZE message based on the current state of the node, thread-safe, but you need to pass the
     // *correct* DB for the thread that's making the call (i.e., you can't use the node's internal DB from a worker
     // thread with a different DB object) - which is why this is static.
-    // Returns true on success, false on failure.
-    static bool _queueSynchronize(const SQLiteNode* const node, SQLitePeer* peer, SQLite& db, SData& response, bool sendAll);
+    static void _queueSynchronize(const SQLiteNode* const node, SQLitePeer* peer, SQLite& db, SData& response, bool sendAll);
 
     bool _isNothingBlockingShutdown() const;
     bool _majoritySubscribed() const;


### PR DESCRIPTION
### Details
See issue, it's pretty detailed.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/406697

### Tests
Testing on commit e1460937 (before rolling back the test hacks):

We successfully time out the query:
```
2024-06-21T19:53:05.538431+00:00 expensidev2004 bedrock10001: xxxxxx (libstuff.cpp:151) SException [sync] [info] Throwing exception with message: 'synchronization query timeout' from sqlitecluster/SQLiteNode.cpp:2154
```

This kills the peer connection:
```
2024-06-21T19:53:05.538542+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:1785) _onMESSAGE [sync] [warn] {cluster_node_0/LEADING} ->{cluster_node_2} Error processing message 'SUBSCRIBE' (synchronization query timeout), reconnecting.
```

Follower reconnects, switches to searching:
```
2024-06-21T19:53:05.538636+00:00 expensidev2004 bedrock10007: xxxxxx (SQLitePeer.cpp:90) postPoll [sync] [hmmm] {cluster_node_0} Lost peer connection after 101ms, reconnecting in 739ms
2024-06-21T19:53:05.538800+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:1970) _changeState [sync] [info] {cluster_node_2/SUBSCRIBING} Switching from 'SUBSCRIBING' to 'SEARCHING'
```

Follower runs through the state machine, succeeds on second try:
```
2024-06-21T19:53:05.578719+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:1970) _changeState [sync] [info] {cluster_node_2/SEARCHING} Switching from 'SEARCHING' to 'SYNCHRONIZING'
2024-06-21T19:53:05.582020+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:1970) _changeState [sync] [info] {cluster_node_2/SYNCHRONIZING} Switching from 'SYNCHRONIZING' to 'WAITING'
2024-06-21T19:53:06.273311+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:1970) _changeState [sync] [info] {cluster_node_2/WAITING} Switching from 'WAITING' to 'SUBSCRIBING'
2024-06-21T19:53:06.291824+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:1970) _changeState [sync] [info] {cluster_node_2/SUBSCRIBING} Switching from 'SUBSCRIBING' to 'FOLLOWING'
```

Auth built and tested against this as well.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
