### PR TITLE
Rollback transaction on DB plugin read query

### DIFF
--- a/plugins/DB.cpp
+++ b/plugins/DB.cpp
@@ -72,6 +72,10 @@ bool BedrockDBCommand::peek(SQLite& db) {
         return false;
     }
 
+    // We rollback here because if we are in a transaction and the querytakes long (which the queries in this command can)
+    // it prevents sqlite from checkpointing and if we accumulate a lot of things to checkpoint, things become slow
+    ((SQLite&) db).rollback();
+
     // Attempt the read-only query
     SQResult result;
     if (!db.read(query, result)) {


### PR DESCRIPTION
### Details
When doing read queries, we can safely rollback the transaction so that the query affects the clusters less (see comment in code)

### Fixed Issues
Context https://expensify.slack.com/archives/C03TQ48KC/p1733151385957989

### Tests
Run a query command:
```
vagrant@expensidev2004:/vagrant/Web-Expensify$ nc localhost 8888
Query: select 1;

200 OK
commitCount: 84478
nodeName: bedrock
peekTime: 574
totalTime: 1943
unaccountedTime: 1366
Content-Length: 4

1
1
```
Check logs that we rolled back before running it:
```
2024-12-02T15:51:31.728346+00:00 expensidev2004 bedrock: xxxxxx (BedrockServer.cpp:2237) buildCommandFromRequest [socket0] [dbug] Deserialized command Query: select 1;
2024-12-02T15:51:31.728506+00:00 expensidev2004 bedrock: bWhbUw (SQLitePool.cpp:46) getIndex [socket0] [dbug] Returning existing DB handle
2024-12-02T15:51:31.728629+00:00 expensidev2004 bedrock: bWhbUw (BedrockCore.cpp:130) peekCommand [socket0] [dbug] Peeking at 'Query: select 1;' with priority: 500
2024-12-02T15:51:31.728709+00:00 expensidev2004 bedrock: bWhbUw (SQLite.cpp:404) beginTransaction [socket0] [info] [concurrent] Beginning transaction
2024-12-02T15:51:31.728788+00:00 expensidev2004 bedrock: bWhbUw (libstuff.cpp:2556) SQuery [socket0] [dbug] BEGIN CONCURRENT
2024-12-02T15:51:31.729024+00:00 expensidev2004 bedrock: bWhbUw (libstuff.cpp:2556) SQuery [socket0] [dbug] PRAGMA query_only = true;
2024-12-02T15:51:31.729098+00:00 expensidev2004 bedrock: bWhbUw (libstuff.cpp:2556) SQuery [socket0] [dbug] ROLLBACK
2024-12-02T15:51:31.729164+00:00 expensidev2004 bedrock: bWhbUw (SQLite.cpp:865) rollback [socket0] [dbug] Transaction rollback with 0 queries attempted, 0 served from cache.
2024-12-02T15:51:31.729210+00:00 expensidev2004 bedrock: bWhbUw (libstuff.cpp:2556) SQuery [socket0] [dbug] select 1;
2024-12-02T15:51:31.729278+00:00 expensidev2004 bedrock: bWhbUw (BedrockCore.cpp:151) peekCommand [socket0] [dbug] Plugin 'DB' peeked command 'Query: select 1;'
```

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
