### PR TITLE
Fix missing dir error, minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ libstuff/libstuff.d
 libstuff/libstuff.h.gch
 .idea
 .clangd
+.nfs*
+.cache
+compile_commands.json

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -4,10 +4,8 @@
 #include <arpa/inet.h>
 #include <cstring>
 #include <fstream>
-#include <iomanip>
 #include <sys/resource.h>
 #include <sys/time.h>
-#include <signal.h>
 
 #include <bedrockVersion.h>
 #include <BedrockCore.h>

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ test/clustertest/testplugin/testplugin.so : $(TESTPLUGINOBJ) $(TESTPLUGINCPP) $(
 $(INTERMEDIATEDIR)/BedrockServer.d $(INTERMEDIATEDIR)/BedrockServer.o: BedrockServer.cpp
 	$(CXX) $(CXXFLAGS) -MMD -MF $(INTERMEDIATEDIR)/BedrockServer.d -MT $(INTERMEDIATEDIR)/BedrockServer.o $(GIT_REVISION) -o $(INTERMEDIATEDIR)/BedrockServer.o -c BedrockServer.cpp
 
-$(INTERMEDIATEDIR)/main.d $(INTERMEDIATEDIR)/main.o: main.cpp
+$(INTERMEDIATEDIR)/main.d $(INTERMEDIATEDIR)/main.o: main.cpp $(INTERMEDIATEDIR)
 	$(CXX) $(CXXFLAGS) -MMD -MF $(INTERMEDIATEDIR)/main.d -MT $(INTERMEDIATEDIR)/main.o $(GIT_REVISION) -o $(INTERMEDIATEDIR)/main.o -c main.cpp
 
 $(INTERMEDIATEDIR)/plugins/MySQL.d $(INTERMEDIATEDIR)/plugins/MySQL.o: plugins/MySQL.cpp


### PR DESCRIPTION
### Details
Fixes:
```
error: unable to open output file '.build/main.o': 'No such file or directory'
```

That happens sometimes.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
