### PR TITLE
Update GH actions cache to 4.2.0 as 4.0 is deprecated

### DIFF
--- a/.github/workflows/bedrock.yml
+++ b/.github/workflows/bedrock.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install the Mold Linker
       uses: rui314/setup-mold@v1
-      
+
     - name: Checkout Bedrock
       uses: actions/checkout@v4.1.0
 
@@ -32,7 +32,7 @@ jobs:
       shell: bash
 
     - name: Set up cache
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4.2.0
       with:
         path: |-
           ${{ env.CCACHE_BASEDIR }}


### PR DESCRIPTION
https://github.com/actions/cache/discussions/1510

Its deprecated so we need to bump this