### PR TITLE
We should no longer depend on the old PCRE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ INTERMEDIATEDIR = .build
 
 # We use the same library paths and required libraries for all binaries.
 LIBPATHS =-L$(PROJECT) -Lmbedtls/library
-LIBRARIES =-Wl,--start-group -lbedrock -lstuff -Wl,--end-group -ldl -lpcrecpp -lpcre2-8 -lpthread -lmbedtls -lmbedx509 -lmbedcrypto -lz -lm
+LIBRARIES =-Wl,--start-group -lbedrock -lstuff -Wl,--end-group -ldl -lpcre2-8 -lpthread -lmbedtls -lmbedx509 -lmbedcrypto -lz -lm
 
 # These targets aren't actual files.
 .PHONY: all test clustertest clean testplugin


### PR DESCRIPTION
### Details
We haven't used this in a long time, we don't need it.

### Fixed Issues
Found while creating new VM here: https://github.com/Expensify/Expensidev/pull/897

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
