### PR TITLE
Decrement thread count on exception.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1653,8 +1653,8 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     // we're changing the state to SEARCHING and sending the cancelAfter property to drop all threads
                     // that depend on the transaction that failed to be threaded.
                     _replicationThreadCount.fetch_sub(1);
-                    _changeState(SQLiteNodeState::SEARCHING, message.calcU64("NewCount") - 1);
                     SWARN("Caught system_error starting _replicate thread with " << _replicationThreadCount.load() << " threads. e.what()=" << e.what());
+                    _changeState(SQLiteNodeState::SEARCHING, message.calcU64("NewCount") - 1);
                     STHROW("Error starting replicate thread so giving up and reconnecting.");
                 }
                 SDEBUG("Done spawning concurrent replicate thread: " << threadID);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1652,6 +1652,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     // and waiting for the transaction that failed will be stuck in an infinite loop. To prevent that
                     // we're changing the state to SEARCHING and sending the cancelAfter property to drop all threads
                     // that depend on the transaction that failed to be threaded.
+                    _replicationThreadCount.fetch_sub(1);
                     _changeState(SQLiteNodeState::SEARCHING, message.calcU64("NewCount") - 1);
                     SWARN("Caught system_error starting _replicate thread with " << _replicationThreadCount.load() << " threads. e.what()=" << e.what());
                     STHROW("Error starting replicate thread so giving up and reconnecting.");


### PR DESCRIPTION
### Details
So, we increment the thread count here, before starting a replication thread:
https://github.com/Expensify/Bedrock/blob/a30c7e15767e3c8c220d60b928b8497e104e3b27/sqlitecluster/SQLiteNode.cpp#L1644

Normally, we will decrement this inside the replication thread when it exits, which is handled here:
https://github.com/Expensify/Bedrock/blob/a30c7e15767e3c8c220d60b928b8497e104e3b27/sqlitecluster/SQLiteNode.cpp#L199

However, if the thread fails to start and throws `system_error`, we will get to this point:
https://github.com/Expensify/Bedrock/blob/a30c7e15767e3c8c220d60b928b8497e104e3b27/sqlitecluster/SQLiteNode.cpp#L1655

Without ever having run the thread, and thus, without the thread count ever being decremented. Further, change state will wait for the thread count to be 0 before it completes, which means the above line blocks and we never log the warning or throw the error.

Here's where _changeState blocks on this:
https://github.com/Expensify/Bedrock/blob/a30c7e15767e3c8c220d60b928b8497e104e3b27/sqlitecluster/SQLiteNode.cpp#L1874-L1880

The fix is to decrement the counter if we hit the exception case. I've also moved logging the warning to above the `_changeState` call so that it will be visible sooner that we've hit this exception.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/440475

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
