### PR TITLE
Add shouldGenerateCrashCommand

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -389,3 +389,7 @@ string BedrockCommand::serializeData() const {
 
 void BedrockCommand::deserializeData(const string& data) {
 }
+
+bool BedrockCommand::shouldGenerateCrashCommand() {
+    return true;
+}

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -187,6 +187,8 @@ class BedrockCommand : public SQLiteCommand {
     };
     CrashMap crashIdentifyingValues;
 
+    virtual bool shouldGenerateCrashCommand();
+
     // Return the timestamp by which this command must finish executing.
     uint64_t timeout() const { return _timeout; }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -470,6 +470,10 @@ void BedrockServer::sync()
                 // like a segfault. Note that it's possible we're in the middle of sending a message to peers when we call
                 // this, which would probably make this message malformed. This is the best we can do.
                 SSetSignalHandlerDieFunc([&](){
+                    if (!command->shouldGenerateCrashCommand()) {
+                        SINFO("Not generating CRASH_COMMAND");
+                        return;
+                    }
                     _clusterMessenger->runOnAll(_generateCrashMessage(command));
                 });
 
@@ -698,6 +702,10 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
     // If a signal is caught on this thread, which should only happen for unrecoverable, yet synchronous
     // signals, like SIGSEGV, this function will be called.
     SSetSignalHandlerDieFunc([&](){
+        if (!command->shouldGenerateCrashCommand()) {
+            SINFO("Not generating CRASH_COMMAND");
+            return;
+        }
         _clusterMessenger->runOnAll(_generateCrashMessage(command));
     });
 


### PR DESCRIPTION
### Details

Adds a function that commands can override to avoid generating a CRASH_COMMAND we don't want

This function will be overridden for `Get` here: https://github.com/Expensify/Auth/pull/12323

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/422785

### Tests

Setup: To force the two different crashes, I modify the code as follows:

In Bedrock `BedrockCore::peekCommand`:

<img width="821" alt="image" src="https://github.com/user-attachments/assets/a71a0e59-60ef-4d5f-9c8a-b466afd13473">

In Auth `Get::peek`:

<img width="553" alt="image" src="https://github.com/user-attachments/assets/aabf0908-56d9-4dd7-bd32-d7fe9b77d806">


1. Connect to bedrock using `nc auth 4444`
2. Send a command to crash it before validating the authToken:
    ```
    Get
    authToken:<autoToken>
    doubleTransaction:true
    ```
3. Look at the logs and verify that a `CRASH_COMMAND` **was not** created
4. Restart bedrock/auth
5. Connect to bedrock using `nc auth 4444`
2. Send a command to crash it after validating the authToken (inside Get::peek):
    ```
    Get
    authToken:<autoToken>
    forceSegFault:true
    ```
3. Look at the logs and verify that a `CRASH_COMMAND` **was** created, and that it has an `accountID=xxxx`


_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
