### PR TITLE
Do not crash if the detach command is sent twice.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1798,8 +1798,12 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
     } else if (SIEquals(command->request.methodLine, "ConflictReport")) {
         response.content = _conflictManager.generateReport();
     } else if (SIEquals(command->request.methodLine, "Detach")) {
-        response.methodLine = "203 DETACHING";
-        _beginShutdown("Detach", true);
+        if (isDetached()) {
+            response.methodLine = "400 Already detached";
+        } else {
+            response.methodLine = "203 DETACHING";
+            _beginShutdown("Detach", true);
+        }
     } else if (SIEquals(command->request.methodLine, "Attach")) {
         // Ensure none of our plugins are blocking attaching
         list<string> blockingPlugins;

--- a/test/clustertest/tests/ControlCommandTest.cpp
+++ b/test/clustertest/tests/ControlCommandTest.cpp
@@ -8,8 +8,7 @@ struct ControlCommandTest : tpunit::TestFixture {
         : tpunit::TestFixture("ControlCommand",
                               BEFORE_CLASS(ControlCommandTest::setup),
                               AFTER_CLASS(ControlCommandTest::teardown),
-                              TEST(ControlCommandTest::testPreventAttach),
-                              TEST(ControlCommandTest::testDoubleDetach)) { }
+                              TEST(ControlCommandTest::testPreventAttach)) { }
 
     BedrockClusterTester* tester;
 
@@ -45,21 +44,6 @@ struct ControlCommandTest : tpunit::TestFixture {
         // Try to attach again, should be allowed now that the sleep in the plugin
         // has passed.
         follower.executeWaitVerifyContent(attachCommand, "204", true);
-    }
-
-    void testDoubleDetach()
-    {
-        // Test a control command
-        BedrockTester& follower = tester->getTester(1);
-
-        // Detach
-        SData detachCommand("detach");
-        follower.executeWaitVerifyContent(detachCommand, "203 DETACHING", true);
-
-        // Wait for it to detach
-        sleep(3);
-
-        follower.executeWaitVerifyContent(detachCommand, "400 Already detached", true);
     }
 
 } __ControlCommandTest;

--- a/test/clustertest/tests/ControlCommandTest.cpp
+++ b/test/clustertest/tests/ControlCommandTest.cpp
@@ -8,7 +8,8 @@ struct ControlCommandTest : tpunit::TestFixture {
         : tpunit::TestFixture("ControlCommand",
                               BEFORE_CLASS(ControlCommandTest::setup),
                               AFTER_CLASS(ControlCommandTest::teardown),
-                              TEST(ControlCommandTest::testPreventAttach)) { }
+                              TEST(ControlCommandTest::testPreventAttach),
+                              TEST(ControlCommandTest::testDoubleDetach)) { }
 
     BedrockClusterTester* tester;
 
@@ -44,6 +45,21 @@ struct ControlCommandTest : tpunit::TestFixture {
         // Try to attach again, should be allowed now that the sleep in the plugin
         // has passed.
         follower.executeWaitVerifyContent(attachCommand, "204", true);
+    }
+
+    void testDoubleDetach()
+    {
+        // Test a control command
+        BedrockTester& follower = tester->getTester(1);
+
+        // Detach
+        SData detachCommand("detach");
+        follower.executeWaitVerifyContent(detachCommand, "203 DETACHING", true);
+
+        // Wait for it to detach
+        sleep(3);
+
+        follower.executeWaitVerifyContent(detachCommand, "400 Already detached", true);
     }
 
 } __ControlCommandTest;

--- a/test/clustertest/tests/DoubleDetachTest.cpp
+++ b/test/clustertest/tests/DoubleDetachTest.cpp
@@ -1,0 +1,38 @@
+#include <iostream>
+
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
+
+struct DoubleDetachTest : tpunit::TestFixture {
+    DoubleDetachTest()
+        : tpunit::TestFixture("DoubleDetach",
+                              BEFORE_CLASS(DoubleDetachTest::setup),
+                              AFTER_CLASS(DoubleDetachTest::teardown),
+                              TEST(DoubleDetachTest::testDoubleDetach)) { }
+
+    BedrockClusterTester* tester;
+
+    void setup() {
+        tester = new BedrockClusterTester();
+    }
+
+    void teardown() {
+        delete tester;
+    }
+
+    void testDoubleDetach()
+    {
+        // Test a control command
+        BedrockTester& follower = tester->getTester(1);
+
+        // Detach
+        SData detachCommand("detach");
+        follower.executeWaitVerifyContent(detachCommand, "203 DETACHING", true);
+
+        // Wait for it to detach
+        sleep(3);
+
+        follower.executeWaitVerifyContent(detachCommand, "400 Already detached", true);
+    }
+
+} __DoubleDetachTest;


### PR DESCRIPTION
### Details
If the detach command is sent twice bedrock segfaults and crashes. As we are now implementing a process which uses the detach command I want to make this a little safer.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/396552

### Tests

<details>
<summary>Testing Before</summary>

Shell logs:
```
vagrant@expensidev2004:/vagrant$ echo -e "detach\nConnection: close\n\n" | /bin/nc.traditional localhost 9999
203 DETACHING
Connection: close
nodeName: auth
totalTime: 837
unaccountedTime: 837
Content-Length: 0

vagrant@expensidev2004:/vagrant$ echo -e "detach\nConnection: close\n\n" | /bin/nc.traditional localhost 9999
203 DETACHING
Connection: close
nodeName: auth
totalTime: 188
unaccountedTime: 188
Content-Length: 0

vagrant@expensidev2004:/vagrant$ echo -e "detach\nConnection: close\n\n" | /bin/nc.traditional localhost 9999
localhost [127.0.0.1] 9999 (?) : Connection refused
```

SystemD logs:
```
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (BedrockServer.cpp:1446) postPoll [main] [info] SHUTDOWN Have 0 socket threads and 0 commands remaining.
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:185) _SSignal_StackTrace [main] [warn] Signal Segmentation fault(11) caused crash, logging stack trace.
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #0: _SSignal_StackTrace(int, siginfo_t*, void*)
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #1: __kernel_rt_sigreturn
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #2: pthread_mutex_lock
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #3: /usr/sbin/bedrock(+0x14d394) [0xaaaacafdf394]
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #4: /usr/sbin/bedrock(+0x17dbac) [0xaaaacb00fbac]
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #5: std::recursive_mutex::lock()
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #6: std::lock_guard<std::recursive_mutex>::lock_guard(std::recursive_mutex&)
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #7: SSynchronizedQueue<bool>::push(bool&&)
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #8: SQLiteNode::notifyCommit() const
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #9: BedrockServer::postPoll(std::map<int, pollfd, std::less<int>, std::allocator<std::pair<int const, pollfd> > >&, unsigned long&)
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #10: main
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #11: __libc_start_main
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:229) _SSignal_StackTrace [main] [warn] Frame #12: /usr/sbin/bedrock(+0x133d78) [0xaaaacafc5d78]
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:237) _SSignal_StackTrace [main] [warn] Calling DIE function.
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:240) _SSignal_StackTrace [main] [warn] DIE function returned.
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:242) _SSignal_StackTrace [main] [warn] Killing peer connections.
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:249) _SSignal_StackTrace [main] [warn] Aborting.
Jul 25 23:21:19 expensidev2004 bedrock[61226]: xxxxxx (SSignal.cpp:252) _SSignal_StackTrace [main] [warn] Already in ABORT.
Jul 25 23:21:19 expensidev2004 systemd[1]: auth.service: Main process exited, code=dumped, status=6/ABRT
Jul 25 23:21:19 expensidev2004 systemd[1]: auth.service: Failed with result 'core-dump'.
```

</details>

<details>
<summary>Testing After</summary>

```
vagrant@expensidev2004:/vagrant$ echo -e "detach\nConnection: close\n\n" | /bin/nc.traditional localhost 9999
203 DETACHING
Connection: close
nodeName: auth
totalTime: 835
unaccountedTime: 835
Content-Length: 0

vagrant@expensidev2004:/vagrant$ echo -e "detach\nConnection: close\n\n" | /bin/nc.traditional localhost 9999
400 Already detached
Connection: close
nodeName: auth
totalTime: 128
unaccountedTime: 128
Content-Length: 0

vagrant@expensidev2004:/vagrant$ echo -e "detach\nConnection: close\n\n" | /bin/nc.traditional localhost 9999
400 Already detached
Connection: close
nodeName: auth
totalTime: 151
unaccountedTime: 151
Content-Length: 0
```

</details>

I also added an automated test to the `clustertest` suite.

<details><summary>Automated test results</summary>

```
vagrant@expensidev2004:/vagrant/Bedrock$ ./test/clustertest/clustertest  -only DoubleDetach
--------------
✅ DoubleDetachTest::testDoubleDetach (3104ms)

[ TEST RESULTS ] Passed: 1, Failed: 0

Slowest Test Classes:
52035ms: DoubleDetach
```

</details> 

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
