### PR TITLE
Reduce the timeout once transaction lock is acquired

### DIFF
--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -46,6 +46,7 @@ class BedrockCommand : public SQLiteCommand {
     static const uint64_t DEFAULT_TIMEOUT = 110'000; // 110 seconds, so clients can have a 2 minutes timeout.
     static const uint64_t DEFAULT_TIMEOUT_FORGET = 60'000 * 60; // 1 hour for `connection: forget` commands.
     static const uint64_t DEFAULT_PROCESS_TIMEOUT = 30'000; // 30 seconds.
+    static const uint64_t DEFAULT_BLOCKING_TRANSACTION_COMMIT_LOCK_TIMEOUT = 10'000; // 10 seconds.
 
     // Constructor to initialize via a request object (by move).
     BedrockCommand(SQLiteCommand&& baseCommand, BedrockPlugin* plugin, bool escalateImmediately_ = false);

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -136,7 +136,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
                 STHROW("501 Failed to begin " + (exclusive ? "exclusive"s : "shared"s) + " transaction");
             }
             if (exclusive) {
-                reduceCommandTimeout(command, BedrockCommand::DEFAULT_BLOCKING_TRANSACTION_COMMIT_LOCK_TIMEOUT);
+                decreaseCommandTimeout(command, BedrockCommand::DEFAULT_BLOCKING_TRANSACTION_COMMIT_LOCK_TIMEOUT);
             }
 
             // We start the timer here to avoid including the time spent acquiring the lock _sharedData.commitLock
@@ -233,7 +233,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
                 STHROW("501 Failed to begin " + (exclusive ? "exclusive"s : "shared"s) + " transaction");
             }
             if (exclusive) {
-                reduceCommandTimeout(command, BedrockCommand::DEFAULT_BLOCKING_TRANSACTION_COMMIT_LOCK_TIMEOUT);
+                decreaseCommandTimeout(command, BedrockCommand::DEFAULT_BLOCKING_TRANSACTION_COMMIT_LOCK_TIMEOUT);
             }
         }
 
@@ -404,13 +404,13 @@ void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, c
     }
 }
 
-void BedrockCore::reduceCommandTimeout(unique_ptr<BedrockCommand>& command, uint64_t timeoutMS)
+void BedrockCore::decreaseCommandTimeout(unique_ptr<BedrockCommand>& command, uint64_t timeoutMS)
 {
     const uint64_t remainingTimeUS = _getRemainingTime(command, false);
     if ((timeoutMS * 1000ull) < remainingTimeUS) {
         command->setTimeout(timeoutMS);
         const int64_t newRemainingTimeUS = _getRemainingTime(command, false);
         _db.setTimeout(newRemainingTimeUS);
-        SINFO("Reduced timeout from " << STIMESTAMP(STimeNow() + remainingTimeUS) << " to " << STIMESTAMP(STimeNow() + newRemainingTimeUS));
+        SINFO("Decreased command timeout from " << STIMESTAMP(STimeNow() + remainingTimeUS) << " to " << STIMESTAMP(STimeNow() + newRemainingTimeUS));
     }
 }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -140,6 +140,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
                 const int64_t newTimeout = STimeNow() + BedrockCommand::DEFAULT_BLOCKING_TRANSACTION_COMMIT_LOCK_TIMEOUT;
                 if (newTimeout < oldTimeout) {
                     SINFO("Reducing blocking commit command timeout from " << STIMESTAMP(oldTimeout) << " to " << STIMESTAMP(newTimeout));
+                    command->setTimeout(newTimeout);
                     _db.setTimeout(newTimeout);
                 }
             }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -137,7 +137,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
             }
             if (exclusive) {
                 const int64_t oldTimeout = command->timeout();
-                const int64_t newTimeout = STimeNow() + BedrockCommand::DEFAULT_BLOCKING_TRANSACTION_COMMIT_LOCK_TIMEOUT;
+                const int64_t newTimeout = STimeNow() + BedrockCommand::DEFAULT_BLOCKING_TRANSACTION_COMMIT_LOCK_TIMEOUT * 1000;
                 if (newTimeout < oldTimeout) {
                     SINFO("Reducing blocking commit command timeout from " << STIMESTAMP(oldTimeout) << " to " << STIMESTAMP(newTimeout));
                     command->setTimeout(newTimeout);

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -61,6 +61,9 @@ class BedrockCore : public SQLiteCore {
 
     void postProcessCommand(unique_ptr<BedrockCommand>& command, bool isBlockingCommitThread);
 
+    // If the remaining time until timeout is bigger than timeoutMS, then the command timeout will be reduced to timeoutMS,
+    // otherwise, nothing happens
+    void reduceCommandTimeout(unique_ptr<BedrockCommand>& command, uint64_t timeoutMS);
   private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.
     string _getExceptionName();

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -61,9 +61,9 @@ class BedrockCore : public SQLiteCore {
 
     void postProcessCommand(unique_ptr<BedrockCommand>& command, bool isBlockingCommitThread);
 
-    // If the remaining time until timeout is bigger than timeoutMS, then the command timeout will be reduced to timeoutMS,
+    // If the remaining time until timeout is greater than timeoutMS, then the command timeout will be decreased to timeoutMS,
     // otherwise, nothing happens
-    void reduceCommandTimeout(unique_ptr<BedrockCommand>& command, uint64_t timeoutMS);
+    void decreaseCommandTimeout(unique_ptr<BedrockCommand>& command, uint64_t timeoutMS);
   private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.
     string _getExceptionName();


### PR DESCRIPTION
### Details

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/278636

### Tests

You can force command to go into blocking commit by applying the following changes in Bedrock:

```diff
-  commitSuccess = core.commit(*_syncNode, transactionID, transactionHash, enableOnPrepareNotifications, onPrepareHandler);
+  if (isBlocking) {
+      commitSuccess = core.commit(*_syncNode, transactionID, transactionHash, enableOnPrepareNotifications, onPrepareHandler);
+  } else {
+      SINFO("Commit conflict, rolling back. FORCED");
+      db.rollback();
+      commitSuccess = false;
+  }
```

here: https://github.com/Expensify/Bedrock/blob/fc673555031c5cb16157f5dad22f176b7625b529/BedrockServer.cpp#L999

Then, you can add some lines in the command `AddComment` to make the command slower if you send a specific message:

- In side `peek`, add: 
    ```cpp
        if (sanitizedComment == "slow peek") {
            sleep(12);
        }
    ```
- In side `process`, add: 
    ```cpp
        if (sanitizedComment == "slow process") {
            sleep(12);
        }
    ```

Finally, test:

1. Sending a message "slow peek" should make `AddCommand` timeout
1. Sending a message "slow process" should make `AddCommand` timeout
2. Sending any other message should work fine

Confirm that you see the log line:

`2024-07-26T02:10:48.635656+00:00 expensidev2004 bedrock: S5Xlxf testing-collection-merge5345@gmail.com (BedrockCore.cpp:144) peekCommand [blockingCommit] [info] Reduced timeout because of blocking commit lock from '2024-07-26 02:11:50' to '2024-07-26 02:10:58'`

Check that the new timeout (2024-07-26 01:34:57) is the same timestamp as the log line plus 10 seconds


_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
