### PR TITLE
Add reason to commands to un/block command port

### DIFF
--- a/test/tests/CommandPortTest.cpp
+++ b/test/tests/CommandPortTest.cpp
@@ -37,4 +37,3 @@ struct CommandPortTest : tpunit::TestFixture {
     }
 
 } __CommandPortTest;
-

--- a/test/tests/CommandPortTest.cpp
+++ b/test/tests/CommandPortTest.cpp
@@ -11,22 +11,20 @@ struct CommandPortTest : tpunit::TestFixture {
         // When we close the command port with a reason
         SData closeCommandPort("SuppressCommandPort");
         closeCommandPort["reason"] = "testCommandPort";
-        string response = tester.executeWaitMultipleData({closeCommandPort})[0].content;
+        STable response = SParseJSONObject(tester.executeWaitMultipleData({closeCommandPort})[0].content);
 
         // The status command should show it in commandPortBlockReasons
         SData status("Status");
-        response = tester.executeWaitMultipleData({status}, 10, true)[0].content;
-        ASSERT_TRUE(SContains(response, "commandPortBlockReasons"));
-        ASSERT_TRUE(SContains(response, "testCommandPort"));
+        response = SParseJSONObject(tester.executeWaitMultipleData({status}, 10, true)[0].content);
+        ASSERT_EQUAL(SParseJSONArray(response["commandPortBlockReasons"]), list<string>{"testCommandPort"});
 
         // When we run ClearCommandPort with a reason different from the one used to close it
         SData badClearCommandPort("ClearCommandPort");
         tester.executeWaitMultipleData({badClearCommandPort}, 10, true);
 
         // The command port should stay close and the status command should still show the reason the port is closed in commandPortBlockReasons
-        response = tester.executeWaitMultipleData({status}, 10, true)[0].content;
-        ASSERT_TRUE(SContains(response, "commandPortBlockReasons"));
-        ASSERT_TRUE(SContains(response, "testCommandPort"));
+        response = SParseJSONObject(tester.executeWaitMultipleData({status}, 10, true)[0].content);
+        ASSERT_EQUAL(SParseJSONArray(response["commandPortBlockReasons"]), list<string>{"testCommandPort"});
 
         // When we run ClearCommandPort with the same reason as the one used to close it
         SData clearCommandPort("ClearCommandPort");
@@ -34,9 +32,8 @@ struct CommandPortTest : tpunit::TestFixture {
         tester.executeWaitMultipleData({clearCommandPort}, 10, true);
 
         // Then the command port should open and the reason should be removed from commandPortBlockReasons
-        response = tester.executeWaitMultipleData({status})[0].content;
-        ASSERT_TRUE(SContains(response, "commandPortBlockReasons"));
-        ASSERT_FALSE(SContains(response, "testCommandPort"));
+        response = SParseJSONObject(tester.executeWaitMultipleData({status})[0].content);
+        ASSERT_EQUAL(SParseJSONArray(response["commandPortBlockReasons"]), list<string>{});
     }
 
 } __CommandPortTest;

--- a/test/tests/CommandPortTest.cpp
+++ b/test/tests/CommandPortTest.cpp
@@ -1,0 +1,43 @@
+#include <libstuff/SData.h>
+#include <test/lib/BedrockTester.h>
+
+struct CommandPortTest : tpunit::TestFixture {
+    CommandPortTest()
+        : tpunit::TestFixture("CommandPort", TEST(CommandPortTest::test)) { }
+
+    void test() {
+        BedrockTester tester;
+
+        // When we close the command port with a reason
+        SData closeCommandPort("SuppressCommandPort");
+        closeCommandPort["reason"] = "testCommandPort";
+        string response = tester.executeWaitMultipleData({closeCommandPort})[0].content;
+
+        // The status command should show it in commandPortBlockReasons
+        SData status("Status");
+        response = tester.executeWaitMultipleData({status}, 10, true)[0].content;
+        ASSERT_TRUE(SContains(response, "commandPortBlockReasons"));
+        ASSERT_TRUE(SContains(response, "testCommandPort"));
+
+        // When we run ClearCommandPort with a reason different from the one used to close it
+        SData badClearCommandPort("ClearCommandPort");
+        tester.executeWaitMultipleData({badClearCommandPort}, 10, true);
+
+        // The command port should stay close and the status command should still show the reason the port is closed in commandPortBlockReasons
+        response = tester.executeWaitMultipleData({status}, 10, true)[0].content;
+        ASSERT_TRUE(SContains(response, "commandPortBlockReasons"));
+        ASSERT_TRUE(SContains(response, "testCommandPort"));
+
+        // When we run ClearCommandPort with the same reason as the one used to close it
+        SData clearCommandPort("ClearCommandPort");
+        clearCommandPort["reason"] = "testCommandPort";
+        tester.executeWaitMultipleData({clearCommandPort}, 10, true);
+
+        // Then the command port should open and the reason should be removed from commandPortBlockReasons
+        response = tester.executeWaitMultipleData({status})[0].content;
+        ASSERT_TRUE(SContains(response, "commandPortBlockReasons"));
+        ASSERT_FALSE(SContains(response, "testCommandPort"));
+    }
+
+} __CommandPortTest;
+


### PR DESCRIPTION
### Details

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/441198

### Tests
Auto

Manual:
- Closed command port with `reason: test`
- Ran status, and confirmed `commandPortBlockReasons` was set to `["test"]`
- Opened command port without reason
- Confirmed command port didn't open
- Opened command port with `reason:test`
- Confirmed command port re-opened

```
/vagrant/Bedrock (carlos-portreason) $ nc localhost 8888
SuppressCommandPort
reason:test

200 OK
nodeName: bedrock
totalTime: 612
unaccountedTime: 612
Content-Length: 0

status

200 OK
Connection: close
nodeName: bedrock
totalTime: 782
unaccountedTime: 782
Content-Length: 662

{"commandCount":1,"commandPortBlockReasons":["test"],"CommitCount":62226,"crashCommandList":[],"crashCommands":0,"host":"0.0.0.0:8889","isLeader":true,"multiWriteEnabled":true,"multiWriteManualBlacklist":[],"peerList":[],"plugins":[{"name":"Cache"},{"name":"Concierge","version":"8025bbd6f4"},{"name":"DB"},{"name":"ExpensifyTableManager","version":"c94d5ad290"},{"name":"Jobs"},{"name":"expensifyBackupManager","version":"44cf19575a"}],"priority":200,"queuedCommandList":[],"state":"LEADING","syncNodeAvailable":true,"syncThreadQueuedCommandList":[],"version":"14fa716e42:Concierge_8025bbd6f4:ExpensifyTableManager_c94d5ad290:expensifyBackupManager_44cf19575a"}
```
```
/vagrant/Bedrock (carlos-portreason) $ nc localhost 8888
localhost [127.0.0.1] 8888 (?) : Connection refused
```
```
/vagrant/Bedrock (carlos-portreason) $ nc localhost 8890
status

200 OK
nodeName: bedrock
totalTime: 165
unaccountedTime: 165
Content-Length: 662

{"commandCount":1,"commandPortBlockReasons":["test"],"CommitCount":62226,"crashCommandList":[],"crashCommands":0,"host":"0.0.0.0:8889","isLeader":true,"multiWriteEnabled":true,"multiWriteManualBlacklist":[],"peerList":[],"plugins":[{"name":"Cache"},{"name":"Concierge","version":"8025bbd6f4"},{"name":"DB"},{"name":"ExpensifyTableManager","version":"c94d5ad290"},{"name":"Jobs"},{"name":"expensifyBackupManager","version":"44cf19575a"}],"priority":200,"queuedCommandList":[],"state":"LEADING","syncNodeAvailable":true,"syncThreadQueuedCommandList":[],"version":"14fa716e42:Concierge_8025bbd6f4:ExpensifyTableManager_c94d5ad290:expensifyBackupManager_44cf19575a"}

ClearCommandPort

200 OK
nodeName: bedrock
totalTime: 101
unaccountedTime: 101
Content-Length: 0

^C
```
```
/vagrant/Bedrock (carlos-portreason) $ nc localhost 8888
localhost [127.0.0.1] 8888 (?) : Connection refused
```
```
/vagrant/Bedrock (carlos-portreason) $ nc localhost 8890
status

200 OK
nodeName: bedrock
totalTime: 192
unaccountedTime: 192
Content-Length: 662

{"commandCount":1,"commandPortBlockReasons":["test"],"CommitCount":62226,"crashCommandList":[],"crashCommands":0,"host":"0.0.0.0:8889","isLeader":true,"multiWriteEnabled":true,"multiWriteManualBlacklist":[],"peerList":[],"plugins":[{"name":"Cache"},{"name":"Concierge","version":"8025bbd6f4"},{"name":"DB"},{"name":"ExpensifyTableManager","version":"c94d5ad290"},{"name":"Jobs"},{"name":"expensifyBackupManager","version":"44cf19575a"}],"priority":200,"queuedCommandList":[],"state":"LEADING","syncNodeAvailable":true,"syncThreadQueuedCommandList":[],"version":"14fa716e42:Concierge_8025bbd6f4:ExpensifyTableManager_c94d5ad290:expensifyBackupManager_44cf19575a"}

ClearCommandPort
reason:test

200 OK
nodeName: bedrock
totalTime: 69
unaccountedTime: 69
Content-Length: 0

^C
```
```
/vagrant/Bedrock (carlos-portreason) $ nc localhost 8888
status

200 OK
nodeName: bedrock
totalTime: 167
unaccountedTime: 167
Content-Length: 656

{"commandCount":1,"commandPortBlockReasons":[],"CommitCount":62226,"crashCommandList":[],"crashCommands":0,"host":"0.0.0.0:8889","isLeader":true,"multiWriteEnabled":true,"multiWriteManualBlacklist":[],"peerList":[],"plugins":[{"name":"Cache"},{"name":"Concierge","version":"8025bbd6f4"},{"name":"DB"},{"name":"ExpensifyTableManager","version":"c94d5ad290"},{"name":"Jobs"},{"name":"expensifyBackupManager","version":"44cf19575a"}],"priority":200,"queuedCommandList":[],"state":"LEADING","syncNodeAvailable":true,"syncThreadQueuedCommandList":[],"version":"14fa716e42:Concierge_8025bbd6f4:ExpensifyTableManager_c94d5ad290:expensifyBackupManager_44cf19575a"}
```
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
