### PR TITLE
Fix mbedtls submodule management in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,17 +49,20 @@ clean:
 	(test -f mbedtls/Makefile && cd mbedtls && $(MAKE) clean) || true
 
 # Rule to build mbedtls.
+MBEDTLS_VERSION = v3.6.2
 MBEDTLS_CONFIG = include/mbedtls/mbedtls_config.h
 MBEDTLS_CONFIG_BAK = $(MBEDTLS_CONFIG).bak
 mbedtls/library/libmbedcrypto.a mbedtls/library/libmbedtls.a mbedtls/library/libmbedx509.a:
+	# This build step assumes nobody wants to locally change mbedtls. So we check if there's a diff and print a warning if there is
+	# If you want to do edit mbedtls locally, too bad. Modify the Makefile. Fork the mbedtls repo and point submodule at our fork if you must.
+	( [ -f mbedtls/.git ] && cd mbedtls && git fetch --quiet --tags && ! git diff --quiet --exit-code "$(MBEDTLS_VERSION)" && echo >&2 "⚠️  Warning: Local changes in 'mbedtls' will be discarded!" && GIT_PAGER=cat git diff "$(MBEDTLS_VERSION)" >&2 ) || true
+
 	# Fully reinitialize mbedtls submodule including nested submodules.
 	git submodule update --init --recursive --force
-
-	# This assumes nobody wants to locally change mbedtls. If you want to do that, too bad. Change the Makefile if you must.
 	cd mbedtls && git reset --hard && git clean -fdx
 
 	# Ensure correct version is checked out.
-	cd mbedtls && git checkout -q v3.6.2
+	cd mbedtls && git checkout -q "$(MBEDTLS_VERSION)"
 
 	# Configure threading options (stash old version of the config file).
 	( cd mbedtls && [ -f "$(MBEDTLS_CONFIG)" ] && git checkout -f "$(MBEDTLS_CONFIG)" && cp "$(MBEDTLS_CONFIG)" "$(MBEDTLS_CONFIG_BAK)" ) || true

--- a/Makefile
+++ b/Makefile
@@ -49,20 +49,14 @@ clean:
 	(test -f mbedtls/Makefile && cd mbedtls && $(MAKE) clean) || true
 
 # Rule to build mbedtls.
-MBEDTLS_VERSION = v3.6.2
 MBEDTLS_CONFIG = include/mbedtls/mbedtls_config.h
 MBEDTLS_CONFIG_BAK = $(MBEDTLS_CONFIG).bak
 mbedtls/library/libmbedcrypto.a mbedtls/library/libmbedtls.a mbedtls/library/libmbedx509.a:
-	# This build step assumes nobody wants to locally change mbedtls. So we check if there's a diff and print a warning if there is
-	# If you want to do edit mbedtls locally, too bad. Modify the Makefile. Fork the mbedtls repo and point submodule at our fork if you must.
-	( [ -f mbedtls/.git ] && cd mbedtls && git fetch --quiet --tags && ! git diff --quiet --exit-code "$(MBEDTLS_VERSION)" && echo >&2 "⚠️  Warning: Local changes in 'mbedtls' will be discarded!" && GIT_PAGER=cat git diff "$(MBEDTLS_VERSION)" >&2 ) || true
-
 	# Fully reinitialize mbedtls submodule including nested submodules.
-	git submodule update --init --recursive --force
-	cd mbedtls && git reset --hard && git clean -fdx
+	git submodule update --init --recursive
 
 	# Ensure correct version is checked out.
-	cd mbedtls && git checkout -q "$(MBEDTLS_VERSION)"
+	cd mbedtls && git checkout -q v3.6.2
 
 	# Configure threading options (stash old version of the config file).
 	( cd mbedtls && [ -f "$(MBEDTLS_CONFIG)" ] && git checkout -f "$(MBEDTLS_CONFIG)" && cp "$(MBEDTLS_CONFIG)" "$(MBEDTLS_CONFIG_BAK)" ) || true


### PR DESCRIPTION
### Details
This is a fix for the error people have been seeing:

- https://expensify.slack.com/archives/C03TQ48KC/p1744649861741569
- https://staging.new.expensify.com/r/688071102200338/8747542760298284830

It seems like the cause it most likely the lack of the `--recursive` flag in `mbedtls`. But after fixing that, I found that the submodule would appear as "dirty" after building because of the changes in the config header. So we reset those changes at the end of the build so that devs don't see the dirty submodule and get confused by changes they didn't make.

### Fixed Issues
n/a - didn't create an issue

### Tests
1. Run `vssh "make clean && make -j16 && sudo systemctl restart bedrock"`. Verify that it works (unclear exactly how to reproduce the original issue if you aren't already).
2. Make a change anywhere in mbedtls, such as the README
3. Run `vssh "make clean && make -j16 && sudo systemctl restart bedrock"`. Verify that it works and that you still have your diff in mbedtls

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
