### PR TITLE
Respond to standup at login correctly.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1736,17 +1736,6 @@ void SQLiteNode::_onConnect(SQLitePeer* peer) {
     login["Version"] = _version;
     login["Permafollower"] = _originalPriority ? "false" : "true";
     _sendToPeer(peer, login);
-
-    // If we're STANDINGUP when a peer connects, send them a STATE message so they know they need to APPROVE or DENY the standup.
-    // Otherwise we will wait for their response that's not coming,and can eventually time out the standup.
-    // OH, If we're already standing up, both these messages have the same state. LOGIN sets the sate, and then it doesn't change here.
-    if (_state == SQLiteNodeState::STANDINGUP) {
-        SData state("STATE");
-        state["StateChangeCount"] = to_string(_stateChangeCount);
-        state["State"] = stateName(_state);
-        state["Priority"] = SToStr(_priority);
-        _sendToPeer(peer, state);
-    }
 }
 
 // --------------------------------------------------------------------------

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1367,7 +1367,6 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
             peer->state = stateFromName(message["State"]);
             const SQLiteNodeState to = peer->state;
             if (from == to) {
-                // This is what happens.
                 // No state change, just new commits?
                 PINFO("Peer received new commit in state '" << stateName(from) << "', commit #" << message["CommitCount"] << " ("
                       << message["Hash"] << ")");
@@ -1520,8 +1519,6 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                 _db.getCommits(commitNum, commitNum, result);
                 _forkedFrom.insert(peer->name);
 
-                // Remove the forked peer as the sync peer.
-     
                 SALERT("Hash mismatch. Peer " << peer->name << " and I have forked at commit " << message["hashMismatchNumber"]
                        << ". I have forked from " << _forkedFrom.size() << " other nodes. I am " << stateName(_state)
                        << " and have hash " << result[0][0] << " for that commit. Peer has hash " << message["hashMismatchValue"] << "."
@@ -1780,7 +1777,6 @@ void SQLiteNode::_onDisconnect(SQLitePeer* peer) {
         PHMMM("Lost our synchronization peer, re-SEARCHING.");
         SASSERTWARN(_state == SQLiteNodeState::SYNCHRONIZING);
         _syncPeer = nullptr;
-        // This happens.
         _changeState(SQLiteNodeState::SEARCHING);
     }
 
@@ -1939,7 +1935,6 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
 
         if (newState >= SQLiteNodeState::STANDINGUP) {
             // Not forked from anyone. Note that this includes both LEADING and FOLLOWING.
-            // We clear this when standing up.
             _forkedFrom.clear();
         }
 
@@ -2231,8 +2226,6 @@ void SQLiteNode::_updateSyncPeer()
                 nonChosenPeers.push_back(peer->name + ":" + to_string(peer->latency/1000) + "ms");
             }
         }
-
-        // Don't includ forked peers.
         SINFO("Updating SYNCHRONIZING peer from " << from << " to " << to << ". Not chosen: " << SComposeList(nonChosenPeers));
 
         // And save the new sync peer internally.

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -267,6 +267,7 @@ class SQLiteNode : public STCPManager {
 
     // Replicates any transactions that have been made on our database by other threads to peers.
     void _sendOutstandingTransactions(const set<uint64_t>& commitOnlyIDs = {});
+    void _sendStandupResponse(SQLitePeer* peer, const SData& message);
     void _sendPING(SQLitePeer* peer);
     void _sendToAllPeers(const SData& message, bool subscribedOnly = false);
     void _sendToPeer(SQLitePeer* peer, const SData& message);


### PR DESCRIPTION
### Details
See investigation in comments here: https://github.com/Expensify/Expensify/issues/426227

When we connect to a peer, if we're `STANDINGUP` we intend to send a `STATE` message indicating that the remote node should approve or deny our standup:
https://github.com/Expensify/Bedrock/blob/cedf037b232737833b449ca94ba06806578d1c86/sqlitecluster/SQLiteNode.cpp#L1810-L1831

However, because the `LOGIN` and `STATE` messages are sent back to back, they will always have the same state (which is `STANDINGUP`).

This means that when processing the `STATE` message we'll always hit this code:
https://github.com/Expensify/Bedrock/blob/cedf037b232737833b449ca94ba06806578d1c86/sqlitecluster/SQLiteNode.cpp#L1364-L1368

Rather than this code:
https://github.com/Expensify/Bedrock/blob/cedf037b232737833b449ca94ba06806578d1c86/sqlitecluster/SQLiteNode.cpp#L1424

We should probably send `STANDUP_RESPONSE` in response to `LOGIN` when the node is `STANDINGUP` and remove the second `STATE` message here.

This will fix the race condition where a late login during standup prevents the cluster from forming which happens because of this line: https://github.com/Expensify/Bedrock/blob/cedf037b232737833b449ca94ba06806578d1c86/sqlitecluster/SQLiteNode.cpp#L2033

However, I think that just puts us in a different bad state in the case we *are* forked from the node that does the late connect. Now it will respond to the `LOGIN` with a `STANDUP_RESPONSE` but this will be a `DENY` which is just as bad.

I think we should adjust the logic to not clear the `_forkedFrom` list until we are actually `LEADING` or `FOLLOWING`. I can imagine some scenario where clearing this in `STANDINGUP` gets us to reset a node that was forked and no longer is, i.e., it was just restored from backup, and it was the final node required to reach quorum. In this case, we would still not form a cluster, we'd need to restart the node that is attempting to stand up.

Thoughts on this?

EDIT: Looking at the code, we won't actually `DENY` due to a hash mismatch, only if we think some other node is leading. So a node that's forked from us (but hasn't realized that yet) can still approve the standup, and it will abstain if it does realize it's forked.

*NOTE:* The code in `_sendStandupResponse` is exactly the block deleted from `_onMESSAGE` with no changes except indentation.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/426227

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
