### PR TITLE
Actually track total class test times, not the time a thread is alive

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -328,6 +328,7 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
         cout << endl;
         cout << "Slowest Test Classes: " << endl;
 
+        // Combine total thread time so its not obscured by multi-threaded tests.
         long long totalTestTime = 0;
         for (auto testTime : testTimes) {
             totalTestTime += testTime.first.count();
@@ -338,7 +339,7 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
             if (it == testTimes.rend()) {
                 break;
             }
-            cout << it->first << ": " << it->second << " " << (static_cast<double>(it->first.count()) / totalTestTime) * 100.0 << "% of total test time" << endl;
+            cout << it->first << ": " << it->second << " : " << (static_cast<double>(it->first.count()) / totalTestTime) * 100.0 << "% of total test time" << endl;
             it++;
         }
 

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -190,6 +190,7 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
         // next thread in the loop.
         thread t = thread([&, threadID]{
            auto start = chrono::steady_clock::now();
+           auto end = start;
 
            threadInitFunction();
             try {
@@ -270,6 +271,9 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
                    }
 
                    tpunit_run_test_class(f);
+
+                   // Do this to capture the longest test classes, not longest thread.
+                   end = chrono::steady_clock::now();
                 }
             } catch (ShutdownException se) {
                 // This will have broken us out of our main loop, so we'll just exit. We also set the exit flag to let
@@ -278,7 +282,7 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
                 exitFlag = true;
                 printf("Thread %d caught shutdown exception, exiting.\n", threadID);
             }
-            auto end = chrono::steady_clock::now();
+
             if (currentTestName.size()) {
                 lock_guard<mutex> lock(testTimeLock);
                 testTimes.emplace(make_pair(chrono::duration_cast<std::chrono::milliseconds>(end - start), currentTestName));

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -189,8 +189,8 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
         // Capture everything by reference except threadID, because we don't want it to be incremented for the
         // next thread in the loop.
         thread t = thread([&, threadID]{
-           auto start = chrono::steady_clock::now();
-           auto end = start;
+           chrono::steady_clock::time_point start = chrono::steady_clock::now();
+           chrono::steady_clock::time_point end = start;
 
            threadInitFunction();
             try {
@@ -255,25 +255,32 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
                         continue;
                     }
 
-                   // At this point, we know this test should run.
-                   if (!f->_multiThreaded) {
-                       printf("--------------\n");
-                   }
-                   {
-                       lock_guard<mutex> lock(currentTestNameMutex);
-                       currentTestPtr = f;
-                       if (f->_name) {
-                           currentTestName = f->_name;
-                       } else {
-                           cout << "test has no name???" << endl;
-                           currentTestName = "UNSPECIFIED";
-                       }
-                   }
+                    // At this point, we know this test should run.
+                    if (!f->_multiThreaded) {
+                        printf("--------------\n");
+                    }
+                    {
+                        lock_guard<mutex> lock(currentTestNameMutex);
+                        currentTestPtr = f;
+                        if (f->_name) {
+                            currentTestName = f->_name;
+                        } else {
+                            cout << "test has no name???" << endl;
+                            currentTestName = "UNSPECIFIED";
+                        }
+                    }
 
-                   tpunit_run_test_class(f);
+                    start = chrono::steady_clock::now();
 
-                   // Do this to capture the longest test classes, not longest thread.
-                   end = chrono::steady_clock::now();
+                    tpunit_run_test_class(f);
+
+                    // Do this to capture the longest test classes, not longest thread.
+                    end = chrono::steady_clock::now();
+
+                   if (currentTestName.size() && currentTestName != "UNSPECIFIED") {
+                        lock_guard<mutex> lock(testTimeLock);
+                        testTimes.emplace(make_pair(chrono::duration_cast<std::chrono::milliseconds>(end - start), currentTestName));
+                    }
                 }
             } catch (ShutdownException se) {
                 // This will have broken us out of our main loop, so we'll just exit. We also set the exit flag to let
@@ -281,11 +288,6 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
                 lock_guard<recursive_mutex> lock(m);
                 exitFlag = true;
                 printf("Thread %d caught shutdown exception, exiting.\n", threadID);
-            }
-
-            if (currentTestName.size()) {
-                lock_guard<mutex> lock(testTimeLock);
-                testTimes.emplace(make_pair(chrono::duration_cast<std::chrono::milliseconds>(end - start), currentTestName));
             }
         });
         threadList.push_back(move(t));
@@ -325,14 +327,22 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
 
         cout << endl;
         cout << "Slowest Test Classes: " << endl;
+
+        long long totalTestTime = 0;
+        for (auto testTime : testTimes) {
+            totalTestTime += testTime.first.count();
+        }
+
         auto it = testTimes.rbegin();
         for (size_t i = 0; i < 10; i++) {
             if (it == testTimes.rend()) {
                 break;
             }
-            cout << it->first << ": " << it->second << endl;
+            cout << it->first << ": " << it->second << " " << (static_cast<double>(it->first.count()) / totalTestTime) * 100.0 << "% of total test time" << endl;
             it++;
         }
+
+        cout << "Total test time across threads: " << totalTestTime << "ms" << endl;
 
         return tpunit_detail_stats()._failures;
     }


### PR DESCRIPTION
cc @tylerkaraszewski 
I realized that the test times at the end are practically the full test time run, not the actual time we spent in a certain class. This fixes that.

result with 16 threads.
```
Slowest Test Classes:
28651ms: InfiniteRetryAfter : 28.5613% of total test time
23967ms: GetJob : 23.892% of total test time
12892ms: CreateJob : 12.8516% of total test time
10254ms: GetJobs : 10.2219% of total test time
8275ms: FailedJobReply : 8.2491% of total test time
4212ms: RequeueJobs : 4.19882% of total test time
2544ms: ChainedHTTP : 2.53604% of total test time
1341ms: Write : 1.3368% of total test time
1160ms: Query : 1.15637% of total test time
1156ms: CommandPort : 1.15238% of total test time
Total test time across threads: 100314ms
```

### Details

### Fixed Issues
Found this 

### Tests
See tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
