### PR TITLE
Fix test compilation in clang.

### DIFF
--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -216,7 +216,6 @@ string BedrockTester::startServer(bool wait) {
 #endif
 
         // Convert our c++ strings to old-school C strings for exec.
-        //char* cargs[args.size() + 1];
         char** cargs = (char**)malloc((args.size() + 1) * sizeof(char*));
         int count = 0;
         for(string arg : args) {

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -20,7 +20,8 @@ const bool BedrockTester::ENABLE_HCTREE{false};
 
 string BedrockTester::getTempFileName(string prefix) {
     string templateStr = "/tmp/" + prefix + "bedrocktest_XXXXXX.db";
-    char buffer[templateStr.size() + 1];
+    char buffer[100];
+    memset(buffer, 0, 100);
     strcpy(buffer, templateStr.c_str());
     int filedes = mkstemps(buffer, 3);
     close(filedes);
@@ -200,22 +201,23 @@ string BedrockTester::startServer(bool wait) {
     #define xstr(a) str(a)
     #define str(a) #a
 
-    list<string> valgrind = SParseList(xstr(VALGRIND), ' ');
-    if (valgrind.size()) {
-        serverName = valgrind.front();
-        cout << "Starting bedrock server in '" << serverName << "' with args: " << endl;
-        auto it = valgrind.rbegin();
-        while (it != valgrind.rend()) {
-            args.push_front(*it);
-            it++;
+        list<string> valgrind = SParseList(xstr(VALGRIND), ' ');
+        if (valgrind.size()) {
+            serverName = valgrind.front();
+            cout << "Starting bedrock server in '" << serverName << "' with args: " << endl;
+            auto it = valgrind.rbegin();
+            while (it != valgrind.rend()) {
+                args.push_front(*it);
+                it++;
+            }
+            cout << SComposeList(args, " ") << endl;
+            cout << "==========================" << endl;
         }
-        cout << SComposeList(args, " ") << endl;
-        cout << "==========================" << endl;
-    }
 #endif
 
         // Convert our c++ strings to old-school C strings for exec.
-        char* cargs[args.size() + 1];
+        //char* cargs[args.size() + 1];
+        char** cargs = (char**)malloc((args.size() + 1) * sizeof(char*));
         int count = 0;
         for(string arg : args) {
             char* newstr = (char*)malloc(arg.size() + 1);
@@ -340,7 +342,7 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
 
     // Spawn a thread for each connection.
     for (int i = 0; i < connections; i++) {
-        threads.emplace_back([&, i](){
+        threads.emplace_back([&](){
             int socket = 0;
 
             // This continues until there are no more requests to process.

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -92,6 +92,9 @@ void tpunit::_TestFixture::registerTests(method* m0,  method* m1,  method* m2,  
     _mutex    = 0;
 }
 
+tpunit::TestFixture::~TestFixture() {
+}
+
 tpunit::_TestFixture::~_TestFixture() {
     delete _afters;
     delete _after_classes;

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -15,7 +15,12 @@ thread_local int tpunit::TestFixture::perFixtureStats::_exceptions = 0;
 thread_local int tpunit::TestFixture::perFixtureStats::_traces = 0;
 
 tpunit::TestFixture::method::method(TestFixture* obj, void (TestFixture::*addr)(), const char* name, unsigned char type)
+// The following pragma lines disable a specific uninitialized variable warning specifically for clang. Ideally we remove this,
+// but it likely means changing the way we invoke every single test (not just in bedrock, but all other repos that use this test framework).
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wuninitialized"
     : _this(obj)
+#pragma clang diagnostic pop
     , _addr(addr)
     , _type(type)
     , _next(0) {

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -5,22 +5,17 @@
 #include <chrono>
 using namespace tpunit;
 
-bool tpunit::TestFixture::exitFlag = false;
+bool tpunit::_TestFixture::exitFlag = false;
 thread_local string tpunit::currentTestName;
-thread_local tpunit::TestFixture* tpunit::currentTestPtr = nullptr;
+thread_local tpunit::_TestFixture* tpunit::currentTestPtr = nullptr;
 thread_local mutex tpunit::currentTestNameMutex;
 
-thread_local int tpunit::TestFixture::perFixtureStats::_assertions = 0;
-thread_local int tpunit::TestFixture::perFixtureStats::_exceptions = 0;
-thread_local int tpunit::TestFixture::perFixtureStats::_traces = 0;
+thread_local int tpunit::_TestFixture::perFixtureStats::_assertions = 0;
+thread_local int tpunit::_TestFixture::perFixtureStats::_exceptions = 0;
+thread_local int tpunit::_TestFixture::perFixtureStats::_traces = 0;
 
-tpunit::TestFixture::method::method(TestFixture* obj, void (TestFixture::*addr)(), const char* name, unsigned char type)
-// The following pragma lines disable a specific uninitialized variable warning specifically for clang. Ideally we remove this,
-// but it likely means changing the way we invoke every single test (not just in bedrock, but all other repos that use this test framework).
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wuninitialized"
+tpunit::_TestFixture::method::method(_TestFixture* obj, void (_TestFixture::*addr)(), const char* name, unsigned char type)
     : _this(obj)
-#pragma clang diagnostic pop
     , _addr(addr)
     , _type(type)
     , _next(0) {
@@ -31,20 +26,26 @@ tpunit::TestFixture::method::method(TestFixture* obj, void (TestFixture::*addr)(
         *dest = 0;
 }
 
-tpunit::TestFixture::method::~method() {
+tpunit::_TestFixture::method::~method() {
     delete _next;
 }
 
-tpunit::TestFixture::stats::stats()
+tpunit::_TestFixture::stats::stats()
     : _failures(0)
     , _passes(0)
     {}
 
-tpunit::TestFixture::perFixtureStats::perFixtureStats()
+tpunit::_TestFixture::perFixtureStats::perFixtureStats()
 {
 }
 
-tpunit::TestFixture::TestFixture(method* m0,  method* m1,  method* m2,  method* m3,  method* m4,
+tpunit::_TestFixture::_TestFixture(const char* name, bool parallel)
+  : _name(name),
+    _parallel(parallel)
+{
+}
+
+void tpunit::_TestFixture::registerTests(method* m0,  method* m1,  method* m2,  method* m3,  method* m4,
                          method* m5,  method* m6,  method* m7,  method* m8,  method* m9,
                          method* m10, method* m11, method* m12, method* m13, method* m14,
                          method* m15, method* m16, method* m17, method* m18, method* m19,
@@ -57,10 +58,7 @@ tpunit::TestFixture::TestFixture(method* m0,  method* m1,  method* m2,  method* 
                          method* m50, method* m51, method* m52, method* m53, method* m54,
                          method* m55, method* m56, method* m57, method* m58, method* m59,
                          method* m60, method* m61, method* m62, method* m63, method* m64,
-                         method* m65, method* m66, method* m67, method* m68, method* m69,
-                         const char* name, bool parallel)
-  : _name(name),
-    _parallel(parallel)
+                         method* m65, method* m66, method* m67, method* m68, method* m69)
 {
     tpunit_detail_fixture_list()->push_back(this);
 
@@ -94,7 +92,7 @@ tpunit::TestFixture::TestFixture(method* m0,  method* m1,  method* m2,  method* 
     _mutex    = 0;
 }
 
-tpunit::TestFixture::~TestFixture() {
+tpunit::_TestFixture::~_TestFixture() {
     delete _afters;
     delete _after_classes;
     delete _befores;
@@ -102,13 +100,13 @@ tpunit::TestFixture::~TestFixture() {
     delete _tests;
 }
 
-int tpunit::TestFixture::tpunit_detail_do_run(int threads, std::function<void()> threadInitFunction) {
+int tpunit::_TestFixture::tpunit_detail_do_run(int threads, std::function<void()> threadInitFunction) {
     const std::set<std::string> include, exclude;
     const std::list<std::string> before, after;
     return tpunit_detail_do_run(include, exclude, before, after, threads, threadInitFunction);
 }
 
-void tpunit::TestFixture::tpunit_run_test_class(TestFixture* f) {
+void tpunit::_TestFixture::tpunit_run_test_class(_TestFixture* f) {
    f->_stats._assertions = 0;
    f->_stats._exceptions = 0;
    tpunit_detail_do_methods(f->_before_classes);
@@ -129,7 +127,7 @@ void tpunit::TestFixture::tpunit_run_test_class(TestFixture* f) {
    }
 }
 
-int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const set<string>& exclude,
+int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const set<string>& exclude,
                                               const list<string>& before, const list<string>& after, int threads,
                                               std::function<void()> threadInitFunction) {
    threadInitFunction();
@@ -138,8 +136,8 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
     * run unless it's in 'exclude'. If 'include' has at least one entry,
     * then only tests in 'include' are run, and 'exclude' is ignored.
     */
-    std::list<TestFixture*> testFixtureList = *tpunit_detail_fixture_list();
-    testFixtureList.sort([&](TestFixture* a, TestFixture* b) {
+    std::list<_TestFixture*> testFixtureList = *tpunit_detail_fixture_list();
+    testFixtureList.sort([&](_TestFixture* a, _TestFixture* b) {
         if (a->_name && b->_name) {
             return strcmp(a->_name, b->_name) < 0;
         }
@@ -179,7 +177,7 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
         _exclude.insert(name);
     }
 
-    list<TestFixture*> afterTests;
+    list<_TestFixture*> afterTests;
     mutex testTimeLock;
     multimap<chrono::milliseconds, string> testTimes;
 
@@ -193,7 +191,7 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
             try {
                 // Do test.
                 while (1) {
-                    TestFixture* f = 0;
+                    _TestFixture* f = 0;
                     {
                         lock_guard<recursive_mutex> lock(m);
                         if (testFixtureList.empty()) {
@@ -333,7 +331,7 @@ int tpunit::TestFixture::tpunit_detail_do_run(const set<string>& include, const 
     return 1;
 }
 
-bool tpunit::TestFixture::tpunit_detail_fp_equal(float lhs, float rhs, unsigned char ulps) {
+bool tpunit::_TestFixture::tpunit_detail_fp_equal(float lhs, float rhs, unsigned char ulps) {
     union {
        float f;
        char  c[4];
@@ -360,7 +358,7 @@ bool tpunit::TestFixture::tpunit_detail_fp_equal(float lhs, float rhs, unsigned 
            ((lhs_u.c[lsb] > rhs_u.c[lsb]) ? lhs_u.c[lsb] - rhs_u.c[lsb] : rhs_u.c[lsb] - lhs_u.c[lsb]) <= ulps;
 }
 
-bool tpunit::TestFixture::tpunit_detail_fp_equal(double lhs, double rhs, unsigned char ulps) {
+bool tpunit::_TestFixture::tpunit_detail_fp_equal(double lhs, double rhs, unsigned char ulps) {
     union {
        double d;
        char   c[8];
@@ -398,25 +396,25 @@ bool tpunit::TestFixture::tpunit_detail_fp_equal(double lhs, double rhs, unsigne
            ((lhs_u.c[lsb] > rhs_u.c[lsb]) ? lhs_u.c[lsb] - rhs_u.c[lsb] : rhs_u.c[lsb] - lhs_u.c[lsb]) <= ulps;
 }
 
-void tpunit::TestFixture::tpunit_detail_assert(TestFixture* f, const char* _file, int _line) {
+void tpunit::_TestFixture::tpunit_detail_assert(_TestFixture* f, const char* _file, int _line) {
     lock_guard<recursive_mutex> lock(*(f->_mutex));
     printf("   assertion #%i at %s:%i\n", ++f->_stats._assertions, _file, _line);
     f->printTestBuffer();
 }
 
-void tpunit::TestFixture::tpunit_detail_exception(TestFixture* f, method* _method, const char* _message) {
+void tpunit::_TestFixture::tpunit_detail_exception(_TestFixture* f, method* _method, const char* _message) {
     lock_guard<recursive_mutex> lock(*(f->_mutex));
     printf("   exception #%i from %s with cause: %s\n", ++f->_stats._exceptions, _method->_name, _message);
     f->printTestBuffer();
 }
 
-void tpunit::TestFixture::tpunit_detail_trace(TestFixture* f, const char* _file, int _line, const char* _message) {
+void tpunit::_TestFixture::tpunit_detail_trace(_TestFixture* f, const char* _file, int _line, const char* _message) {
     lock_guard<recursive_mutex> lock(*(f->_mutex));
     printf("   trace #%i at %s:%i: %s\n", ++f->_stats._traces, _file, _line, _message);
     f->printTestBuffer();
 }
 
-void tpunit::TestFixture::tpunit_detail_do_method(tpunit::TestFixture::method* m) {
+void tpunit::_TestFixture::tpunit_detail_do_method(tpunit::_TestFixture::method* m) {
     try {
        // If we're exiting, then don't try and run any more tests.
        if (exitFlag) {
@@ -438,14 +436,14 @@ void tpunit::TestFixture::tpunit_detail_do_method(tpunit::TestFixture::method* m
     }
 }
 
-void tpunit::TestFixture::tpunit_detail_do_methods(tpunit::TestFixture::method* m) {
+void tpunit::_TestFixture::tpunit_detail_do_methods(tpunit::_TestFixture::method* m) {
     while (m) {
        tpunit_detail_do_method(m);
        m = m->_next;
     }
 }
 
-void tpunit::TestFixture::tpunit_detail_do_tests(TestFixture* f) {
+void tpunit::_TestFixture::tpunit_detail_do_tests(_TestFixture* f) {
     method* t = f->_tests;
     list<thread> testThreads;
     while(t) {
@@ -499,35 +497,35 @@ void tpunit::TestFixture::tpunit_detail_do_tests(TestFixture* f) {
     }
 }
 
-void tpunit::TestFixture::TESTINFO(const string& newLog) {
+void tpunit::_TestFixture::TESTINFO(const string& newLog) {
     lock_guard<recursive_mutex> lock(*(_mutex));
 
     // Format the buffer with an indent as we print it out.
     testOutputBuffer += "    " + newLog + "\n";
 }
 
-void tpunit::TestFixture::printTestBuffer() {
+void tpunit::_TestFixture::printTestBuffer() {
     lock_guard<recursive_mutex> lock(*(_mutex));
 
     cout << testOutputBuffer;
     testOutputBuffer = "";
 }
 
-tpunit::TestFixture::stats& tpunit::TestFixture::tpunit_detail_stats() {
+tpunit::_TestFixture::stats& tpunit::_TestFixture::tpunit_detail_stats() {
     static stats _stats;
     return _stats;
 }
 
-list<tpunit::TestFixture*>* tpunit::TestFixture::tpunit_detail_fixture_list() {
-    static list<TestFixture*>* _fixtureList = new list<TestFixture*>;
+list<tpunit::_TestFixture*>* tpunit::_TestFixture::tpunit_detail_fixture_list() {
+    static list<_TestFixture*>* _fixtureList = new list<_TestFixture*>;
     return _fixtureList;
 }
 
 int tpunit::Tests::run(int threads, std::function<void()> threadInitFunction) {
-    return TestFixture::tpunit_detail_do_run(threads, threadInitFunction);
+    return _TestFixture::tpunit_detail_do_run(threads, threadInitFunction);
 }
 
 int tpunit::Tests::run(const set<string>& include, const set<string>& exclude,
                        const list<string>& before, const list<string>& after, int threads, std::function<void()> threadInitFunction) {
-    return TestFixture::tpunit_detail_do_run(include, exclude, before, after, threads, threadInitFunction);
+    return _TestFixture::tpunit_detail_do_run(include, exclude, before, after, threads, threadInitFunction);
 }

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -60,10 +60,10 @@ using namespace std;
  * TRACE(message); adds a trace to the test output with a user
  * specified string message.
  */
-#define ABORT() tpunit::TestFixture::tpunit_detail_assert(tpunit::currentTestPtr, __FILE__, __LINE__); return;
-#define FAIL()  tpunit::TestFixture::tpunit_detail_assert(tpunit::currentTestPtr, __FILE__, __LINE__);
+#define ABORT() tpunit::_TestFixture::tpunit_detail_assert(tpunit::currentTestPtr, __FILE__, __LINE__); return;
+#define FAIL()  tpunit::_TestFixture::tpunit_detail_assert(tpunit::currentTestPtr, __FILE__, __LINE__);
 #define PASS()  /* do nothing */
-#define TRACE(message) tpunit::TestFixture::tpunit_detail_trace(tpunit::currentTestPtr, __FILE__, __LINE__, message);
+#define TRACE(message) tpunit::_TestFixture::tpunit_detail_trace(tpunit::currentTestPtr, __FILE__, __LINE__, message);
 
 /**
  * The set of core macros for basic predicate testing of boolean
@@ -196,10 +196,10 @@ namespace tpunit {
 
    /**
     * The primary class that provides the integration point for creating user
-    * defined test cases. To get started one only needs to derive from TestFixture,
+    * defined test cases. To get started one only needs to derive from _TestFixture,
     * define a few test methods and register them with the base constructor.
     */
-   class TestFixture {
+   class _TestFixture {
       public:
 
          static bool exitFlag;
@@ -224,12 +224,12 @@ namespace tpunit {
           * Internal class encapsulating a registered test method.
           */
          struct method {
-            method(TestFixture* obj, void (TestFixture::*addr)(), const char* name, unsigned char type);
+            method(_TestFixture* obj, void (_TestFixture::*addr)(), const char* name, unsigned char type);
 
             ~method();
 
-            TestFixture* _this;
-            void (TestFixture::*_addr)();
+            _TestFixture* _this;
+            void (_TestFixture::*_addr)();
             char _name[1024];
 
             enum {
@@ -255,82 +255,24 @@ namespace tpunit {
 
       public:
 
-         // Use constructor delegation to add an optional default 'name' parameter that works as a first argument.
-         // This lets us keep backwards compatibility with existing tests, and add a name to new tests without having
-         // to add 70 '0's for a bunch of unused methods.
-         // DO NOT ADD MORE THAN 70 METHODS TO A TEST FIXTURE. If you need more, split the test file into multiple files
-         // so that you can run these tests more efficiently in parallel.
-         TestFixture(const char* name,
-                     method* m0,      method* m1  = 0, method* m2  = 0, method* m3  = 0, method* m4  = 0,
-                     method* m5  = 0, method* m6  = 0, method* m7  = 0, method* m8  = 0, method* m9  = 0,
-                     method* m10 = 0, method* m11 = 0, method* m12 = 0, method* m13 = 0, method* m14 = 0,
-                     method* m15 = 0, method* m16 = 0, method* m17 = 0, method* m18 = 0, method* m19 = 0,
-                     method* m20 = 0, method* m21 = 0, method* m22 = 0, method* m23 = 0, method* m24 = 0,
-                     method* m25 = 0, method* m26 = 0, method* m27 = 0, method* m28 = 0, method* m29 = 0,
-                     method* m30 = 0, method* m31 = 0, method* m32 = 0, method* m33 = 0, method* m34 = 0,
-                     method* m35 = 0, method* m36 = 0, method* m37 = 0, method* m38 = 0, method* m39 = 0,
-                     method* m40 = 0, method* m41 = 0, method* m42 = 0, method* m43 = 0, method* m44 = 0,
-                     method* m45 = 0, method* m46 = 0, method* m47 = 0, method* m48 = 0, method* m49 = 0,
-                     method* m50 = 0, method* m51 = 0, method* m52 = 0, method* m53 = 0, method* m54 = 0,
-                     method* m55 = 0, method* m56 = 0, method* m57 = 0, method* m58 = 0, method* m59 = 0,
-                     method* m60 = 0, method* m61 = 0, method* m62 = 0, method* m63 = 0, method* m64 = 0,
-                     method* m65 = 0, method* m66 = 0, method* m67 = 0, method* m68 = 0, method* m69 = 0)
-                     : TestFixture( m0,  m1,  m2,  m3,  m4,  m5,  m6,  m7,  m8,  m9,
-                                    m10, m11, m12, m13, m14, m15, m16, m17, m18, m19,
-                                    m20, m21, m22, m23, m24, m25, m26, m27, m28, m29,
-                                    m30, m31, m32, m33, m34, m35, m36, m37, m38, m39,
-                                    m40, m41, m42, m43, m44, m45, m46, m47, m48, m49,
-                                    m50, m51, m52, m53, m54, m55, m56, m57, m58, m59,
-                                    m60, m61, m62, m63, m64, m65, m66, m67, m68, m69, name) { }
+         _TestFixture(const char* name, bool parallel);
 
-         TestFixture(bool parallel, const char* name,
-                     method* m0,      method* m1  = 0, method* m2  = 0, method* m3  = 0, method* m4  = 0,
-                     method* m5  = 0, method* m6  = 0, method* m7  = 0, method* m8  = 0, method* m9  = 0,
-                     method* m10 = 0, method* m11 = 0, method* m12 = 0, method* m13 = 0, method* m14 = 0,
-                     method* m15 = 0, method* m16 = 0, method* m17 = 0, method* m18 = 0, method* m19 = 0,
-                     method* m20 = 0, method* m21 = 0, method* m22 = 0, method* m23 = 0, method* m24 = 0,
-                     method* m25 = 0, method* m26 = 0, method* m27 = 0, method* m28 = 0, method* m29 = 0,
-                     method* m30 = 0, method* m31 = 0, method* m32 = 0, method* m33 = 0, method* m34 = 0,
-                     method* m35 = 0, method* m36 = 0, method* m37 = 0, method* m38 = 0, method* m39 = 0,
-                     method* m40 = 0, method* m41 = 0, method* m42 = 0, method* m43 = 0, method* m44 = 0,
-                     method* m45 = 0, method* m46 = 0, method* m47 = 0, method* m48 = 0, method* m49 = 0,
-                     method* m50 = 0, method* m51 = 0, method* m52 = 0, method* m53 = 0, method* m54 = 0,
-                     method* m55 = 0, method* m56 = 0, method* m57 = 0, method* m58 = 0, method* m59 = 0,
-                     method* m60 = 0, method* m61 = 0, method* m62 = 0, method* m63 = 0, method* m64 = 0,
-                     method* m65 = 0, method* m66 = 0, method* m67 = 0, method* m68 = 0, method* m69 = 0)
-                     : TestFixture( m0,  m1,  m2,  m3,  m4,  m5,  m6,  m7,  m8,  m9,
-                                    m10, m11, m12, m13, m14, m15, m16, m17, m18, m19,
-                                    m20, m21, m22, m23, m24, m25, m26, m27, m28, m29,
-                                    m30, m31, m32, m33, m34, m35, m36, m37, m38, m39,
-                                    m40, m41, m42, m43, m44, m45, m46, m47, m48, m49,
-                                    m50, m51, m52, m53, m54, m55, m56, m57, m58, m59,
-                                    m60, m61, m62, m63, m64, m65, m66, m67, m68, m69, name, parallel) { }
+         void registerTests(method* m0,       method* m1 = 0, method* m2  = 0, method* m3  = 0, method* m4  = 0,
+                            method* m5  = 0, method* m6  = 0, method* m7  = 0, method* m8  = 0, method* m9  = 0,
+                            method* m10 = 0, method* m11 = 0, method* m12 = 0, method* m13 = 0, method* m14 = 0,
+                            method* m15 = 0, method* m16 = 0, method* m17 = 0, method* m18 = 0, method* m19 = 0,
+                            method* m20 = 0, method* m21 = 0, method* m22 = 0, method* m23 = 0, method* m24 = 0,
+                            method* m25 = 0, method* m26 = 0, method* m27 = 0, method* m28 = 0, method* m29 = 0,
+                            method* m30 = 0, method* m31 = 0, method* m32 = 0, method* m33 = 0, method* m34 = 0,
+                            method* m35 = 0, method* m36 = 0, method* m37 = 0, method* m38 = 0, method* m39 = 0,
+                            method* m40 = 0, method* m41 = 0, method* m42 = 0, method* m43 = 0, method* m44 = 0,
+                            method* m45 = 0, method* m46 = 0, method* m47 = 0, method* m48 = 0, method* m49 = 0,
+                            method* m50 = 0, method* m51 = 0, method* m52 = 0, method* m53 = 0, method* m54 = 0,
+                            method* m55 = 0, method* m56 = 0, method* m57 = 0, method* m58 = 0, method* m59 = 0,
+                            method* m60 = 0, method* m61 = 0, method* m62 = 0, method* m63 = 0, method* m64 = 0,
+                            method* m65 = 0, method* m66 = 0, method* m67 = 0, method* m68 = 0, method* m69 = 0);
 
-         /**
-          * Base constructor to register methods with the test fixture. A test
-          * fixture can register up to 70 methods. DO NOT expand this beyond 70 tests.
-          * Split your tests into more files/suites if you need more than 70 tests
-          * so that you can run these tests more efficiently in parallel.
-          *
-          * @param[in] m0..m49 The methods to register with the test fixture.
-          */
-         TestFixture(method* m0,      method* m1  = 0, method* m2  = 0, method* m3  = 0, method* m4  = 0,
-                     method* m5  = 0, method* m6  = 0, method* m7  = 0, method* m8  = 0, method* m9  = 0,
-                     method* m10 = 0, method* m11 = 0, method* m12 = 0, method* m13 = 0, method* m14 = 0,
-                     method* m15 = 0, method* m16 = 0, method* m17 = 0, method* m18 = 0, method* m19 = 0,
-                     method* m20 = 0, method* m21 = 0, method* m22 = 0, method* m23 = 0, method* m24 = 0,
-                     method* m25 = 0, method* m26 = 0, method* m27 = 0, method* m28 = 0, method* m29 = 0,
-                     method* m30 = 0, method* m31 = 0, method* m32 = 0, method* m33 = 0, method* m34 = 0,
-                     method* m35 = 0, method* m36 = 0, method* m37 = 0, method* m38 = 0, method* m39 = 0,
-                     method* m40 = 0, method* m41 = 0, method* m42 = 0, method* m43 = 0, method* m44 = 0,
-                     method* m45 = 0, method* m46 = 0, method* m47 = 0, method* m48 = 0, method* m49 = 0,
-                     method* m50 = 0, method* m51 = 0, method* m52 = 0, method* m53 = 0, method* m54 = 0,
-                     method* m55 = 0, method* m56 = 0, method* m57 = 0, method* m58 = 0, method* m59 = 0,
-                     method* m60 = 0, method* m61 = 0, method* m62 = 0, method* m63 = 0, method* m64 = 0,
-                     method* m65 = 0, method* m66 = 0, method* m67 = 0, method* m68 = 0, method* m69 = 0,
-                     const char* name = 0, bool parallel = false);
-
-         ~TestFixture();
+         ~_TestFixture();
 
          /**
           * Create a new method to register with the test fixture.
@@ -340,7 +282,7 @@ namespace tpunit {
           */
          template <typename C>
          method* Method(void (C::*_method)(), const char* _name, unsigned char _type) {
-            return new method(this, static_cast<void (TestFixture::*)()>(_method), _name, _type);
+            return new method(this, static_cast<void (_TestFixture::*)()>(_method), _name, _type);
          }
 
          static int tpunit_detail_do_run(int threads = 1, std::function<void()> threadInitFunction = [](){});
@@ -355,11 +297,11 @@ namespace tpunit {
           */
          void TESTINFO(const string& newLog);
 
-         static void tpunit_detail_assert(TestFixture* f, const char* _file, int _line);
+         static void tpunit_detail_assert(_TestFixture* f, const char* _file, int _line);
 
-         static void tpunit_detail_exception(TestFixture* f, method* _method, const char* _message);
+         static void tpunit_detail_exception(_TestFixture* f, method* _method, const char* _message);
 
-         static void tpunit_detail_trace(TestFixture* f, const char* _file, int _line, const char* _message);
+         static void tpunit_detail_trace(_TestFixture* f, const char* _file, int _line, const char* _message);
 
       protected:
 
@@ -385,17 +327,17 @@ namespace tpunit {
 
       private:
 
-         static void tpunit_run_test_class(TestFixture*);
+         static void tpunit_run_test_class(_TestFixture*);
 
          static void tpunit_detail_do_method(method* m);
 
          static void tpunit_detail_do_methods(method* m);
 
-         static void tpunit_detail_do_tests(TestFixture* f);
+         static void tpunit_detail_do_tests(_TestFixture* f);
 
          static stats& tpunit_detail_stats();
 
-         static std::list<TestFixture*>* tpunit_detail_fixture_list();
+         static std::list<_TestFixture*>* tpunit_detail_fixture_list();
 
          /**
           * Takes the test buffer and outputs it to cout
@@ -412,7 +354,85 @@ namespace tpunit {
          bool _multiThreaded;
    };
 
-   extern thread_local tpunit::TestFixture* currentTestPtr;
+   class TestFixture : public _TestFixture {
+public:
+         // Use constructor delegation to add an optional default 'name' parameter that works as a first argument.
+         // This lets us keep backwards compatibility with existing tests, and add a name to new tests without having
+         // to add 70 '0's for a bunch of unused methods.
+         // DO NOT ADD MORE THAN 70 METHODS TO A TEST FIXTURE. If you need more, split the test file into multiple files
+         // so that you can run these tests more efficiently in parallel.
+         TestFixture(const char* name,
+                     method* m0,      method* m1  = 0, method* m2  = 0, method* m3  = 0, method* m4  = 0,
+                     method* m5  = 0, method* m6  = 0, method* m7  = 0, method* m8  = 0, method* m9  = 0,
+                     method* m10 = 0, method* m11 = 0, method* m12 = 0, method* m13 = 0, method* m14 = 0,
+                     method* m15 = 0, method* m16 = 0, method* m17 = 0, method* m18 = 0, method* m19 = 0,
+                     method* m20 = 0, method* m21 = 0, method* m22 = 0, method* m23 = 0, method* m24 = 0,
+                     method* m25 = 0, method* m26 = 0, method* m27 = 0, method* m28 = 0, method* m29 = 0,
+                     method* m30 = 0, method* m31 = 0, method* m32 = 0, method* m33 = 0, method* m34 = 0,
+                     method* m35 = 0, method* m36 = 0, method* m37 = 0, method* m38 = 0, method* m39 = 0,
+                     method* m40 = 0, method* m41 = 0, method* m42 = 0, method* m43 = 0, method* m44 = 0,
+                     method* m45 = 0, method* m46 = 0, method* m47 = 0, method* m48 = 0, method* m49 = 0,
+                     method* m50 = 0, method* m51 = 0, method* m52 = 0, method* m53 = 0, method* m54 = 0,
+                     method* m55 = 0, method* m56 = 0, method* m57 = 0, method* m58 = 0, method* m59 = 0,
+                     method* m60 = 0, method* m61 = 0, method* m62 = 0, method* m63 = 0, method* m64 = 0,
+                     method* m65 = 0, method* m66 = 0, method* m67 = 0, method* m68 = 0, method* m69 = 0)
+                : _TestFixture(name, false)
+         {
+                    registerTests(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, m22, m23, m24, m25, m26, m27, m28, m29, m30, m31, m32, m33, m34, m35, m36, m37, m38, m39, m40, m41, m42, m43, m44, m45, m46, m47, m48, m49, m50, m51, m52, m53, m54, m55, m56, m57, m58, m59, m60, m61, m62, m63, m64, m65, m66, m67, m68, m69);
+         }
+
+         TestFixture(bool parallel, const char* name,
+                     method* m0,      method* m1  = 0, method* m2  = 0, method* m3  = 0, method* m4  = 0,
+                     method* m5  = 0, method* m6  = 0, method* m7  = 0, method* m8  = 0, method* m9  = 0,
+                     method* m10 = 0, method* m11 = 0, method* m12 = 0, method* m13 = 0, method* m14 = 0,
+                     method* m15 = 0, method* m16 = 0, method* m17 = 0, method* m18 = 0, method* m19 = 0,
+                     method* m20 = 0, method* m21 = 0, method* m22 = 0, method* m23 = 0, method* m24 = 0,
+                     method* m25 = 0, method* m26 = 0, method* m27 = 0, method* m28 = 0, method* m29 = 0,
+                     method* m30 = 0, method* m31 = 0, method* m32 = 0, method* m33 = 0, method* m34 = 0,
+                     method* m35 = 0, method* m36 = 0, method* m37 = 0, method* m38 = 0, method* m39 = 0,
+                     method* m40 = 0, method* m41 = 0, method* m42 = 0, method* m43 = 0, method* m44 = 0,
+                     method* m45 = 0, method* m46 = 0, method* m47 = 0, method* m48 = 0, method* m49 = 0,
+                     method* m50 = 0, method* m51 = 0, method* m52 = 0, method* m53 = 0, method* m54 = 0,
+                     method* m55 = 0, method* m56 = 0, method* m57 = 0, method* m58 = 0, method* m59 = 0,
+                     method* m60 = 0, method* m61 = 0, method* m62 = 0, method* m63 = 0, method* m64 = 0,
+                     method* m65 = 0, method* m66 = 0, method* m67 = 0, method* m68 = 0, method* m69 = 0)
+                : _TestFixture(name, parallel)
+         {
+            registerTests(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, m22, m23, m24, m25, m26, m27, m28, m29, m30, m31, m32, m33, m34, m35, m36, m37, m38, m39, m40, m41, m42, m43, m44, m45, m46, m47, m48, m49, m50, m51, m52, m53, m54, m55, m56, m57, m58, m59, m60, m61, m62, m63, m64, m65, m66, m67, m68, m69);
+         }
+
+         /**
+          * Base constructor to register methods with the test fixture. A test
+          * fixture can register up to 70 methods. DO NOT expand this beyond 70 tests.
+          * Split your tests into more files/suites if you need more than 70 tests
+          * so that you can run these tests more efficiently in parallel.
+          *
+          * @param[in] m0..m49 The methods to register with the test fixture.
+          */
+         TestFixture(method* m0,      method* m1  = 0, method* m2  = 0, method* m3  = 0, method* m4  = 0,
+                     method* m5  = 0, method* m6  = 0, method* m7  = 0, method* m8  = 0, method* m9  = 0,
+                     method* m10 = 0, method* m11 = 0, method* m12 = 0, method* m13 = 0, method* m14 = 0,
+                     method* m15 = 0, method* m16 = 0, method* m17 = 0, method* m18 = 0, method* m19 = 0,
+                     method* m20 = 0, method* m21 = 0, method* m22 = 0, method* m23 = 0, method* m24 = 0,
+                     method* m25 = 0, method* m26 = 0, method* m27 = 0, method* m28 = 0, method* m29 = 0,
+                     method* m30 = 0, method* m31 = 0, method* m32 = 0, method* m33 = 0, method* m34 = 0,
+                     method* m35 = 0, method* m36 = 0, method* m37 = 0, method* m38 = 0, method* m39 = 0,
+                     method* m40 = 0, method* m41 = 0, method* m42 = 0, method* m43 = 0, method* m44 = 0,
+                     method* m45 = 0, method* m46 = 0, method* m47 = 0, method* m48 = 0, method* m49 = 0,
+                     method* m50 = 0, method* m51 = 0, method* m52 = 0, method* m53 = 0, method* m54 = 0,
+                     method* m55 = 0, method* m56 = 0, method* m57 = 0, method* m58 = 0, method* m59 = 0,
+                     method* m60 = 0, method* m61 = 0, method* m62 = 0, method* m63 = 0, method* m64 = 0,
+                     method* m65 = 0, method* m66 = 0, method* m67 = 0, method* m68 = 0, method* m69 = 0,
+                     const char* name = 0, bool parallel = false)
+                : _TestFixture(name, parallel)
+         {
+            registerTests(m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, m22, m23, m24, m25, m26, m27, m28, m29, m30, m31, m32, m33, m34, m35, m36, m37, m38, m39, m40, m41, m42, m43, m44, m45, m46, m47, m48, m49, m50, m51, m52, m53, m54, m55, m56, m57, m58, m59, m60, m61, m62, m63, m64, m65, m66, m67, m68, m69);
+         }
+
+         ~TestFixture();
+   };
+
+   extern thread_local tpunit::_TestFixture* currentTestPtr;
 
    /**
     * Convenience class containing the entry point to run all registered tests.


### PR DESCRIPTION
### Details

This is an alternate take on something @johnmlee101 was trying here: https://github.com/Expensify/Bedrock/pull/1816

Clang complains about the base class being uninitialized the way that the constructors for our tests are set up. John got around this by making the derived class constructor call a base class constructor that doesn't set all the methods, and then after the base class is initialized, calls a `registerTests` method. The problem is that this requires changing every single test cpp file to call `registerTests`. This is a minor annoyance for Bedrock, but will require changing hundreds of files for Auth.

My change does essentially the same thing, including keeping the `registerTests` method, but does it in a different way so that we don't need to change any of the cpp files.

My change renames the existing `TestFixture` class to `_TestFixture`. The new class inherits from the existing `_TestFixture` class.

The constructors for the new class mimic the existing (before rename) `TextFixture` constructors so that all of the existing tests that create `TestFixture` objects can continue to compile with out changes.

Internally, all the `_TestFixture` constructors do is essentially this:

```
TestFixture::TestFixture(name, big_list_of_methods) :
    _TestFixture(name) // Call the base class constructor with no methods, which is what causes the error.
{
    // Now that the base class is initialized, register our methods.
    registerTests(big_list_of_methods);
}
```

Fundamentally the idea is the same as @johnmlee101's change but without changing the public interface.

The ultimate idea here is to piecemeal together as many changes for clang comparability as we can without breaking the gcc build, so that at the final step, the last PR to switch compilers is as small as possible, and we've already verified everything works. This should let us not worry about the tests.


This also fixes some minor compilation issues with `BedrockTester.cpp` since we're fixing tests anyway.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/411196

### Tests
I've tested that auth tests still build and run.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
