### PR TITLE
Explicitly add back deprecated default constructors

### DIFF
--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -10,6 +10,7 @@ class SQResultRow : public vector<string> {
   public:
     SQResultRow();
     SQResultRow(SQResult& result, size_t count = 0);
+    SQResultRow(SQResultRow const&) = default;
     void push_back(const string& s);
     string& operator[](const size_t& key);
     const string& operator[](const size_t& key) const;
@@ -26,6 +27,9 @@ class SQResult {
     // Attributes
     vector<string> headers;
     vector<SQResultRow> rows;
+
+    SQResult() = default;
+    SQResult(SQResult const&) = default;
 
     // Accessors
     bool empty() const;


### PR DESCRIPTION
### Details
Not having these is deprecated. Certain tools complain.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
