### PR TITLE
Add stack trace to a file in case of crash

### DIFF
--- a/libstuff/SSignal.cpp
+++ b/libstuff/SSignal.cpp
@@ -210,7 +210,8 @@ void _SSignal_StackTrace(int signum, siginfo_t *info, void *ucontext) {
                 SWARN("Stack depth is " << depth << " only logging first and last 20 frames.");
             }
 
-            // Create a file to write the backtraceso we can write those logs in case we lose rsyslog due to a huge backlog.
+            // We mainly depend on syslog to investigate crashes, but when performance is real bad, sometimes we lose those logs.
+            // For cases like those, we'll also save the stack trace for the crash in a file.
             int fd = creat(format("/tmp/bedrock_crash_{}.log", STimeNow()).c_str(), 0666);
             for (int i = 0; i < depth; i++) {
                 if (depth > 40 && i >= 20 && i < depth - 20) {
@@ -238,10 +239,7 @@ void _SSignal_StackTrace(int signum, siginfo_t *info, void *ucontext) {
                 }
                 free(frame);
             }
-            // only try to close fd if it was successfully opened, otherwise we'll crash
-            if (fd != -1) {
-                close(fd);
-            }
+            close(fd);
 
             // Done.
             free(callstack);

--- a/libstuff/SSignal.cpp
+++ b/libstuff/SSignal.cpp
@@ -234,7 +234,7 @@ void _SSignal_StackTrace(int signum, siginfo_t *info, void *ucontext) {
                 string fullLogLine = format("Frame #{}: {}", i, tolog);
                 SWARN(fullLogLine);
                 if (fd != -1) {
-                    fullLogLine = format("{}{}",fullLogLine, "\n");
+                    fullLogLine = format("{}{}", fullLogLine, "\n");
                     write(fd, fullLogLine.c_str(), strlen(fullLogLine.c_str()));
                 }
                 free(frame);


### PR DESCRIPTION
### Details

This PR will change the SSignal handler to also save the crash stack trace to a file in cases where we might lose the logs because of the rsyslog backlog.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/432725

### Tests
I applied the following diff to my code which will generate an infinite recursion, built and restarted bedrock in my VM:
```
diff --git a/main.cpp b/main.cpp
index 56989a86..d0073d22 100644
--- a/main.cpp
+++ b/main.cpp
@@ -138,7 +138,19 @@ set<string> loadPlugins(SData& args) {
 
     return postProcessedNames;
 }
-
+int addForever2(int from);
+int addForever1(int from) {
+    if (from == INT_MAX) {
+        return from;
+    }
+    return addForever2(from + 1);
+}
+int addForever2(int from) {
+    if (from == INT_MAX) {
+        return from;
+    }
+    return addForever1(from + 1);
+}
 /////////////////////////////////////////////////////////////////////////////
 int main(int argc, char* argv[]) {
     // Process the command line
@@ -342,6 +354,7 @@ int main(int argc, char* argv[]) {
 
     // Keep going until someone kills it (either via TERM or Control^C)
     while (!(SGetSignal(SIGTERM) || SGetSignal(SIGINT))) {
+        addForever1(1);
         if (SGetSignals()) {
             // Log and clear any outstanding signals.
             SALERT("Uncaught signals (" << SGetSignalDescription() << "), ignoring.");
```

That generated the following file:

```
vagrant@expensidev2004:/vagrant/Bedrock$ sudo cat /tmp/bedrock_crash_1728489186029074.log 
Frame #0: _SSignal_StackTrace(int, siginfo_t*, void*)
Frame #1: __kernel_rt_sigreturn
Frame #2: addForever2(int)
Frame #3: addForever1(int)
Frame #4: addForever2(int)
Frame #5: addForever1(int)
Frame #6: addForever2(int)
Frame #7: addForever1(int)
Frame #8: addForever2(int)
Frame #9: addForever1(int)
Frame #10: addForever2(int)
Frame #11: addForever1(int)
Frame #12: addForever2(int)
Frame #13: addForever1(int)
Frame #14: addForever2(int)
Frame #15: addForever1(int)
Frame #16: addForever2(int)
Frame #17: addForever1(int)
Frame #18: addForever2(int)
Frame #19: addForever1(int)
Frame #261225: addForever1(int)
Frame #261226: addForever2(int)
Frame #261227: addForever1(int)
Frame #261228: addForever2(int)
Frame #261229: addForever1(int)
Frame #261230: addForever2(int)
Frame #261231: addForever1(int)
Frame #261232: addForever2(int)
Frame #261233: addForever1(int)
Frame #261234: addForever2(int)
Frame #261235: addForever1(int)
Frame #261236: addForever2(int)
Frame #261237: addForever1(int)
Frame #261238: addForever2(int)
Frame #261239: addForever1(int)
Frame #261240: addForever2(int)
Frame #261241: addForever1(int)
Frame #261242: main
Frame #261243: __libc_start_main
Frame #261244: /usr/sbin/bedrock(+0x10c138) [0xaaaae77a9138]
```
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
