### PR TITLE
Fix formatting of canned repeat schedules in jobs documentation

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -193,8 +193,8 @@ The above takes some getting used to, but is incredibly powerful for expressing 
 ### Canned Repeat Schedules
 Confused by all the above?  No problem -- there are a few "canned" patterns built in for simplicity:
 
-* **HOURLY** = FINISHED, + 1 HOUR
-* **DAILY** = FINISHED, + 1 DAY
-* **WEEKLY** = FINISHED, + 7 DAYS
+* **HOURLY** = FINISHED, +1 HOUR
+* **DAILY** = FINISHED, +1 DAY
+* **WEEKLY** = FINISHED, +7 DAYS
 
 These are useful if you generally want something to happen *approximately but no greater* than the indicated frequency.


### PR DESCRIPTION
cc @tgolen 

### Details
Update the documentation with the correct format for scheduling jobs. I copied and pasted those values for this [issue](https://github.com/Expensify/Expensify/issues/508233) and the scheduling was failing because the repeat schedule didn't have the correct format. 

### Fixed Issues
N/A

### Tests
N/A
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
