### PR TITLE
Log which peers are logged in

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -592,6 +592,7 @@ bool SQLiteNode::update() {
         // How many peers have we logged in to?
         size_t numFullPeers = 0;
         size_t numLoggedInFullPeers = 0;
+        list<string> loggedInPeers;
         SQLitePeer* freshestPeer = nullptr;
         for (const auto& peer : _peerList) {
             // Count how many full peers (non-permafollowers) we have, and how many are logged in.
@@ -605,6 +606,7 @@ bool SQLiteNode::update() {
 
             // Find the freshest non-broken peer (including permafollowers).
             if (peer->loggedIn) {
+                loggedInPeers.push_back(peer->name);
                 if (_forkedFrom.count(peer->name)) {
                     SWARN("Hash mismatch. Forked from peer " << peer->name << " so not considering it.");
                     continue;
@@ -617,7 +619,7 @@ bool SQLiteNode::update() {
             }
         }
 
-        SINFO("Signed in to " << numLoggedInFullPeers << " of " << numFullPeers << " full peers (plus " << (_peerList.size() - numFullPeers) << " permafollowers).");
+        SINFO("Signed in to " << numLoggedInFullPeers << " of " << numFullPeers << " full peers (plus " << (_peerList.size() - numFullPeers) << " permafollowers): " << SQList(loggedInPeers));
 
         // We just keep searching until we are connected to at least half the full peers.
         // Note that `numLoggedInFullPeers == numFullPeers` is adequate to satisfy the cluster size, because we do not include ourselves in the cluster size.

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -619,7 +619,7 @@ bool SQLiteNode::update() {
             }
         }
 
-        SINFO("Signed in to " << numLoggedInFullPeers << " of " << numFullPeers << " full peers (plus " << (_peerList.size() - numFullPeers) << " permafollowers): " << SQList(loggedInPeers));
+        SINFO("Signed in to " << numLoggedInFullPeers << " of " << numFullPeers << " full peers (plus " << (_peerList.size() - numFullPeers) << " permafollowers): " << SComposeList(loggedInPeers));
 
         // We just keep searching until we are connected to at least half the full peers.
         // Note that `numLoggedInFullPeers == numFullPeers` is adequate to satisfy the cluster size, because we do not include ourselves in the cluster size.


### PR DESCRIPTION
### Details

This would have helped me understand quicker from logs which nodes are connected and which nodes aren't.

### Tests

Run cluster tests, check logs
```
2024-09-30T16:29:59.804672+00:00 expensidev2004 bedrock10004: xxxxxx (SQLiteNode.cpp:622) update [sync] [info] {cluster_node_1/SEARCHING} Signed in to 0 of 2 full peers (plus 0 permafollowers): 

2024-09-30T16:30:00.233168+00:00 expensidev2004 bedrock10007: xxxxxx (SQLiteNode.cpp:622) update [sync] [info] {cluster_node_2/SEARCHING} Signed in to 1 of 2 full peers (plus 0 permafollowers): cluster_node_0

2024-09-30T16:30:00.234614+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:622) update [sync] [info] {cluster_node_0/SEARCHING} Signed in to 1 of 2 full peers (plus 0 permafollowers): cluster_node_2

2024-09-30T16:30:09.526673+00:00 expensidev2004 bedrock10001: xxxxxx (SQLiteNode.cpp:622) update [sync] [info] {cluster_node_0/SEARCHING} Signed in to 2 of 2 full peers (plus 0 permafollowers): cluster_node_1, cluster_node_2
```