### PR TITLE
Add header info to readDB even in HCTree mode

### DIFF
--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -576,8 +576,9 @@ bool BedrockTester::readDB(const string& query, SQResult& result, bool online)
         SData command("Query");
         command["Query"] = fixedQuery;
         command["Format"] = "JSON";
-        auto row0 = SParseJSONObject(executeWaitMultipleData({command})[0].content)["rows"];
-        auto headerString = SParseJSONObject(executeWaitMultipleData({command})[0].content)["headers"];
+        auto commandResult = executeWaitMultipleData({command});
+        auto row0 = SParseJSONObject(commandResult[0].content)["rows"];
+        auto headerString = SParseJSONObject(commandResult[0].content)["headers"];
 
         list<string> headers = SParseJSONArray(headerString);
         for (const auto& h : headers) {

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -577,6 +577,12 @@ bool BedrockTester::readDB(const string& query, SQResult& result, bool online)
         command["Query"] = fixedQuery;
         command["Format"] = "JSON";
         auto row0 = SParseJSONObject(executeWaitMultipleData({command})[0].content)["rows"];
+        auto headerString = SParseJSONObject(executeWaitMultipleData({command})[0].content)["headers"];
+
+        list<string> headers = SParseJSONArray(headerString);
+        for (const auto& h : headers) {
+            result.headers.push_back(h);
+        }
 
         list<string> rows = SParseJSONArray(row0);
         for (const string& rowStr : rows) {


### PR DESCRIPTION
### Details

### Fixed Issues
https://github.com/Expensify/Expensify/issues/337537

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
