### PR TITLE
If the majority of logged in full peers responds with abstain, then re-search.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -865,7 +865,7 @@ bool SQLiteNode::update() {
         }
 
         // If the majority of full peers responds with abstain, then re-search.
-        const bool majorityAbstained = abstainCount * 2 >= numFullPeers;
+        const bool majorityAbstained = abstainCount * 2 > numFullPeers;
         if (majorityAbstained) {
             // Majority abstained, meaning we're probably forked,
             // so we go back to searching so we can go back to synchronizing and see if we're forked.

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -864,12 +864,12 @@ bool SQLiteNode::update() {
             }
         }
 
-        // If the majority of logged in full peers responds with abstain, then re-search.
-        bool majorityAbstained = abstainCount * 2 >= numLoggedInFullPeers;
-        if (allResponded && majorityAbstained) {
+        // If the majority of full peers responds with abstain, then re-search.
+        const bool majorityAbstained = abstainCount * 2 >= numFullPeers;
+        if (majorityAbstained) {
             // Majority abstained, meaning we're probably forked,
-            // so we go back to searching so we can go back to synchronizing and see that we're forked.
-            SHMMM("Majority of logged in full peers abstained; re-SEARCHING.");
+            // so we go back to searching so we can go back to synchronizing and see if we're forked.
+            SHMMM("Majority of full peers abstained; re-SEARCHING.");
             _changeState(SQLiteNodeState::SEARCHING);
             return true; // Re-update
         }


### PR DESCRIPTION
cc @johnmlee101 @madmax330 @danieldoglas 

### Details

https://github.com/Expensify/Expensify/issues/426230#issuecomment-2346834808

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/426230

### Tests

@tylerkaraszewski is there a way to test this? Is it feasible to update `ForkedNodeApprovalTest` to test this scenario? 
