### PR TITLE
Add `STimestampToEpoch`

### DIFF
--- a/libstuff/STime.cpp
+++ b/libstuff/STime.cpp
@@ -19,6 +19,13 @@ string SComposeTime(const string& format, uint64_t when) {
     return string(buf, length);
 }
 
+uint64_t STimestampToEpoch(const string& format, const string& timestamp) {
+    struct tm time;
+    memset(&time, 0, sizeof(struct tm));
+    strptime(timestamp.c_str(), format.c_str(), &time);
+    return mktime(&time);
+}
+
 int SDaysInMonth(int year, int month) {
     // 30 days hath September...
     if (month == 4 || month == 6 || month == 9 || month == 11) {

--- a/libstuff/STime.cpp
+++ b/libstuff/STime.cpp
@@ -1,5 +1,6 @@
 #include "libstuff.h"
 
+#include <cstring>
 #include <sys/time.h>
 
 uint64_t STimeNow() {

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -161,6 +161,7 @@ uint64_t STimeNow();
 uint64_t STimeThisMorning(); // Timestamp for this morning at midnight GMT
 int SDaysInMonth(int year, int month);
 string SComposeTime(const string& format, uint64_t when);
+uint64_t STimestampToEpoch(const string& format, const string& timestamp);
 timeval SToTimeval(uint64_t when);
 string SFirstOfMonth(const string& timeStamp, const int64_t& offset = 0);
 


### PR DESCRIPTION
### Details
We use this in a few places in Auth so thought I'd add it to Bedrock to DRY things up a bit. See https://github.com/Expensify/Auth/pull/11569/files for more context

### Fixed Issues
Related to https://github.com/Expensify/Expensify/issues/410925

### Tests
Tested with https://github.com/Expensify/Auth/pull/11569
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
