### PR TITLE
Change SWARN to SHMMM when servers fail to connect

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2523,7 +2523,7 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 STHROW("Incoming socket didn't send a message for over 5s, closing.");
             }
         } catch (const SException& e) {
-            SWARN("Incoming connection failed from '" << socket->addr << "' (" << e.what() << ")");
+            SHMMM("Incoming connection failed from '" << socket->addr << "' (" << e.what() << ")");
             socketsToRemove.push_back(socket);
             delete socket;
         }


### PR DESCRIPTION
### Details

Whenever there's a deploy or servers have to reconnect, there's a chance that the connection fails. This will retry anyway and has been happening for a long time so we should be able to demote this to a HMMM rather than a WARN.

### Fixed Issues
Fixes [GH_LINK](https://github.com/Expensify/Expensify/issues/464819)

### Tests

N/A

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
