### PR TITLE
Pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/actions/composite/setup-certificate-1p/action.yml
+++ b/.github/actions/composite/setup-certificate-1p/action.yml
@@ -5,7 +5,8 @@ runs:
   using: composite
   steps:
     - name: Install 1Password CLI
-      uses: 1password/install-cli-action@v1
+      # v1
+      uses: 1password/install-cli-action@143a85f84a90555d121cde2ff5872e393a47ab9f
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ env.OP_SERVICE_ACCOUNT_TOKEN }}
 

--- a/.github/workflows/bedrock.yml
+++ b/.github/workflows/bedrock.yml
@@ -20,10 +20,12 @@ jobs:
     steps:
 
     - name: Install the Mold Linker
-      uses: rui314/setup-mold@v1
+      # v1
+      uses: rui314/setup-mold@f80524ca6eeaa76759b57fb78ddce5d87a20c720
 
     - name: Checkout Bedrock
-      uses: actions/checkout@v4.1.0
+      # v4.1.0
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
     - name: Get Date for cache
       id: get-date
@@ -32,7 +34,8 @@ jobs:
       shell: bash
 
     - name: Set up cache
-      uses: actions/cache@v4.2.0
+      # v4.2.0
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
       with:
         path: |-
           ${{ env.CCACHE_BASEDIR }}
@@ -77,7 +80,8 @@ jobs:
 
     - name: Setup tmate session
       if: runner.debug == '1'
-      uses: mxschmitt/action-tmate@v3
+      # v3
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48
       timeout-minutes: 60
       with:
         limit-access-to-actor: true


### PR DESCRIPTION
Coming from https://expensify.slack.com/archives/CC7NECV4L/p1743022578963949, this pull request updates all mutable action references to use immutable commit hashes instead. This is a security measure to protect from supply chain attacks.