### PR TITLE
Fix typo in warn message

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -713,7 +713,7 @@ bool SQLiteNode::update() {
         SASSERTWARN(_db.getUncommittedHash().empty());
 
         if (_isShuttingDown) {
-            SWARN("Shutting down in WAITING, how did we here here?");
+            SWARN("Shutting down in WAITING, how did we get here?");
 
             // Return false to allow the poll loop to run again. This is here for legacy reasons form before the above warning was added.
             // Probably this whole block can be removed if that warning never fires.


### PR DESCRIPTION
### Details
Fixes a typo in a wan message as found in https://github.com/Expensify/Expensify/issues/461502

### Fixed Issues
Related https://github.com/Expensify/Expensify/issues/461502

### Tests
N/A
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
