### PR TITLE
Log commit number in a log line that's not performance

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -806,7 +806,7 @@ int SQLite::commit(const string& description, function<void()>* preCheckpointCal
             }
             _sharedData.checkpointInProgress.clear();
         }
-        SINFO(description << " COMMIT complete in " << time << ". Wrote " << (endPages - startPages)
+        SINFO(description << " COMMIT " << SToStr(_sharedData.commitCount) << " complete in " << time << ". Wrote " << (endPages - startPages)
               << " pages. WAL file size is " << sz << " bytes. " << _queryCount << " queries attempted, " << _cacheHits
               << " served from cache. Used journal " << _journalName);
         _queryCount = 0;


### PR DESCRIPTION
### Details
This will make it easier to find when a specific commit was replicated by adding the data to a line that's in ES

### Fixed Issues
Context https://expensify.slack.com/archives/C03TQ48KC/p1732822060312889?thread_ts=1732821585.689939&cid=C03TQ48KC

### Tests
Did a write and checked logs:
```
2024-11-28T19:59:33.985485+00:00 expensidev2004 bedrock: QwHP7k ionatan@expensify.com (SQLite.cpp:811) commit [socket38] [info] LEADING COMMIT 2467 complete in 0.10ms. Wrote 10 pages. WAL file size is 4124152 bytes. 15 queries attempted, 1 served from cache. Used journal journal0005
```
Checked the journals to ensure that was indeed the lastID in them and it had the commit above the log line

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
