### PR TITLE
Log the last time we spontaneously disconnected from the cluster when forked.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1591,7 +1591,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                 uint64_t commitNum = SToUInt64(message["hashMismatchNumber"]);
                 _db.getCommits(commitNum, commitNum, result);
                 _forkedFrom.insert(peer->name);
-                
+     
                 SALERT("Hash mismatch. Peer " << peer->name << " and I have forked at commit " << message["hashMismatchNumber"]
                        << ". I have forked from " << _forkedFrom.size() << " other nodes. I am " << stateName(_state)
                        << " and have hash " << result[0][0] << " for that commit. Peer has hash " << message["hashMismatchValue"] << "."
@@ -2792,11 +2792,11 @@ void SQLiteNode::kill() {
 }
 
 string SQLiteNode::_getLostQuorumLogMessage() const {
-    string lostQuormMessage;
+    string lostQuorumMessage;
     if (_lastLostQuorum) {
-        lostQuormMessage = " Lost Quorum at: " + STIMESTAMP_MS(_lastLostQuorum) + " (" + 
+        lostQuorumMessage = " Lost Quorum at: " + STIMESTAMP_MS(_lastLostQuorum) + " (" + 
         to_string((double)(STimeNow() - _lastLostQuorum) / 1000000.0) + " seconds ago).";
     }
     
-    return lostQuormMessage;
+    return lostQuorumMessage;
 }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1592,9 +1592,6 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                 _db.getCommits(commitNum, commitNum, result);
                 _forkedFrom.insert(peer->name);
                 
-                // Testing.
-                _lastLostQuorum = STimeNow() - 10'000'000;
-
                 SALERT("Hash mismatch. Peer " << peer->name << " and I have forked at commit " << message["hashMismatchNumber"]
                        << ". I have forked from " << _forkedFrom.size() << " other nodes. I am " << stateName(_state)
                        << " and have hash " << result[0][0] << " for that commit. Peer has hash " << message["hashMismatchValue"] << "."

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -606,8 +606,7 @@ bool SQLiteNode::update() {
             // Find the freshest non-broken peer (including permafollowers).
             if (peer->loggedIn) {
                 if (_forkedFrom.count(peer->name)) {
-                    // UPDATE LOG LINE.
-                    SWARN("Hash mismatch. Forked from peer " << peer->name << " so not considering it.");
+                    SWARN("Hash mismatch. Forked from peer " << peer->name << " so not considering it." << _getLostQuorumLogMessage());
                     continue;
                 }
 
@@ -2034,9 +2033,7 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
         // loop. It's entirely possible that we do this for valid reasons - it may be the peer that has the bad database and not us, and there are plenty of other reasons we could switch to
         // SEARCHING, but in those cases, we just wait an extra second before trying again.
         if (newState == SQLiteNodeState::SEARCHING && _forkedFrom.size()) {
-            
-            // UPDATE LOG LINE.
-            SWARN("Going searching while forked peers present, sleeping 1 second.");
+            SWARN("Going searching while forked peers present, sleeping 1 second." << _getLostQuorumLogMessage());
             sleep(1);
         }
 

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -320,6 +320,10 @@ class SQLiteNode : public STCPManager {
     // Set to true to indicate we're attempting to shut down.
     atomic<bool> _isShuttingDown;
 
+    // When we spontaneously lose quorum (do to an unexpected node disconnection) we log the time. Later, if we detect we've forked,
+    // We show this time in a log line as a diagnostic message.
+    atomic<uint64_t> _lastLostQuorum = 0;
+
     // Store the ID of the last transaction that we replicated to peers. Whenever we do an update, we will try and send
     // any new committed transactions to peers, and update this value.
     uint64_t _lastSentTransactionID;

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -322,7 +322,7 @@ class SQLiteNode : public STCPManager {
     // Set to true to indicate we're attempting to shut down.
     atomic<bool> _isShuttingDown;
 
-    // When we spontaneously lose quorum (do to an unexpected node disconnection) we log the time. Later, if we detect we've forked,
+    // When we spontaneously lose quorum (due to an unexpected node disconnection) we log the time. Later, if we detect we've forked,
     // We show this time in a log line as a diagnostic message.
     atomic<uint64_t> _lastLostQuorum = 0;
 

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -228,6 +228,8 @@ class SQLiteNode : public STCPManager {
 
     void _changeState(SQLiteNodeState newState, uint64_t commitIDToCancelAfter = 0);
 
+    string _getLostQuorumLogMessage() const;
+
     // Handlers for transaction messages.
     void _handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SData& message, bool wasConflict);
     void _handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const SData& message, uint64_t dequeueTime, uint64_t threadStartTime);


### PR DESCRIPTION
### Details

This adds extra logging to the `Hash mismatch` log lines to indicate if we've recently lost quorum due to a disconnection.

It is more-or-less expected that losing quorum while leading will result in a forked DB node. There's no way for the node to anticipate that it is about to lose quorum, and so it will continue committing parallel transaction until it notices the disconnect, at which point it's too late. Another node will begin leading and this node will have commits that it was unable to send.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/384477 https://github.com/Expensify/Expensify/issues/422697

### Tests
Artificially setting the timestamp logs:
```
2024-09-18T15:30:53.388360-05:00 expensidev2004 bedrock10004: xxxxxx (SQLiteNode.cpp:1604) _onMESSAGE [sync] [eror] {cluster_node_0/SYNCHRONIZING} Hash mismatch. I have forked from over half the cluster. This is unrecoverable. Lost Quorum at: 2024-09-18 20:30:43.388 (10.000014 seconds ago).
```

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
