### PR TITLE
Remove log params that are not related to Bedrock

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -41,57 +41,17 @@ void SLogStackTrace(int level) {
 }
 
 // If the param name is not in this whitelist, we will log <REDACTED> in addLogParams.
-static const set<string> PARAMS_WHITELIST = {
-    "accountID",
-    "authEmail",
-    "accountIDs",
-    "attendees",
-    "bankAccountID",
-    "cardData",
-    "cardID",
-    "clientUpdateID",
+static set<string> PARAMS_WHITELIST = {
     "command",
-    "companyName",
-    "companyWebsite",
     "Connection",
     "Content-Length",
     "count",
-    "currentTime",
-    "domainAccountID",
-    "domainName",
-    "email",
-    "errorMessage",
-    "feed",
-    "feedCountry",
-    "feedID",
-    "feedName",
-    "field",
-    "index",
     "indexName",
-    "invoice",
     "isUnique",
-    "key",
-    "lastIP",
     "logParam",
-    "nvpName",
-    "policyAccountID",
-    "policyID",
-    "reimbursementEntryID",
-    "reportID",
     "requestID",
-    "requestTimestamp",
-    "secondaryLogin",
-    "shouldCompleteOnboarding",
-    "shouldDismissHybridAppOnboarding",
     "status",
-    "step",
-    "timeDiff",
-    "token",
-    "transactionID",
-    "type",
     "userID",
-    "secondaryLogin",
-    "walletBankAccountID"
 };
 
 string addLogParams(string&& message, const STable& params) {
@@ -113,4 +73,8 @@ string addLogParams(string&& message, const STable& params) {
     }
 
     return message;
+}
+
+void SWhitelistLogParams(set<string> params) {
+    PARAMS_WHITELIST.insert(params.begin(), params.end());
 }

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -233,6 +233,9 @@ void SLogLevel(int level);
 // Stack trace logging
 void SLogStackTrace(int level = LOG_WARNING);
 
+// This method will allow plugins to whitelist log params they need to log.
+void SWhitelistLogParams(set<string> params);
+
 // This is a drop-in replacement for syslog that directly logs to `/run/systemd/journal/syslog` bypassing journald.
 void SSyslogSocketDirect(int priority, const char* format, ...);
 


### PR DESCRIPTION
Getting this back to the codebase now that we found why Auth tests were failing.

Reverts Expensify/Bedrock#1989

<!-- Use PullerBear to assign a reviewer. CC anyone who you think should/could look at these changes -->

This PR depends on https://github.com/Expensify/Bedrock/pull/1988
### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR moves all params whitelist that are specific to auth to a function in auth that will be called when the auth plugin is started.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/448720

### Auth / Web / Mobile Tests
N/A, if tests pass we're good since we throw if the parameters are not whitelisted.
<!-- What new or existing automated tests cover your change? What tests on web/mobile did you do to validate your changes? -->

### Query Timings/Plans
N/A
<!--
Did you modify or add a new query? How will this affect the query plan or timings?
**NOTE:** Get the query plan on **prod** and not on dev. This is because the prod DB has very different data from yours, which may cause the query planner to behave differently.
-->

<!--
- Don't forget to test on large accounts/policies, ask somebody in with [DB access](https://sites.google.com/a/expensify.com/manifesto/security/concentric-rings?pli=1) to run these in the production database if needed. Some examples of large accounts are:
    - expenses@ef.com - 1988459
    - expensify@thoughtworks.com - 12957057
    - Concierge - 8392101 (good to test with if query involves DM chat reports that could include Concierge)

If you need a big chat, some large chats are:
    - 64225371
    - 64819207

If you need a policy shared with thousands of accounts, you can use:
    - 109FA7B0CA4E18F9
    - E435B5B670F07DF1
-->

<!--
### Accounting
Does this PR relate in any way to the purchases table and/or moving money (eg, Stripe, Marqeta)? If yes, describe how and request a review from an accounting team member.
This is very important as messing up the purchases data could result in failing a financial audit.
-->
