### PR TITLE
Only return matches when there were matches

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2826,8 +2826,8 @@ bool SREMatch(const string& regExp, const string& input, bool caseSensitive, boo
 
     int result = pcre2_match(re, (PCRE2_SPTR8)input.c_str(), input.size(), 0, matchFlags, matchData, matchContext); 
 
-    // If the caller wanted to receive matches, figure them out.
-    if (matches) {
+    // If the caller wanted to receive matches, and we have them, figure them out.
+    if (result > 0 && matches) {
         PCRE2_SIZE* ovector = pcre2_get_ovector_pointer(matchData);
         int count = pcre2_get_ovector_count(matchData);
         for (int i = 0; i < count; ++i) {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2826,6 +2826,11 @@ bool SREMatch(const string& regExp, const string& input, bool caseSensitive, boo
 
     int result = pcre2_match(re, (PCRE2_SPTR8)input.c_str(), input.size(), 0, matchFlags, matchData, matchContext); 
 
+    // Clear out existing matches.
+    if (matches) {
+        matches.clear();
+    }
+
     // If the caller wanted to receive matches, and we have them, figure them out.
     if (result > 0 && matches) {
         PCRE2_SIZE* ovector = pcre2_get_ovector_pointer(matchData);

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2828,7 +2828,7 @@ bool SREMatch(const string& regExp, const string& input, bool caseSensitive, boo
 
     // Clear out existing matches.
     if (matches) {
-        matches.clear();
+        matches->clear();
     }
 
     // If the caller wanted to receive matches, and we have them, figure them out.


### PR DESCRIPTION
### Details
Currently this will attempt to return match data ven if there are no matches, and will throw an exception.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
