### PR TITLE
Add optional<T> handling for PrintEquality

### DIFF
--- a/test/lib/PrintEquality.h
+++ b/test/lib/PrintEquality.h
@@ -5,6 +5,7 @@
 #include <set>
 #include <map>
 #include <list>
+#include <optional>
 
 using namespace std;
 
@@ -28,6 +29,16 @@ ostream& operator<<(ostream& output, const map<T, U>& val)
         output << k << ": " << v << endl;
     }
     return output << "}";
+}
+
+template<typename T>
+ostream& operator<<(ostream& output, const std::optional<T>& val)
+{
+    if (val.has_value()) {
+        return output << val.value();
+    }
+
+    return output << "(nullopt)";
 }
 
 class PrintEquality {


### PR DESCRIPTION
### Details
There are places where we use optional<T> in Auth. When doing `ASSERT_EQUAL` with an optional value that's a `nullopt` we currently get a crash and a lengthy stack trace.

This PR adds support for printing nullopt in `optional<T>` as `(nullopt)`, so they end up like this instead:

```
stonks != (nullopt)
   assertion #1 at test/test/udf/UserDefinedFieldFormulaTest.cpp:79
```

### Fixed Issues


### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
