### PR TITLE
Add the policy account Id to param whitelist

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -53,7 +53,8 @@ static const set<string> PARAMS_WHITELIST = {
     "policyID",
     "companyName",
     "companyWebsite",
-    "invoice"
+    "invoice",
+    "policyAccountID"
 };
 
 string addLogParams(string&& message, const map<string, string>& params) {


### PR DESCRIPTION
### Details

a new param for the log whitelist required for here https://github.com/Expensify/Auth/pull/12760

### Fixed Issues
Related to https://github.com/Expensify/Auth/pull/12760

### Tests

N/A

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
