### PR TITLE
Add new params to log allowlist

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -57,6 +57,8 @@ static const set<string> PARAMS_WHITELIST = {
     "policyAccountID",
     "policyID",
     "reportID",
+    "shouldCompleteOnboarding",
+    "shouldDismissHybridAppOnboarding",
     "token",
     "transactionID",
     "type",


### PR DESCRIPTION
### Details
Add 2 new params are allowed to be logged 

### Fixed Issues
Part of broader changes for https://github.com/Expensify/Expensify/issues/441716

### Tests
N/A

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
