### PR TITLE
[exploration] SQuery::prepare util

### DIFF
--- a/libstuff/SQuery.cpp
+++ b/libstuff/SQuery.cpp
@@ -1,0 +1,22 @@
+#include "SQuery.h"
+
+string SQuery::prepare(const string& query, const map<string, QuerySerializable>& params)
+{
+    string preparedQuery = query;
+    for (const auto& param: params) {
+        const string placeholder = "{" + param.first + "}";
+        string replacement;
+
+        // Use std::visit to call the correct overload of SQ
+        std::visit([&replacement](auto&& arg) {
+            replacement = SQ(arg);
+        }, param.second);
+
+        size_t pos = 0;
+        while ((pos = preparedQuery.find(placeholder, pos)) != std::string::npos) {
+            preparedQuery.replace(pos, placeholder.length(), replacement);
+            pos += replacement.length();
+        }
+    }
+    return preparedQuery;
+}

--- a/libstuff/SQuery.h
+++ b/libstuff/SQuery.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "libstuff.h"
+
+#include <string>
+#include <variant>
+
+using namespace std;
+
+class SQuery {
+    using QuerySerializable = variant<const char*, string&, int, unsigned, uint64_t, int64_t, double>;
+    static string prepare(const string& query, const map<string, QuerySerializable>& params);
+};

--- a/libstuff/SQuery.h
+++ b/libstuff/SQuery.h
@@ -8,6 +8,7 @@
 using namespace std;
 
 class SQuery {
-    using QuerySerializable = variant<const char*, string&, int, unsigned, uint64_t, int64_t, double>;
+public:
+    using QuerySerializable = variant<const char*, string, int, unsigned, uint64_t, int64_t, double>;
     static string prepare(const string& query, const map<string, QuerySerializable>& params);
 };

--- a/test/tests/SQueryTest.cpp
+++ b/test/tests/SQueryTest.cpp
@@ -1,0 +1,20 @@
+#include <libstuff/SQuery.h>
+#include <test/lib/BedrockTester.h>
+
+struct SQueryTest : tpunit::TestFixture {
+    SQueryTest() : tpunit::TestFixture(true, "SQuery",
+        TEST(SQueryTest::testPrepare)
+        )
+    {}
+
+    void testPrepare() {
+        // single param
+        ASSERT_EQUAL(SQuery::prepare("SELECT * FROM accounts WHERE accountID = {accountID};", {{"accountID", 42}}), "SELECT * FROM accounts WHERE accountID = 42;");
+
+        // multiple params
+        ASSERT_EQUAL(SQuery::prepare("SELECT * FROM reports WHERE accountID = {accountID} AND reportID = {reportID};", {{"accountID", 42}, {"reportID", 52}}), "SELECT * FROM reports WHERE accountID = 42 AND reportID = 52;");
+
+        // multiple params, multiple instances
+        ASSERT_EQUAL(SQuery::prepare("SELECT * FROM reportActions WHERE action == {actionCreated} OR (action != {actionCreated} AND created < {timestamp});", {{"actionCreated", "CREATED"}, {"timestamp", "2024-01-01 12:00:00"}}), "SELECT * FROM reportActions WHERE action == 'CREATED' OR (action != 'CREATED' AND created < '2024-01-01 12:00:00');");
+    }
+} __SQueryTest;


### PR DESCRIPTION
### Details
This is something I've wanted to write for a while - just a nicer way to write queries in a single string and bind params in a clear way. This meant to be a developer productivity boost that makes reading, writing, and editing queries easier. It works like this:

```c++
const string query = SQuery::prepare(
    "SELECT reportActionID "
    "FROM reportActions "
    "WHERE reportID = {iouReportID} "
      "AND JSON_VALID(message) "
      "AND JSON_EXTRACT(message, '$.type') == {moneyRequestCreate} "
      "AND JSON_EXTRACT(message, '$.IOUTransactionID') == {transactionID};",
    {
        {"iouReportID", IOUReportID},
        {"moneyRequestCreate", ReportAction::ACTION_MONEY_REQUEST_TYPE_CREATE},
        {"transactionID", transactionID},
    }
);
```

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
