### PR TITLE
Auto-detect file format of existing db

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -97,7 +97,7 @@ void BedrockServer::sync()
     // We use fewer FDs on test machines that have other resource restrictions in place.
 
     SINFO("Setting dbPool size to: " << _dbPoolSize);
-    _dbPool = make_shared<SQLitePool>(_dbPoolSize, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), journalTables, mmapSizeGB, args.isSet("-hctree"), args["-checkpointMode"]);
+    _dbPool = make_shared<SQLitePool>(_dbPoolSize, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), journalTables, mmapSizeGB, args.isSet("-newDBsUseHctree"), args["-checkpointMode"]);
     SQLite& db = _dbPool->getBase();
 
     // Initialize the command processor.

--- a/main.cpp
+++ b/main.cpp
@@ -309,18 +309,13 @@ int main(int argc, char* argv[]) {
     // Reset the database if requested
     if (args.isSet("-clean")) {
         // Remove it
-        SDEBUG("Resetting database");
+        SINFO("Resetting database");
         string db = args["-db"];
         unlink(db.c_str());
-    } else if (args.isSet("-bootstrap")) {
-        // Allow for bootstraping a node with no database file in place.
-        SINFO("Loading in bootstrap mode, skipping check for database existance.");
-    } else if (args.isSet("-hctree")) {
-        SINFO("Starting in hctree mode, skipping check for database existance.");
-    } else {
-        // Otherwise verify the database exists
-        SDEBUG("Verifying database exists");
-        SASSERT(SFileExists(args["-db"]));
+        unlink(string(db + "-pagemap").c_str());
+        unlink(string(db + "-wal2").c_str());
+        unlink(string(db + "-wal").c_str());
+        unlink(string(db + "-shm").c_str());
     }
 
     // Set our soft limit to the same as our hard limit to allow for more file handles.

--- a/main.cpp
+++ b/main.cpp
@@ -304,10 +304,8 @@ int main(int argc, char* argv[]) {
     // We default to PASSIVE checkpoint everywhere as that has been the value proven to work fine for many years.
     SETDEFAULT("-checkpointMode", "PASSIVE");
 
-    args["-plugins"] = SComposeList(loadPlugins(args));
-
     // Reset the database if requested
-    if (args.isSet("-clean")) {
+    if (args.isSet("-clean") || args.isSet("-bootstrap") ) {
         // Remove it
         SINFO("Resetting database");
         string db = args["-db"];
@@ -317,6 +315,8 @@ int main(int argc, char* argv[]) {
         unlink(string(db + "-wal").c_str());
         unlink(string(db + "-shm").c_str());
     }
+
+    args["-plugins"] = SComposeList(loadPlugins(args));
 
     // Set our soft limit to the same as our hard limit to allow for more file handles.
     struct rlimit limits;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -356,6 +356,7 @@ class SQLite {
     // Initializers to support RAII-style allocation in constructors.
     static string initializeFilename(const string& filename);
     static SharedData& initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames, bool hctree);
+    static bool validateDBFormat(const string& filename, bool hctree);
     static sqlite3* initializeDB(const string& filename, int64_t mmapSizeGB, bool hctree);
     static vector<string> initializeJournal(sqlite3* db, int minJournalTables);
     void commonConstructorInitialization(bool hctree = false);
@@ -366,6 +367,8 @@ class SQLite {
 
     // The maximum number of rows to store in the journal before we start truncating old ones.
     uint64_t _maxJournalSize;
+
+    const bool _hctree;
 
     // The underlying sqlite3 DB handle.
     sqlite3* _db;

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -17,7 +17,7 @@
 PortMap BedrockTester::ports;
 mutex BedrockTester::_testersMutex;
 set<BedrockTester*> BedrockTester::_testers;
-const bool BedrockTester::ENABLE_HCTREE{false};
+const bool BedrockTester::ENABLE_HCTREE{true};
 
 string BedrockTester::getTempFileName(const string& prefix) {
     string templateStr = "/tmp/" + prefix + "bedrocktest_XXXXXX.db";
@@ -92,7 +92,7 @@ BedrockTester::BedrockTester(const map<string, string>& args,
     };
 
     if (ENABLE_HCTREE) {
-        defaultArgs["-hctree"] = "";
+        defaultArgs["-newDBsUseHctree"] = "";
     }
 
     // Set defaults.

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -17,7 +17,7 @@
 PortMap BedrockTester::ports;
 mutex BedrockTester::_testersMutex;
 set<BedrockTester*> BedrockTester::_testers;
-const bool BedrockTester::ENABLE_HCTREE{true};
+const bool BedrockTester::ENABLE_HCTREE{false};
 
 string BedrockTester::getTempFileName(const string& prefix) {
     string templateStr = "/tmp/" + prefix + "bedrocktest_XXXXXX.db";


### PR DESCRIPTION
### Details

Deletes old DB files when started in `-bootstrap` mode to make sure that the DB is clean before restoring from backup.

Also detects the DB filetype from the file header explicitly, and adjusts the state of the `hctree` flag to match the actual DB file.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/501034

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
