### PR TITLE
Remove a bunch of logs

### DIFF
--- a/BedrockConflictManager.cpp
+++ b/BedrockConflictManager.cpp
@@ -38,9 +38,6 @@ void BedrockConflictManager::recordTables(const string& commandName, const set<s
             }
         }
     }
-
-    // And increase the count for each used table.
-    SINFO("Command " << commandName << " used tables: " << SComposeList(tables));
 }
 
 string BedrockConflictManager::generateReport() {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1006,7 +1006,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                             command->response["commitCount"] = to_string(db.getCommitCount());
                             command->complete = true;
                         } else {
-                            SINFO("Conflict or state change committing " << command->request.methodLine << " on worker thread.");
+                            SINFO("Conflict or state change committing " << command->request.methodLine);
                             if (_enableConflictPageLocks) {
                                 lastConflictTable = db.getLastConflictTable();
 
@@ -1501,7 +1501,7 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
     const string& pluginName = command->request["plugin"];
 
     if (command->socket) {
-        SINFO("[performance] Command " << command->request.methodLine << " has a socket, going to try to reply.");
+        SDEBUG("[performance] Command " << command->request.methodLine << " has a socket, going to try to reply.");
         if (!pluginName.empty()) {
             // Let the plugin handle it
             SINFO("Plugin '" << pluginName << "' handling response '" << command->response.methodLine
@@ -1519,7 +1519,7 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
                 SINFO("No socket to reply for: '" << command->request.methodLine << "' #" << command->initiatingClientID);
                 command->handleFailedReply();
             } else {
-                SINFO("[performance] Replied");
+                SDEBUG("[performance] Replied");
             }
         }
 
@@ -1535,7 +1535,7 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
         }
         command->handleFailedReply();
     }
-    SINFO("[performance] Finished replying to command " << command->request.methodLine << " moving on to the next command.");
+    SDEBUG("[performance] Finished replying to command " << command->request.methodLine);
 }
 
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1520,7 +1520,6 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
     const string& pluginName = command->request["plugin"];
 
     if (command->socket) {
-        SDEBUG("[performance] Command " << command->request.methodLine << " has a socket, going to try to reply.");
         if (!pluginName.empty()) {
             // Let the plugin handle it
             SINFO("Plugin '" << pluginName << "' handling response '" << command->response.methodLine
@@ -1537,8 +1536,6 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
                 // If we can't send (client closed the socket?), alert our plugin it's response was never sent.
                 SINFO("No socket to reply for: '" << command->request.methodLine << "' #" << command->initiatingClientID);
                 command->handleFailedReply();
-            } else {
-                SDEBUG("[performance] Replied");
             }
         }
 
@@ -1554,7 +1551,6 @@ void BedrockServer::_reply(unique_ptr<BedrockCommand>& command) {
         }
         command->handleFailedReply();
     }
-    SDEBUG("[performance] Finished replying to command " << command->request.methodLine);
 }
 
 

--- a/libstuff/SScheduledPriorityQueue.h
+++ b/libstuff/SScheduledPriorityQueue.h
@@ -28,7 +28,7 @@ class SScheduledPriorityQueue {
 
     // Typedefs are here for legibility's sake.
     typedef int Priority;
-    typedef uint64_t Timeout; 
+    typedef uint64_t Timeout;
     typedef uint64_t Scheduled;
 
     // If nothing becomes available to dequeue while waiting, a timeout_error exception is thrown.
@@ -188,7 +188,6 @@ void SScheduledPriorityQueue<T>::push(T&& item, Priority priority, Scheduled sch
     _lookupByTimeout.insert(make_pair(timeout, make_pair(priority, scheduled)));
     queue.emplace(scheduled, ItemTimeoutPair(move(item), timeout));
     _queueCondition.notify_one();
-    SINFO("Enqueued command with timeout " << timeout);
 }
 
 template<typename T>

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -430,7 +430,7 @@ bool SQLite::beginTransaction(SQLite::TRANSACTION_TYPE type) {
     // We actively track transaction counts incrementing and decrementing to log the number of active open transactions at any given moment.
     _sharedData.openTransactionCount++;
 
-    SINFO("Beginning transaction - open transaction count: " << (_sharedData.openTransactionCount));
+    SINFO("Beginning transaction - open transactions: " << (_sharedData.openTransactionCount));
     uint64_t before = STimeNow();
     _insideTransaction = !SQuery(_db, "starting db transaction", "BEGIN CONCURRENT");
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -430,7 +430,7 @@ bool SQLite::beginTransaction(SQLite::TRANSACTION_TYPE type) {
     // We actively track transaction counts incrementing and decrementing to log the number of active open transactions at any given moment.
     _sharedData.openTransactionCount++;
 
-    SINFO("Beginning transaction - open transactions: " << (_sharedData.openTransactionCount));
+    SINFO("Beginning transaction - open transaction count: " << (_sharedData.openTransactionCount));
     uint64_t before = STimeNow();
     _insideTransaction = !SQuery(_db, "starting db transaction", "BEGIN CONCURRENT");
 

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -3,12 +3,12 @@
 #include "SQLiteCore.h"
 #include "SQLite.h"
 #include "SQLiteNode.h"
-    
+
 SQLiteCore::SQLiteCore(SQLite& db) : _db(db)
 { }
 
 bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, bool needsPluginNotification, void (*notificationHandler)(SQLite& _db, int64_t tableID)) noexcept {
-    
+
     // This handler only needs to exist in prepare so we scope it here to automatically unset
     // the handler function once we are done with prepare.
     {
@@ -33,7 +33,6 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
     // Perform the actual commit, rollback if it fails.
     int errorCode = _db.commit(SQLiteNode::stateName(node.getState()));
     if (errorCode == SQLITE_BUSY_SNAPSHOT) {
-        SINFO("Commit conflict, rolling back.");
         _db.rollback();
         return false;
     } else if (errorCode == SQLite::COMMIT_DISABLED) {


### PR DESCRIPTION
### Details

We're logging too much, which results in a rsyslog backlog, which in turn causes bedrock to hang, as we have seen many times in the past. We need to remove some logs again.

Most of these logs are either unused or repeated. Here's some PRs where we added some:
- https://github.com/Expensify/Bedrock/pull/2114/files
- https://github.com/Expensify/Bedrock/pull/1549/files
- https://github.com/Expensify/Bedrock/pull/499/files
- https://github.com/Expensify/Bedrock/pull/255/files

This PR will need to be deployed after these changes: https://github.com/Expensify/Salt/pull/14985

### Fixed Issues
Fixes  https://github.com/Expensify/Expensify/issues/504372

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
