### PR TITLE
Only log whitelisted params in addLogParams

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -3,6 +3,7 @@
 
 // Global logging state shared between all threads
 atomic<int> _g_SLogMask(LOG_INFO);
+atomic<bool> GLOBAL_IS_LIVE{true};
 
 void SLogStackTrace(int level) {
     // If the level isn't set in the log mask, nothing more to do
@@ -60,6 +61,9 @@ string addLogParams(string&& message, const map<string, string>& params) {
         const auto& param = *next(params.begin(), i);
         string value = param.second;
         if (!SContains(PARAMS_WHITELIST, param.first )) {
+            if (!GLOBAL_IS_LIVE) {
+                STHROW("500 Log param not in the whitelist, either do not log that or add it to PARAMS_WHITELIST if it's not sensitive");
+            }
             value = "<REDACTED>";
         }
         message += param.first + ": '" + value + "'";

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -39,6 +39,14 @@ void SLogStackTrace(int level) {
     }
 }
 
+// If the param name is not in this whitelist, we will log <REDACTED> in addLogParams.
+static const set<string> PARAMS_WHITELIST = {
+    "accountID",
+    "command",
+    "indexName",
+    "isUnique",
+};
+
 string addLogParams(string&& message, const map<string, string>& params) {
     if (params.empty()) {
         return message;
@@ -50,7 +58,11 @@ string addLogParams(string&& message, const map<string, string>& params) {
             message += " ";
         }
         const auto& param = *next(params.begin(), i);
-        message += param.first + ": '" + param.second + "'";
+        string value = param.second;
+        if (!SContains(PARAMS_WHITELIST, param.first )) {
+            value = "<REDACTED>";
+        }
+        message += param.first + ": '" + value + "'";
     }
 
     return message;

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -53,20 +53,17 @@ string addLogParams(string&& message, const map<string, string>& params) {
         return message;
     }
 
-    message += " ~~ ";
-    for (size_t i = 0; i < params.size(); ++i) {
-        if (i > 0) {
-            message += " ";
-        }
-        const auto& param = *next(params.begin(), i);
-        string value = param.second;
-        if (!SContains(PARAMS_WHITELIST, param.first )) {
+    message += " ~~";
+    for (const auto& [key, value] : params) {
+        message += " ";
+        string valueToLog = value;
+        if (!SContains(PARAMS_WHITELIST, key)) {
             if (!GLOBAL_IS_LIVE) {
                 STHROW("500 Log param not in the whitelist, either do not log that or add it to PARAMS_WHITELIST if it's not sensitive");
             }
-            value = "<REDACTED>";
+            valueToLog = "<REDACTED>";
         }
-        message += param.first + ": '" + value + "'";
+        message += key + ": '" + valueToLog + "'";
     }
 
     return message;

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -28,6 +28,9 @@ struct SData;
 
 using namespace std;
 
+// Global indicating whether we're running the server on dev or production.
+extern atomic<bool> GLOBAL_IS_LIVE;
+
 // Initialize libstuff on every thread before calling any of its functions
 void SInitialize(string threadName = "", const char* processName = 0);
 

--- a/main.cpp
+++ b/main.cpp
@@ -149,6 +149,8 @@ int main(int argc, char* argv[]) {
         cout << "Protip: check syslog for details, or run 'bedrock -?' for help" << endl;
     }
 
+    GLOBAL_IS_LIVE = args.isSet("-live");
+
     // Initialize the sqlite library before any other code has a chance to do anything with it.
     // Set the logging callback for sqlite errors.
     SASSERT(sqlite3_config(SQLITE_CONFIG_LOG, SQLite::_sqliteLogCallback, 0) == SQLITE_OK);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -460,7 +460,7 @@ bool SQLite::verifyTable(const string& tableName, const string& sql, bool& creat
 }
 
 bool SQLite::verifyIndex(const string& indexName, const string& tableName, const string& indexSQLDefinition, bool isUnique, bool createIfNotExists) {
-    SINFO("Verifying index", {{"indexName", indexName}, {"isUnique?", to_string(isUnique)}});
+    SINFO("Verifying index", {{"indexName", indexName}, {"isUnique", to_string(isUnique)}});
     SQResult result;
     SASSERT(read("SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name=" + SQ(tableName) + " AND name=" + SQ(indexName) + ";", result));
 


### PR DESCRIPTION

### Details

Followup to https://github.com/Expensify/Bedrock/pull/1875 cc @danieldoglas @iwiznia 

We will inevitably log sensitive data one day. This should greatly help prevent that from happening. 


### Fixed Issues
https://expensify.slack.com/archives/C03TQ48KC/p1728575765999519?thread_ts=1728575026.926699&cid=C03TQ48KC

### Tests

Before the change in `sqlitecluster/SQLite.cpp`:
```
2024-10-10T17:45:51.017151+00:00 expensidev2004 bedrock: xxxxxx (SQLite.cpp:463) verifyIndex [sync] [info] Verifying index ~~ indexName: 'onyxUpdates_0001_channelType_updateID_channelID' isUnique?: '<REDACTED>'
```

After the change:
```
2024-10-10T17:46:13.305626+00:00 expensidev2004 bedrock: xxxxxx (SQLite.cpp:463) verifyIndex [sync] [info] Verifying index ~~ indexName: 'onyxUpdates_0001_channelType_updateID_channelID' isUnique: '0'
```

After the change to throw:
```
2024-10-16T17:30:46.907101+00:00 expensidev2004 bedrock: xxxxxx (libstuff.cpp:156) SException [sync] [info] Throwing exception with message: '500 Log param not in the whitelist, either do not log that or add it to PARAMS_WHITELIST if it's not sensitive' from libstuff/SLog.cpp:65
2024-10-16T17:30:46.907123+00:00 expensidev2004 bedrock: xxxxxx (libstuff.cpp:2778) STerminateHandler [sync] [alrt] Terminating with uncaught exception '(mangled) 10SException'.
```