### PR TITLE
Check for LEADING *after* waiting to be LEADING or FOLLOWING

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -777,10 +777,6 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
             (_blacklistedParallelCommands.find(command->request.methodLine) == _blacklistedParallelCommands.end());
     }
 
-    // More checks for parallel writing.
-    canWriteParallel = canWriteParallel && (getState() == SQLiteNodeState::LEADING);
-    canWriteParallel = canWriteParallel && (command->writeConsistency == SQLiteNode::ASYNC);
-
     int64_t lastConflictPage = 0;
     while (true) {
 
@@ -796,6 +792,10 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
         if (waitCount) {
             SINFO("Waited for " << waitCount << " loops for node to be ready.");
         }
+
+        // More checks for parallel writing.
+        canWriteParallel = canWriteParallel && (getState() == SQLiteNodeState::LEADING);
+        canWriteParallel = canWriteParallel && (command->writeConsistency == SQLiteNode::ASYNC);
 
         // If there are outstanding HTTPS requests on this command (from a previous call to `peek`) we process them here.
         size_t networkLoopCount = 0;


### PR DESCRIPTION
### Details
This fixes a bug noticed when investigating a fork.

If we attempt to start a command, but are not LEADING or FOLLOWING (see lines 783-796, the collapsed section between the changes) we wait until we are before doing anything.

However, we've performed the `canWriteParallel` before we wait for this state change, so we could have been SEARCHING before the wait, and LEADING after. This will cause `canWriteParallel` to be `false` when it should not be. This leads to commands running in the sync thread that do not need to.

This change moves the check for `LEADING` to after the state of the server has stabilized.

I don't believe this actually affects the fork that occurred, but it is a detriment to performance.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/384477

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
