### PR TITLE
Add some log params for policy audit logs

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -52,6 +52,10 @@ static set<string> PARAMS_WHITELIST = {
     "requestID",
     "status",
     "userID",
+    "policyID",
+    "employeeEmail",
+    "approver",
+    "approvers",
 };
 
 string addLogParams(string&& message, const STable& params) {

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -56,6 +56,7 @@ static set<string> PARAMS_WHITELIST = {
     "employeeEmail",
     "approver",
     "approvers",
+    "employees",
 };
 
 string addLogParams(string&& message, const STable& params) {


### PR DESCRIPTION
### Details

### Fixed Issues
I am adding these params for https://github.com/Expensify/Auth/pull/13426

### Tests
I tested these with https://github.com/Expensify/Auth/pull/13426
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
