### PR TITLE
Seperate out request body

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -372,7 +372,7 @@ void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, c
 
     STable logParams;
     if (!e.body.empty()) {
-        logParams["request_body"] = e.body;
+        logParams = SParseJSONObject(e.body);
     }
 
     if (SContains(e.what(), "_ALERT_")) {

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -369,19 +369,22 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool i
 
 void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e, SQLite* db, const BedrockServer* server) {
     string msg = "Error processing command '" + command->request.methodLine + "' (" + e.what() + "), ignoring.";
+
+    STable logParams;
     if (!e.body.empty()) {
-        msg = msg + " Request body: " + e.body;
+        logParams["request_body"] = e.body;
     }
+
     if (SContains(e.what(), "_ALERT_")) {
-        SALERT(msg);
+        SALERT(msg, logParams);
     } else if (SContains(e.what(), "_WARN_")) {
-        SWARN(msg);
+        SWARN(msg, logParams);
     } else if (SContains(e.what(), "_HMMM_")) {
-        SHMMM(msg);
+        SHMMM(msg, logParams);
     } else if (SStartsWith(e.what(), "50")) {
-        SALERT(msg); // Alert on 500 level errors.
+        SALERT(msg, logParams); // Alert on 500 level errors.
     } else {
-        SINFO(msg);
+        SINFO(msg, logParams);
     }
 
     // Set the response to the values from the exception, if set.


### PR DESCRIPTION
### Details
Seperates out the request body from the msg so bugbots can be created even with different params

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/472994

### Tests
Compiled auth
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
