### PR TITLE
Enable REUSEPORT on socket

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1808,6 +1808,9 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking) {
             if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char*)&enable, sizeof(enable)))
                 STHROW("couldn't set REUSEADDR");
 
+            if (setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char*)&enable, sizeof(enable)))
+                STHROW("couldn't set REUSEPORT");
+
             // Bind to the configured port
             sockaddr_in addr;
             memset(&addr, 0, sizeof(addr));
@@ -3197,4 +3200,3 @@ SString& SString::operator=(const bool from) {
     string::operator=(from ? "true" : "false");
     return *this;
 }
-

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1803,11 +1803,13 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking) {
 
         // If this is a port, bind
         if (isPort) {
-            // Enable port reuse (so we don't have TIME_WAIT binding issues) and
+            // Enable address reuse so that we can startup a new process while the old one is shutting down
+            // and to handle connections left in TCP TIME_WAIT state
             u_long enable = 1;
             if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char*)&enable, sizeof(enable)))
                 STHROW("couldn't set REUSEADDR");
 
+            // Enable port reuse as well for the same reason as the above
             if (setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char*)&enable, sizeof(enable)))
                 STHROW("couldn't set REUSEPORT");
 


### PR DESCRIPTION
### Details
We saw this error earlier today when force killing Bedrock

```
2024-09-17T10:54:49.339209+00:00 db2.lax bedrock: xxxxxx (libstuff.cpp:1851) S_socket [sync] [warn] Failed to open TCP port '0.0.0.0:4445': couldn't bind(errno=98 'Address already in use')
```

According to https://stackoverflow.com/questions/24194961/how-do-i-use-setsockoptso-reuseaddr we may need to set this option on the socket as well

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/423501
https://expensify.slack.com/archives/C07MB1741UP/p1726571353758699

### Tests
I started up a second bedrock in dev using the same ports before this change and got this error:

```
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:19) SLogStackTrace [main] [dbug]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:19) SLogStackTrace [main] [dbug] SLogStackTrace(int) [0xaaaae9356f00]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:19) SLogStackTrace [main] [dbug] S_socket(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool, bool) [0xaaaae937499c]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:19) SLogStackTrace [main] [dbug] STCPManager::openPort(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int) [0xaaaae9349d64]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:19) SLogStackTrace [main] [dbug] BedrockServer::BedrockServer(SData const&) [0xaaaae91dbfd8]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:19) SLogStackTrace [main] [dbug] /usr/sbin/bedrock(main+0x9310) [0xaaaae91a3d78]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:19) SLogStackTrace [main] [dbug] /lib/aarch64-linux-gnu/libc.so.6(__libc_start_main+0xe8) [0xffffb93d7e10]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:19) SLogStackTrace [main] [dbug] /usr/sbin/bedrock(+0x101578) [0xaaaae9194578]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (libstuff.cpp:154) SException [main] [info] Throwing exception with message: 'couldn't bind' from libstuff/libstuff.cpp:1818
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (libstuff.cpp:1851) S_socket [main] [warn] Failed to open TCP port 'localhost:9999': couldn't bind(errno=98 'Address already in use')
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (STCPManager.cpp:325) openPort [main] [warn] Couldn't open port localhost:9999 with 0 retries remaining.
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (STCPManager.cpp:339) openPort [main] [eror] Failed to open port localhost:9999 and no more retries.
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:28) SLogStackTrace [main] [warn]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:28) SLogStackTrace [main] [warn] SLogStackTrace(int) [0xaaaae9356f00]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:28) SLogStackTrace [main] [warn] STCPManager::openPort(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int) [0xaaaae934a674]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:28) SLogStackTrace [main] [warn] BedrockServer::BedrockServer(SData const&) [0xaaaae91dbfd8]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:28) SLogStackTrace [main] [warn] /usr/sbin/bedrock(main+0x9310) [0xaaaae91a3d78]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:28) SLogStackTrace [main] [warn] /lib/aarch64-linux-gnu/libc.so.6(__libc_start_main+0xe8) [0xffffb93d7e10]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SLog.cpp:28) SLogStackTrace [main] [warn] /usr/sbin/bedrock(+0x101578) [0xaaaae9194578]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:185) _SSignal_StackTrace [main] [warn] Signal Aborted(6) caused crash, logging stack trace.
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:230) _SSignal_StackTrace [main] [warn] Frame #0: _SSignal_StackTrace(int, siginfo_t*, void*)
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:230) _SSignal_StackTrace [main] [warn] Frame #1: __kernel_rt_sigreturn
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:230) _SSignal_StackTrace [main] [warn] Frame #2: gsignal
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:230) _SSignal_StackTrace [main] [warn] Frame #3: abort
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:230) _SSignal_StackTrace [main] [warn] Frame #4: STCPManager::openPort(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:230) _SSignal_StackTrace [main] [warn] Frame #5: BedrockServer::BedrockServer(SData const&)
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:230) _SSignal_StackTrace [main] [warn] Frame #6: main
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:230) _SSignal_StackTrace [main] [warn] Frame #7: __libc_start_main
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:230) _SSignal_StackTrace [main] [warn] Frame #8: /usr/sbin/bedrock(+0x101578) [0xaaaae9194578]
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:238) _SSignal_StackTrace [main] [warn] Calling DIE function.
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:241) _SSignal_StackTrace [main] [warn] DIE function returned.
Sep 17 13:12:46 expensidev2004 bedrock[404784]: xxxxxx (SSignal.cpp:253) _SSignal_StackTrace [main] [warn] Already in ABORT.
```

With this change, I was able to start the second instance without the same error.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
