### PR TITLE
Don't operate on null pointer

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -287,15 +287,16 @@ void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg) {
         const char* pageOffset = strstr(zMsg, "conflict at page") + 17;
         _conflictPage = atol(pageOffset);
 
-        // 17 is the length of "part of db table" and the following space.
-        const char* tableOffset = strstr(pageOffset, "part of db table") + 17;
-
         // Check if the tableOffset exists since not all conflicts are on tables
+        const char* tableOffset = strstr(pageOffset, "part of db table");
         if (tableOffset) {
+            // 17 is the length of "part of db table" and the following space.
+            tableOffset += 17;
+
             // Based on the SQLite log line, we should always have ';' after the table name,
             // so let's find it and use it to limit the size of the substring we need
             const char* semicolonOffset = strstr(tableOffset, ";");
-            
+
             // Let's add this check in case the SQLite log changes and we don't notice it
             // since this would generate a runtime error.
             if (semicolonOffset) {


### PR DESCRIPTION
### Details

### Fixed Issues
Caused by https://github.com/Expensify/Bedrock/pull/1882/files#diff-6cca2e6a219aa7f2d6c430b05478aa480eeaafd46c51bbe7e4e43d9ac7a64ce9R291

Fixes a seg fault on this line.

cc @danieldoglas @tylerkaraszewski 

### Tests

Ran all Auth tests.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
