### PR TITLE
Allow blocking API calls in peek/prepeek/postProcess

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -166,7 +166,7 @@ void BedrockCommand::_waitForHTTPSRequests() {
         // Why would there be no sockets? It's because Auth::Stripe, as a rate-limiting feature, attaches sockets to requests after their made.
         // This means a request can sit around with no actual socket attached to it for some length of time until it's turn to talk to Stripe comes up.
         // If that happens though, and we're sitting in `poll` when it becomes our turn, we will wait the full five minute timeout of the original `poll`
-        // call before we time out and try again wit the newly-attached socket.
+        // call before we time out and try again with the newly-attached socket.
         // Setting this to one second lets us try again more frequently.
         maxWaitUs = min(maxWaitUs, 1'000'000ul);
         S_poll(fdm, maxWaitUs);

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -142,7 +142,18 @@ void BedrockCommand::_waitForTransactions() {
         if (now < timeout()) {
             maxWaitUs = timeout() - now;
         } else {
-            // TODO: Need to set an error state on every incomplete request and mark them finished.
+            // This uses the same starting point as in areHttpsRequestsComplete, for efficiency.
+            // We won't iterate over large numbers of known completed requests, instead starting
+            // from the the point of the list of known completed request.
+            auto requestIt = (_lastContiguousCompletedTransaction == httpsRequests.end()) ? httpsRequests.begin() : _lastContiguousCompletedTransaction;
+            while (requestIt != httpsRequests.end()) {
+                if (!(*requestIt)->response) {
+                    (*requestIt)->response = 500;
+                }
+                requestIt++;
+            }
+
+            // Timed everything out, can return.
             break;
         }
 

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -130,7 +130,7 @@ bool BedrockCommand::areHttpsRequestsComplete() const {
     return true;
 }
 
-void BedrockCommand::_waitForTransactions() {
+void BedrockCommand::_waitForHTTPSRequests() {
     uint64_t startTime = 0;
     while (!areHttpsRequestsComplete()) {
         // Wait until the command's timeout, or break early if the command has timed out.
@@ -182,14 +182,14 @@ void BedrockCommand::_waitForTransactions() {
     }
 }
 
-void BedrockCommand::waitForTransactions() {
+void BedrockCommand::waitForHTTPSRequests() {
     if (_inDBReadOperation || _inDBWriteOperation) {
         STHROW("500 Can not wait for transactions with DB assigned");
     }
-    _waitForTransactions();
+    _waitForHTTPSRequests();
 }
 
-void BedrockCommand::waitForTransactions(SQLite& db) {
+void BedrockCommand::waitForHTTPSRequests(SQLite& db) {
     bool wasInTransaction = db.insideTransaction();
     if (wasInTransaction) {
         if (!_inDBReadOperation) {
@@ -198,7 +198,7 @@ void BedrockCommand::waitForTransactions(SQLite& db) {
         db.rollback();
     }
 
-    _waitForTransactions();
+    _waitForHTTPSRequests();
 
     if (wasInTransaction) {
         if (!db.beginTransaction(db.getLastTransactionType())) {

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -161,7 +161,7 @@ void BedrockCommand::_waitForHTTPSRequests() {
         prePoll(fdm);
 
         // We never wait more than 1 second in `poll`. There are two uses for this. One is that at shutdown, we want to kill any sockets that have are making no progress.
-        // We don't want these to be stuck sitting for 5 minutes doing nothing while thew server hangs, so we will interrupt every second to check on them.
+        // We don't want these to be stuck sitting for 5 minutes doing nothing while the server hangs, so we will interrupt every second to check on them.
         // The other case is that there can be no sockets at all.
         // Why would there be no sockets? It's because Auth::Stripe, as a rate-limiting feature, attaches sockets to requests after their made.
         // This means a request can sit around with no actual socket attached to it for some length of time until it's turn to talk to Stripe comes up.

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -2,6 +2,8 @@
 #include <libstuff/SHTTPSManager.h>
 #include "BedrockCommand.h"
 #include "BedrockPlugin.h"
+#include "sqlitecluster/SQLite.h"
+#include "test/clustertest/BedrockClusterTester.h"
 
 atomic<size_t> BedrockCommand::_commandCount(0);
 
@@ -125,6 +127,17 @@ bool BedrockCommand::areHttpsRequestsComplete() const {
         requestIt++;
     }
     return true;
+}
+
+void BedrockCommand::waitForTransaction(SQLite& db, SHTTPSManager:: Transaction* transaction) {
+    if (! _isPeeking) {
+        STHROW("500 Can only wait for transaction in peek/prepeek");
+    }
+    db.rollback();
+    // TODO: wait
+    if (!db.beginTransaction(db.getLastTransactionType())) {
+        STHROW("501 Failed to begin transaction");
+    }
 }
 
 void BedrockCommand::reset(BedrockCommand::STAGE stage) {

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -163,7 +163,7 @@ void BedrockCommand::_waitForHTTPSRequests() {
         // We never wait more than 1 second in `poll`. There are two uses for this. One is that at shutdown, we want to kill any sockets that have are making no progress.
         // We don't want these to be stuck sitting for 5 minutes doing nothing while the server hangs, so we will interrupt every second to check on them.
         // The other case is that there can be no sockets at all.
-        // Why would there be no sockets? It's because Auth::Stripe, as a rate-limiting feature, attaches sockets to requests after their made.
+        // Why would there be no sockets? It's because Auth::Stripe, as a rate-limiting feature, attaches sockets to requests after they're made.
         // This means a request can sit around with no actual socket attached to it for some length of time until it's turn to talk to Stripe comes up.
         // If that happens though, and we're sitting in `poll` when it becomes our turn, we will wait the full five minute timeout of the original `poll`
         // call before we time out and try again with the newly-attached socket.

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -100,12 +100,12 @@ class BedrockCommand : public SQLiteCommand {
     // If it is not, this will throw.
     // The reason for this is because the current transaction will be rolled back and then restarted at the end of waiting
     // for network requests, which will break everything if done from `process`.
-    void waitForTransactions(SQLite& db);
+    void waitForHTTPSRequests(SQLite& db);
 
     // This call is the same as the above, but is only allowed if you are neither peeking *nor* processing.
     // It is intended only for use when the command is not assigned a DB at all, and thus does not need rolling back and
     // restarting.
-    void waitForTransactions();
+    void waitForHTTPSRequests();
 
     // Bedrock will call this before each `processCommand` (note: not `peekCommand`) for each plugin to allow it to
     // enable query rewriting. If a plugin would like to enable query rewriting, this should return true, and it should
@@ -296,8 +296,8 @@ class BedrockCommand : public SQLiteCommand {
     // Set to true whene we are in `process`.
     bool _inDBWriteOperation = false;
 
-    // Internal function that provides the main functionality for waitForTransactions().
-    void _waitForTransactions();
+    // Internal function that provides the main functionality for waitForHTTPSRequests().
+    void _waitForHTTPSRequests();
 
     // Set certain initial state on construction. Common functionality to several constructors.
     void _init();

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -5,6 +5,7 @@
 class BedrockPlugin;
 
 class BedrockCommand : public SQLiteCommand {
+  friend class BedrockCore;
   public:
     enum Priority {
         PRIORITY_MIN = 0,
@@ -92,6 +93,11 @@ class BedrockCommand : public SQLiteCommand {
 
     // Take a serialized list of HTTPS requests as from `serializeHTTPSRequests` and deserialize them into the `httpsRequests` object.
     void deserializeHTTPSRequests(const string& serializedHTTPSRequests);
+
+    // Blocks until the given transaction completes.
+    // Only allowed in peek or prePeek, throws otherwise.
+    // Will roll back the current DB transaction and restart it before returning.
+    void waitForTransaction(SQLite& db, SHTTPSManager::Transaction* transaction);
 
     // Bedrock will call this before each `processCommand` (note: not `peekCommand`) for each plugin to allow it to
     // enable query rewriting. If a plugin would like to enable query rewriting, this should return true, and it should
@@ -275,6 +281,10 @@ class BedrockCommand : public SQLiteCommand {
     bool _commitEmptyTransactions;
 
   private:
+
+    // Set to true when we are in `peek` or `prePeek`.
+    bool _isPeeking = false;
+
     // Set certain initial state on construction. Common functionality to several constructors.
     void _init();
 

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -296,6 +296,9 @@ class BedrockCommand : public SQLiteCommand {
     // Set to true whene we are in `process`.
     bool _inDBWriteOperation = false;
 
+    // Internal function that provides the main functionality for waitForTransactions().
+    void _waitForTransactions();
+
     // Set certain initial state on construction. Common functionality to several constructors.
     void _init();
 

--- a/BedrockCommand.h
+++ b/BedrockCommand.h
@@ -96,7 +96,7 @@ class BedrockCommand : public SQLiteCommand {
 
     // Blocks until all outstanding HTTPS transactions are complete.
     // If called from inside an active DB transaction, this will validate that the transaction is running inside
-    // `peek` or `prePeek` (`postProcess` could also probably be allowed, but currently is not).
+    // `peek`, `prePeek` or `postProcess`.
     // If it is not, this will throw.
     // The reason for this is because the current transaction will be rolled back and then restarted at the end of waiting
     // for network requests, which will break everything if done from `process`.

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -83,9 +83,9 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlo
 
             // prePeek.
             command->reset(BedrockCommand::STAGE::PREPEEK);
-            command->_isPeeking = true;
+            command->_inDBReadOperation = true;
             command->prePeek(_db);
-            command->_isPeeking = false;
+            command->_inDBReadOperation = false;
             SDEBUG("Plugin '" << command->getName() << "' prePeeked command '" << request.methodLine << "'");
 
             if (!content.empty()) {
@@ -103,18 +103,18 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlo
             if (!command->shouldSuppressTimeoutWarnings()) {
                 SALERT("Command " << command->request.methodLine << " timed out after " << e.time() / 1000 << "ms.");
             }
-            command->_isPeeking = false;
+            command->_inDBReadOperation = false;
             STHROW("555 Timeout prePeeking command");
         }
     } catch (const SException& e) {
         _handleCommandException(command, e, &_db, &_server);
         command->complete = true;
-        command->_isPeeking = false;
+        command->_inDBReadOperation = false;
     } catch (...) {
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
         command->response.methodLine = "500 Unhandled Exception";
         command->complete = true;
-        command->_isPeeking = false;
+        command->_inDBReadOperation = false;
 
     }
     _db.clearTimeout();
@@ -153,9 +153,9 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
 
             // Peek.
             command->reset(BedrockCommand::STAGE::PEEK);
-            command->_isPeeking = true;
+            command->_inDBReadOperation = true;
             bool completed = command->peek(_db);
-            command->_isPeeking = false;
+            command->_inDBReadOperation = false;
             SDEBUG("Plugin '" << command->getName() << "' peeked command '" << request.methodLine << "'");
 
             if (!completed) {
@@ -170,7 +170,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
             if (!command->shouldSuppressTimeoutWarnings()) {
                 SALERT("Command " << command->request.methodLine << " timed out after " << e.time()/1000 << "ms.");
             }
-            command->_isPeeking = false;
+            command->_inDBReadOperation = false;
             STHROW("555 Timeout peeking command");
         }
 
@@ -195,16 +195,16 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
         }
     } catch (const SException& e) {
         command->repeek = false;
-        command->_isPeeking = false;
+        command->_inDBReadOperation = false;
         _handleCommandException(command, e, &_db, &_server);
     } catch (const SHTTPSManager::NotLeading& e) {
         command->repeek = false;
-        command->_isPeeking = false;
+        command->_inDBReadOperation = false;
         returnValue = RESULT::SHOULD_PROCESS;
         SINFO("Command '" << request.methodLine << "' wants to make HTTPS request, queuing for processing.");
     } catch (...) {
         command->repeek = false;
-        command->_isPeeking = false;
+        command->_inDBReadOperation = false;
         SALERT("Unhandled exception typename: " << SGetCurrentExceptionName() << ", command: " << request.methodLine);
         command->response.methodLine = "500 Unhandled Exception";
     }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -833,7 +833,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
         canWriteParallel = canWriteParallel && (command->writeConsistency == SQLiteNode::ASYNC);
 
         // If there are outstanding HTTPS requests on this command (from a previous call to `peek`) we process them here.
-        command->waitForTransactions();
+        command->waitForHTTPSRequests();
 
         // Get a DB handle to work on. This will automatically be returned when dbScope goes out of scope.
         if (!_dbPool) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -692,6 +692,15 @@ void BedrockServer::worker(int threadId)
     }
 }
 
+bool BedrockServer::isShuttingDown() {
+    bool shuttingDown = false;
+    auto _syncNodeCopy = atomic_load(&_syncNode);
+    if (_shutdownState.load() != RUNNING || (_syncNodeCopy && _syncNodeCopy->getState() == SQLiteNodeState::STANDINGDOWN)) {
+        shuttingDown = true;
+    }
+    return shuttingDown;
+}
+
 void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlocking, bool hasDedicatedThread) {
     // If there's no sync node (because we're detaching/attaching), we can only queue a command for later.
     // Also,if this command is scheduled in the future, we can't just run it, we need to enqueue it to run at that point.
@@ -824,54 +833,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
         canWriteParallel = canWriteParallel && (command->writeConsistency == SQLiteNode::ASYNC);
 
         // If there are outstanding HTTPS requests on this command (from a previous call to `peek`) we process them here.
-        size_t networkLoopCount = 0;
-        uint64_t postPollCumulativeTime = 0;
-        while (!command->areHttpsRequestsComplete()) {
-            networkLoopCount++;
-            fd_map fdm;
-            command->prePoll(fdm);
-
-            // Determine how long we'll wait in `poll`.
-            uint64_t maxWaitUs = 0;
-
-            // The default case is to wait until the command will time out.
-            uint64_t now = STimeNow();
-            if (now < command->timeout()) {
-                maxWaitUs = command->timeout() - now;
-            } else {
-                // The command is already timed out. This will hit the check for core.isTimedOut(command) below.
-                break;
-            }
-
-            // We never wait more than 1 second in `poll`. There are two uses for this. One is that at shutdown, we want to kill any sockets that have are making no progress.
-            // We don't want these to be stuck sitting for 5 minutes doing nothing while thew server hangs, so we will interrupt every second to check on them.
-            // The other case is that there can be no sockets at all.
-            // Why would there be no sockets? It's because Auth::Stripe, as a rate-limiting feature, attaches sockets to requests after their made.
-            // This means a request can sit around with no actual socket attached to it for some length of time until it's turn to talk to Stripe comes up.
-            // If that happens though, and we're sitting in `poll` when it becomes our turn, we will wait the full five minute timeout of the original `poll`
-            // call before we time out and try again wit the newly-attached socket.
-            // Setting this to one second lets us try again more frequently.
-            maxWaitUs = min(maxWaitUs, 1'000'000ul);
-            bool shuttingDown = false;
-            auto _syncNodeCopy = atomic_load(&_syncNode);
-            if (_shutdownState.load() != RUNNING || (_syncNodeCopy && _syncNodeCopy->getState() == SQLiteNodeState::STANDINGDOWN)) {
-                shuttingDown = true;
-            }
-
-            // Ok, go ahead and `poll`.
-            S_poll(fdm, maxWaitUs);
-
-            // The 3rd parameter to `postPoll` here is the total allowed idle time on this connection. We will kill connections that do nothing at all after 5 minutes normally,
-            // or after only 5 seconds when we're shutting down so that we can clean up and move along.
-            uint64_t ignore{0};
-            auto start = STimeNow();
-            command->postPoll(fdm, ignore, shuttingDown ? 5'000 : 300'000);
-            postPollCumulativeTime += (STimeNow() - start);
-        }
-
-        if (networkLoopCount) {
-            SINFO("Completed HTTPS request in " << networkLoopCount << " loops with " << postPollCumulativeTime << "us total time in postPoll");
-        }
+        command->waitForTransactions();
 
         // Get a DB handle to work on. This will automatically be returned when dbScope goes out of scope.
         if (!_dbPool) {

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -185,6 +185,8 @@ class BedrockServer : public SQLiteServer {
     void blockCommandPort(const string& reason) override;
     void unblockCommandPort(const string& reason) override;
 
+    bool isShuttingDown();
+
     // Legacy version of above.
     void suppressCommandPort(const string& reason, bool suppress, bool manualOverride = false);
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -350,7 +350,12 @@ void SQLite::exclusiveUnlockDB() {
     _sharedData.commitLock.unlock();
 }
 
-bool SQLite::beginTransaction(TRANSACTION_TYPE type) {
+SQLite::TRANSACTION_TYPE SQLite::getLastTransactionType() {
+    return _lastTransactionType;
+}
+
+bool SQLite::beginTransaction(SQLite::TRANSACTION_TYPE type) {
+    _lastTransactionType = type;
     if (type == TRANSACTION_TYPE::EXCLUSIVE) {
         if (isSyncThread) {
             // Blocking the sync thread has catastrophic results (forking) and so we either get this quickly, or we fail the transaction.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -191,6 +191,8 @@ class SQLite {
     uint64_t getLastTransactionTiming(uint64_t& begin, uint64_t& read, uint64_t& write, uint64_t& prepare,
                                       uint64_t& commit, uint64_t& rollback);
 
+    TRANSACTION_TYPE getLastTransactionType();
+
     // Returns the number of changes that were performed in the last query.
     size_t getLastWriteChangeCount();
 
@@ -376,6 +378,9 @@ class SQLite {
 
     // The name of the journal table that this particular DB handle with write to.
     string _journalName;
+
+    // Stored whenever we begin a transaction to allow stopping and restarting with the same transaction type.
+    TRANSACTION_TYPE _lastTransactionType = TRANSACTION_TYPE::SHARED;
 
     // True when we have a transaction in progress.
     bool _insideTransaction = false;

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -334,7 +334,7 @@ bool TestPluginCommand::peek(SQLite& db) {
         if (responseNow) {
             STHROW("500 Shouldn't have a response yet");
         }
-        waitForTransactions(db);
+        waitForHTTPSRequests(db);
         responseNow = httpsRequests.back()->response;
         if (responseNow != 200) {
             STHROW("500 expected 200 response");

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -103,7 +103,8 @@ unique_ptr<BedrockCommand> BedrockPlugin_TestPlugin::getCommand(SQLiteCommand&& 
         "preparehandler",
         "testquery",
         "testPostProcessTimeout",
-        "EscalateSerializedData"
+        "EscalateSerializedData",
+        "httpswait"
     };
     for (auto& cmdName : supportedCommands) {
         if (SStartsWith(baseCommand.request.methodLine, cmdName)) {
@@ -324,6 +325,21 @@ bool TestPluginCommand::peek(SQLite& db) {
             // Reset so the tester can attach this time.
             pluginPtr->shouldPreventAttach = false;
         }).detach();
+        return true;
+    } else if (SStartsWith(request.methodLine, "httpswait")) {
+        SData newRequest("GET / HTTP/1.1");
+        newRequest["Host"] = "example.com";
+        httpsRequests.push_back(plugin().httpsManager->send("https://example.com/", newRequest));
+        int responseNow = httpsRequests.back()->response;
+        if (responseNow) {
+            STHROW("500 Shouldn't have a response yet");
+        }
+        waitForTransactions(db);
+        responseNow = httpsRequests.back()->response;
+        if (responseNow != 200) {
+            STHROW("500 expected 200 response");
+        }
+        response.content = httpsRequests.back()->fullResponse.content;
         return true;
     } else if (SStartsWith(request.methodLine, "chainedrequest")) {
         // Let's see what the user wanted to request.

--- a/test/clustertest/tests/HTTPSTest.cpp
+++ b/test/clustertest/tests/HTTPSTest.cpp
@@ -23,7 +23,7 @@ struct HTTPSTest : tpunit::TestFixture {
                               BEFORE_CLASS(HTTPSTest::setup),
                               AFTER_CLASS(HTTPSTest::teardown),
                               TEST(HTTPSTest::testMultipleRequests),
-                              TEST(HTTPSTest::testWaitForTransactions),
+                              TEST(HTTPSTest::testWaitForHTTPSRequests),
                               TEST(HTTPSTest::test)) { }
 
     BedrockClusterTester* tester;
@@ -45,7 +45,7 @@ struct HTTPSTest : tpunit::TestFixture {
         ASSERT_EQUAL(lines.size(), 3);
     }
 
-    void testWaitForTransactions() {
+    void testWaitForHTTPSRequests() {
         BedrockTester& brtester = tester->getTester(1);
         SData request("httpswait");
         auto result = brtester.executeWaitMultipleData({request});

--- a/test/clustertest/tests/HTTPSTest.cpp
+++ b/test/clustertest/tests/HTTPSTest.cpp
@@ -1,3 +1,4 @@
+#include "libstuff/libstuff.h"
 #include <libstuff/SData.h>
 #include <test/clustertest/BedrockClusterTester.h>
 
@@ -13,7 +14,7 @@
  *
  * However, to actually verify that you saw a conflict during the test, you can look at the logs for something like:
  *
- * Feb 22 00:32:16 vagrant-ubuntu-trusty-64 bedrock: brcluster_node_0 (SQLiteNode.cpp:1298) update [sync] [warn] 
+ * Feb 22 00:32:16 vagrant-ubuntu-trusty-64 bedrock: brcluster_node_0 (SQLiteNode.cpp:1298) update [sync] [warn]
  *     {brcluster_node_0/LEADING} ROLLBACK, conflicted on sync: brcluster_node_0#109 : sendrequest
  */
 struct HTTPSTest : tpunit::TestFixture {
@@ -22,6 +23,7 @@ struct HTTPSTest : tpunit::TestFixture {
                               BEFORE_CLASS(HTTPSTest::setup),
                               AFTER_CLASS(HTTPSTest::teardown),
                               TEST(HTTPSTest::testMultipleRequests),
+                              TEST(HTTPSTest::testWaitForTransactions),
                               TEST(HTTPSTest::test)) { }
 
     BedrockClusterTester* tester;
@@ -41,6 +43,13 @@ struct HTTPSTest : tpunit::TestFixture {
         auto result = brtester.executeWaitVerifyContent(request);
         auto lines = SParseList(result, '\n');
         ASSERT_EQUAL(lines.size(), 3);
+    }
+
+    void testWaitForTransactions() {
+        BedrockTester& brtester = tester->getTester(1);
+        SData request("httpswait");
+        auto result = brtester.executeWaitMultipleData({request});
+        ASSERT_TRUE(SStartsWith(result[0].methodLine, "200"));
     }
 
     void test() {


### PR DESCRIPTION
### Details

With this change you can add:
```
waitForTransactions(db);
```

After any creation of an https request and it will wait until that request completes, and then continue.

This can only be called from within the main read operations of a command: `prePeek`, `peek`, and `postProcess`. It cannot be called from `process`.

It will rollback and then restart the current database transaction, so it breaks transactionality at this point. We have always done this when making HTTPS requests, so this is not new, but it's worth considering.

This will add network time to `peek` timing for commands that use it. This probably isn't a problem, but will affect our graphs, so we should be aware.

### Fixed Issues
Fixes GH_LINK

### Tests

Tested auth against `c08db35` to make sure existing code doesn't break.
[ TEST RESULTS ] Passed: 4418, Failed: 0

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
