### PR TITLE
Revert "Latest HC-Tree fixes"

### DIFF
--- a/libstuff/sqlite3.h
+++ b/libstuff/sqlite3.h
@@ -148,7 +148,7 @@ extern "C" {
 */
 #define SQLITE_VERSION        "3.50.0"
 #define SQLITE_VERSION_NUMBER 3050000
-#define SQLITE_SOURCE_ID      "2025-04-28 14:58:38 a126de5b6515c6e881fc30ad659c5ec10b6d3179d8bf3701afac64f4efa83b98"
+#define SQLITE_SOURCE_ID      "2025-04-19 17:52:04 6ef69c050403ab94a6235bb02078bea5cbff908eafa406bb3a2eea47f9fdd7c8"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
Reverts Expensify/Bedrock#2161

HC-Tree broke on virt1.lax with this.