### PR TITLE
Adding read/write queries metrics

### DIFF
--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -509,7 +509,9 @@ class SQLite {
     set<string> _tablesUsed;
 
     // Number of queries that have been attempted in this transaction (for metrics only).
-    mutable int64_t _queryCount = 0;
+    mutable int64_t _readQueryCount = 0;
+
+    mutable int64_t _writeQueryCount = 0;
 
     // Number of queries found in cache in this transaction (for metrics only).
     mutable int64_t _cacheHits = 0;


### PR DESCRIPTION
### Details
This adds a read/write query distinction in our logs so we can create a dashboard for it.

### Fixed Issues
part of https://expensify.slack.com/archives/C07PP7QV8P5/p1733773976411629?thread_ts=1733438328.141159&cid=C07PP7QV8P5

### Tests

Checked local logs:

```
2024-12-16T20:17:56.392730+00:00 expensidev2004 bedrock: sDMTkq dd@doglas.dev (SQLite.cpp:891) rollback [socket6] [info] [performance] Transaction rollback with 4 read queries attempted, 0 write queries attempted, 0 served from cache.
2024-12-16T20:17:56.456390+00:00 expensidev2004 bedrock: xxxxxx (SQLite.cpp:834) commit [sync] [info] LEADING COMMIT 6 complete in 0.29ms. Wrote 63 pages. WAL file size is 284312 bytes. 222 read queries attempted, 54 write queries attempted, 46 served from cache. Used journal journal0000
```
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
