### PR TITLE
Revert "Add log params"

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -60,8 +60,6 @@ static set<string> PARAMS_WHITELIST = {
     "approver",
     "approvers",
     "employees",
-    "mergeFromEmail",
-    "mergeToEmail",
 };
 
 string addLogParams(string&& message, const STable& params) {


### PR DESCRIPTION
Reverts Expensify/Bedrock#2044

Per [this notice](https://expensify.slack.com/archives/C03TQ48KC/p1736449550401129), these should be added in Auth instead.