### PR TITLE
Outputting crash command list

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1671,22 +1671,19 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         {
             // Make it known if anything is known to cause crashes.
             shared_lock<decltype(_crashCommandMutex)> lock(_crashCommandMutex);
-            map<string, vector<string>> crashCommandData;
+            vector<string> crashCommandListArray;
 
             size_t totalCount = 0;
             for (const auto& s : _crashCommands) {
                 totalCount += s.second.size();
+                
+                vector<string> paramsArray;
                 for (const STable& params : s.second) {
-                    crashCommandData[s.first].push_back(SComposeJSONObject(params));
+                    paramsArray.push_back(SComposeJSONObject(params));
                 }
-            }
-
-            // Create a final JSON-like structure
-            STable crashCommandList;
-            vector<string> crashCommandListArray;
-            for (const auto& [command, data] : crashCommandData) {
+                
                 STable commandObject;
-                commandObject[command] = SComposeJSONArray(data);
+                commandObject[s.first] = SComposeJSONArray(paramsArray);
                 crashCommandListArray.push_back(SComposeJSONObject(commandObject));
             }
             content["crashCommands"] = totalCount;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1671,11 +1671,14 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         {
             // Make it known if anything is known to cause crashes.
             shared_lock<decltype(_crashCommandMutex)> lock(_crashCommandMutex);
+            vector<string> crashCommandList;
             size_t totalCount = 0;
             for (const auto& s : _crashCommands) {
+                crashCommandList.push_back(s.first);
                 totalCount += s.second.size();
             }
             content["crashCommands"] = totalCount;
+            content["crashCommandList"] = SComposeList(crashCommandList);
         }
 
         // On leader, return the current multi-write blacklists.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1679,7 +1679,9 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
                 
                 vector<string> paramsArray;
                 for (const STable& params : s.second) {
-                    paramsArray.push_back(SComposeJSONObject(params));
+                    if (!params.empty()) {
+                        paramsArray.push_back(SComposeJSONObject(params));
+                    }
                 }
                 
                 STable commandObject;


### PR DESCRIPTION
### Details
Outputs the list of crash commands in status,

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/442357

### Tests
Tested locally.
Case 1: No crash command `"crashCommandList":[]`
```
status

200 OK
nodeName: auth
totalTime: 3023
unaccountedTime: 3023
Content-Length: 504

{"commandCount":1,"commandPortBlockReasons":[],"CommitCount":201219,"crashCommandList":[],"crashCommands":0,"host":"0.0.0.0:4445","isLeader":true,"multiWriteEnabled":true,"multiWriteManualBlacklist":[],"peerList":[],"plugins":[{"name":"Auth","version":1},{"name":"DB"},{"name":"expensifyBackupManager","version":"44cf19575a"}],"priority":-1,"queuedCommandList":[],"state":"LEADING","syncNodeAvailable":true,"syncThreadQueuedCommandList":[],"version":"05b5902ff3:Auth_1:expensifyBackupManager_44cf19575a"}
```

Case 2: Single crash command, `"crashCommandList":[{"DeleteReport":[]}]`
```
CRASH_COMMAND
Content-Length:14

DeleteReport

200 OK
nodeName: auth
totalTime: 3604
unaccountedTime: 3604
Content-Length: 0

status

200 OK
nodeName: auth
totalTime: 1090
unaccountedTime: 1090
Content-Length: 523

{"commandCount":1,"commandPortBlockReasons":[],"CommitCount":201219,"crashCommandList":[{"DeleteReport":[]}],"crashCommands":1,"host":"0.0.0.0:4445","isLeader":true,"multiWriteEnabled":true,"multiWriteManualBlacklist":[],"peerList":[],"plugins":[{"name":"Auth","version":1},{"name":"DB"},{"name":"expensifyBackupManager","version":"44cf19575a"}],"priority":-1,"queuedCommandList":[],"state":"LEADING","syncNodeAvailable":true,"syncThreadQueuedCommandList":[],"version":"05b5902ff3:Auth_1:expensifyBackupManager_44cf19575a"}
```

Case 3: two crash commands, `"crashCommandList":[{"DeleteReport":[]},{"GuidedSetup":[{"accountID":12345},{"accountID":67890}]}]`
```
CRASH_COMMAND
Content-Length: 30

GuidedSetup
accountID: 12345

200 OK
nodeName: auth
totalTime: 317
unaccountedTime: 317
Content-Length: 0

CRASH_COMMAND
Content-Length: 30

GuidedSetup
accountID: 67890

200 OK
nodeName: auth
totalTime: 613
unaccountedTime: 613
Content-Length: 0

status

200 OK
nodeName: auth
totalTime: 1482
unaccountedTime: 1482
Content-Length: 581

{"commandCount":1,"commandPortBlockReasons":[],"CommitCount":201219,"crashCommandList":[{"DeleteReport":[]},{"GuidedSetup":[{"accountID":12345},{"accountID":67890}]}],"crashCommands":3,"host":"0.0.0.0:4445","isLeader":true,"multiWriteEnabled":true,"multiWriteManualBlacklist":[],"peerList":[],"plugins":[{"name":"Auth","version":1},{"name":"DB"},{"name":"expensifyBackupManager","version":"44cf19575a"}],"priority":-1,"queuedCommandList":[],"state":"LEADING","syncNodeAvailable":true,"syncThreadQueuedCommandList":[],"version":"05b5902ff3:Auth_1:expensifyBackupManager_44cf19575a"}
```
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
