### PR TITLE
Add Control Command OpenDBHandlesAndRunQuery

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1814,6 +1814,7 @@ bool BedrockServer::_isControlCommand(const unique_ptr<BedrockCommand>& command)
         SIEquals(command->request.methodLine, "BlockWrites")            ||
         SIEquals(command->request.methodLine, "UnblockWrites")          ||
         SIEquals(command->request.methodLine, "SetMaxSocketThreads")    ||
+        SIEquals(command->request.methodLine, "OpenDBHandlesAndRunQuery") ||
         SIEquals(command->request.methodLine, "CRASH_COMMAND")
         ) {
         return true;
@@ -1973,6 +1974,63 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
             _maxSocketThreads = newMax;
         } else {
             response.methodLine = "401 Don't Use Zero";
+        }
+    } else if (SIEquals(command->request.methodLine, "OpenDBHandlesAndRunQuery")) {
+        // Note that calling this with more handles than the pool is configured to open will effectively lock up the server.
+        // Calling it with fewer than that should eventually work but may have big performance impacts if this number
+        // is very close to the maximum allowed.
+        // Whether or not this creates a bunch of handles or recycles existing handles is indeterminate.
+        size_t handlesCount = command->request.calcU64("handlesCount");
+        size_t maxThreads = 16;
+        if (command->request.isSet("maxThreads")) {
+            maxThreads = command->request.calcU64("maxThreads");
+        }
+
+        if (handlesCount < 0 || maxThreads < 1 || maxThreads > 1000) {
+            response.methodLine = "405 Pick saner values.";
+        }
+
+        auto dbPoolCopy = atomic_load(&_dbPool);
+        if (dbPoolCopy && handlesCount) {
+            SINFO("Reserving " << handlesCount << " DB handles.");
+            vector<size_t> indicies(handlesCount);
+            vector<size_t> timings(handlesCount);
+            list<thread> threads;
+
+            // Grab the indices of the handles we'll load.
+            for (size_t index = 0; index < handlesCount; index++) {
+                indicies[index] = dbPoolCopy->getIndex(false);
+            }
+
+            SINFO("Reserved " << handlesCount << " DB handles, initializing.");
+            atomic<size_t> index(0);
+            for (size_t t = 0; t < maxThreads; t++) {
+                threads.emplace_back([&](){
+                    while (true) {
+                        size_t current_index = index.fetch_add(1);
+                        if (current_index >= handlesCount) {
+                            return;
+                        }
+                        uint64_t startTime = STimeNow();
+                        dbPoolCopy->initializeIndex(current_index).read("SELECT name FROM sqlite_schema;");
+                        uint64_t endTime = STimeNow();
+
+                        timings[current_index] = endTime - startTime;
+                    }
+                });
+            }
+
+            // Wait for them all to initialize.
+            for (thread& t : threads) {
+                t.join();
+            }
+
+            SINFO("Initialized " << handlesCount << " DB handles, cleaning up.");
+            for (size_t i = 0; i < handlesCount; i++) {
+                dbPoolCopy->returnToPool(indicies[i]);
+            }
+            SINFO("Returned " << handlesCount << " DB handles.");
+            command->response.content = SComposeList(timings, "\n");
         }
     }
 }


### PR DESCRIPTION
### Details

This is a redo of https://github.com/Expensify/Bedrock/pull/2082 with only 1 functional change: we do 1 query after opening the db handle: https://github.com/Expensify/Bedrock/pull/2129/files#diff-85aada0d0eb5de20bbc68017e21f8051525423072c9bfd097c7ca324d25c6125R2015

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/458560

### Tests

```
OpenDBHandlesAndRunQuery
handlesCount:20
maxThreads:5
```

This results in slow queries:
```
2025-03-12T19:58:35.149749+00:00 expensidev2004 bedrock: (libstuff.cpp:2694) SQuery [] [info] Query completed (29ms): SELECT name FROM sqlite_schema;
2025-03-12T19:58:35.149779+00:00 expensidev2004 bedrock: (libstuff.cpp:2694) SQuery [] [info] Query completed (29ms): SELECT name FROM sqlite_schema;
2025-03-12T19:58:35.149806+00:00 expensidev2004 bedrock: (SQLite.cpp:105) initializeDB [] [info] Opening database '/var/bedrock/main.db'.
2025-03-12T19:58:35.149834+00:00 expensidev2004 bedrock: (libstuff.cpp:2694) SQuery [] [info] Query completed (29ms): SELECT name FROM sqlite_schema;
```

This query is supposed to take less than 1ms. I expect we'll see something similar on production.

For Auth, this query currently takes 10ms and returns 1301 rows. 
