### PR TITLE
Remove old GCC references

### DIFF
--- a/.github/workflows/bedrock.yml
+++ b/.github/workflows/bedrock.yml
@@ -60,9 +60,6 @@ jobs:
         sudo apt-get update -y
         sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install rsyslog cmake libpcre2-dev libsodium-dev libgpgme11-dev libstdc++-13-dev
 
-        # Install gcc. Can be removed after clang transition is complete.
-        sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install gcc-13 g++-13
-
         # Install clang.
         sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install clang-18 lldb-18 lld-18 clangd-18 clang-tidy-18 clang-format-18 clang-tools-18 llvm-18-dev lld-18 lldb-18 llvm-18-tools libomp-18-dev libc++-18-dev libc++abi-18-dev libclang-common-18-dev libclang-18-dev libclang-cpp18-dev libunwind-18-dev
 
@@ -75,8 +72,8 @@ jobs:
         tar -xf ccache-4.8.3-linux-x86_64.tar.xz
         sudo cp ccache-4.8.3-linux-x86_64/ccache /usr/local/bin/ccache
         ccache -V
-        ln -s /usr/local/bin/ccache /usr/local/bin/gcc-13
-        ln -s /usr/local/bin/ccache /usr/local/bin/g++-13
+        ln -s /usr/local/bin/ccache /usr/local/bin/clang-18
+        ln -s /usr/local/bin/ccache /usr/local/bin/clang++-18
 
     - name: Setup tmate session
       if: runner.debug == '1'

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -29,15 +29,8 @@ mark_fold() {
   echo "::group::${name}"
 }
 
-if [ -f "../Bedrock/use_clang" ]; then
-    echo "Building with clang."
-    export CC="clang-18"
-    export CXX="clang++-18"
-else
-    echo "Building with gcc."
-    export CC="gcc-13"
-    export CXX="g++-13"
-fi
+export CC="clang-18"
+export CXX="clang++-18"
 
 # don't print out versions until after they are installed
 ${CC} --version

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ You can build from scratch as follows:
     # Install some dependencies
     sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     sudo apt-get update
-    sudo apt-get install build-essential gcc-13 g++-13 libpcre++-dev zlib1g-dev
+    sudo apt-get install build-essential libpcre++-dev zlib1g-dev
 
     # Build it
     cd Bedrock

--- a/test/clustertest/tests/ClusterUpgradeTest.cpp
+++ b/test/clustertest/tests/ClusterUpgradeTest.cpp
@@ -69,7 +69,7 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
             ASSERT_FALSE(system(("cd " + brReleaseDir + " && cd Bedrock && git checkout " + bedrockTagName + "  > /dev/null").c_str()));
 
             // Build the release.
-            ASSERT_FALSE(system(("cd " + brReleaseDir + " && cd Bedrock && CXX=g++-13 CC=gcc-13 make -j8 > /dev/null").c_str()));
+            ASSERT_FALSE(system(("cd " + brReleaseDir + " && cd Bedrock && CXX=clang++-18 CC=clang-18 make -j8 > /dev/null").c_str()));
 
             // Save the final product.
             mkdir(prodBedrockDirName.c_str(), 0755);


### PR DESCRIPTION
### Details
Remove references to gcc now that it's not used.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/411196

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
