### PR TITLE
[HOLD] Allocate all SQLite pool handles on init

### DIFF
--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -13,6 +13,12 @@ SQLitePool::SQLitePool(size_t maxDBs,
   _baseDB(filename, cacheSize, maxJournalSize, minJournalTables, mmapSizeGB, hctree),
   _objects(_maxDBs, nullptr)
 {
+    SINFO("Allocating SQLitePool handles.");
+    for (size_t i = 0; i < _maxDBs; i++) {
+        initializeIndex(i);
+        _availableHandles.insert(i);
+    }
+    SINFO("Allocated " << _maxDBs << " handles for SQLitePool.");
 }
 
 SQLitePool::~SQLitePool() {


### PR DESCRIPTION
### Details
@tylerkaraszewski this causes us to allocate the entirety of a SQLitePool on creation, which for our largest pools is at start up time. We hope this prevents random slow PRAGMAs from starting new handles JIT.

### Fixed Issues
https://expensify.slack.com/archives/C07PP7QV8P5/p1733855847062219

Fixes https://github.com/Expensify/Expensify/issues/453048

### Tests
Existing. Ran tests, saw expected logs. 
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
