### PR TITLE
Add new test and remove warning line for sucessful matches

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2865,7 +2865,7 @@ string SREReplace(const string& regExp, const string& input, const string& repla
         if (i == 0 && result == PCRE2_ERROR_NOMEMORY) {
             // This is the expected case on the first run, there's not enough space to store the result, so we allocate the space and do it again.
             output = (char*)malloc(outSize);
-        } else if (result) {
+        } else if (result < 0) {
             SWARN("Regex replacement failed with result " << result << ", returning nothing.");
             break;
         }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2867,6 +2867,8 @@ string SREReplace(const string& regExp, const string& input, const string& repla
             output = (char*)malloc(outSize);
         } else if (result < 0) {
             SWARN("Regex replacement failed with result " << result << ", returning nothing.");
+            output = (char*)malloc(1);
+            *output = 0;
             break;
         }
     }

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -688,6 +688,11 @@ struct LibStuff : tpunit::TestFixture {
         // And test case sensitivity (enabled)
         string result3 = SREReplace("CAT", from, "dinosaur", false);
         ASSERT_EQUAL(result3, expected);
+
+        // Test match groups.
+        string from2 = "a cat did something to a dog";
+        string result4 = SREReplace("cat(.*)dog", from2, "chicken$1horse");
+        ASSERT_EQUAL(result4, "a chicken did something to a horse");
     }
 
     void SQResultTest() {


### PR DESCRIPTION
### Details

Adds test for replacements with backreferences and removes a warning when successfully matching.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/411196

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
