### PR TITLE
Add rollback to postProcess

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -361,6 +361,7 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool i
 
     // The command is complete.
     command->complete = true;
+    _db.rollback();
     _db.clearTimeout();
 
     // Reset, we can write now.


### PR DESCRIPTION
### Details

Context: https://expensify.slack.com/archives/C05CBC62HGW/p1738208970608929?thread_ts=1738090282.125069&cid=C05CBC62HGW

It seems like `postProcessCommand` doesn't clear the db's query cache at the end, so it is possible that subsequent command's `prePeek` may read stale data from this cache. This can only happen for a subsequent command's `prePeek` and not `peek` because `peek` clears the cache when it opens a new transaction.

I'm not sure if this can happen in production, I was only able to confirm it running tests.

### Fixed Issues
Fixes flakey tests mentioned here: https://github.com/Expensify/Auth/pull/13089#discussion_r1934500303

### Tests

You have to run `ShareReportsWithAdminOrAuditorTest` a lot of times while having checked out this PR: https://github.com/Expensify/Auth/pull/13089

I ran the test 400 times without failure (before this fix, I got 8 failures in 200 runs)
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
