### PR TITLE
[HOLD] Upgrade mbedtls to 3.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@ clean:
 mbedtls/library/libmbedcrypto.a mbedtls/library/libmbedtls.a mbedtls/library/libmbedx509.a:
 	git submodule init
 	git submodule update
-	cd mbedtls && git checkout -q v2.26.0
+	cd mbedtls && git checkout -q v3.6.0
+	cd mbedtls && git submodule update --init
 	cd mbedtls && $(MAKE) no_test
 
 # We select all of the cpp files (and manually add sqlite3.c) that will be in libstuff.

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ clean:
 mbedtls/library/libmbedcrypto.a mbedtls/library/libmbedtls.a mbedtls/library/libmbedx509.a:
 	git submodule init
 	git submodule update
-	cd mbedtls && git checkout -q v3.6.0
+	cd mbedtls && git checkout -q v3.5.2
 	cd mbedtls && git submodule update --init
 	cd mbedtls && $(MAKE) no_test
 

--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -112,7 +112,7 @@ string SSSLGetState(SSSLState* ssl) {
 #define SSLSTATE(_STATE_)                                                                                              \
     case _STATE_:                                                                                                      \
         return #_STATE_
-    switch (ssl->ssl.state) {
+    switch (ssl->ssl.private_state) {
         SSLSTATE(MBEDTLS_SSL_HELLO_REQUEST);
         SSLSTATE(MBEDTLS_SSL_CLIENT_HELLO);
         SSLSTATE(MBEDTLS_SSL_SERVER_HELLO);

--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -1,7 +1,7 @@
 #include "SSSLState.h"
 
 #include <mbedtls/error.h>
-#include <mbedtls/net.h>
+#include <mbedtls/net_sockets.h>
 
 #include <libstuff/libstuff.h>
 #include <libstuff/SFastBuffer.h>

--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -30,11 +30,9 @@ SSSLState* SSSLOpen(int s, SX509* x509) {
 
     mbedtls_ctr_drbg_seed(&state->ctr_drbg, mbedtls_entropy_func, &state->ec, 0, 0);
     mbedtls_ssl_config_defaults(&state->conf, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM, 0);
-
-    mbedtls_ssl_setup(&state->ssl, &state->conf);
-
     mbedtls_ssl_conf_authmode(&state->conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
     mbedtls_ssl_conf_rng(&state->conf, mbedtls_ctr_drbg_random, &state->ctr_drbg);
+
     mbedtls_ssl_set_bio(&state->ssl, &state->s, mbedtls_net_send, mbedtls_net_recv, 0);
 
     if (x509) {
@@ -42,6 +40,10 @@ SSSLState* SSSLOpen(int s, SX509* x509) {
         mbedtls_ssl_conf_ca_chain(&state->conf, x509->srvcert.next, 0);
         SASSERT(mbedtls_ssl_conf_own_cert(&state->conf, &x509->srvcert, &x509->pk) == 0);
     }
+
+    // Do this at the end, since we don't want to modify the conf context after we've initialized it with our ssl context.
+    mbedtls_ssl_setup(&state->ssl, &state->conf);
+
     return state;
 }
 
@@ -49,6 +51,7 @@ SSSLState* SSSLOpen(int s, SX509* x509) {
 int SSSLSend(SSSLState* sslState, const char* buffer, int length) {
     // Send as much as possible and report what happened
     SASSERT(sslState && buffer);
+
     const int numSent = mbedtls_ssl_write(&sslState->ssl, (unsigned char*)buffer, length);
     if (numSent > 0) {
         return numSent;

--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -36,7 +36,7 @@ void STCPManager::prePoll(fd_map& fdm, Socket& socket) {
             // Have we completed the handshake?
             SASSERT(socket.ssl);
             SSSLState* sslState = socket.ssl;
-            if (sslState->ssl.state == MBEDTLS_SSL_HANDSHAKE_OVER) {
+            if (sslState->ssl.private_state == MBEDTLS_SSL_HANDSHAKE_OVER) {
                 // Handshake done -- send if we have anything buffered
                 if (!socket.sendBufferEmpty()) {
                     SFDset(fdm, socket.s, SWRITEEVTS);
@@ -44,7 +44,7 @@ void STCPManager::prePoll(fd_map& fdm, Socket& socket) {
             } else {
                 // Handshake isn't done -- send if SSL wants to
                 bool write;
-                switch (sslState->ssl.state) {
+                switch (sslState->ssl.private_state) {
                 case MBEDTLS_SSL_HELLO_REQUEST:
                 case MBEDTLS_SSL_CLIENT_HELLO:
                 case MBEDTLS_SSL_CLIENT_CERTIFICATE:

--- a/libstuff/SX509.cpp
+++ b/libstuff/SX509.cpp
@@ -48,5 +48,6 @@ void SX509Close(SX509* x509) {
     // Clean up
     mbedtls_x509_crt_free(&x509->srvcert);
     mbedtls_pk_free(&x509->pk);
+    mbedtls_ctr_drbg_free(&x509->ctr_drbg);
     delete x509;
 }

--- a/libstuff/SX509.cpp
+++ b/libstuff/SX509.cpp
@@ -1,6 +1,7 @@
 #include "SX509.h"
 
 #include <cstring>
+#include <mbedtls/ctr_drbg.h>
 
 #include <libstuff/libstuff.h>
 
@@ -13,17 +14,16 @@ SX509* SX509Open() {
 // --------------------------------------------------------------------------
 SX509* SX509Open(const string& pem, const string& srvCrt, const string& caCrt) {
     // Use either the supplied credentials, or defaults for testing
-    const char* pemPtr = (pem.empty() ? mbedtls_test_srv_key : pem.c_str());
-    const char* srvCrtPtr = (srvCrt.empty() ? mbedtls_test_srv_crt : srvCrt.c_str());
-    const char* caCrtPtr = (caCrt.empty() ? mbedtls_test_ca_crt : caCrt.c_str());
+    const char* pemPtr =  pem.c_str();
+    const char* srvCrtPtr = srvCrt.c_str();
+    const char* caCrtPtr = caCrt.c_str();
 
     // Just create a fake certificate from the PolarSSL defaults
     SX509* x509 = new SX509;
     mbedtls_x509_crt_init(&(x509->srvcert));
     mbedtls_pk_init(&(x509->pk));
     try {
-        // Load and initialize this key
-        if (mbedtls_pk_parse_key(&x509->pk, (unsigned char*)pemPtr, (int)strlen(pemPtr) + 1, NULL, 0)) {
+        if (mbedtls_pk_parse_key(&x509->pk, (unsigned char*)pemPtr, (int)strlen(pemPtr) + 1, NULL, 0, mbedtls_ctr_drbg_random, NULL)) {
             STHROW("parsing key");
         }
         if (mbedtls_x509_crt_parse(&x509->srvcert, (unsigned char*)srvCrtPtr, (int)strlen(srvCrtPtr) + 1)) {

--- a/libstuff/SX509.cpp
+++ b/libstuff/SX509.cpp
@@ -14,7 +14,7 @@ SX509* SX509Open() {
 // --------------------------------------------------------------------------
 SX509* SX509Open(const string& pem, const string& srvCrt, const string& caCrt) {
     // Use either the supplied credentials, or defaults for testing
-    const char* pemPtr =  pem.c_str();
+    const char* pemPtr = pem.c_str();
     const char* srvCrtPtr = srvCrt.c_str();
     const char* caCrtPtr = caCrt.c_str();
 
@@ -23,6 +23,7 @@ SX509* SX509Open(const string& pem, const string& srvCrt, const string& caCrt) {
     mbedtls_x509_crt_init(&(x509->srvcert));
     mbedtls_pk_init(&(x509->pk));
     try {
+        // Load and initialize this key
         if (mbedtls_pk_parse_key(&x509->pk, (unsigned char*)pemPtr, (int)strlen(pemPtr) + 1, NULL, 0, mbedtls_ctr_drbg_random, NULL)) {
             STHROW("parsing key");
         }

--- a/libstuff/SX509.cpp
+++ b/libstuff/SX509.cpp
@@ -1,7 +1,6 @@
 #include "SX509.h"
 
 #include <cstring>
-#include <mbedtls/certs.h>
 
 #include <libstuff/libstuff.h>
 

--- a/libstuff/SX509.cpp
+++ b/libstuff/SX509.cpp
@@ -14,17 +14,18 @@ SX509* SX509Open() {
 // --------------------------------------------------------------------------
 SX509* SX509Open(const string& pem, const string& srvCrt, const string& caCrt) {
     // Use either the supplied credentials, or defaults for testing
-    const char* pemPtr = pem.c_str();
-    const char* srvCrtPtr = srvCrt.c_str();
-    const char* caCrtPtr = caCrt.c_str();
+    const char* pemPtr = (pem.empty() ? test_srv_key_rsa : pem.c_str());
+    const char* srvCrtPtr = (srvCrt.empty() ? test_srv_crt_rsa_sha256 : srvCrt.c_str());
+    const char* caCrtPtr = (caCrt.empty() ? test_ca_crt_rsa_sha256 : caCrt.c_str());
 
     // Just create a fake certificate from the PolarSSL defaults
     SX509* x509 = new SX509;
     mbedtls_x509_crt_init(&(x509->srvcert));
     mbedtls_pk_init(&(x509->pk));
+    mbedtls_ctr_drbg_init(&(x509->ctr_drbg));
     try {
         // Load and initialize this key
-        if (mbedtls_pk_parse_key(&x509->pk, (unsigned char*)pemPtr, (int)strlen(pemPtr) + 1, NULL, 0, mbedtls_ctr_drbg_random, NULL)) {
+        if (mbedtls_pk_parse_key(&x509->pk, (unsigned char*)pemPtr, (int)strlen(pemPtr) + 1, NULL, 0, mbedtls_ctr_drbg_random, &x509->ctr_drbg)) {
             STHROW("parsing key");
         }
         if (mbedtls_x509_crt_parse(&x509->srvcert, (unsigned char*)srvCrtPtr, (int)strlen(srvCrtPtr) + 1)) {

--- a/libstuff/SX509.h
+++ b/libstuff/SX509.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <mbedtls/ctr_drbg.h>
 #include <mbedtls/pk.h>
 #include <mbedtls/x509_crt.h>
 #include <string>
@@ -10,7 +11,85 @@ struct SX509 {
     // Attributes
     mbedtls_x509_crt srvcert;
     mbedtls_pk_context pk;
+    mbedtls_ctr_drbg_context ctr_drbg;
 };
+
+#define TEST_SRV_KEY_RSA_PEM                                                   \
+    "-----BEGIN RSA PRIVATE KEY-----\r\n"                                      \
+    "MIIEpAIBAAKCAQEAwU2j3efNHdEE10lyuJmsDnjkOjxKzzoTFtBa5M2jAIin7h5r\r\n"     \
+    "lqdStJDvLXJ6PiSa/LY0rCT1d+AmZIycsCh9odrqjObJHJa8/sEEUrM21KP64bF2\r\n"     \
+    "2JDBYbRmUjaiJlOqq3ReB30Zgtsq2B+g2Q0cLUlm91slc0boC4pPaQy1AJDh2oIQ\r\n"     \
+    "Zn2uVCuLZXmRoeJhw81ASQjuaAzxi4bSRr/QuKoRAx5/VqgaHkQYDw+Fi9qLRF7i\r\n"     \
+    "GMZiL8dmjfpd2H3zJ4kpAcWQDj8n8TDISg7v1t7HxydrxwU9esQCPJodPg/oNJhb\r\n"     \
+    "y3NLUpbYEaIsgIhpOVrTD7DeWS8Rx/fqEgEwlwIDAQABAoIBAQCXR0S8EIHFGORZ\r\n"     \
+    "++AtOg6eENxD+xVs0f1IeGz57Tjo3QnXX7VBZNdj+p1ECvhCE/G7XnkgU5hLZX+G\r\n"     \
+    "Z0jkz/tqJOI0vRSdLBbipHnWouyBQ4e/A1yIJdlBtqXxJ1KE/ituHRbNc4j4kL8Z\r\n"     \
+    "/r6pvwnTI0PSx2Eqs048YdS92LT6qAv4flbNDxMn2uY7s4ycS4Q8w1JXnCeaAnYm\r\n"     \
+    "WYI5wxO+bvRELR2Mcz5DmVnL8jRyml6l6582bSv5oufReFIbyPZbQWlXgYnpu6He\r\n"     \
+    "GTc7E1zKYQGG/9+DQUl/1vQuCPqQwny0tQoX2w5tdYpdMdVm+zkLtbajzdTviJJa\r\n"     \
+    "TWzL6lt5AoGBAN86+SVeJDcmQJcv4Eq6UhtRr4QGMiQMz0Sod6ettYxYzMgxtw28\r\n"     \
+    "CIrgpozCc+UaZJLo7UxvC6an85r1b2nKPCLQFaggJ0H4Q0J/sZOhBIXaoBzWxveK\r\n"     \
+    "nupceKdVxGsFi8CDy86DBfiyFivfBj+47BbaQzPBj7C4rK7UlLjab2rDAoGBAN2u\r\n"     \
+    "AM2gchoFiu4v1HFL8D7lweEpi6ZnMJjnEu/dEgGQJFjwdpLnPbsj4c75odQ4Gz8g\r\n"     \
+    "sw9lao9VVzbusoRE/JGI4aTdO0pATXyG7eG1Qu+5Yc1YGXcCrliA2xM9xx+d7f+s\r\n"     \
+    "mPzN+WIEg5GJDYZDjAzHG5BNvi/FfM1C9dOtjv2dAoGAF0t5KmwbjWHBhcVqO4Ic\r\n"     \
+    "BVvN3BIlc1ue2YRXEDlxY5b0r8N4XceMgKmW18OHApZxfl8uPDauWZLXOgl4uepv\r\n"     \
+    "whZC3EuWrSyyICNhLY21Ah7hbIEBPF3L3ZsOwC+UErL+dXWLdB56Jgy3gZaBeW7b\r\n"     \
+    "vDrEnocJbqCm7IukhXHOBK8CgYEAwqdHB0hqyNSzIOGY7v9abzB6pUdA3BZiQvEs\r\n"     \
+    "3LjHVd4HPJ2x0N8CgrBIWOE0q8+0hSMmeE96WW/7jD3fPWwCR5zlXknxBQsfv0gP\r\n"     \
+    "3BC5PR0Qdypz+d+9zfMf625kyit4T/hzwhDveZUzHnk1Cf+IG7Q+TOEnLnWAWBED\r\n"     \
+    "ISOWmrUCgYAFEmRxgwAc/u+D6t0syCwAYh6POtscq9Y0i9GyWk89NzgC4NdwwbBH\r\n"     \
+    "4AgahOxIxXx2gxJnq3yfkJfIjwf0s2DyP0kY2y6Ua1OeomPeY9mrIS4tCuDQ6LrE\r\n"     \
+    "TB6l9VGoxJL4fyHnZb8L5gGvnB1bbD8cL6YPaDiOhcRseC9vBiEuVg==\r\n"             \
+    "-----END RSA PRIVATE KEY-----\r\n"
+
+#define TEST_SRV_CRT_RSA_SHA256_PEM                                            \
+    "-----BEGIN CERTIFICATE-----\r\n"                                          \
+    "MIIDNzCCAh+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADA7MQswCQYDVQQGEwJOTDER\r\n"     \
+    "MA8GA1UECgwIUG9sYXJTU0wxGTAXBgNVBAMMEFBvbGFyU1NMIFRlc3QgQ0EwHhcN\r\n"     \
+    "MTkwMjEwMTQ0NDA2WhcNMjkwMjEwMTQ0NDA2WjA0MQswCQYDVQQGEwJOTDERMA8G\r\n"     \
+    "A1UECgwIUG9sYXJTU0wxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcN\r\n"     \
+    "AQEBBQADggEPADCCAQoCggEBAMFNo93nzR3RBNdJcriZrA545Do8Ss86ExbQWuTN\r\n"     \
+    "owCIp+4ea5anUrSQ7y1yej4kmvy2NKwk9XfgJmSMnLAofaHa6ozmyRyWvP7BBFKz\r\n"     \
+    "NtSj+uGxdtiQwWG0ZlI2oiZTqqt0Xgd9GYLbKtgfoNkNHC1JZvdbJXNG6AuKT2kM\r\n"     \
+    "tQCQ4dqCEGZ9rlQri2V5kaHiYcPNQEkI7mgM8YuG0ka/0LiqEQMef1aoGh5EGA8P\r\n"     \
+    "hYvai0Re4hjGYi/HZo36Xdh98yeJKQHFkA4/J/EwyEoO79bex8cna8cFPXrEAjya\r\n"     \
+    "HT4P6DSYW8tzS1KW2BGiLICIaTla0w+w3lkvEcf36hIBMJcCAwEAAaNNMEswCQYD\r\n"     \
+    "VR0TBAIwADAdBgNVHQ4EFgQUpQXoZLjc32APUBJNYKhkr02LQ5MwHwYDVR0jBBgw\r\n"     \
+    "FoAUtFrkpbPe0lL2udWmlQ/rPrzH/f8wDQYJKoZIhvcNAQELBQADggEBAC465FJh\r\n"     \
+    "Pqel7zJngHIHJrqj/wVAxGAFOTF396XKATGAp+HRCqJ81Ry60CNK1jDzk8dv6M6U\r\n"     \
+    "HoS7RIFiM/9rXQCbJfiPD5xMTejZp5n5UYHAmxsxDaazfA5FuBhkfokKK6jD4Eq9\r\n"     \
+    "1C94xGKb6X4/VkaPF7cqoBBw/bHxawXc0UEPjqayiBpCYU/rJoVZgLqFVP7Px3sv\r\n"     \
+    "a1nOrNx8rPPI1hJ+ZOg8maiPTxHZnBVLakSSLQy/sWeWyazO1RnrbxjrbgQtYKz0\r\n"     \
+    "e3nwGpu1w13vfckFmUSBhHXH7AAS/HpKC4IH7G2GAk3+n8iSSN71sZzpxonQwVbo\r\n"     \
+    "pMZqLmbBm/7WPLc=\r\n"                                                     \
+    "-----END CERTIFICATE-----\r\n"
+
+#define TEST_CA_CRT_RSA_SHA256_PEM                                             \
+    "-----BEGIN CERTIFICATE-----\r\n"                                          \
+    "MIIDQTCCAimgAwIBAgIBAzANBgkqhkiG9w0BAQsFADA7MQswCQYDVQQGEwJOTDER\r\n"     \
+    "MA8GA1UECgwIUG9sYXJTU0wxGTAXBgNVBAMMEFBvbGFyU1NMIFRlc3QgQ0EwHhcN\r\n"     \
+    "MTkwMjEwMTQ0NDAwWhcNMjkwMjEwMTQ0NDAwWjA7MQswCQYDVQQGEwJOTDERMA8G\r\n"     \
+    "A1UECgwIUG9sYXJTU0wxGTAXBgNVBAMMEFBvbGFyU1NMIFRlc3QgQ0EwggEiMA0G\r\n"     \
+    "CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDA3zf8F7vglp0/ht6WMn1EpRagzSHx\r\n"     \
+    "mdTs6st8GFgIlKXsm8WL3xoemTiZhx57wI053zhdcHgH057Zk+i5clHFzqMwUqny\r\n"     \
+    "50BwFMtEonILwuVA+T7lpg6z+exKY8C4KQB0nFc7qKUEkHHxvYPZP9al4jwqj+8n\r\n"     \
+    "YMPGn8u67GB9t+aEMr5P+1gmIgNb1LTV+/Xjli5wwOQuvfwu7uJBVcA0Ln0kcmnL\r\n"     \
+    "R7EUQIN9Z/SG9jGr8XmksrUuEvmEF/Bibyc+E1ixVA0hmnM3oTDPb5Lc9un8rNsu\r\n"     \
+    "KNF+AksjoBXyOGVkCeoMbo4bF6BxyLObyavpw/LPh5aPgAIynplYb6LVAgMBAAGj\r\n"     \
+    "UDBOMAwGA1UdEwQFMAMBAf8wHQYDVR0OBBYEFLRa5KWz3tJS9rnVppUP6z68x/3/\r\n"     \
+    "MB8GA1UdIwQYMBaAFLRa5KWz3tJS9rnVppUP6z68x/3/MA0GCSqGSIb3DQEBCwUA\r\n"     \
+    "A4IBAQA4qFSCth2q22uJIdE4KGHJsJjVEfw2/xn+MkTvCMfxVrvmRvqCtjE4tKDl\r\n"     \
+    "oK4MxFOek07oDZwvtAT9ijn1hHftTNS7RH9zd/fxNpfcHnMZXVC4w4DNA1fSANtW\r\n"     \
+    "5sY1JB5Je9jScrsLSS+mAjyv0Ow3Hb2Bix8wu7xNNrV5fIf7Ubm+wt6SqEBxu3Kb\r\n"     \
+    "+EfObAT4huf3czznhH3C17ed6NSbXwoXfby7stWUDeRJv08RaFOykf/Aae7bY5PL\r\n"     \
+    "yTVrkAnikMntJ9YI+hNNYt3inqq11A5cN0+rVTst8UKCxzQ4GpvroSwPKTFkbMw4\r\n"     \
+    "/anT1dVxr/BtwJfiESoK3/4CeXR1\r\n"                                         \
+    "-----END CERTIFICATE-----\r\n"
+
+const char test_srv_key_rsa[] = TEST_SRV_KEY_RSA_PEM;
+const char test_srv_crt_rsa_sha256[] = TEST_SRV_CRT_RSA_SHA256_PEM;
+const char test_ca_crt_rsa_sha256[] = TEST_CA_CRT_RSA_SHA256_PEM;
 
 // X509 Certificates
 extern SX509* SX509Open();

--- a/libstuff/SX509.h
+++ b/libstuff/SX509.h
@@ -6,14 +6,8 @@
 
 using namespace std;
 
-// Wraps a X509 Cert
-struct SX509 {
-    // Attributes
-    mbedtls_x509_crt srvcert;
-    mbedtls_pk_context pk;
-    mbedtls_ctr_drbg_context ctr_drbg;
-};
-
+// These were all imported from certs.c from MbedTLS, now that they do not expose these publicly.
+// They should only be used for testing purposes ONLY.
 #define TEST_SRV_KEY_RSA_PEM                                                   \
     "-----BEGIN RSA PRIVATE KEY-----\r\n"                                      \
     "MIIEpAIBAAKCAQEAwU2j3efNHdEE10lyuJmsDnjkOjxKzzoTFtBa5M2jAIin7h5r\r\n"     \
@@ -86,6 +80,15 @@ struct SX509 {
     "yTVrkAnikMntJ9YI+hNNYt3inqq11A5cN0+rVTst8UKCxzQ4GpvroSwPKTFkbMw4\r\n"     \
     "/anT1dVxr/BtwJfiESoK3/4CeXR1\r\n"                                         \
     "-----END CERTIFICATE-----\r\n"
+
+// Wraps a X509 Cert
+struct SX509 {
+    // Attributes
+    mbedtls_x509_crt srvcert;
+    mbedtls_pk_context pk;
+    // This context is necessary when parsing a cert key.
+    mbedtls_ctr_drbg_context ctr_drbg;
+};
 
 const char test_srv_key_rsa[] = TEST_SRV_KEY_RSA_PEM;
 const char test_srv_crt_rsa_sha256[] = TEST_SRV_CRT_RSA_SHA256_PEM;


### PR DESCRIPTION
Turns out 3.6.0 doesn't work with TLS v1.3 

Was trying to figure this out for awhile and got errors like https://github.com/Mbed-TLS/mbedtls/issues/9223

and internal errors, but once I downgraded to 3.5.2 it worked instantly. 

The rest is optimizations and improvements to move to 3.0+ but we'll still need to upgrade at some point to a higher version once they fix the issues. 