### PR TITLE
Update `SPerformanceTimer` to log immediate

### DIFF
--- a/libstuff/SPerformanceTimer.cpp
+++ b/libstuff/SPerformanceTimer.cpp
@@ -1,11 +1,12 @@
 #include <libstuff/libstuff.h>
 #include "SPerformanceTimer.h"
 
-SPerformanceTimer::SPerformanceTimer(string description, map<string, chrono::steady_clock::duration> defaults)
+SPerformanceTimer::SPerformanceTimer(string description, bool logImmediate, map<string, chrono::steady_clock::duration> defaults)
   : _description(description),
   _lastLogStart(chrono::steady_clock::now()),
   _defaults(defaults),
-  _totals(_defaults)
+  _totals(_defaults),
+  _logImmediate(logImmediate)
 {}
 
 void SPerformanceTimer::start(const string& type) {
@@ -17,6 +18,12 @@ void SPerformanceTimer::stop() {
     // Get the time, and the time since last start.
     auto now = chrono::steady_clock::now();
     auto duration = now - _lastStart;
+
+    if (_logImmediate) {
+        double durationMS = chrono::duration_cast<chrono::duration<double, std::milli>>(duration).count();
+        SINFO(_description << " " << _lastType << " in " << durationMS << " ms.");
+        return;
+    }
 
     // Record this time.
     auto it = _totals.find(_lastType);

--- a/libstuff/SPerformanceTimer.h
+++ b/libstuff/SPerformanceTimer.h
@@ -3,7 +3,7 @@
 
 class SPerformanceTimer {
   public:
-    SPerformanceTimer(string description, map<string, chrono::steady_clock::duration> defaults = {});
+    SPerformanceTimer(string description, bool logImmediate = true, map<string, chrono::steady_clock::duration> defaults = {});
     void start(const string& type);
     void stop();
     void log(chrono::steady_clock::duration elapsed);
@@ -15,4 +15,5 @@ class SPerformanceTimer {
     string _lastType;
     map <string, chrono::steady_clock::duration> _defaults;
     map <string, chrono::steady_clock::duration> _totals;
+    bool _logImmediate;
 };

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1130,7 +1130,7 @@ int64_t SQLite::getLastConflictPage() const {
 SQLite::SharedData::SharedData() :
 nextJournalCount(0),
 _commitEnabled(true),
-_commitLockTimer("commit lock timer", {
+_commitLockTimer("commit lock timer", false, {
     {"EXCLUSIVE", chrono::steady_clock::duration::zero()},
     {"SHARED", chrono::steady_clock::duration::zero()},
 })


### PR DESCRIPTION
cc @coleaeason curious what you will say about these changes or if you have ideas on how else to do this. We appear to be using `SPerformanceTimer` in only one place. So, I decided to make it a general purpose / single use timer by default.

### Details

Related to some logging I'd like to do in slow commands for fast-apis

### Fixed Issues

Related to https://github.com/Expensify/Expensify/issues/393215

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
