### PR TITLE
Test performance of first query

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -199,8 +199,9 @@ void SQLite::commonConstructorInitialization(bool hctree) {
     SASSERT(!_filename.empty());
     SASSERT(_maxJournalSize > 0);
 
+    uint64_t startTime = STimeNow();
     if (_mmapSizeGB) {
-        SASSERT(!_wrapSQuery(_db, "enabling memory-mapped I/O", "PRAGMA mmap_size=" + to_string(_mmapSizeGB * 1024 * 1024 * 1024) + ";"));
+        SASSERT(!SQuery(_db, "enabling memory-mapped I/O", "PRAGMA mmap_size=" + to_string(_mmapSizeGB * 1024 * 1024 * 1024) + ";"));
     }
 
     // Enable tracing for performance analysis.
@@ -209,8 +210,10 @@ void SQLite::commonConstructorInitialization(bool hctree) {
     // Update the cache. -size means KB; +size means pages
     if (_cacheSize) {
         SINFO("Setting cache_size to " << _cacheSize << "KB");
-        _wrapSQuery(_db, "increasing cache size", "PRAGMA cache_size = -" + SQ(_cacheSize) + ";");
+        SQuery(_db, "increasing cache size", "PRAGMA cache_size = -" + SQ(_cacheSize) + ";");
     }
+    uint64_t elapsed = STimeNow() - startTime;
+    SINFO("Pragma init time: " << elapsed / 1000 << "ms.");
 
     // Register the authorizer callback which allows callers to whitelist particular data in the DB.
     sqlite3_set_authorizer(_db, _sqliteAuthorizerCallback, this);

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -426,7 +426,7 @@ bool SQLite::beginTransaction(SQLite::TRANSACTION_TYPE type) {
 
     SINFO("Beginning transaction - open transaction count: " << (_sharedData.openTransactionCount));
     uint64_t before = STimeNow();
-    _insideTransaction = !_wrapSQuery(_db, "starting db transaction", "BEGIN CONCURRENT");
+    _insideTransaction = !SQuery(_db, "starting db transaction", "BEGIN CONCURRENT");
 
     // Because some other thread could commit once we've run `BEGIN CONCURRENT`, this value can be slightly behind
     // where we're actually able to start such that we know we shouldn't get a conflict if this commits successfully on
@@ -1223,7 +1223,7 @@ int SQLite::getPreparedStatements(const string& query, list<sqlite3_stmt*>& stat
 void SQLite::setQueryOnly(bool enabled) {
     SQResult result;
     string query = "PRAGMA query_only = "s + (enabled ? "true" : "false") + ";";
-    _wrapSQuery(_db, "set query_only", query, result);
+    SQuery(_db, "set query_only", query, result);
 }
 
 int64_t SQLite::getLastConflictPage() const {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1292,7 +1292,7 @@ int SQLite::_wrapSQuery(sqlite3* db, const char* e, const string& sql, SQResult&
         string sqlToLog = sql.substr(0, 20000);
         SRedactSensitiveValues(sqlToLog);
         if ((int64_t)elapsed > warnThreshold) {
-            SWARN("Slow first query (" << elapsed / 1000 << "ms): " << sqlToLog);
+            SWARN("Slow query (first query) (" << elapsed / 1000 << "ms): " << sqlToLog);
         } else {
             SINFO("First query completed (" << elapsed / 1000 << "ms): " << sqlToLog);
         }
@@ -1314,7 +1314,7 @@ int SQLite::_wrapSQuery(sqlite3* db, const char* e, const string& sql, int64_t w
         string sqlToLog = sql.substr(0, 20000);
         SRedactSensitiveValues(sqlToLog);
         if ((int64_t)elapsed > warnThreshold) {
-            SWARN("Slow first query (" << elapsed / 1000 << "ms): " << sqlToLog);
+            SWARN("Slow query (first query) (" << elapsed / 1000 << "ms): " << sqlToLog);
         } else {
             SINFO("First query completed (" << elapsed / 1000 << "ms): " << sqlToLog);
         }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1284,3 +1284,13 @@ map<uint64_t, tuple<string, string, uint64_t>> SQLite::SharedData::popCommittedT
     _committedTransactions.clear();
     return result;
 }
+
+int SQLite::_wrapSQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold, bool skipInfoWarn)
+{
+    return SQuery(db, e, sql, result, warnThreshold, skipInfoWarn);
+}
+
+int SQLite::_wrapSQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold, bool skipInfoWarn)
+{
+    return SQuery(db, e, sql, warnThreshold, skipInfoWarn);
+}

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -478,6 +478,10 @@ class SQLite {
     // Registering this has the important side effect of preventing the DB from auto-checkpointing.
     static int _walHookCallback(void* sqliteObject, sqlite3* db, const char* name, int walFileSize);
 
+    // Wrappers around SQuery that exist to let us check if we're running the first query on a handle.
+    int _wrapSQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipInfoWarn = false);
+    int _wrapSQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipInfoWarn = false);
+
     mutable uint64_t _timeoutLimit = 0;
     mutable uint64_t _timeoutStart;
     mutable uint64_t _timeoutError;
@@ -522,6 +526,9 @@ class SQLite {
 
     // Number of queries found in cache in this transaction (for metrics only).
     mutable int64_t _cacheHits = 0;
+
+    // Set to true only for the first query on an object to diagnose performance problems that seem to stem from this.
+    mutable bool _isFirstQuery{true};
 
     // A string indicating the name of the transaction (typically a command name) for metric purposes.
     string _transactionName;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -479,8 +479,8 @@ class SQLite {
     static int _walHookCallback(void* sqliteObject, sqlite3* db, const char* name, int walFileSize);
 
     // Wrappers around SQuery that exist to let us check if we're running the first query on a handle.
-    int _wrapSQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipInfoWarn = false);
-    int _wrapSQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipInfoWarn = false);
+    int _wrapSQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipInfoWarn = false) const;
+    int _wrapSQuery(sqlite3* db, const char* e, const string& sql, int64_t warnThreshold = 2000 * STIME_US_PER_MS, bool skipInfoWarn = false) const;
 
     mutable uint64_t _timeoutLimit = 0;
     mutable uint64_t _timeoutStart;


### PR DESCRIPTION
### Details
This separates out slow query logging to log the first queries on each SQLite object separately.

This does not count certain queries as "first queries", notably `PRAGMA query_only`, `PRAGMA mmap_size`, `PRAGMA cache_size` and `BEGIN CONCURRENT`.

### Fixed Issues
Diagnosing: https://github.com/Expensify/Expensify/issues/458560#issuecomment-2934250193

### Tests

You can just run the tests and watch the logs.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
