### PR TITLE
Demote warning

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2712,7 +2712,8 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
 
         // We don't warn for constraints errors because sometimes they're allowed, and BedrockCore.cpp will warn for the ones that aren't.
         // This prevents creating bugbot issues for the allowed cases. We still log as INFO though so we can diagnose the query with the problem.
-        if (error == SQLITE_CONSTRAINT) {
+        // We also don't warn for `interrupt` because it generally means a timeout which is handled separately.
+        if (error == SQLITE_CONSTRAINT || error == SQLITE_INTERRUPT) {
             SINFO("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);
         } else {
             SWARN("'" << e << "', query failed with error #" << error << " (" << sqlite3_errmsg(db) << "): " << sqlToLog);


### PR DESCRIPTION
### Details
Demotes this warning, it's handled separately with the code that handles timeouts.
### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/438274

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
