### PR TITLE
Silence warning

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1850,7 +1850,7 @@ void SQLiteNode::_onDisconnect(SQLitePeer* peer) {
             // Store the time at which this happened for diagnostic purposes.
             _lastLostQuorum = STimeNow();
             for (const auto* p : _peerList) {
-                SWARN("[clustersync] Peer " << p->name << " logged in? " << (p->loggedIn ? "TRUE" : "FALSE") << (p->permaFollower ? " (permaFollower)" : ""));
+                SINFO("[clustersync] Peer " << p->name << " logged in? " << (p->loggedIn ? "TRUE" : "FALSE") << (p->permaFollower ? " (permaFollower)" : ""));
             }
             _changeState(SQLiteNodeState::SEARCHING);
         }


### PR DESCRIPTION
### Details
The modified line is really just there as extra detail related to this line just above it:
https://github.com/Expensify/Bedrock/blob/0b8f440a6cd6e3322af8ba76117c3bb81159bda2/sqlitecluster/SQLiteNode.cpp#L1848

This was harmless before but now that it's creating a bugbot issue we can demote it.
### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/450156

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
