### PR TITLE
Update logging macros to accept a map of parameters

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -742,9 +742,9 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
         auto _clusterMessengerCopy = _clusterMessenger;
         bool result = _clusterMessengerCopy->runOnPeer(*command, false);
         if (result) {
-            SINFO("Synchronizing while accepting commands, so forwarded " << command->request.methodLine << " to peer successfully");
+            SINFO("Synchronizing while accepting commands; successfully forwarded the command to peer", {{"command", command->request.methodLine}});
         } else {
-            SWARN("Synchronizing while accepting commands, so forwarded " << command->request.methodLine << " to peer, but failed.");
+            SWARN("Synchronizing while accepting commands, but failed to forward the command to peer.", {{"command", command->request.methodLine}});
         }
     }
 

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -38,3 +38,24 @@ void SLogStackTrace(int level) {
         }
     }
 }
+
+string addLogParams(const string& message) {
+    return message;
+}
+
+string addLogParams(const string& message, const map<string, string>& params) {
+    std::string result = message;
+
+    if (!params.empty()) {
+        result += " ~~ ";
+        for (size_t i = 0; i < params.size(); ++i) {
+            if (i > 0) {
+                result += " ";
+            }
+            const auto& param = *std::next(params.begin(), i);
+            result += param.first + ": '" + param.second + "'";
+        }
+    }
+
+    return result;
+}

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -39,20 +39,19 @@ void SLogStackTrace(int level) {
     }
 }
 
-string addLogParams(const string& message, const map<string, string>& params) {
-    string result = message;
+string addLogParams(string&& message, const map<string, string>& params) {
     if (params.empty()) {
-        return result;
+        return message;
     }
 
-    result += " ~~ ";
+    message += " ~~ ";
     for (size_t i = 0; i < params.size(); ++i) {
         if (i > 0) {
-            result += " ";
+            message += " ";
         }
         const auto& param = *next(params.begin(), i);
-        result += param.first + ": '" + param.second + "'";
+        message += param.first + ": '" + param.second + "'";
     }
 
-    return result;
+    return message;
 }

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -39,12 +39,8 @@ void SLogStackTrace(int level) {
     }
 }
 
-string addLogParams(const string& message) {
-    return message;
-}
-
 string addLogParams(const string& message, const map<string, string>& params) {
-    std::string result = message;
+    string result = message;
 
     if (!params.empty()) {
         result += " ~~ ";
@@ -52,7 +48,7 @@ string addLogParams(const string& message, const map<string, string>& params) {
             if (i > 0) {
                 result += " ";
             }
-            const auto& param = *std::next(params.begin(), i);
+            const auto& param = *next(params.begin(), i);
             result += param.first + ": '" + param.second + "'";
         }
     }

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -41,16 +41,17 @@ void SLogStackTrace(int level) {
 
 string addLogParams(const string& message, const map<string, string>& params) {
     string result = message;
+    if (params.empty()) {
+        return result;
+    }
 
-    if (!params.empty()) {
-        result += " ~~ ";
-        for (size_t i = 0; i < params.size(); ++i) {
-            if (i > 0) {
-                result += " ";
-            }
-            const auto& param = *next(params.begin(), i);
-            result += param.first + ": '" + param.second + "'";
+    result += " ~~ ";
+    for (size_t i = 0; i < params.size(); ++i) {
+        if (i > 0) {
+            result += " ";
         }
+        const auto& param = *next(params.begin(), i);
+        result += param.first + ": '" + param.second + "'";
     }
 
     return result;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2821,8 +2821,8 @@ bool SREMatch(const string& regExp, const string& input, bool caseSensitive, boo
         STHROW("Bad regex: " + regExp);
     }
 
-    pcre2_match_context* matchContext = pcre2_match_context_create(0); 
-    pcre2_set_depth_limit(matchContext, 1000); 
+    pcre2_match_context* matchContext = pcre2_match_context_create(0);
+    pcre2_set_depth_limit(matchContext, 1000);
     pcre2_match_data* matchData = pcre2_match_data_create_from_pattern(re, 0);
 
     int result = pcre2_match(re, (PCRE2_SPTR8)input.c_str() + startOffset, input.size() - startOffset, 0, matchFlags, matchData, matchContext);
@@ -2880,8 +2880,8 @@ string SREReplace(const string& regExp, const string& input, const string& repla
     if (!re) {
         STHROW("Bad regex: " + regExp);
     }
-    pcre2_match_context* matchContext = pcre2_match_context_create(0); 
-    pcre2_set_depth_limit(matchContext, 1000); 
+    pcre2_match_context* matchContext = pcre2_match_context_create(0);
+    pcre2_set_depth_limit(matchContext, 1000);
     for (int i = 0; i < 2; i++) {
         int result = pcre2_substitute(re, (PCRE2_SPTR8)input.c_str(), input.size(), 0, substituteFlags, 0, matchContext, (PCRE2_SPTR8)replacement.c_str(), replacement.size(), (PCRE2_UCHAR*)output, &outSize);
         if (i == 0 && result == PCRE2_ERROR_NOMEMORY) {
@@ -3197,4 +3197,3 @@ SString& SString::operator=(const bool from) {
     string::operator=(from ? "true" : "false");
     return *this;
 }
-

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -230,7 +230,7 @@ void SSyslogSocketDirect(int priority, const char* format, ...);
 // Atomic pointer to the syslog function that we'll actually use. Easy to change to `syslog` or `SSyslogSocketDirect`.
 extern atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc;
 
-string addLogParams(const string& message, const map<string, string>& params = {});
+string addLogParams(string&& message, const map<string, string>& params = {});
 
 // **NOTE: rsyslog default max line size is 8k bytes. We split on 7k byte boundaries in order to fit the syslog line prefix and the expanded \r\n to #015#012
 #define SWHEREAMI SThreadLogPrefix + "(" + basename((char*)__FILE__) + ":" + SToStr(__LINE__) + ") " + __FUNCTION__ + " [" + SThreadLogName + "] "

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -230,9 +230,6 @@ void SSyslogSocketDirect(int priority, const char* format, ...);
 // Atomic pointer to the syslog function that we'll actually use. Easy to change to `syslog` or `SSyslogSocketDirect`.
 extern atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc;
 
-//template <typename T>
-//string addLogParams(const string& message, const map<string, T> params);
-
 string addLogParams(const string& message, const map<string, string>& params = {});
 
 // **NOTE: rsyslog default max line size is 8k bytes. We split on 7k byte boundaries in order to fit the syslog line prefix and the expanded \r\n to #015#012

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -240,7 +240,9 @@ string addLogParams(const string& message, const map<string, string>& params = {
 #define SSYSLOG(_PRI_, _MSG_, ...)                                              \
     do {                                                                        \
         if (_g_SLogMask & (1 << (_PRI_))) {                                     \
-            const string s = addLogParams(_MSG_, ##__VA_ARGS__);                \
+            ostringstream __out;                                                \
+            __out << _MSG_;                                                     \
+            const string s = addLogParams(__out.str(), ##__VA_ARGS__);          \
             const string prefix = SWHEREAMI;                                    \
             for (size_t i = 0; i < s.size(); i += 7168) {                       \
                 (*SSyslogFunc)(_PRI_, "%s", (prefix + s.substr(i, 7168)).c_str()); \
@@ -249,42 +251,14 @@ string addLogParams(const string& message, const map<string, string>& params = {
     } while (false)
 
 #define SLOGPREFIX ""
-#define SDEBUG(_MSG_, ...)                          \
-    do {                                            \
-        stringstream ss;                            \
-        ss << "[dbug] " << SLOGPREFIX << _MSG_;     \
-        SSYSLOG(LOG_INFO, ss.str(), ##__VA_ARGS__); \
-    } while (false)
-#define SINFO(_MSG_, ...)                           \
-    do {                                            \
-        stringstream ss;                            \
-        ss << "[info] " << SLOGPREFIX << _MSG_;     \
-        SSYSLOG(LOG_INFO, ss.str(), ##__VA_ARGS__); \
-    } while (false)
-#define SHMMM(_MSG_, ...)                           \
-    do {                                            \
-        stringstream ss;                            \
-        ss << "[hmmm] " << SLOGPREFIX << _MSG_;     \
-        SSYSLOG(LOG_INFO, ss.str(), ##__VA_ARGS__); \
-    } while (false)
-#define SWARN(_MSG_, ...)                           \
-    do {                                            \
-        stringstream ss;                            \
-        ss << "[warn] " << SLOGPREFIX << _MSG_;     \
-        SSYSLOG(LOG_INFO, ss.str(), ##__VA_ARGS__); \
-    } while (false)
-#define SALERT(_MSG_, ...)                          \
-    do {                                            \
-        stringstream ss;                            \
-        ss << "[alrt] " << SLOGPREFIX << _MSG_;     \
-        SSYSLOG(LOG_INFO, ss.str(), ##__VA_ARGS__); \
-    } while (false)
-
-#define SERROR(_MSG_)                                       \
+#define SDEBUG(_MSG_, ...) SSYSLOG(LOG_DEBUG, "[dbug] " << SLOGPREFIX << _MSG_, ##__VA_ARGS__)
+#define SINFO(_MSG_, ...) SSYSLOG(LOG_INFO, "[info] " << SLOGPREFIX << _MSG_, ##__VA_ARGS__)
+#define SHMMM(_MSG_, ...) SSYSLOG(LOG_NOTICE, "[hmmm] " << SLOGPREFIX << _MSG_, ##__VA_ARGS__)
+#define SWARN(_MSG_, ...) SSYSLOG(LOG_WARNING, "[warn] " << SLOGPREFIX << _MSG_, ##__VA_ARGS__)
+#define SALERT(_MSG_, ...) SSYSLOG(LOG_ALERT, "[alrt] " << SLOGPREFIX << _MSG_, ##__VA_ARGS__)
+#define SERROR(_MSG_, ...)                                  \
     do {                                                    \
-        stringstream ss;                                    \
-        ss << "[eror] " << SLOGPREFIX << _MSG_;             \
-        SSYSLOG(LOG_ERR, ss.str(), map<string, string>());  \
+        SSYSLOG(LOG_ERR, "[eror] " << SLOGPREFIX << _MSG_, ##__VA_ARGS__); \
         SLogStackTrace();                                   \
         abort();                                            \
     } while (false)

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -233,8 +233,7 @@ extern atomic<void (*)(int priority, const char *format, ...)> SSyslogFunc;
 //template <typename T>
 //string addLogParams(const string& message, const map<string, T> params);
 
-string addLogParams(const string& message, const map<string, string>& params);
-string addLogParams(const string& message);
+string addLogParams(const string& message, const map<string, string>& params = {});
 
 // **NOTE: rsyslog default max line size is 8k bytes. We split on 7k byte boundaries in order to fit the syslog line prefix and the expanded \r\n to #015#012
 #define SWHEREAMI SThreadLogPrefix + "(" + basename((char*)__FILE__) + ":" + SToStr(__LINE__) + ") " + __FUNCTION__ + " [" + SThreadLogName + "] "

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -438,7 +438,7 @@ bool SQLite::verifyTable(const string& tableName, const string& sql, bool& creat
 }
 
 bool SQLite::verifyIndex(const string& indexName, const string& tableName, const string& indexSQLDefinition, bool isUnique, bool createIfNotExists) {
-    SINFO("Verifying index '" << indexName << "'. isUnique? " << to_string(isUnique));
+    SINFO("Verifying index", {{"indexName", indexName}, {"isUnique?", to_string(isUnique)}});
     SQResult result;
     SASSERT(read("SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name=" + SQ(tableName) + " AND name=" + SQ(indexName) + ";", result));
 


### PR DESCRIPTION
### Details

We fail to auto-assign many Bedrock-generated warns and alerts because we fail to get the git blame due to the log message being variant in many places. This problem does not exist in other repos, thanks to logging params. This PR aims to replicate this system in Bedrock so that it can be widely used by everyone, allowing our auto-assigning script to easily find blame. 

Please let me know what you think.

### Fixed Issues
Related with https://github.com/Expensify/Expensify/issues/386799

### Tests
```
2024-09-20T08:25:48.559859-05:00 expensidev2004 bedrock: xxxxxx (SQLite.cpp:441) verifyIndex [sync] [info] Verifying index ~~ indexName: 'jobsPriorityNextRunManualSmartScan' isUnique?: '0'
```

_________
**Internal Testing Reminder:** when changing Bedrock, please compile auth against your new changes
