### PR TITLE
Show warning if wrong test name

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -184,7 +184,6 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
     list<_TestFixture*> afterTests;
     mutex testTimeLock;
     multimap<chrono::milliseconds, string> testTimes;
-    int testsRun = 0; // Track number of tests actually run in this invocation
 
     for (int threadID = 0; threadID < threads; threadID++) {
         // Capture everything by reference except threadID, because we don't want it to be incremented for the
@@ -275,12 +274,6 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
 
                     tpunit_run_test_class(f);
 
-                    // Mark that a test was run
-                    {
-                        lock_guard<recursive_mutex> lock(m);
-                        testsRun++;
-                    }
-
                     // Do this to capture the longest test classes, not longest thread.
                     end = chrono::steady_clock::now();
 
@@ -324,8 +317,8 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
     }
 
     // Print message if no tests were found for the given include set
-    if (include.size() > 0 && testsRun == 0) {
-        printf("\xE2\x9A\xA0  Could not find any test matching, make sure the test name is right: "); // ⚠️
+    if (include.size() > 0 && tpunit_detail_stats()._passes == 0 && tpunit_detail_stats()._failures == 0) {
+        printf("\xE2\x9D\x8C  Could not find any test matching, make sure the test name is right: ");
         bool first = true;
         for (const auto& name : include) {
             if (!first) printf(", ");

--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -186,7 +186,9 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
     list<_TestFixture*> afterTests;
     mutex testTimeLock;
     multimap<chrono::milliseconds, string> testTimes;
-    std::map<std::string, bool> includeMatched; // Track which include patterns matched at least one test
+
+    // Track which include patterns matched at least one test
+    std::map<std::string, bool> includeMatched;
     for (const auto& name : include) {
         includeMatched[name] = false;
     }
@@ -229,14 +231,13 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
                         if (f->_name) {
                             for (const string& includedName : _include) {
                                 try {
-                                    std::regex pattern("^" + includedName + "$", std::regex::ECMAScript);
-                                    if (std::regex_match(f->_name, pattern)) {
+                                    if (regex_match(f->_name, regex("^" + includedName + "$"))) {
                                         included = true;
                                         // Mark this pattern as matched
                                         includeMatched[includedName] = true;
                                         break;
                                     }
-                                } catch (const std::regex_error& e) {
+                                } catch (const regex_error& e) {
                                     cout << "Invalid pattern: " << includedName << ", skipping." << endl;
                                 }
                             }
@@ -299,7 +300,7 @@ int tpunit::_TestFixture::tpunit_detail_do_run(const set<string>& include, const
                 printf("Thread %d caught shutdown exception, exiting.\n", threadID);
             }
         });
-        threadList.push_back(std::move(t));
+        threadList.push_back(move(t));
     }
 
     // Wait for them all to finish.


### PR DESCRIPTION
### Details
Just a minor improvement to highlight in terminal if the wrong test name is passed.

### Fixed Issues
N/A

### Tests
<img width="820" alt="Screenshot 2025-05-15 at 1 50 17 PM" src="https://github.com/user-attachments/assets/4a2baa2d-cf22-4496-8f4b-af86ab7eb33a" />
<img width="830" alt="Screenshot 2025-05-15 at 1 50 01 PM" src="https://github.com/user-attachments/assets/0e23ed3a-18dc-46e4-803b-81ff8754c13b" />
<img width="884" alt="Screenshot 2025-05-15 at 1 49 50 PM" src="https://github.com/user-attachments/assets/997a98d4-e02f-48d9-8911-0df62dbeb910" />

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
