### PR TITLE
Add actionlint.yml to make actionlint pass

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,8 @@
+# This file contains the config for actionlint.
+# See https://github.com/rhysd/actionlint/blob/main/docs/config.md
+#
+# Primarily, we use this config to define some large runners that are not registered in actionlint
+self-hosted-runner:
+  labels:
+    - ubuntu-24.04-v64
+


### PR DESCRIPTION
### Details
Per https://expensify.slack.com/archives/C03TQ48KC/p1746581999763049, I'm going through and getting workflow checks passing on all repos that have them. Generally these changes are easy to fix but by fixing them before re-enabling the check it should limit disruption.

### Fixed Issues
related to https://github.com/Expensify/Expensify/issues/484931

### Tests
Clone the Expensify/GitHub-Actions repo into Expensidev. Then run these three commands from this repo:

```bash
../GitHub-Actions/scripts/actionlint.sh
../GitHub-Actions/scripts/validateImmutableActionRefs.sh
../GitHub-Actions/scripts/validateWorkflowSchemas.sh
```