### PR TITLE
Correctly handle all 200 Spotnana responses

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -93,7 +93,7 @@ void SStandaloneHTTPSManager::postPoll(fd_map& fdm, SStandaloneHTTPSManager::Tra
         // content. Why this is the what constitutes a valid response is lost to time. Any well-formed response should
         // be valid here, and this should get cleaned up. However, this requires testing anything that might rely on
         // the existing behavior, which is an exercise for later.
-        if (SContains(transaction.fullResponse.methodLine, " 200 ") || transaction.fullResponse.content.size()) {
+        if (SContains(transaction.fullResponse.methodLine, " 200") || transaction.fullResponse.content.size()) {
             // Pass the transaction down to the subclass.
             _onRecv(&transaction);
         } else {

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -89,7 +89,7 @@ void SStandaloneHTTPSManager::postPoll(fd_map& fdm, SStandaloneHTTPSManager::Tra
         // Shut down the socket, we're done with it.
         transaction.s->shutdown(Socket::CLOSED);
 
-        // This is supposed to check for a "200 OK" response, which it does very poorly. It also checks for message
+        // This is supposed to check for a "200" response, which it does very poorly. It also checks for message
         // content. Why this is the what constitutes a valid response is lost to time. Any well-formed response should
         // be valid here, and this should get cleaned up. However, this requires testing anything that might rely on
         // the existing behavior, which is an exercise for later.


### PR DESCRIPTION
### Details
Spotnana is not sending `200 OK`, but `HTTP/1.1 200` (sometimes). We need to handle that correctly.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/431982

### Tests
Will be tested after deploy with real Spotnana flows
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
