### PR TITLE
Fix Deadlock

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -405,12 +405,12 @@ int SQLiteNode::getPriority() const {
 }
 
 void SQLiteNode::setShutdownPriority() {
-    SINFO("Setting priority to 1, will stop leading if required.");
+    SINFO("Setting priority to 1.");
     unique_lock<decltype(_stateMutex)> uniqueLock(_stateMutex);
     _priority = 1;
 
     if (_state == SQLiteNodeState::LEADING) {
-        _startStandDown = true;
+        SINFO("Will shop leading.");
     } else {
         SData state("STATE");
         state["StateChangeCount"] = to_string(_stateChangeCount);
@@ -1124,8 +1124,8 @@ bool SQLiteNode::update() {
         // Check to see if we should stand down. We'll finish any outstanding commits before we actually do.
         if (_state == SQLiteNodeState::LEADING) {
             string standDownReason;
-            if (_startStandDown) {
-                standDownReason = "Standing down";
+            if (_priority == 1) {
+                standDownReason = "Priority changed to 1, standing down.";
             } else if (_isShuttingDown) {
                 // Graceful shutdown. Set priority 1 and stand down so we'll re-connect to the new leader and finish
                 // up our commands.

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -591,6 +591,7 @@ bool SQLiteNode::update() {
         // If no peers, we're the leader, unless we're shutting down.
         if (_peerList.empty()) {
             SHMMM("No peers configured, jumping to LEADING");
+            _priority = _originalPriority;
             _changeState(SQLiteNodeState::LEADING);
 
             // Run `update` again immediately.

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -406,11 +406,10 @@ int SQLiteNode::getPriority() const {
 
 void SQLiteNode::setShutdownPriority() {
     SINFO("Setting priority to 1, will stop leading if required.");
-    unique_lock<decltype(_stateMutex)> uniqueLock(_stateMutex);
     _priority = 1;
 
     if (_state == SQLiteNodeState::LEADING) {
-        _changeState(SQLiteNodeState::STANDINGDOWN);
+        beginShutdown();
     } else {
         SData state("STATE");
         state["StateChangeCount"] = to_string(_stateChangeCount);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -410,7 +410,7 @@ void SQLiteNode::setShutdownPriority() {
     _priority = 1;
 
     if (_state == SQLiteNodeState::LEADING) {
-        SINFO("Will shop leading.");
+        SINFO("Will stop leading.");
     } else {
         SData state("STATE");
         state["StateChangeCount"] = to_string(_stateChangeCount);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -402,4 +402,6 @@ class SQLiteNode : public STCPManager {
     // A pointer to a SQLite instance that is passed to plugin's stateChanged function. This prevents plugins from operating on the same handle that
     // the sync node is when they run queries in stateChanged.
     SQLite* pluginDB;
+
+    atomic<bool> _startStandDown = false;
 };

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -402,6 +402,4 @@ class SQLiteNode : public STCPManager {
     // A pointer to a SQLite instance that is passed to plugin's stateChanged function. This prevents plugins from operating on the same handle that
     // the sync node is when they run queries in stateChanged.
     SQLite* pluginDB;
-
-    atomic<bool> _startStandDown = false;
 };


### PR DESCRIPTION
### Details
This is much harder to explain what it does than the actual code looks. This fixes a deadlock condition that can happen if we try to shut down while a QUORUM transaction is in progress.

When we do a QUORUM transaction, we require at least two loops through `update` in the sync thread. We start the transaction here:
https://github.com/Expensify/Bedrock/blob/806331e8e5b078a7a6cc2b4f70f8653a28250cfb/BedrockServer.cpp#L498

Which locks `commitLock` here:
https://github.com/Expensify/Bedrock/blob/806331e8e5b078a7a6cc2b4f70f8653a28250cfb/sqlitecluster/SQLite.cpp#L375-L386

This is held across calls to `SQLiteNode::update` until the transaction completes.

Meanwhile, if another thread (which can be a socket thread for `Detach` or `BeginBackup` commands, or the main thread when `SIGINT` is received) calls `beginShutdown` it calls `setShutdownPriority` here:
https://github.com/Expensify/Bedrock/blob/806331e8e5b078a7a6cc2b4f70f8653a28250cfb/BedrockServer.cpp#L1985

In the existing code, `setShutdownPriority` calls `changeState` here:
https://github.com/Expensify/Bedrock/blob/806331e8e5b078a7a6cc2b4f70f8653a28250cfb/sqlitecluster/SQLiteNode.cpp#L409-L413

Notably, it locks `_stateMutex` before doing so, which is expected, any operation that can change the state of the node needs to call this, so that the state doesn't change in the middle of other operations that depend on it.

However, `_changeState` needs to lock the commit mutex (via `exclusiveLockDB`) here:
https://github.com/Expensify/Bedrock/blob/806331e8e5b078a7a6cc2b4f70f8653a28250cfb/sqlitecluster/SQLiteNode.cpp#L2013-L2015

But because the QUORUM command is underway, it cannot get the commit lock, so it blocks while it is already holding `_stateMutex`.

Meanwhile, back in the sync thread, while we wait for the transaction to complete we call `postPoll` in a loop. We are holding `commitLock` the entire time as we need to complete this transaction without conflicts.
https://github.com/Expensify/Bedrock/blob/806331e8e5b078a7a6cc2b4f70f8653a28250cfb/BedrockServer.cpp#L252

But because `_postPoll` can call `_changeState` it also needs to lock the state mutex:
https://github.com/Expensify/Bedrock/blob/806331e8e5b078a7a6cc2b4f70f8653a28250cfb/sqlitecluster/SQLiteNode.cpp#L2527

So, what we get is:

1. The sync thread locks commitLock and broadcasts QUORUM command.
2. The server receives a shutdown message, so calls `setShutdownPriority`.
3. `setShutdownPriority` locks the state mutex and blocks waiting for the commitLock.
4. The sync thread attempts to read from the network in `postPoll` to see if the cluster has approved it's command, but blocks waiting for the state mutex.
5. Deadlock.

The fix is to not call `_changeState` directly from `setShutdownPriority`. Instead, we notice the priority change this makes in the next `update()` loop, and change the state there, avoiding the deadlock.

This would be fairly hard to trigger in production given our infrequent use of QUORUM commands, but is possible. It was easily reprducible when working on HC-Tree, because the test changes for that require a lot of stopping and restarting servers, and we could send a shutdown message to servers while they were running the initial quorum transaction that creates the database schema fairly easily.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/337537

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
