### PR TITLE
Call SStopSignalThread() in clustertest

### DIFF
--- a/test/clustertest/main.cpp
+++ b/test/clustertest/main.cpp
@@ -74,6 +74,7 @@ int main(int argc, char* argv[]) {
     }
 
 
+    cout << "Running tests" <<endl;
 
     int retval = 0;
     {
@@ -87,7 +88,11 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    cout << "DONE running tests" <<endl;
+
     SStopSignalThread();
+
+    cout << "DONE calling SStopSignalThread" <<endl;
 
     // Tester gets destroyed here. Everything's done.
     return retval;

--- a/test/clustertest/main.cpp
+++ b/test/clustertest/main.cpp
@@ -73,9 +73,6 @@ int main(int argc, char* argv[]) {
         threads = SToInt(args["-threads"]);
     }
 
-
-    cout << "Running tests" <<endl;
-
     int retval = 0;
     {
         for (int i = 0; i < repeatCount; i++) {
@@ -88,11 +85,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    cout << "DONE running tests" <<endl;
-
     SStopSignalThread();
-
-    cout << "DONE calling SStopSignalThread" <<endl;
 
     // Tester gets destroyed here. Everything's done.
     return retval;

--- a/test/clustertest/main.cpp
+++ b/test/clustertest/main.cpp
@@ -87,6 +87,8 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    SStopSignalThread();
+
     // Tester gets destroyed here. Everything's done.
     return retval;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -92,5 +92,6 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    SStopSignalThread();
     return retval;
 }


### PR DESCRIPTION
### Details

Same as https://github.com/Expensify/Auth/pull/12397 ?

### Fixed Issues
https://expensify.slack.com/archives/C07J32337/p1728576939023589?thread_ts=1728576188.474759&cid=C07J32337 ?

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
