### PR TITLE
Add "topic" to PARAMS_WHITELIST

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -42,25 +42,25 @@ void SLogStackTrace(int level) {
 
 // If the param name is not in this whitelist, we will log <REDACTED> in addLogParams.
 static set<string> PARAMS_WHITELIST = {
+    "approver",
+    "approvers",
     "command",
     "Connection",
     "Content-Length",
     "count",
+    "employeeEmail",
+    "employees",
     "indexName",
     "isUnique",
     "logParam",
     "message",
     "peer",
+    "policyID",
     "reason",
     "requestID",
     "status",
-    "userID",
-    "policyID",
-    "employeeEmail",
-    "approver",
-    "approvers",
-    "employees",
     "topic",
+    "userID",
 };
 
 string addLogParams(string&& message, const STable& params) {

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -60,6 +60,7 @@ static set<string> PARAMS_WHITELIST = {
     "approver",
     "approvers",
     "employees",
+    "topic",
 };
 
 string addLogParams(string&& message, const STable& params) {


### PR DESCRIPTION
### Details
Supporting https://github.com/Expensify/Auth/pull/15580, adds `topic` as a loggable param

### Fixed Issues
None, but related to https://github.com/Expensify/Expensify/issues/504787

### Tests
None
