### PR TITLE
Add includes for libstdc14

### DIFF
--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -5,7 +5,9 @@
 #include <libgen.h>
 #include <syslog.h>
 
+#include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <functional>
 #include <iomanip>
 #include <list>


### PR DESCRIPTION
### Details
Resolving compilation issues for moving to libstdc14

```
libstuff/libstuff.cpp:356:5: error: use of undeclared identifier 'transform'
  356 |     transform(value.begin(), value.end(), value.begin(), ::tolower);
      |     ^
libstuff/libstuff.cpp:361:5: error: use of undeclared identifier 'transform'
  361 |     transform(value.begin(), value.end(), value.begin(), ::toupper);
      |     ^
libstuff/libstuff.cpp:2993:12: error: no matching function for call to 'find'
 2993 |     return ::find(valueList.begin(), valueList.end(), string(value)) != valueList.end();
      |            ^~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/streambuf_iterator.h:435:5: note: candidate template ignored: could not match 'istreambuf_iterator' against '_List_const_iterator'
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^
3 errors generated.
sqlitecluster/SQLiteNode.cpp:102:10: error: no member named 'sort' in namespace 'std'
  102 |     std::sort(peerList.begin(), peerList.end(),
      |     ~~~~~^
sqlitecluster/SQLiteNode.cpp:2609:15: error: no matching function for call to 'lower_bound'
 2609 |     auto it = lower_bound(_peerList.begin(), _peerList.end(), &searchPeer, [](const SQLitePeer* peer1, const SQLitePeer* peer2) { return peer1->name < peer2->name; });
      |               ^~~~~~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/stl_algobase.h:1527:5: note: candidate function template not viable: requires 3 arguments, but 4 were provided
 1527 |     lower_bound(_ForwardIterator __first, _ForwardIterator __last,
      |     ^           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1528 |                 const _Tp& __val)
      |                 ~~~~~~~~~~~~~~~~
2 errors generated.
In file included from plugins/Jobs.cpp:1:
In file included from plugins/Jobs.h:2:
/home/runner/work/Bedrock/Bedrock/libstuff/libstuff.h:380:12: error: no matching function for call to 'find'
  380 |     return ::find(valueList.begin(), valueList.end(), value) != valueList.end();
      |            ^~~~~~
plugins/Jobs.cpp:1461:10: note: in instantiation of function template specialization 'SContains<long>' requested here
 1461 |     if (!SContains(validPriorities, priority)) {
      |          ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/streambuf_iterator.h:435:5: note: candidate template ignored: could not match 'istreambuf_iterator' against '_List_const_iterator'
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^
1 error generated.
```

### Fixed Issues
related to https://github.com/Expensify/Expensify/issues/474534

### Tests
If tests pass, this works
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
