### PR TITLE
Added _endFunction call to fix timing issues

### DIFF
--- a/libstuff/SScheduledPriorityQueue.h
+++ b/libstuff/SScheduledPriorityQueue.h
@@ -335,6 +335,7 @@ list<T> SScheduledPriorityQueue<T>::getAll() {
     // Iterate across each map in each queue and pull out all the items.
     for (auto& queue: _queue) {
         for (auto& p : queue.second) {
+            _endFunction(p.second.item);
             items.emplace_back(move(p.second.item));
         }
     }


### PR DESCRIPTION
### Details

This fixes a timing issue that may occur when commands are transitioned from blocking queue to worker queue ([see this comment for details](https://github.com/Expensify/Expensify/issues/452434#issuecomment-2932384656)), by making the `getAll()` queue function run the queued command's `_endFunction()`, which in turn runs `stopTiming()`.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/452434

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
