### PR TITLE
Release DB handle on follower when escalating command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -953,6 +953,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                     if (!canWriteParallel) {
                         // Roll back the transaction, it'll get re-run in the sync thread.
                         core.rollback();
+                        dbScope.release();
                         auto _clusterMessengerCopy = _clusterMessenger;
                         if (getState() == SQLiteNodeState::LEADING) {
                             // Limit the command timeout to 20s to avoid blocking the sync thread long enough to cause the cluster to give up and elect a new leader (causing a fork), which happens

--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -87,7 +87,7 @@ void SQLitePool::returnToPool(size_t index) {
     _wait.notify_one();
 }
 
-SQLiteScopedHandle::SQLiteScopedHandle(SQLitePool& pool, size_t index) : _pool(pool), _index(index), _released(true)
+SQLiteScopedHandle::SQLiteScopedHandle(SQLitePool& pool, size_t index) : _pool(pool), _index(index), _released(false)
 {}
 
 void SQLiteScopedHandle::release() {

--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -87,11 +87,18 @@ void SQLitePool::returnToPool(size_t index) {
     _wait.notify_one();
 }
 
-SQLiteScopedHandle::SQLiteScopedHandle(SQLitePool& pool, size_t index) : _pool(pool), _index(index)
+SQLiteScopedHandle::SQLiteScopedHandle(SQLitePool& pool, size_t index) : _pool(pool), _index(index), _released(true)
 {}
 
+void SQLiteScopedHandle::release() {
+    if (!_released) {
+        _pool.returnToPool(_index);
+        _released = true;
+    }
+}
+
 SQLiteScopedHandle::~SQLiteScopedHandle() {
-    _pool.returnToPool(_index);
+    release();
 }
 
 SQLite& SQLiteScopedHandle::db() {

--- a/sqlitecluster/SQLitePool.h
+++ b/sqlitecluster/SQLitePool.h
@@ -53,8 +53,10 @@ class SQLiteScopedHandle {
     SQLiteScopedHandle(SQLitePool& pool, size_t index);
     ~SQLiteScopedHandle();
     SQLite& db();
+    void release();
 
   private:
     SQLitePool& _pool;
     size_t _index;
+    bool _released;
 };


### PR DESCRIPTION
### Details

This just releases the DB handle before escalation, freeing it up for others to use.

### Fixed Issues
Fixes https://expensify.slack.com/archives/C07PP7QV8P5/p1728324082742299

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
