### PR TITLE
Remove 24% of Bedrock logs

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1030,8 +1030,6 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                             // loop and send it to followers. NOTE: we don't check for null here, that should be
                             // impossible inside a worker thread.
                             _syncNode->notifyCommit();
-                            SINFO("Committed leader transaction #" << transactionID << "(" << transactionHash << "). Command: '" << command->request.methodLine << "', blocking: "
-                                  << (isBlocking ? "true" : "false"));
                             _conflictManager.recordTables(command->request.methodLine, db.getTablesUsed());
                             // So we must still be leading, and at this point our commit has succeeded, let's
                             // mark it as complete. We add the currentCommit count here as well.

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2722,7 +2722,6 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
 
     // But we log for commit conflicts as well, to keep track of how often this happens with this experimental feature.
     if (extErr == SQLITE_BUSY_SNAPSHOT) {
-        SHMMM("[concurrent] commit conflict.");
         return extErr;
     }
     return error;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -393,7 +393,7 @@ bool SQLite::beginTransaction(TRANSACTION_TYPE type) {
     // We actively track transaction counts incrementing and decrementing to log the number of active open transactions at any given moment.
     _sharedData.openTransactionCount++;
 
-    SINFO("[concurrent] Beginning transaction - open transaction count: " << (_sharedData.openTransactionCount));
+    SINFO("Beginning transaction - open transaction count: " << (_sharedData.openTransactionCount));
     uint64_t before = STimeNow();
     _insideTransaction = !SQuery(_db, "starting db transaction", "BEGIN CONCURRENT");
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -677,11 +677,9 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash) {
     // where this journal in particular has accumulated a large backlog.
     static const size_t deleteLimit = 10;
     if (minJournalEntry < oldestCommitToKeep) {
-        auto startUS = STimeNow();
         shared_lock<shared_mutex> lock(_sharedData.writeLock);
         string query = "DELETE FROM " + _journalName + " WHERE id < " + SQ(oldestCommitToKeep) + " LIMIT " + SQ(deleteLimit);
         SASSERT(!SQuery(_db, "Deleting oldest journal rows", query));
-        size_t deletedCount = sqlite3_changes(_db);
     }
 
     // We lock this here, so that we can guarantee the order in which commits show up in the database.


### PR DESCRIPTION
### Details

We're trying to reduce log volume which seems problematic during harvesting. All of these removed logs have existing counterparts.

Here are the log line counts for 37 seconds of such a period of time:
```
Counts for each file:
SQLite.cpp:396: 94887
BedrockCore.cpp:273: 94529
Jobs.cpp:773: 87157
SQLite.cpp:686: 66456
SQLite.cpp:902: 63029
SQLite.cpp:261: 62667
BedrockServer.cpp:1041: 62588
libstuff.cpp:2725: 62586
SQLite.cpp:775: 62586
SQLite.cpp:837: 62586
SQLiteCore.cpp:36: 62586
SQLite.cpp:874: 62586
SQLite.cpp:887: 62586
BedrockServer.cpp:930: 51824
Jobs.cpp:1101: 34759
BedrockCommand.cpp:282: 32399
SQLiteNode.cpp:478: 31954
SQLite.cpp:829: 31940
BedrockServer.cpp:1034: 31940
BedrockConflictManager.cpp:43: 31940
BedrockServer.cpp:1563: 31661
BedrockServer.cpp:1529: 31660
BedrockServer.cpp:1547: 31660
Jobs.cpp:513: 29974
Jobs.cpp:613: 29852
Jobs.cpp:295: 29758
Jobs.cpp:478: 29725
Jobs.cpp:261: 28302
Jobs.cpp:1177: 26095
BedrockServer.cpp:1094: 10755
BedrockCore.cpp:414: 10724
BedrockServer.cpp:681: 10723
BedrockServer.cpp:2263: 4774
BedrockServer.cpp:2401: 4692
SQLite.cpp:820: 2001
Jobs.cpp:832: 974
BedrockServer.cpp:2187: 739
SQLite.cpp:695: 461
Cache.cpp:193: 163
SQLite.cpp:899: 89
CaptureAgentActivity.cpp:77: 56
libstuff.cpp:2692: 53
libstuff.cpp:156: 36
BedrockCore.cpp:384: 36
Jobs.cpp:315: 30
Concierge.cpp:916: 25
Concierge.cpp:919: 25
Jobs.cpp:515: 21
CaptureAgentActivity.cpp:102: 20
CaptureAgentActivity.cpp:66: 19
CaptureAgentActivity.cpp:89: 19
CaptureAgentActivity.cpp:112: 17
AutoTimer.cpp:22: 9
SQLite.cpp:106: 6
SQLite.cpp:186: 6
SQLitePool.cpp:59: 6
SPerformanceTimer.cpp:52: 4
main.cpp:384: 4
libstuff.cpp:1975: 3
CaptureAgentActivity.cpp:72: 2
CaptureAgentActivity.cpp:55: 1
Jobs.cpp:1157: 1
SQLiteNode.cpp:2664: 1
SQLiteNode.cpp:1257: 1

PHP logs: 527758
Other logs: 3474
```

### Fixed Issues
https://expensify.slack.com/archives/C05CBC62HGW/p1736772832409169?thread_ts=1736264200.243169&cid=C05CBC62HGW

Fixes https://github.com/Expensify/Expensify/issues/457478

### Tests

none
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
