### PR TITLE
Whitelist attendees for logs

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -43,6 +43,7 @@ void SLogStackTrace(int level) {
 // If the param name is not in this whitelist, we will log <REDACTED> in addLogParams.
 static const set<string> PARAMS_WHITELIST = {
     "accountID",
+    "attendees"
     "cardID",
     "command",
     "companyName",


### PR DESCRIPTION
### Details

Added to PARAMS_WHITELIST so we can log it from Auth.


### Fixed Issues
Part of https://github.com/Expensify/Auth/pull/13113

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
