### PR TITLE
Demote inactionable warning

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -760,7 +760,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
         if (result) {
             SINFO("Synchronizing while accepting commands; successfully forwarded the command to peer", {{"command", command->request.methodLine}});
         } else {
-            SWARN("Synchronizing while accepting commands, but failed to forward the command to peer.", {{"command", command->request.methodLine}});
+            SHMMM("Synchronizing while accepting commands, but failed to forward the command to peer.", {{"command", command->request.methodLine}});
         }
     }
 


### PR DESCRIPTION
### Details
This is an uncommon but inactionable condition, no need to to create issues to fix it.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/438270

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
