### PR TITLE
 Make _TestFixture::exitFlag atomic for thread-safe signal handling

### DIFF
--- a/test/lib/tpunit++.cpp
+++ b/test/lib/tpunit++.cpp
@@ -3,9 +3,10 @@
 #include <iostream>
 #include <regex>
 #include <chrono>
+#include <atomic>
 using namespace tpunit;
 
-bool tpunit::_TestFixture::exitFlag = false;
+atomic<bool> tpunit::_TestFixture::exitFlag(false);
 thread_local string tpunit::currentTestName;
 thread_local tpunit::_TestFixture* tpunit::currentTestPtr = nullptr;
 thread_local mutex tpunit::currentTestNameMutex;

--- a/test/lib/tpunit++.hpp
+++ b/test/lib/tpunit++.hpp
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <algorithm>
 #include <functional>
+#include <atomic>
 #include <test/lib/PrintEquality.h>
 using namespace std;
 
@@ -202,7 +203,7 @@ namespace tpunit {
    class _TestFixture {
       public:
 
-         static bool exitFlag;
+         static std::atomic<bool> exitFlag;
 
          struct perFixtureStats {
             perFixtureStats();


### PR DESCRIPTION
### Details
Related to: https://github.com/Expensify/Auth/pull/15341

This PR refactors the `tpunit::_TestFixture::exitFlag` within the tpunit++ library, changing its type from a plain bool to `atomic<bool>`.

The existing `exitFlag` is intended to signal the test framework to stop processing further tests (e.g., by throwing a `ShutdownException` when the flag is true). If this flag is set by an asynchronous mechanism, such as a signal handler executing in a different context or interrupting a thread, using a plain bool can lead to data races and visibility issues on concurrent access through signal handling [introduced in this PR](https://github.com/Expensify/Auth/pull/15341).

Existing tpunit behavior should not be affected.

### Fixed Issues

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
