### PR TITLE
Allow `Status` command to complete even during state change.

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1721,7 +1721,6 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         // Coalesce all of the peer data into one value to return or return
         // an error message if we timed out getting the peerList data.
         list<string> peerList;
-        // This blocks during state change
         list<STable> peerData = getPeerInfo();
         for (const STable& peerTable : peerData) {
             peerList.push_back(SComposeJSONObject(peerTable));

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1721,6 +1721,7 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         // Coalesce all of the peer data into one value to return or return
         // an error message if we timed out getting the peerList data.
         list<string> peerList;
+        // This blocks during state change
         list<STable> peerData = getPeerInfo();
         for (const STable& peerTable : peerData) {
             peerList.push_back(SComposeJSONObject(peerTable));

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -685,12 +685,6 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash) {
                << commitCount << ", limit: " << _maxJournalSize << ", in " << (STimeNow() - startUS) << "us.");
     }
 
-    // So let's say that a replicate thread is running the above. Neither the write or commit lock is held.
-
-    // Let's say another thread calls `exclusiveLockDB`. It grabs the commit lock.
-    // We grab the write lock above. Other thread waits. We release writeLock, it acquires it. Writes are now blocked.
-    // We attempot to grab commitLock below. We block.
-
     // We lock this here, so that we can guarantee the order in which commits show up in the database.
     if (!_mutexLocked) {
         auto start = STimeNow();

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -34,7 +34,7 @@
  * Any public methods must not call other public methods.
  *
  * `_replicate` is a special exception because it runs in multiple threads internally. It needs to handle locking if it
- * changes any internal state (and it calls `changeState`, which it does).
+ * changes any internal state (and it calls `changeState`, which does).
  *
  */
 

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -25,16 +25,16 @@
  * Rules for maintaining SQLiteNode methods so that atomicity works as intended.
  *
  * No non-const members should be publicly exposed.
- * Any public method that is `const` must shared_lock<>(nodeMutex).
+ * Any public method that is `const` must shared_lock<>(_stateMutex).
  * Alternatively, a public `const` method that is a simple getter for an atomic property can skip the lock.
- * Any public method that is non-const must unique_lock<>(nodeMutex) before changing any internal state, and must hold
+ * Any public method that is non-const must unique_lock<>(_stateMutex) before changing any internal state, and must hold
  * this lock until it is done changing state to make this method's changes atomic.
  * Any private methods must not call public methods.
- * Any private methods must not lock nodeMutex (for recursion reasons).
+ * Any private methods must not lock _stateMutex (for recursion reasons).
  * Any public methods must not call other public methods.
  *
  * `_replicate` is a special exception because it runs in multiple threads internally. It needs to handle locking if it
- * changes any internal state (and it calls `changeState`, which does).
+ * changes any internal state (and it calls `changeState`, which it does).
  *
  */
 

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -225,6 +225,7 @@ void SQLitePeer::getCommit(uint64_t& count, string& hashString) const {
 }
 
 STable SQLitePeer::getData() const {
+    lock_guard<decltype(peerMutex)> lock(peerMutex);
     // Add all of our standard stuff.
     STable result({
         {"name", name},


### PR DESCRIPTION
### Details

`Status` previously blocked during `_stateChange` because it called `getPeerInfo`.

Both `getPeerInfo` and `_changeState` locked `_stateMutex`, so if we were mid-state-change, `Status` would wait.

This typically was fast, but could be slow if we were changing state away from `FOLLOWING`, which can take a while as we wait for replication threads to finish.

In particular, we observed the following problem:

1. We call `BlockWrites` to prevent DB writes to take a ZFS snapshot. This prohibits replication threads from finishing (they need to write).
2. Leader stands down for unrelated reasons (a backup, in this case).
3. When we notice leader's disappearance, we switch away from FOLLOWING, which never completes, because the replicate threads are blocked.
4. The ZFS snapshot script calls `Status` to check if it can re-enable writes. It never finishes because Bedrock is stuck mid-state-change away from `FOLLOWING`.
5. The `UnblockWrites` command that would get everything moving again is never sent.

This changes `Status` to not block on `_changeState`, which prevents this externally-triggered deadlock. It does this by making `peer->getData` atomic, so that it does not need to lock `_stateMutex`.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/446454

### Tests

I wrote a test to replicate this issue. 

It spun up a five node cluster, spamming commands at node 2 (0-indexed) to perform a stream of writes.

Then, on node 4, it repeatedly called `BlockWrites`, `Status`, and `UnblockWrites`.

After a few seconds, it stopped leader (node 0) to allow node 1 to stand up.

This test relaibly got stuck waiting for `Status` before this fix, and reliably completes after it.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
