### PR TITLE
Move DELETE out of commit lock

### DIFF
--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -48,7 +48,7 @@ mark_fold end test_bedrock
 
 mark_fold start test_bedrock_cluster
 cd test/clustertest
-./clustertest -threads 1 -only Escalate
+./clustertest -threads 1 -except DoubleDetach
 # ControlCommand,DoubleDetach,Escalate
 cd ../..
 mark_fold end test_bedrock_cluster

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -48,7 +48,7 @@ mark_fold end test_bedrock
 
 mark_fold start test_bedrock_cluster
 cd test/clustertest
-./clustertest -threads 1 -only BadCommand,BroadcastCommand,ClusterUpgrade,ConflictSpam,ControlCommand,DoubleDetach,Escalate,FastStandDown,FinishJob,ForkCheck,FutureExecution,GracefulFailover,HTTPS,JobID
+./clustertest -threads 1 -only BadCommand,BroadcastCommand,ClusterUpgrade,ConflictSpam,ControlCommand,DoubleDetach,Escalate
 cd ../..
 mark_fold end test_bedrock_cluster
 

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -48,7 +48,7 @@ mark_fold end test_bedrock
 
 mark_fold start test_bedrock_cluster
 cd test/clustertest
-./clustertest -threads 1 -only BadCommand,BroadcastCommand,ClusterUpgrade,ConflictSpam
+./clustertest -threads 1 -only ControlCommand,DoubleDetach,Escalate
 cd ../..
 mark_fold end test_bedrock_cluster
 

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -48,7 +48,7 @@ mark_fold end test_bedrock
 
 mark_fold start test_bedrock_cluster
 cd test/clustertest
-./clustertest -threads 1 -only ConflictSpam
+./clustertest -threads 1 -only BadCommand,BroadcastCommand,ClusterUpgrade,ConflictSpam,ControlCommand,DoubleDetach,Escalate,FastStandDown,FinishJob,ForkCheck,FutureExecution,GracefulFailover,HTTPS,JobID
 cd ../..
 mark_fold end test_bedrock_cluster
 

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -48,7 +48,7 @@ mark_fold end test_bedrock
 
 mark_fold start test_bedrock_cluster
 cd test/clustertest
-./clustertest -threads 1 -only DoubleDetach
+./clustertest -threads 1 -only Escalate
 # ControlCommand,DoubleDetach,Escalate
 cd ../..
 mark_fold end test_bedrock_cluster

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -48,7 +48,7 @@ mark_fold end test_bedrock
 
 mark_fold start test_bedrock_cluster
 cd test/clustertest
-./clustertest -threads 1
+./clustertest -threads 1 -only ConflictSpam
 cd ../..
 mark_fold end test_bedrock_cluster
 

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -48,7 +48,7 @@ mark_fold end test_bedrock
 
 mark_fold start test_bedrock_cluster
 cd test/clustertest
-./clustertest -threads 1 -except DoubleDetach
+./clustertest -threads 1 -only DoubleDetach
 # ControlCommand,DoubleDetach,Escalate
 cd ../..
 mark_fold end test_bedrock_cluster

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -48,7 +48,7 @@ mark_fold end test_bedrock
 
 mark_fold start test_bedrock_cluster
 cd test/clustertest
-./clustertest -threads 8
+./clustertest -threads 1
 cd ../..
 mark_fold end test_bedrock_cluster
 

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -48,7 +48,7 @@ mark_fold end test_bedrock
 
 mark_fold start test_bedrock_cluster
 cd test/clustertest
-./clustertest -threads 1 -only ControlCommand
+./clustertest -threads 1 -only DoubleDetach
 # ControlCommand,DoubleDetach,Escalate
 cd ../..
 mark_fold end test_bedrock_cluster

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -48,8 +48,7 @@ mark_fold end test_bedrock
 
 mark_fold start test_bedrock_cluster
 cd test/clustertest
-./clustertest -threads 1 -only DoubleDetach
-# ControlCommand,DoubleDetach,Escalate
+./clustertest -threads 8
 cd ../..
 mark_fold end test_bedrock_cluster
 

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -48,7 +48,8 @@ mark_fold end test_bedrock
 
 mark_fold start test_bedrock_cluster
 cd test/clustertest
-./clustertest -threads 1 -only ControlCommand,DoubleDetach,Escalate
+./clustertest -threads 1 -only ControlCommand
+# ControlCommand,DoubleDetach,Escalate
 cd ../..
 mark_fold end test_bedrock_cluster
 

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -48,7 +48,7 @@ mark_fold end test_bedrock
 
 mark_fold start test_bedrock_cluster
 cd test/clustertest
-./clustertest -threads 1 -only BadCommand,BroadcastCommand,ClusterUpgrade,ConflictSpam,ControlCommand,DoubleDetach,Escalate
+./clustertest -threads 1 -only BadCommand,BroadcastCommand,ClusterUpgrade,ConflictSpam
 cd ../..
 mark_fold end test_bedrock_cluster
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -646,7 +646,7 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash) {
     _journalName = _journalNames[journalID % _journalNames.size()];
 
     // It's possible to attempt to commit a transaction with no writes. We'll skip truncating the journal in this case to avoid
-    // Turning a no=op into a write.
+    // Turning a no-op into a write.
     if (_uncommittedQuery.size()) {
         // Look up the oldest commit in our chosen journal, and compute the oldest commit we intend to keep.
         SQResult result;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -354,7 +354,6 @@ class SQLite {
     static SharedData& initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames, bool hctree);
     static sqlite3* initializeDB(const string& filename, int64_t mmapSizeGB, bool hctree);
     static vector<string> initializeJournal(sqlite3* db, int minJournalTables);
-    static uint64_t initializeJournalSize(sqlite3* db, const vector<string>& journalNames);
     void commonConstructorInitialization(bool hctree = false);
 
     // The filename of this DB, canonicalized to its full path on disk.
@@ -374,9 +373,6 @@ class SQLite {
 
     // The name of the journal table that this particular DB handle with write to.
     string _journalName;
-
-    // The current size of the journal, in rows. TODO: Why isn't this in SharedData?
-    uint64_t _journalSize;
 
     // True when we have a transaction in progress.
     bool _insideTransaction = false;

--- a/test/clustertest/tests/DoubleDetachTest.cpp
+++ b/test/clustertest/tests/DoubleDetachTest.cpp
@@ -23,27 +23,20 @@ struct DoubleDetachTest : tpunit::TestFixture {
     void testDoubleDetach()
     {
         // Test a control command
-        cout << "A" << endl;
         BedrockTester& follower = tester->getTester(1);
 
         // Detach
-        cout << "B" << endl;
         SData detachCommand("Detach");
-        cout << "C" << endl;
         follower.executeWaitVerifyContent(detachCommand, "203 DETACHING", true);
 
         // Wait for it to detach
-        cout << "D" << endl;
         sleep(3);
 
-        cout << "E" << endl;
         follower.executeWaitVerifyContent(detachCommand, "400 Already detached", true);
-        cout << "F" << endl;
 
         // Re-attach to make shutdown clean.
         SData attachCommand("Attach");
         follower.executeWaitVerifyContent(attachCommand, "204 ATTACHING", true);
-        cout << "G" << endl;
     }
 
 } __DoubleDetachTest;

--- a/test/clustertest/tests/DoubleDetachTest.cpp
+++ b/test/clustertest/tests/DoubleDetachTest.cpp
@@ -28,7 +28,7 @@ struct DoubleDetachTest : tpunit::TestFixture {
 
         // Detach
         cout << "B" << endl;
-        SData detachCommand("detach");
+        SData detachCommand("Detach");
         cout << "C" << endl;
         follower.executeWaitVerifyContent(detachCommand, "203 DETACHING", true);
 
@@ -39,6 +39,11 @@ struct DoubleDetachTest : tpunit::TestFixture {
         cout << "E" << endl;
         follower.executeWaitVerifyContent(detachCommand, "400 Already detached", true);
         cout << "F" << endl;
+
+        // Re-attach to make shutdown clean.
+        SData attachCommand("Attach");
+        follower.executeWaitVerifyContent(attachCommand, "204 ATTACHING", true);
+        cout << "G" << endl;
     }
 
 } __DoubleDetachTest;

--- a/test/clustertest/tests/DoubleDetachTest.cpp
+++ b/test/clustertest/tests/DoubleDetachTest.cpp
@@ -23,16 +23,22 @@ struct DoubleDetachTest : tpunit::TestFixture {
     void testDoubleDetach()
     {
         // Test a control command
+        cout << "A" << endl;
         BedrockTester& follower = tester->getTester(1);
 
         // Detach
+        cout << "B" << endl;
         SData detachCommand("detach");
+        cout << "C" << endl;
         follower.executeWaitVerifyContent(detachCommand, "203 DETACHING", true);
 
         // Wait for it to detach
+        cout << "D" << endl;
         sleep(3);
 
+        cout << "E" << endl;
         follower.executeWaitVerifyContent(detachCommand, "400 Already detached", true);
+        cout << "F" << endl;
     }
 
 } __DoubleDetachTest;


### PR DESCRIPTION
### Details
This moves the DELETE from the journal to just before the commit lock is acquired (except for blocking commands, which already have acquired it).

It also reworks how we count what's in the journal that needs deleting to be simpler and more accurate.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/453375

### Tests
This currently breaks the DoubleDetach test, but only in GH actions.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
