### PR TITLE
Revert "Add recipientEmail to the whitelist"

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -62,7 +62,6 @@ static set<string> PARAMS_WHITELIST = {
     "employees",
     "mergeFromEmail",
     "mergeToEmail",
-    "recipientEmail",
 };
 
 string addLogParams(string&& message, const STable& params) {


### PR DESCRIPTION
Reverts Expensify/Bedrock#2051

Added the param to the wrong whitelist, reverting this.