### PR TITLE
Add adminID and auditorID to allowed params

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -60,6 +60,7 @@ static set<string> PARAMS_WHITELIST = {
     "approver",
     "approvers",
     "employees",
+    "accountID",
     "adminID",
     "auditorID",
 };

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -60,6 +60,8 @@ static set<string> PARAMS_WHITELIST = {
     "approver",
     "approvers",
     "employees",
+    "adminID",
+    "auditorID",
 };
 
 string addLogParams(string&& message, const STable& params) {


### PR DESCRIPTION
### Details

### Fixed Issues
Needed for https://github.com/Expensify/Auth/pull/13897

### Tests
Just adding constant to whitelist. 
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
