### PR TITLE
Fix fork when COMMIT_TRANSACTION is dropped

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2566,22 +2566,9 @@ STCPManager::Socket* SQLiteNode::_acceptSocket() {
 void SQLiteNode::_processPeerMessages(uint64_t& nextActivity, SQLitePeer* peer, bool unlimited) {
     try {
         size_t messagesDeqeued = 0;
-        if (unlimited) {
-            if (peer->socket) {
-                string recvBuffer = peer->socket->recvBuffer.c_str();
-                if (recvBuffer.size()) {
-                    SINFO("TYLER: peer recv buffer " << peer->socket->recvBuffer);
-                }
-            } else {
-                SINFO("TYLER: no socket");
-            }
-        }
         while (true) {
             SData message = peer->popMessage();
             _onMESSAGE(peer, message);
-            if (unlimited) {
-                SINFO("TYLER: processed message with unlimited set " << message.methodLine);
-            }
             messagesDeqeued++;
             if (messagesDeqeued >= 100 && !unlimited) {
                 // We should run again immediately, we have more to do.
@@ -2664,7 +2651,6 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     // Now check established peer connections.
     for (SQLitePeer* peer : _peerList) {
         auto result = peer->postPoll(fdm, nextActivity);
-
         switch (result) {
             case SQLitePeer::PeerPostPollStatus::JUST_CONNECTED:
             {

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -278,6 +278,8 @@ class SQLiteNode : public STCPManager {
 
     void _dieIfForkedFromCluster();
 
+    void _processPeerMessages(uint64_t& nextActivity, SQLitePeer* peer, bool unlimited = false);
+
     const string _commandAddress;
     const string _name;
     const vector<SQLitePeer*> _peerList;

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -121,7 +121,8 @@ SQLitePeer::PeerPostPollStatus SQLitePeer::postPoll(fd_map& fdm, uint64_t& nextA
                 } else {
                     SHMMM("Lost peer connection after " << (STimeNow() - socket->openTime) / 1000 << "ms, reconnecting in " << delay / 1000 << "ms");
                 }
-                reset();
+                // Can't reset until the buffer is cleared.
+                // reset();
                 nextReconnect = STimeNow() + delay;
                 nextActivity = min(nextActivity, nextReconnect.load());
                 return PeerPostPollStatus::SOCKET_CLOSED;

--- a/sqlitecluster/SQLitePeer.cpp
+++ b/sqlitecluster/SQLitePeer.cpp
@@ -121,8 +121,6 @@ SQLitePeer::PeerPostPollStatus SQLitePeer::postPoll(fd_map& fdm, uint64_t& nextA
                 } else {
                     SHMMM("Lost peer connection after " << (STimeNow() - socket->openTime) / 1000 << "ms, reconnecting in " << delay / 1000 << "ms");
                 }
-                // Can't reset until the buffer is cleared.
-                // reset();
                 nextReconnect = STimeNow() + delay;
                 nextActivity = min(nextActivity, nextReconnect.load());
                 return PeerPostPollStatus::SOCKET_CLOSED;

--- a/sqlitecluster/SQLitePeer.h
+++ b/sqlitecluster/SQLitePeer.h
@@ -104,6 +104,7 @@ class SQLitePeer {
     mutable recursive_mutex peerMutex;
 
     // Not named with an underscore because it's only sort-of private (see friend class declaration above).
+  public:
     STCPManager::Socket* socket = nullptr;
 };
 

--- a/sqlitecluster/SQLitePeer.h
+++ b/sqlitecluster/SQLitePeer.h
@@ -45,6 +45,8 @@ class SQLitePeer {
     // If there are no messages, throws `std::out_of_range`.
     SData popMessage();
 
+    // NOTE: If this returns PeerPostPollStatus::SOCKET_CLOSED then the caller must call `reset` on this peer.
+    // This is not done internally becuase we need to expose the outstanding data on the socket before deleting it.
     PeerPostPollStatus postPoll(fd_map& fdm, uint64_t& nextActivity);
 
     // Send a message to this peer. Thread-safe.
@@ -104,7 +106,6 @@ class SQLitePeer {
     mutable recursive_mutex peerMutex;
 
     // Not named with an underscore because it's only sort-of private (see friend class declaration above).
-  public:
     STCPManager::Socket* socket = nullptr;
 };
 


### PR DESCRIPTION
### Details
This fixes a possible fork where followers fail to handle a commit sent by leader.

The existing behavior is that leader sends a BEGIN_TRANSACTION followed by a COMMIT_TRANSACTION to followers. When it is shutting down, one of these pairs is the final transaction sent to followers, and then the sockets to followers are closed.

The leader behavior is correct, the problem exists on followers.

When the follower is reading data off the socket, it reads the data that was sent before closing, and then marks the data as closed:
https://github.com/Expensify/Bedrock/blob/a88cf54db5fd133bdd4d1639b0e6611cbfe4948b/libstuff/STCPManager.cpp#L119-L139

When the SQLitePeer object sees that the socket has been closed, it calls `reset()` on it's socket and returns `SOCKET_CLOSED` to `SQLiteNode`.

The problem is that it's possible that the `COMMIT_TRANSACTION` message is read immediately before the `close` on the socket, in the same call to `postPoll` (it's feasible even more messages are read on the same call, but they would all have the same issue).

We only tried to handle messages in the case that SQLitePeer::postPoll returned `PeerPostPollStatus::OK`:
https://github.com/Expensify/Bedrock/blob/a88cf54db5fd133bdd4d1639b0e6611cbfe4948b/sqlitecluster/SQLiteNode.cpp#L2673

So in this case, the `COMMIT_TRANSACTION` message was discarded.

However, this could lead to a fork, because the follower would never commit the last transaction sent by leader. Then when leader came back up, it could be out of sync with the follower.

This was easily reproducible on the HC-Tree branch, not because of any property of HC-Tree, but because the tests start and stop leader a lot more often for HC-Tree, making this occurrence more likely.

The fix was to:

1. Handle any messages that were received in the last `postPoll` even for `PeerPostPollStatus::JUST_CONNECTED`, `PeerPostPollStatus::SOCKET_ERROR`, and `PeerPostPollStatus::SOCKET_CLOSED` return values from `SQLitePeer::postPoll` (only `SOCKET_CLOSED` actually exhibited the problem here, but the others are for completeness). I extracted the logic here to a method called `_processPeerMessages` for this.
2. The peer messages need to still exist when we go to process them, which means we can't call `reset` on the `SQLitePeer`'s socket before handling them. I moved the call to `reset()` out of `SQLitePeer::postPoll` and into `SQLiteNode::postPoll`.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/337537

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
