### PR TITLE
Redact the "edits" field in any logged queries

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2913,6 +2913,9 @@ void SRedactSensitiveValues(string& s) {
 
     // Remove anything inside "html" because we intentionally don't log chats.
     s = SREReplace("\"html\":\".*\"", s, "\"html\":\"<REDACTED>\"");
+
+    // Remove anything inside "edits" because these are also chats.
+    s = SREReplace("\"edits\":\".*\"", s, "\"edits\":\"<REDACTED>\"");
 }
 
 SStopwatch::SStopwatch() {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2915,7 +2915,7 @@ void SRedactSensitiveValues(string& s) {
     s = SREReplace("\"html\":\".*\"", s, "\"html\":\"<REDACTED>\"");
 
     // Remove anything inside "edits" because these are also chats.
-    s = SREReplace("\"edits\":\\[\".*?\"\\]", s, "\"edits\":[\"REDACTED\"]");
+    s = SREReplace(R"(\"edits\":\[.*?\])", s, "\"edits\":[\"REDACTED\"]");
 }
 
 SStopwatch::SStopwatch() {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2915,7 +2915,7 @@ void SRedactSensitiveValues(string& s) {
     s = SREReplace("\"html\":\".*\"", s, "\"html\":\"<REDACTED>\"");
 
     // Remove anything inside "edits" because these are also chats.
-    s = SREReplace("\"edits\":\".*\"", s, "\"edits\":\"<REDACTED>\"");
+    s = SREReplace("\"edits\":\\[\".*?\"\\]", s, "\"edits\":[\"REDACTED\"]");
 }
 
 SStopwatch::SStopwatch() {


### PR DESCRIPTION
### Details

Discovered while investigating: https://github.com/Expensify/Expensify/issues/381602

We are logging deleted report comments when people delete them.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/430811

### Tests

Apply this diff since the queries need to be over 10ms to show on dev and probably won't be

```diff
diff --git a/libstuff/libstuff.cpp b/libstuff/libstuff.cpp
index 7275931f..56b27131 100644
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2667,7 +2667,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
     }

     uint64_t elapsed = STimeNow() - startTime;
-    if (!skipInfoWarn && ((int64_t)elapsed > warnThreshold || (int64_t)elapsed > 10000)) {
+    if (!skipInfoWarn && true) {
         // Avoid logging queries so long that we need dozens of lines to log them.
         string sqlToLog = sql.substr(0, 20000);
         SRedactSensitiveValues(sqlToLog);
```

1. Compile Auth
2. Update a comment
3. Tail logs for `UPDATE reportActions SET message =`
4. Verify that "edits" says `edits: ["REDACTED"]`
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
