### PR TITLE
Support building with clang (currently disabled)

### DIFF
--- a/.github/workflows/bedrock.yml
+++ b/.github/workflows/bedrock.yml
@@ -55,7 +55,7 @@ jobs:
 
         # For clang.
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        echo "deb https://travis:${{ env.TRAVIS_APT_PASSWORD }}@$APT_MIRROR_URL/mirror/apt.llvm.org/focal/ llvm-toolchain-focal-18 main" | sudo tee -a /etc/apt/sources.list
+        echo "deb https://travis:${{ secrets.TRAVIS_APT_PASSWORD }}@$APT_MIRROR_URL/mirror/apt.llvm.org/focal/ llvm-toolchain-focal-18 main" | sudo tee -a /etc/apt/sources.list
 
         sudo apt-get update -y
         sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install rsyslog cmake libpcre2-dev libsodium-dev libgpgme11-dev libstdc++-13-dev

--- a/.github/workflows/bedrock.yml
+++ b/.github/workflows/bedrock.yml
@@ -52,8 +52,21 @@ jobs:
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C
         wget -qO - https://package.perforce.com/perforce.pubkey --no-check-certificate | sudo apt-key add -
         echo "deb [arch=amd64] https://travis:${{ secrets.TRAVIS_APT_PASSWORD }}@$APT_MIRROR_URL/mirror/ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal main" | sudo tee -a /etc/apt/sources.list
+
+        # For clang.
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-18 main" | sudo tee -a /etc/apt/sources.list
+        echo "deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-18 main" | sudo tee -a /etc/apt/sources.list
+
         sudo apt-get update -y
-        sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install rsyslog cmake gcc-13 g++-13 libpcre2-dev libsodium-dev libgpgme11-dev libstdc++-13-dev
+        sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install rsyslog cmake libpcre2-dev libsodium-dev libgpgme11-dev libstdc++-13-dev
+
+        # Install gcc. Can be removed after clang transition is complete.
+        sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install gcc-13 g++-13
+
+        # Install clang.
+        sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install clang-18 lldb-18 lld-18 clangd-18 clang-tidy-18 clang-format-18 clang-tools-18 llvm-18-dev lld-18 lldb-18 llvm-18-tools libomp-18-dev libc++-18-dev libc++abi-18-dev libclang-common-18-dev libclang-18-dev libclang-cpp18-dev libunwind-18-dev
+
         sudo locale-gen "en_US.UTF-8"
         sudo service rsyslog start
 

--- a/.github/workflows/bedrock.yml
+++ b/.github/workflows/bedrock.yml
@@ -55,8 +55,7 @@ jobs:
 
         # For clang.
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-18 main" | sudo tee -a /etc/apt/sources.list
-        echo "deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-18 main" | sudo tee -a /etc/apt/sources.list
+        echo "deb https://travis:${{ env.TRAVIS_APT_PASSWORD }}@$APT_MIRROR_URL/mirror/apt.llvm.org/focal/ llvm-toolchain-focal-18 main" | sudo tee -a /etc/apt/sources.list
 
         sudo apt-get update -y
         sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install rsyslog cmake libpcre2-dev libsodium-dev libgpgme11-dev libstdc++-13-dev

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,3 @@
-# If $CC and $CXX are defined as environment variables, those will be used here. However, if they aren't then GNU make
-# automatically defines them as `cc` and `g++`. Ultimately, we'd like those names to work, or the environment variables
-# to be set, but for the time being we need to override the defaults so that our existing dev environment works. This
-# can be removed when that is resolved.
-ifeq ($(CC),cc)
-CC = gcc-13
-endif
-ifeq ($(CXX),g++)
-CXX = g++-13
-endif
-
 # Set the optimization level from the environment, or default to -O2.
 ifndef BEDROCK_OPTIM_COMPILE_FLAG
 	BEDROCK_OPTIM_COMPILE_FLAG = -O2

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-export CXX=g++-13
-export CC=gcc-13
-
 # Add the current working directory to $PATH so that tests can find bedrock.
 export PATH=$PATH:`pwd`
 
@@ -31,6 +28,16 @@ mark_fold() {
 
   echo "::group::${name}"
 }
+
+if [ -f "../Bedrock/use_clang" ]; then
+    echo "Building with clang."
+    export CC="clang-18"
+    export CXX="clang++-18"
+else
+    echo "Building with gcc."
+    export CC="gcc-13"
+    export CXX="g++-13"
+fi
 
 # don't print out versions until after they are installed
 ${CC} --version


### PR DESCRIPTION
### Details

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/411196

### Tests

You can see that commit `0181cd0` built with clang:
<img width="1512" alt="Screenshot 2024-08-20 at 15 59 52" src="https://github.com/user-attachments/assets/9f100da8-a56b-4f8e-b95a-5218dd62d0b0">

And commit `23c046c` built with gcc:
<img width="1512" alt="Screenshot 2024-08-20 at 16 22 54" src="https://github.com/user-attachments/assets/6776a181-2517-4dc0-9f02-e8e68aee42fb">


_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
