### PR TITLE
Disable cache outside transactions

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -511,7 +511,7 @@ bool SQLite::read(const string& query, SQResult& result, bool skipInfoWarn) cons
     } else {
         _isDeterministicQuery = true;
         queryResult = !SQuery(_db, "read only query", query, result, 2000 * STIME_US_PER_MS, skipInfoWarn);
-        if (_isDeterministicQuery && queryResult) {
+        if (_isDeterministicQuery && queryResult && insideTransaction()) {
             _queryCache.emplace(make_pair(query, result));
         }
     }

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -216,7 +216,7 @@ class SQLite {
     const string getMostRecentSQLiteErrorLog() const;
 
     // Returns true if we're inside an uncommitted transaction.
-    bool insideTransaction() { return _insideTransaction; }
+    bool insideTransaction() const { return _insideTransaction; }
 
     // Looks up the exact SQL of a paricular commit to the database, as well as gets the SHA1 hash of the database
     // immediately following tha commit.


### PR DESCRIPTION
### Details
This disables caching query results when we're not in a transaction (particularly, in prePeek). Because there is no transaction, there's no way to know if the database has changed after any of these queries. This was discovered in the HC-Tree version of `JoinAccessiblePolicyTest` but it could happen in any command with prePeek.


### Fixed Issues
https://github.com/Expensify/Expensify/issues/337537

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
