### PR TITLE
Allow returning result for write queries

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -617,7 +617,7 @@ bool SQLite::_writeIdempotent(const string& query, SQResult& result, bool always
                 _currentlyRunningRewritten = false;
             }
         } else {
-            resultCode = SQuery(_db, "read/write transaction", query);
+            resultCode = SQuery(_db, "read/write transaction", query, result);
         }
     }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -566,18 +566,25 @@ bool SQLite::write(const string& query) {
     }
 
     // This is literally identical to the idempotent version except for the check for _noopUpdateMode.
-    return _writeIdempotent(query);
+    SQResult ignore;
+    return _writeIdempotent(query, ignore);
 }
 
 bool SQLite::writeIdempotent(const string& query) {
-    return _writeIdempotent(query);
+    SQResult ignore;
+    return _writeIdempotent(query, ignore);
+}
+
+bool SQLite::writeIdempotent(const string& query, SQResult& result) {
+    return _writeIdempotent(query, result);
 }
 
 bool SQLite::writeUnmodified(const string& query) {
-    return _writeIdempotent(query, true);
+    SQResult ignore;
+    return _writeIdempotent(query, ignore, true);
 }
 
-bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
+bool SQLite::_writeIdempotent(const string& query, SQResult& result, bool alwaysKeepQueries) {
     SASSERT(_insideTransaction);
     _queryCache.clear();
     _queryCount++;
@@ -600,7 +607,7 @@ bool SQLite::_writeIdempotent(const string& query, bool alwaysKeepQueries) {
     {
         shared_lock<shared_mutex> lock(_sharedData.writeLock);
         if (_enableRewrite) {
-            resultCode = SQuery(_db, "read/write transaction", query, 2'000'000, true);
+            resultCode = SQuery(_db, "read/write transaction", query, result, 2'000'000, true);
             if (resultCode == SQLITE_AUTH) {
                 // Run re-written query.
                 _currentlyRunningRewritten = true;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -570,6 +570,16 @@ bool SQLite::write(const string& query) {
     return _writeIdempotent(query, ignore);
 }
 
+bool SQLite::write(const string& query, SQResult& result) {
+    if (_noopUpdateMode) {
+        SALERT("Non-idempotent write in _noopUpdateMode. Query: " << query);
+        return true;
+    }
+
+    // This is literally identical to the idempotent version except for the check for _noopUpdateMode.
+    return _writeIdempotent(query, result);
+}
+
 bool SQLite::writeIdempotent(const string& query) {
     SQResult ignore;
     return _writeIdempotent(query, ignore);

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <libstuff/sqlite3.h>
+#include <libstuff/SQResult.h>
 #include <libstuff/SPerformanceTimer.h>
 
 class SQLite {
@@ -108,6 +109,7 @@ class SQLite {
     // It's intended to be used for `mockRequest` enabled commands, such that we only run a version of them that's
     // known to be repeatable. What counts as repeatable is up to the individual command.
     bool writeIdempotent(const string& query);
+    bool writeIdempotent(const string& query, SQResult& result);
 
     // This runs a query completely unchanged, always adding it to the uncommitted query, such that it will be recorded
     // in the journal even if it had no effect on the database. This lets replicated or synchronized queries be added
@@ -400,7 +402,7 @@ class SQLite {
     static thread_local int64_t _conflictPage;
     static thread_local string _conflictTable;
 
-    bool _writeIdempotent(const string& query, bool alwaysKeepQueries = false);
+    bool _writeIdempotent(const string& query, SQResult& result, bool alwaysKeepQueries = false);
 
     // Constructs a UNION query from a list of 'query parts' over each of our journal tables.
     // Fore each table, queryParts will be joined with that table's name as a separator. I.e., if you have a tables

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -109,6 +109,9 @@ class SQLite {
     // It's intended to be used for `mockRequest` enabled commands, such that we only run a version of them that's
     // known to be repeatable. What counts as repeatable is up to the individual command.
     bool writeIdempotent(const string& query);
+
+    // Executes a write query and retrieves the result.
+    // Designed for use with queries that include a RETURNING clause
     bool writeIdempotent(const string& query, SQResult& result);
 
     // This runs a query completely unchanged, always adding it to the uncommitted query, such that it will be recorded

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -101,9 +101,13 @@ class SQLite {
     bool addColumn(const string& tableName, const string& column, const string& columnType);
 
     // Performs a read/write query (eg, INSERT, UPDATE, DELETE). This is added to the current transaction's query list.
-    // Returns true  on success.
+    // Returns true on success.
     // If we're in noop-update mode, this call alerts and performs no write, but returns as if it had completed.
     bool write(const string& query);
+
+    // Performs a read/write query
+    // Designed for use with queries that include a RETURNING clause
+    bool write(const string& query, SQResult& result);
 
     // This is the same as `write` except it runs successfully without any warnings or errors in noop-update mode.
     // It's intended to be used for `mockRequest` enabled commands, such that we only run a version of them that's


### PR DESCRIPTION
### Details
SQLite supports RETURNING clause(https://www.sqlite.org/lang_returning.html) that supports both read and write operations at a time.
Modify the SQLite handler to allow passing result reference for WRITE queries

### Fixed Issues
Required for  https://github.com/Expensify/App/issues/51832

### Tests

Tests with PR https://github.com/Expensify/Auth/pull/13393
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
