### PR TITLE
Revert "Remove log params that are not related to Bedrock"

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -41,17 +41,57 @@ void SLogStackTrace(int level) {
 }
 
 // If the param name is not in this whitelist, we will log <REDACTED> in addLogParams.
-static set<string> PARAMS_WHITELIST = {
+static const set<string> PARAMS_WHITELIST = {
+    "accountID",
+    "authEmail",
+    "accountIDs",
+    "attendees",
+    "bankAccountID",
+    "cardData",
+    "cardID",
+    "clientUpdateID",
     "command",
+    "companyName",
+    "companyWebsite",
     "Connection",
     "Content-Length",
     "count",
+    "currentTime",
+    "domainAccountID",
+    "domainName",
+    "email",
+    "errorMessage",
+    "feed",
+    "feedCountry",
+    "feedID",
+    "feedName",
+    "field",
+    "index",
     "indexName",
+    "invoice",
     "isUnique",
+    "key",
+    "lastIP",
     "logParam",
+    "nvpName",
+    "policyAccountID",
+    "policyID",
+    "reimbursementEntryID",
+    "reportID",
     "requestID",
+    "requestTimestamp",
+    "secondaryLogin",
+    "shouldCompleteOnboarding",
+    "shouldDismissHybridAppOnboarding",
     "status",
+    "step",
+    "timeDiff",
+    "token",
+    "transactionID",
+    "type",
     "userID",
+    "secondaryLogin",
+    "walletBankAccountID"
 };
 
 string addLogParams(string&& message, const STable& params) {
@@ -73,8 +113,4 @@ string addLogParams(string&& message, const STable& params) {
     }
 
     return message;
-}
-
-void SWhitelistLogParams(set<string> params) {
-    PARAMS_WHITELIST.insert(params.begin(), params.end());
 }

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -233,9 +233,6 @@ void SLogLevel(int level);
 // Stack trace logging
 void SLogStackTrace(int level = LOG_WARNING);
 
-// This method will allow plugins to whitelist log params they need to log.
-void SWhitelistLogParams(set<string> params);
-
 // This is a drop-in replacement for syslog that directly logs to `/run/systemd/journal/syslog` bypassing journald.
 void SSyslogSocketDirect(int priority, const char* format, ...);
 


### PR DESCRIPTION
Reverts Expensify/Bedrock#1988

This is breaking when we try to insert params from Auth. I'll revert it for now until I can figure out why.