### PR TITLE
Use set_match_limit_recursion in SREMatch

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2806,11 +2806,11 @@ bool SIsValidSQLiteDateModifier(const string& modifier) {
 }
 
 bool SREMatch(const string& regExp, const string& s) {
-    return pcrecpp::RE(regExp).FullMatch(s);
+    return pcrecpp::RE(regExp, pcrecpp::RE_Options().set_match_limit_recursion(1000)).FullMatch(s);
 }
 
 bool SREMatch(const string& regExp, const string& s, string& match) {
-    return pcrecpp::RE(regExp).FullMatch(s, &match);
+    return pcrecpp::RE(regExp, pcrecpp::RE_Options().set_match_limit_recursion(1000)).FullMatch(s, &match);
 }
 
 void SRedactSensitiveValues(string& s) {


### PR DESCRIPTION
### Details

Same as  https://github.com/Expensify/Auth/pull/11244

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
