### PR TITLE
Make SRandom::randStr() not require a reference

### DIFF
--- a/libstuff/SRandom.cpp
+++ b/libstuff/SRandom.cpp
@@ -18,13 +18,13 @@ uint64_t SRandom::rand64() {
     return _distribution64(_generator);
 }
 
-string SRandom::randStr(uint& length) {
+string SRandom::randStr(uint length) {
     string str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     string newstr;
     int pos;
-    while(newstr.size() != length) {
+    while (newstr.size() != length) {
         pos = (rand64() % (str.size() - 1));
-        newstr += str.substr(pos,1);
+        newstr += str.substr(pos, 1);
     }
     return newstr;
 }

--- a/libstuff/SRandom.h
+++ b/libstuff/SRandom.h
@@ -10,7 +10,7 @@ class SRandom {
   public:
     static uint64_t rand64();
     static uint64_t limitedRand64(uint64_t min, uint64_t max);
-    static string randStr(uint& length);
+    static string randStr(uint length);
 
   private:
     static mt19937_64 _generator;


### PR DESCRIPTION
@tylerkaraszewski This updates `SRandom::randStr()` to not require a reference. I'm not sure why we originally implemented it this way (we being me). We have a bunch of code in Auth like this:

```c++
int64_t size = 123;
string rand = SRandom::randStr(size);
```

instead of being able to just do this:

```c++
string rand = SRandom::randStr(123):
```

### Fixed Issues
Confusing code

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
