### PR TITLE
Update GHA to use new runner

### DIFF
--- a/.github/workflows/bedrock.yml
+++ b/.github/workflows/bedrock.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   Run_Bedrock_Tests:
     name: "Create Bedrock and Test"
-    runs-on: ubuntu-20.04-v64 # The biggest and best for my baby
+    runs-on: ubuntu-20.04-v64-2 # The biggest and best for my baby
     timeout-minutes: 30
     steps:
 
@@ -90,4 +90,3 @@ jobs:
       with:
         files: |-
           ./bedrock
-


### PR DESCRIPTION
### Details

Same as https://github.com/Expensify/Auth/pull/12140

### Fixed Issues
Fixes GHA not running with the old runner

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
