### PR TITLE
Last clang compatibility changes besides the compiler change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ clean:
 mbedtls/library/libmbedcrypto.a mbedtls/library/libmbedtls.a mbedtls/library/libmbedx509.a:
 	git submodule init
 	git submodule update
-	cd mbedtls && git checkout -q v2.26.0
+	cd mbedtls && git checkout -q v2.28.8
 	cd mbedtls && $(MAKE) no_test
 
 # We select all of the cpp files (and manually add sqlite3.c) that will be in libstuff.
@@ -94,7 +94,7 @@ CLUSTERTESTOBJ = $(CLUSTERTESTCPP:%.cpp=$(INTERMEDIATEDIR)/%.o)
 CLUSTERTESTDEP = $(CLUSTERTESTCPP:%.cpp=$(INTERMEDIATEDIR)/%.d)
 
 # And the same for the test plugin.
-TESTPLUGINCPP = test/clustertest/testplugin/TestPlugin.cpp
+TESTPLUGINCPP = test/clustertest/testplugin/TestPlugin.cpp test/clustertest/testplugin/ExternPointer.cpp
 TESTPLUGINOBJ = $(TESTPLUGINCPP:%.cpp=$(INTERMEDIATEDIR)/%.o)
 TESTPLUGINTDEP = $(TESTPLUGINCPP:%.cpp=$(INTERMEDIATEDIR)/%.d)
 

--- a/test/clustertest/testplugin/ExternPointer.cpp
+++ b/test/clustertest/testplugin/ExternPointer.cpp
@@ -1,0 +1,2 @@
+// Literaly just exists for BadCommandTest to need to reference something weird.
+int* __pointerToFakeIntArray;

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -7,6 +7,8 @@
 #include <libstuff/SQResult.h>
 #include <libstuff/SX509.h>
 
+extern int* __pointerToFakeIntArray;
+
 mutex BedrockPlugin_TestPlugin::dataLock;
 map<string, string> BedrockPlugin_TestPlugin::arbitraryData;
 
@@ -275,9 +277,11 @@ bool TestPluginCommand::peek(SQLite& db) {
     } else if (SStartsWith(request.methodLine, "exceptioninpeek")) {
         throw 1;
     } else if (SStartsWith(request.methodLine, "generatesegfaultpeek")) {
-        int* i = 0;
-        int x = *i;
-        response["invalid"] = to_string(x);
+        int total = 0;
+        for (int i = 0; i < 1000000; i++) {
+            total += __pointerToFakeIntArray[i];
+        }
+        response["invalid"] = to_string(total);
     } else if (SStartsWith(request.methodLine, "generateassertpeek")) {
         SASSERT(0);
         response["invalid"] = "nope";
@@ -481,9 +485,11 @@ void TestPluginCommand::process(SQLite& db) {
     } else if (SStartsWith(request.methodLine, "exceptioninprocess")) {
         throw 2;
     } else if (SStartsWith(request.methodLine, "generatesegfaultprocess")) {
-        int* i = 0;
-        int x = *i;
-        response["invalid"] = to_string(x);
+        int total = 0;
+        for (int i = 0; i < 1000000; i++) {
+            total += __pointerToFakeIntArray[i];
+        }
+        response["invalid"] = to_string(total);
     } else if (SStartsWith(request.methodLine, "ineffectiveUpdate")) {
         // This command does nothing on purpose so that we can run it in 10x mode and verify it replicates OK.
         return;


### PR DESCRIPTION
### Details
This does two things to make everything work in clang. one is update to the latest mbedtls v2 point release.

The second is weirder. in `BadCommandTest` we intentionally cause bedrock to segfault to verify that it crashes leader but the followers blacklist the bad command that caused the crash.

Well, when compiling with clang, the simple segfault didn't crash. It seemed the compiler was smart enough to know that what we were doing had no useful effect and optimized it out. I tried several simple things and every time the compiler skipped them.

So I made this more complex, I put an array in a separate file, where the compiler wouldn't know if it was actually defined or not (since it compiles one cpp file at a time). This forces it to assume that the array actually contains the million numbers that we say it does.

The when we want this to crash, we read 1,000,000 numbers out of uninitialized memory and add them all together. This reliably crashes even when built with clang.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/411196

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
