### PR TITLE
Handle open transactions monitoring on nodes

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -401,12 +401,12 @@ bool SQLite::beginTransaction(TRANSACTION_TYPE type) {
     // Reset before the query, as it's possible the query sets these.
     _autoRolledBack = false;
 
-    SINFO("[concurrent] Beginning transaction - open transaction count: " << (_sharedData.openTransactionCount + 1));
-    uint64_t before = STimeNow();
-    _insideTransaction = !SQuery(_db, "starting db transaction", "BEGIN CONCURRENT");
-
     // We actively track transaction counts incrementing and decrementing to log the number of active open transactions at any given moment.
     _sharedData.openTransactionCount++;
+
+    SINFO("[concurrent] Beginning transaction - open transaction count: " << (_sharedData.openTransactionCount));
+    uint64_t before = STimeNow();
+    _insideTransaction = !SQuery(_db, "starting db transaction", "BEGIN CONCURRENT");
 
     // Because some other thread could commit once we've run `BEGIN CONCURRENT`, this value can be slightly behind
     // where we're actually able to start such that we know we shouldn't get a conflict if this commits successfully on

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -406,7 +406,6 @@ bool SQLite::beginTransaction(TRANSACTION_TYPE type) {
     _insideTransaction = !SQuery(_db, "starting db transaction", "BEGIN CONCURRENT");
 
     _sharedData.incrementOpenTransactions();
-    SINFO("Open transaction count: " << _sharedData.openTransactionCount);
 
     // Because some other thread could commit once we've run `BEGIN CONCURRENT`, this value can be slightly behind
     // where we're actually able to start such that we know we shouldn't get a conflict if this commits successfully on

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -314,6 +314,11 @@ class SQLite {
         // If set to false, this prevents any thread from being able to commit to the DB.
         atomic<bool> _commitEnabled;
 
+        // These blocks are to monitor the number of open transactions on the whole server.
+        void incrementOpenTransactions();
+        void decrementOpenTransactions();
+        atomic<int64_t> openTransactionCount;
+
         SPerformanceTimer _commitLockTimer;
 
         // We use this flag to prevent to threads running checkpoints t the same time.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -314,9 +314,7 @@ class SQLite {
         // If set to false, this prevents any thread from being able to commit to the DB.
         atomic<bool> _commitEnabled;
 
-        // These blocks are to monitor the number of open transactions on the whole server.
-        void incrementOpenTransactions();
-        void decrementOpenTransactions();
+        // This variable is used to monitor the number of open transactions on the whole server.
         atomic<int64_t> openTransactionCount;
 
         SPerformanceTimer _commitLockTimer;


### PR DESCRIPTION
### Details

### Fixed Issues
Part 1 of https://github.com/Expensify/Expensify/issues/452045

### Tests
Bedrock tests
```
2024-12-10T18:16:47.739493+00:00 expensidev2004 bedrock: UV2v3J (SQLite.cpp:404) beginTransaction [blockingCommit] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.739660+00:00 expensidev2004 bedrock: HRelDZ (SQLite.cpp:404) beginTransaction [socket62] [info] [concurrent] Beginning transaction - open transaction count: 9
2024-12-10T18:16:47.740257+00:00 expensidev2004 bedrock: HRelDZ (SQLite.cpp:404) beginTransaction [socket62] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.740411+00:00 expensidev2004 bedrock: GA1otB (SQLite.cpp:404) beginTransaction [socket56] [info] [concurrent] Beginning transaction - open transaction count: 9
2024-12-10T18:16:47.740853+00:00 expensidev2004 bedrock: yyzhSr (SQLite.cpp:404) beginTransaction [socket58] [info] [concurrent] Beginning transaction - open transaction count: 9
2024-12-10T18:16:47.741166+00:00 expensidev2004 bedrock: ADYgd7 (SQLite.cpp:404) beginTransaction [socket54] [info] [concurrent] Beginning transaction - open transaction count: 9
2024-12-10T18:16:47.741453+00:00 expensidev2004 bedrock: d0jgqy (SQLite.cpp:404) beginTransaction [socket61] [info] [concurrent] Beginning transaction - open transaction count: 9
2024-12-10T18:16:47.741812+00:00 expensidev2004 bedrock: wWXMeu (SQLite.cpp:404) beginTransaction [socket57] [info] [concurrent] Beginning transaction - open transaction count: 9
2024-12-10T18:16:47.742175+00:00 expensidev2004 bedrock: ZV4YvM (SQLite.cpp:404) beginTransaction [socket61] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.742487+00:00 expensidev2004 bedrock: RXR1zA (SQLite.cpp:404) beginTransaction [blockingCommit] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.742921+00:00 expensidev2004 bedrock: HRelDZ (SQLite.cpp:404) beginTransaction [socket62] [info] [concurrent] Beginning transaction - open transaction count: 7
2024-12-10T18:16:47.742989+00:00 expensidev2004 bedrock: 8KZ2eN (SQLite.cpp:404) beginTransaction [socket53] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.743236+00:00 expensidev2004 bedrock: GA1otB (SQLite.cpp:404) beginTransaction [socket56] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.743464+00:00 expensidev2004 bedrock: yyzhSr (SQLite.cpp:404) beginTransaction [socket58] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.743726+00:00 expensidev2004 bedrock: ADYgd7 (SQLite.cpp:404) beginTransaction [socket54] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.743987+00:00 expensidev2004 bedrock: FQNhwa (SQLite.cpp:404) beginTransaction [socket59] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.744409+00:00 expensidev2004 bedrock: ZV4YvM (SQLite.cpp:404) beginTransaction [socket61] [info] [concurrent] Beginning transaction - open transaction count: 7
2024-12-10T18:16:47.744438+00:00 expensidev2004 bedrock: MSRvcN (SQLite.cpp:404) beginTransaction [blockingCommit] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.744940+00:00 expensidev2004 bedrock: VVzlPd (SQLite.cpp:404) beginTransaction [socket60] [info] [concurrent] Beginning transaction - open transaction count: 7
2024-12-10T18:16:47.744966+00:00 expensidev2004 bedrock: HRelDZ (SQLite.cpp:404) beginTransaction [socket62] [info] [concurrent] Beginning transaction - open transaction count: 7
2024-12-10T18:16:47.745202+00:00 expensidev2004 bedrock: 8KZ2eN (SQLite.cpp:404) beginTransaction [socket53] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.745451+00:00 expensidev2004 bedrock: GA1otB (SQLite.cpp:404) beginTransaction [socket56] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.745879+00:00 expensidev2004 bedrock: ADYgd7 (SQLite.cpp:404) beginTransaction [socket54] [info] [concurrent] Beginning transaction - open transaction count: 7
2024-12-10T18:16:47.746129+00:00 expensidev2004 bedrock: FQNhwa (SQLite.cpp:404) beginTransaction [socket59] [info] [concurrent] Beginning transaction - open transaction count: 7
2024-12-10T18:16:47.746374+00:00 expensidev2004 bedrock: ZV4YvM (SQLite.cpp:404) beginTransaction [socket61] [info] [concurrent] Beginning transaction - open transaction count: 7
2024-12-10T18:16:47.746409+00:00 expensidev2004 bedrock: wWXMeu (SQLite.cpp:404) beginTransaction [blockingCommit] [info] [concurrent] Beginning transaction - open transaction count: 8
2024-12-10T18:16:47.746936+00:00 expensidev2004 bedrock: KTcimX (SQLite.cpp:404) beginTransaction [socket57] [info] [concurrent] Beginning transaction - open transaction count: 7
2024-12-10T18:16:47.747161+00:00 expensidev2004 bedrock: VVzlPd (SQLite.cpp:404) beginTransaction [socket60] [info] [concurrent] Beginning transaction - open transaction count: 7
2024-12-10T18:16:47.747410+00:00 expensidev2004 bedrock: 8KZ2eN (SQLite.cpp:404) beginTransaction [socket53] [info] [concurrent] Beginning transaction - open transaction count: 7
2024-12-10T18:16:47.747949+00:00 expensidev2004 bedrock: jb77sr (SQLite.cpp:404) beginTransaction [socket60] [info] [concurrent] Beginning transaction - open transaction count: 6
2024-12-10T18:16:47.748246+00:00 expensidev2004 bedrock: ZV4YvM (SQLite.cpp:404) beginTransaction [socket61] [info] [concurrent] Beginning transaction - open transaction count: 5
2024-12-10T18:16:47.748275+00:00 expensidev2004 bedrock: 5EOPar (SQLite.cpp:404) beginTransaction [blockingCommit] [info] [concurrent] Beginning transaction - open transaction count: 5
2024-12-10T18:16:47.748996+00:00 expensidev2004 bedrock: KTcimX (SQLite.cpp:404) beginTransaction [socket57] [info] [concurrent] Beginning transaction - open transaction count: 5
2024-12-10T18:16:47.749034+00:00 expensidev2004 bedrock: tZwL51 (SQLite.cpp:404) beginTransaction [socket55] [info] [concurrent] Beginning transaction - open transaction count: 6
2024-12-10T18:16:47.749153+00:00 expensidev2004 bedrock: GA1otB (SQLite.cpp:404) beginTransaction [socket56] [info] [concurrent] Beginning transaction - open transaction count: 6
2024-12-10T18:16:47.749479+00:00 expensidev2004 bedrock: 8KZ2eN (SQLite.cpp:404) beginTransaction [socket53] [info] [concurrent] Beginning transaction - open transaction count: 6
2024-12-10T18:16:47.749958+00:00 expensidev2004 bedrock: jb77sr (SQLite.cpp:404) beginTransaction [socket60] [info] [concurrent] Beginning transaction - open transaction count: 5
2024-12-10T18:16:47.750051+00:00 expensidev2004 bedrock: TBYRLC (SQLite.cpp:404) beginTransaction [socket53] [info] [concurrent] Beginning transaction - open transaction count: 6
2024-12-10T18:16:47.750668+00:00 expensidev2004 bedrock: 8EbYfF (SQLite.cpp:404) beginTransaction [socket60] [info] [concurrent] Beginning transaction - open transaction count: 4
```

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
