### PR TITLE
Throw instead of crashing when writing outside of transaction

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -586,7 +586,7 @@ bool SQLite::writeUnmodified(const string& query) {
 
 bool SQLite::_writeIdempotent(const string& query, SQResult& result, bool alwaysKeepQueries) {
     if (!_insideTransaction) {
-        STHROW("Attempted to write outside of transaction");
+        STHROW("500 Attempted to write outside of transaction");
     }
 
     _queryCache.clear();

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -585,7 +585,10 @@ bool SQLite::writeUnmodified(const string& query) {
 }
 
 bool SQLite::_writeIdempotent(const string& query, SQResult& result, bool alwaysKeepQueries) {
-    SASSERT(_insideTransaction);
+    if (!_insideTransaction) {
+        STHROW("Attempted to write outside of transaction");
+    }
+
     _queryCache.clear();
     _writeQueryCount++;
 


### PR DESCRIPTION
### Details

Right now, if you attempt to write in peek or prePeek then we crash. This PR changes that so that we throw an error instead of crashing. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/466913

### Tests
I updated the addComment command locally to attempt to do a write in prePeek. Before the change that generates a crash: 
<img width="1342" alt="Screenshot 2025-02-05 at 11 56 50 AM" src="https://github.com/user-attachments/assets/1a23a317-1834-4669-b49a-7b6969b89115" />


After the change, no crash, the command just errors out. 
<img width="1347" alt="Screenshot 2025-02-05 at 11 55 05 AM" src="https://github.com/user-attachments/assets/7c939a67-f059-469e-b421-0ca63c1c5486" />

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
