### PR TITLE
Lower log level of warning in SREReplace

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2892,7 +2892,7 @@ string SREReplace(const string& regExp, const string& input, const string& repla
             // This is the expected case on the first run, there's not enough space to store the result, so we allocate the space and do it again.
             output = (char*)malloc(outSize);
         } else if (result < 0) {
-            SWARN("Regex replacement failed with result " << result << ", returning nothing.");
+            SHMMM("Regex replacement failed with result " << result << ", returning nothing.");
             output = (char*)malloc(1);
             *output = 0;
             break;


### PR DESCRIPTION
### Details
This log doesn't seem like it needs to be a warn so lowering it to hmmm instead

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/473465

### Tests
None
