### PR TITLE
Use SQLiteScopedHandle in OpenDBHandlesAndRunQuery

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2012,7 +2012,12 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command) {
                             return;
                         }
                         uint64_t startTime = STimeNow();
-                        dbPoolCopy->initializeIndex(current_index).read("SELECT name FROM sqlite_schema;");
+                        dbPoolCopy->initializeIndex(current_index);
+                        {
+                            SQLiteScopedHandle dbScope(*_dbPool, _dbPool->getIndex());
+                            SQLite& db = dbScope.db();
+                            db.read("SELECT name FROM sqlite_schema;");
+                        }
                         uint64_t endTime = STimeNow();
 
                         timings[current_index] = endTime - startTime;


### PR DESCRIPTION
### Details

https://expensify.slack.com/archives/C05CBC62HGW/p1742242058021559?thread_ts=1741899101.373909&cid=C05CBC62HGW

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/458560

### Tests
Ran
```
OpenDBHandlesAndRunQuery
handlesCount:100
maxThreads:5
```

->


```
2025-03-17T20:14:32.461400+00:00 expensidev2004 bedrock: xxxxxx (BedrockServer.cpp:2033) _control [socket0] [info] Initialized 100 DB handles, cleaning up.
2025-03-17T20:14:32.461466+00:00 expensidev2004 bedrock: xxxxxx (SQLitePool.cpp:85) returnToPool [socket0] [dbug] DB handle returned to pool.
2025-03-17T20:14:32.465271+00:00 expensidev2004 bedrock: message repeated 99 times: [ xxxxxx (SQLitePool.cpp:85) returnToPool [socket0] [dbug] DB handle returned to pool.]
2025-03-17T20:14:32.465309+00:00 expensidev2004 bedrock: xxxxxx (BedrockServer.cpp:2037) _control [socket0] [info] Returned 100 DB handles.
2025-03-17T20:14:32.465390+00:00 expensidev2004 bedrock: xxxxxx (BedrockCommand.cpp:286) finalizeTimingInfo [socket0] [info] command 'OpenDBHandlesAndRunQuery' timing info (ms): prePeek:0 (count: 0), peek:0 (count:0), process:0 (count:0), postProcess:0 (count:0), total:109, unaccounted:109, blockingCommitThreadTime:0, exclusiveTransactionLockTime:0. Commit: worker:0, sync:0. Queue: worker:0, sync:0, blocking:0, pageLock:0, escalation:0. Blocking: prePeek:0, peek:0, process:0, postProcess:0, commit:0. Upstream: peek:0, process:0, total:0, unaccounted:0.
```
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
