### PR TITLE
Only shorten blcoking timeouts for non-quorum commands

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -135,7 +135,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
             if (!_db.beginTransaction(exclusive ? SQLite::TRANSACTION_TYPE::EXCLUSIVE : SQLite::TRANSACTION_TYPE::SHARED)) {
                 STHROW("501 Failed to begin " + (exclusive ? "exclusive"s : "shared"s) + " transaction");
             }
-            if (exclusive) {
+            if (exclusive && command->writeConsistency != SQLiteNode::QUORUM) {
                 decreaseCommandTimeout(command, BedrockCommand::DEFAULT_BLOCKING_TRANSACTION_COMMIT_LOCK_TIMEOUT);
             }
 

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -232,7 +232,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
             if (!_db.beginTransaction(exclusive ? SQLite::TRANSACTION_TYPE::EXCLUSIVE : SQLite::TRANSACTION_TYPE::SHARED)) {
                 STHROW("501 Failed to begin " + (exclusive ? "exclusive"s : "shared"s) + " transaction");
             }
-            if (exclusive) {
+            if (exclusive && command->writeConsistency != SQLiteNode::QUORUM) {
                 decreaseCommandTimeout(command, BedrockCommand::DEFAULT_BLOCKING_TRANSACTION_COMMIT_LOCK_TIMEOUT);
             }
         }


### PR DESCRIPTION
### Details

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/418167

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
