### PR TITLE
Add easy way to turn on proxy

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -7,10 +7,10 @@
 #include <libstuff/libstuff.h>
 #include <sqlitecluster/SQLiteNode.h>
 
-const string SStandaloneHTTPSManager::proxyAddress = initProxyAddress();
+const string SStandaloneHTTPSManager::proxyAddressHTTPS = initProxyAddressHTTPS();
 
-string SStandaloneHTTPSManager::initProxyAddress() {
-    const char* proxyString = getenv("HTTP_PROXY");
+string SStandaloneHTTPSManager::initProxyAddressHTTPS() {
+    const char* proxyString = getenv("HTTPS_PROXY");
     if (proxyString != nullptr) {
         return proxyString;
     }
@@ -190,9 +190,9 @@ SStandaloneHTTPSManager::Transaction* SStandaloneHTTPSManager::_httpsSend(const 
     try {
         // If a proxy is set, and it's allowed to use it, go through the proxy.
         bool isHttps = SStartsWith(url, "https://");
-        if (isHttps && allowProxy && proxyAddress.size()) {
+        if (isHttps && allowProxy && proxyAddressHTTPS.size()) {
             string proxyHost, path;
-            SParseURI(proxyAddress, proxyHost, path);
+            SParseURI(proxyAddressHTTPS, proxyHost, path);
             SINFO("Proxying " << url << " through " << proxyHost);
             s = new SHTTPSProxySocket(proxyHost, host);
         } else {

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -193,6 +193,7 @@ SStandaloneHTTPSManager::Transaction* SStandaloneHTTPSManager::_httpsSend(const 
         if (isHttps && allowProxy && proxyAddress.size()) {
             string proxyHost, path;
             SParseURI(proxyAddress, proxyHost, path);
+            SINFO("Proxying " << url << " through " << proxyHost);
             s = new SHTTPSProxySocket(proxyHost, host);
         } else {
             s = new Socket(host, isHttps);

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -1,10 +1,21 @@
 #include "SHTTPSManager.h"
+#include "SHTTPSProxySocket.h"
 #include "libstuff/STCPManager.h"
 
 #include <BedrockPlugin.h>
 #include <BedrockServer.h>
 #include <libstuff/libstuff.h>
 #include <sqlitecluster/SQLiteNode.h>
+
+const string SStandaloneHTTPSManager::proxyAddress = initProxyAddress();
+
+string SStandaloneHTTPSManager::initProxyAddress() {
+    const char* proxyString = getenv("HTTP_PROXY");
+    if (proxyString != nullptr) {
+        return proxyString;
+    }
+    return "";
+}
 
 SHTTPSManager::SHTTPSManager(BedrockPlugin& plugin_) : plugin(plugin_)
 {
@@ -160,7 +171,7 @@ SStandaloneHTTPSManager::Transaction* SStandaloneHTTPSManager::_createErrorTrans
     return transaction;
 }
 
-SStandaloneHTTPSManager::Transaction* SStandaloneHTTPSManager::_httpsSend(const string& url, const SData& request) {
+SStandaloneHTTPSManager::Transaction* SStandaloneHTTPSManager::_httpsSend(const string& url, const SData& request, bool allowProxy) {
     // Open a connection, optionally using SSL (if the URL is HTTPS). If that doesn't work, then just return a
     // completed transaction with an error response.
     string host, path;
@@ -177,7 +188,15 @@ SStandaloneHTTPSManager::Transaction* SStandaloneHTTPSManager::_httpsSend(const 
     // If this is going to be an https transaction, create a certificate and give it to the socket.
     Socket* s = nullptr;
     try {
-        s = new Socket(host, SStartsWith(url, "https://"));
+        // If a proxy is set, and it's allowed to use it, go through the proxy.
+        bool isHttps = SStartsWith(url, "https://");
+        if (isHttps && allowProxy && proxyAddress.size()) {
+            string proxyHost, path;
+            SParseURI(proxyAddress, proxyHost, path);
+            s = new SHTTPSProxySocket(proxyHost, host);
+        } else {
+            s = new Socket(host, isHttps);
+        }
     } catch (const SException& exception) {
         delete transaction;
         return _createErrorTransaction();

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -25,6 +25,8 @@ class SStandaloneHTTPSManager : public STCPManager {
         const string requestID;
     };
 
+    static const string proxyAddress;
+
     // Constructor/Destructor
     SStandaloneHTTPSManager();
     SStandaloneHTTPSManager(const string& pem, const string& srvCrt, const string& caCrt);
@@ -50,9 +52,11 @@ class SStandaloneHTTPSManager : public STCPManager {
     const string _caCrt;
 
     // Methods
-    Transaction* _httpsSend(const string& url, const SData& request);
+    Transaction* _httpsSend(const string& url, const SData& request, bool allowProxy = false);
     Transaction* _createErrorTransaction();
     virtual bool _onRecv(Transaction* transaction);
+
+    static string initProxyAddress();
 };
 
 class SHTTPSManager : public SStandaloneHTTPSManager {

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -25,7 +25,7 @@ class SStandaloneHTTPSManager : public STCPManager {
         const string requestID;
     };
 
-    static const string proxyAddress;
+    static const string proxyAddressHTTPS;
 
     // Constructor/Destructor
     SStandaloneHTTPSManager();
@@ -56,7 +56,7 @@ class SStandaloneHTTPSManager : public STCPManager {
     Transaction* _createErrorTransaction();
     virtual bool _onRecv(Transaction* transaction);
 
-    static string initProxyAddress();
+    static string initProxyAddressHTTPS();
 };
 
 class SHTTPSManager : public SStandaloneHTTPSManager {


### PR DESCRIPTION
### Details
Adds switch to easily turn on the proxy if it's set and the caller wants it.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/478907

### Tests
This has been tested in a super basic way by disabling `TestSpotnana` in Auth.cpp so that the real `Spotnana.cpp` is always used, and the with this PR: https://github.com/Expensify/Auth/pull/14875 we see this line logged:
https://github.com/Expensify/Bedrock/pull/2147/files#diff-c18b991209228423ff082b8d50aee49e1d1d29e4b2395c00ae6384274445a7e6R196

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
