### PR TITLE
Log if we are committing a blank query

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -657,6 +657,9 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash) {
 
     // These are the values we're currently operating on, until we either commit or rollback.
     _sharedData.prepareTransactionInfo(commitCount + 1, _uncommittedQuery, _uncommittedHash, _dbCountAtStart);
+    if (_uncommittedQuery.empty()) {
+        SINFO("Will commmit blank query");
+    }
 
     int result = SQuery(_db, "updating journal", query);
     _prepareElapsed += STimeNow() - before;


### PR DESCRIPTION
### Details
Logging when we commit a blank query

### Fixed Issues
[Fixes GH_LINK](https://github.com/Expensify/Expensify/issues/400579

### Tests
None
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
