### PR TITLE
Blocking command port when node is not caught up

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -260,16 +260,15 @@ void BedrockServer::sync()
                 }
                 const string blockReason = "COMMITS_LAGGING_BEHIND";
                 // If 
-                if (currentCommitCountDiff > 50'000) {
+                if (!_isCommandPortLikelyBlocked && currentCommitCountDiff > 50'000) {
                     SINFO("Node is lagging behind, blocking command port so it can catch up.");
                     blockCommandPort(blockReason);
-                } else if (currentCommitCountDiff < 10'000 && _commandPortBlockReasons.find(blockReason) == _commandPortBlockReasons.end()) {
-                    // We verify if we have the block reason we expected before unblocking so we don't call unblock every time, which will 
-                    // generate a warning if we don't have the block reason.
+                } else if (_isCommandPortLikelyBlocked && currentCommitCountDiff < 10'000 && _commandPortBlockReasons.find(blockReason) == _commandPortBlockReasons.end()) {
+                    // We verify if we have the block reason we expected before calling unblock. Unblock would generate a warning, and we don't
+                    // want to do that if don't really need to.
                     SINFO("Node is caught up enough, unblocking command port.");
                     unblockCommandPort(blockReason);
                 }
-
             });
             _syncNodeQueuedCommands.postPoll(fdm);
             _notifyDoneSync.postPoll(fdm);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1598,6 +1598,8 @@ virtual void isCommandPortClosed(const string& reason) {
     if (!strlen(reason)) {
         return _isCommandPortLikelyBlocked;
     }
+    // Get the shared mutex so we don't execute read operations while changing the set
+    shared_mutex<mutex> lock(_portMutex);
     return _commandPortBlockReasons.find(reason) != _commandPortBlockReasons.end();
 }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1594,7 +1594,7 @@ void BedrockServer::unblockCommandPort(const string& reason) {
     }
 }
 
-virtual void isCommandPortClosed(const string& reason) {
+virtual bool isCommandPortClosed(const string& reason) {
     if (!strlen(reason)) {
         return _isCommandPortLikelyBlocked;
     }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -184,6 +184,7 @@ class BedrockServer : public SQLiteServer {
     // You must block and unblock the command port with *identical strings*.
     void blockCommandPort(const string& reason) override;
     void unblockCommandPort(const string& reason) override;
+    bool isCommandPortClosed(const string& reason) override;
 
     // Legacy version of above.
     void suppressCommandPort(const string& reason, bool suppress, bool manualOverride = false);
@@ -377,7 +378,7 @@ class BedrockServer : public SQLiteServer {
     atomic<bool> _detach;
 
     // Pointers to the ports on which we accept commands.
-    mutex _portMutex;
+    shared_mutex _portMutex;
 
     // The "control port" is intended to be open to privileged clients (i.e., localhost and other nodes in the Bedrock
     // cluster) it can be used to run any command including commands meant for cluster operations, changing server

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -184,7 +184,6 @@ class BedrockServer : public SQLiteServer {
     // You must block and unblock the command port with *identical strings*.
     void blockCommandPort(const string& reason) override;
     void unblockCommandPort(const string& reason) override;
-    bool isCommandPortClosed(const string& reason) override;
 
     // Legacy version of above.
     void suppressCommandPort(const string& reason, bool suppress, bool manualOverride = false);
@@ -378,7 +377,7 @@ class BedrockServer : public SQLiteServer {
     atomic<bool> _detach;
 
     // Pointers to the ports on which we accept commands.
-    shared_mutex _portMutex;
+    mutex _portMutex;
 
     // The "control port" is intended to be open to privileged clients (i.e., localhost and other nodes in the Bedrock
     // cluster) it can be used to run any command including commands meant for cluster operations, changing server

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -182,8 +182,8 @@ class BedrockServer : public SQLiteServer {
     void onNodeLogin(SQLitePeer* peer) override;
 
     // You must block and unblock the command port with *identical strings*.
-    void blockCommandPort(const string& reason);
-    void unblockCommandPort(const string& reason);
+    void blockCommandPort(const string& reason) override;
+    void unblockCommandPort(const string& reason) override;
 
     // Legacy version of above.
     void suppressCommandPort(const string& reason, bool suppress, bool manualOverride = false);

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1289,6 +1289,8 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
             _server.blockCommandPort(blockReason);
             _blockedCommandPort = true;
         } else if (currentCommitDifference < 1'000 && _blockedCommandPort) {
+            // We'll open the command port again if we're 1k commits behind, which
+            // translates to ~2s of commits.
             SINFO("Node is caught up enough (behind by " + SToStr(currentCommitDifference) + " commits), re-opening command port.");
             _server.unblockCommandPort(blockReason);
             _blockedCommandPort = false;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1657,13 +1657,10 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     }
                     const int64_t currentCommitDifference = message.calcU64("NewCount") - getCommitCount();
                     const string blockReason = "COMMITS_LAGGING_BEHIND";
-                    // If 
-                    if (!_isCommandPortLikelyBlocked && currentCommitCountDiff > 50'000) {
-                        SINFO("Node is lagging behind, blocking command port so it can catch up.");
+                    if (currentCommitCountDiff > 50'000 && !isCommandPortClosed(blockReason)) {
+                        SINFO("Node is lagging behind, closing command port so it can catch up.");
                         blockCommandPort(blockReason);
-                    } else if (_isCommandPortLikelyBlocked && currentCommitCountDiff < 10'000 && _commandPortBlockReasons.find(blockReason) == _commandPortBlockReasons.end()) {
-                        // We verify if we have the block reason we expected before calling unblock. Unblock would generate a warning, and we don't
-                        // want to do that if don't really need to.
+                    } else if (isCommandPortClosed(blockReason) && currentCommitCountDiff < 10'000) {
                         SINFO("Node is caught up enough, unblocking command port.");
                         unblockCommandPort(blockReason);
                     }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1289,7 +1289,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
             _server.blockCommandPort(blockReason);
             _blockedCommandPort = true;
         } else if (currentCommitDifference < 1'000 && _blockedCommandPort) {
-            SINFO("Node is caught up enough, unblocking command port.");
+            SINFO("Node is caught up enough (behind by " + SToStr(currentCommitDifference) + " commits), re-opening command port.");
             _server.unblockCommandPort(blockReason);
             _blockedCommandPort = false;
         }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1287,9 +1287,11 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
         if (peer == _leadPeer && currentCommitDifference >= 12'500 && !_blockedCommandPort) {
             SINFO("Node is lagging behind, closing command port so it can catch up.");
             _server.blockCommandPort(blockReason);
+            _blockedCommandPort = true;
         } else if (currentCommitDifference < 1'000 && _blockedCommandPort) {
             SINFO("Node is caught up enough, unblocking command port.");
             _server.unblockCommandPort(blockReason);
+            _blockedCommandPort = false;
         }
         // Classify and process the message
         if (SIEquals(message.methodLine, "LOGIN")) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1285,7 +1285,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
         const string blockReason = "COMMITS_LAGGING_BEHIND";
         const int64_t currentCommitDifference =  peer->commitCount - getCommitCount();
         if (peer == _leadPeer && currentCommitDifference >= 12'500 && !_blockedCommandPort) {
-            SINFO("Node is lagging behind, closing command port so it can catch up.");
+            SINFO("Node is behind by " + SToStr(currentCommitDifference) + " commits, closing command port so it can catch up.");
             _server.blockCommandPort(blockReason);
             _blockedCommandPort = true;
         } else if (currentCommitDifference < 1'000 && _blockedCommandPort) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1284,16 +1284,16 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
         // so we can catch up with the cluster before processing new commands.
         const string blockReason = "COMMITS_LAGGING_BEHIND";
         const int64_t currentCommitDifference =  peer->commitCount - getCommitCount();
-        if (peer == _leadPeer && currentCommitDifference >= 12'500 && !_blockedCommandPort) {
+        if (peer == _leadPeer && currentCommitDifference >= 12'500 && !_blockedCommandPortForBeingBehind) {
             SINFO("Node is behind by " + SToStr(currentCommitDifference) + " commits, closing command port so it can catch up.");
             _server.blockCommandPort(blockReason);
-            _blockedCommandPort = true;
-        } else if (currentCommitDifference < 1'000 && _blockedCommandPort) {
+            _blockedCommandPortForBeingBehind = true;
+        } else if (currentCommitDifference < 1'000 && _blockedCommandPortForBeingBehind) {
             // We'll open the command port again if we're 1k commits behind, which
             // translates to ~2s of commits.
             SINFO("Node is caught up enough (behind by " + SToStr(currentCommitDifference) + " commits), re-opening command port.");
             _server.unblockCommandPort(blockReason);
-            _blockedCommandPort = false;
+            _blockedCommandPortForBeingBehind = false;
         }
         // Classify and process the message
         if (SIEquals(message.methodLine, "LOGIN")) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1655,15 +1655,6 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                             }
                         }
                     }
-                    const int64_t currentCommitDifference = message.calcU64("NewCount") - getCommitCount();
-                    const string blockReason = "COMMITS_LAGGING_BEHIND";
-                    if (currentCommitDifference > 50'000 && !_server.isCommandPortClosed(blockReason)) {
-                        SINFO("Node is lagging behind, closing command port so it can catch up.");
-                        _server.blockCommandPort(blockReason);
-                    } else if (currentCommitDifference < 10'000 && _server.isCommandPortClosed(blockReason)) {
-                        SINFO("Node is caught up enough, unblocking command port.");
-                        _server.unblockCommandPort(blockReason);
-                    }
                 } catch (const system_error& e) {
                     // If the server is strugling and falling behind on replication, we might have too many threads
                     // causing a resource exhaustion. If that happens, all the transactions that are already threaded

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1283,7 +1283,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
         // represents ~30s of commits. If we're behind, let's close the command port
         // so we can catch up with the cluster before processing new commands.
         const string blockReason = "COMMITS_LAGGING_BEHIND";
-        const int64_t currentCommitDifference = getCommitCount() - peer->commitCount;
+        const int64_t currentCommitDifference =  peer->commitCount - getCommitCount();
         if (peer == _leadPeer && currentCommitDifference >= 12'500 && !_blockedCommandPort) {
             SINFO("Node is lagging behind, closing command port so it can catch up.");
             _server.blockCommandPort(blockReason);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -364,9 +364,10 @@ class SQLiteNode : public STCPManager {
     // Stopwatch to track if we're giving up on the server preventing a standdown.
     SStopwatch _standDownTimeout;
 
-   // Our current State.
+    // Our current State.
     atomic<SQLiteNodeState> _state;
 
+    atomic<bool> _blockedCommandPort{false};
     // This is an integer that increments every time we change states. This is useful for responses to state changes
     // (i.e., approving standup) to verify that the messages we're receiving are relevant to the current state change,
     // and not stale responses to old changes.

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -368,7 +368,7 @@ class SQLiteNode : public STCPManager {
     atomic<SQLiteNodeState> _state;
 
     // Keeps track if we have closed the command port for commits fallen behind.
-    bool _blockedCommandPort{false};
+    bool _blockedCommandPortForBeingBehind{false};
 
     // This is an integer that increments every time we change states. This is useful for responses to state changes
     // (i.e., approving standup) to verify that the messages we're receiving are relevant to the current state change,

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -243,7 +243,7 @@ class SQLiteNode : public STCPManager {
     void _onDisconnect(SQLitePeer* peer);
 
     // Called when the peer sends us a message; throw an SException to reconnect.
-    void _onMESSAGE(SQLitePeer* peer, const SData& message);
+    void _onMESSAGE(SQLitePeer* peer, const SData& message, function<void(int64_t)> commandPortCallback = nullptr);
     void _reconnectAll();
     void _reconnectPeer(SQLitePeer* peer);
     void _recvSynchronize(SQLitePeer* peer, const SData& message);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -165,7 +165,7 @@ class SQLiteNode : public STCPManager {
     void kill();
 
     // Handle any read/write events that occurred.
-    void postPoll(fd_map& fdm, uint64_t& nextActivity, function<void(int64_t)> commandPortCallback = nullptr);
+    void postPoll(fd_map& fdm, uint64_t& nextActivity);
 
     // Constructor/Destructor
     SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, const string& name, const string& host,
@@ -243,7 +243,7 @@ class SQLiteNode : public STCPManager {
     void _onDisconnect(SQLitePeer* peer);
 
     // Called when the peer sends us a message; throw an SException to reconnect.
-    void _onMESSAGE(SQLitePeer* peer, const SData& message, function<void(int64_t)> commandPortCallback = nullptr);
+    void _onMESSAGE(SQLitePeer* peer, const SData& message);
     void _reconnectAll();
     void _reconnectPeer(SQLitePeer* peer);
     void _recvSynchronize(SQLitePeer* peer, const SData& message);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -367,7 +367,9 @@ class SQLiteNode : public STCPManager {
     // Our current State.
     atomic<SQLiteNodeState> _state;
 
-    atomic<bool> _blockedCommandPort{false};
+    // Keeps track if we have closed the command port for commits fallen behind.
+    bool _blockedCommandPort{false};
+
     // This is an integer that increments every time we change states. This is useful for responses to state changes
     // (i.e., approving standup) to verify that the messages we're receiving are relevant to the current state change,
     // and not stale responses to old changes.

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -165,7 +165,7 @@ class SQLiteNode : public STCPManager {
     void kill();
 
     // Handle any read/write events that occurred.
-    void postPoll(fd_map& fdm, uint64_t& nextActivity);
+    void postPoll(fd_map& fdm, uint64_t& nextActivity, function<void(int64_t)> commandPortCallback = nullptr);
 
     // Constructor/Destructor
     SQLiteNode(SQLiteServer& server, shared_ptr<SQLitePool> dbPool, const string& name, const string& host,

--- a/sqlitecluster/SQLiteServer.h
+++ b/sqlitecluster/SQLiteServer.h
@@ -15,7 +15,7 @@ class SQLiteServer : public STCPManager {
     virtual void notifyStateChangeToPlugins(SQLite& db, SQLiteNodeState newState) = 0;
 
     // You must block and unblock the command port with *identical strings*.
-    virtual void blockCommandPort(const string& reason);
-    virtual void unblockCommandPort(const string& reason);
-    virtual bool isCommandPortClosed(const string& reason);
+    virtual void blockCommandPort(const string& reason) = 0;
+    virtual void unblockCommandPort(const string& reason) = 0;
+    virtual bool isCommandPortClosed(const string& reason) = 0;
 };

--- a/sqlitecluster/SQLiteServer.h
+++ b/sqlitecluster/SQLiteServer.h
@@ -17,5 +17,5 @@ class SQLiteServer : public STCPManager {
     // You must block and unblock the command port with *identical strings*.
     virtual void blockCommandPort(const string& reason);
     virtual void unblockCommandPort(const string& reason);
-    virtual void isCommandPortClosed(const string& reason);
+    virtual bool isCommandPortClosed(const string& reason);
 };

--- a/sqlitecluster/SQLiteServer.h
+++ b/sqlitecluster/SQLiteServer.h
@@ -17,4 +17,5 @@ class SQLiteServer : public STCPManager {
     // You must block and unblock the command port with *identical strings*.
     virtual void blockCommandPort(const string& reason);
     virtual void unblockCommandPort(const string& reason);
+    virtual void isCommandPortClosed(const string& reason);
 };

--- a/sqlitecluster/SQLiteServer.h
+++ b/sqlitecluster/SQLiteServer.h
@@ -17,5 +17,4 @@ class SQLiteServer : public STCPManager {
     // You must block and unblock the command port with *identical strings*.
     virtual void blockCommandPort(const string& reason) = 0;
     virtual void unblockCommandPort(const string& reason) = 0;
-    virtual bool isCommandPortClosed(const string& reason) = 0;
 };

--- a/sqlitecluster/SQLiteServer.h
+++ b/sqlitecluster/SQLiteServer.h
@@ -13,4 +13,8 @@ class SQLiteServer : public STCPManager {
 
     // We call this method whenever a node changes state
     virtual void notifyStateChangeToPlugins(SQLite& db, SQLiteNodeState newState) = 0;
+
+    // You must block and unblock the command port with *identical strings*.
+    virtual void blockCommandPort(const string& reason);
+    virtual void unblockCommandPort(const string& reason);
 };

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -28,7 +28,6 @@ class TestServer : public SQLiteServer {
     virtual void notifyStateChangeToPlugins(SQLite& db, SQLiteNodeState newState) {}
     virtual void blockCommandPort(const string& reason) { };
     virtual void unblockCommandPort(const string& reason) { };
-    virtual bool isCommandPortClosed(const string& reason) { return false; };
 };
 
 struct SQLiteNodeTest : tpunit::TestFixture {

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -26,6 +26,8 @@ class TestServer : public SQLiteServer {
     virtual bool canStandDown() { return true; }
     virtual void onNodeLogin(SQLitePeer* peer) { }
     virtual void notifyStateChangeToPlugins(SQLite& db, SQLiteNodeState newState) {}
+    virtual void blockCommandPort(const string& reason) { };
+    virtual void unblockCommandPort(const string& reason) { };
 };
 
 struct SQLiteNodeTest : tpunit::TestFixture {

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -28,6 +28,7 @@ class TestServer : public SQLiteServer {
     virtual void notifyStateChangeToPlugins(SQLite& db, SQLiteNodeState newState) {}
     virtual void blockCommandPort(const string& reason) { };
     virtual void unblockCommandPort(const string& reason) { };
+    virtual bool isCommandPortClosed(const string& reason) { return false; };
 };
 
 struct SQLiteNodeTest : tpunit::TestFixture {


### PR DESCRIPTION
### Details

This PR blocks the command port if a node is more than 12.5K commits behind the leader, and reopens when we're 1K behind.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/437855

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
