### PR TITLE
dont treat pragma schema_version and rollback as first queries

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -631,7 +631,7 @@ bool SQLite::_writeIdempotent(const string& query, SQResult& result, bool always
 
     // First, check our current state
     SQResult results;
-    SASSERT(!_wrapSQuery(_db, "looking up schema version", "PRAGMA schema_version;", results));
+    SASSERT(!SQuery(_db, "looking up schema version", "PRAGMA schema_version;", results));
     SASSERT(!results.empty() && !results[0].empty());
     uint64_t schemaBefore = SToUInt64(results[0][0]);
     uint64_t changesBefore = sqlite3_total_changes(_db);
@@ -672,7 +672,7 @@ bool SQLite::_writeIdempotent(const string& query, SQResult& result, bool always
     }
 
     // See if the query changed anything
-    SASSERT(!_wrapSQuery(_db, "looking up schema version", "PRAGMA schema_version;", results));
+    SASSERT(!SQuery(_db, "looking up schema version", "PRAGMA schema_version;", results));
     SASSERT(!results.empty() && !results[0].empty());
     uint64_t schemaAfter = SToUInt64(results[0][0]);
     uint64_t changesAfter = sqlite3_total_changes(_db);
@@ -901,7 +901,7 @@ void SQLite::rollback() {
                 SINFO("Rolling back transaction: " << _uncommittedQuery.substr(0, 100));
             }
             uint64_t before = STimeNow();
-            SASSERT(!_wrapSQuery(_db, "rolling back db transaction", "ROLLBACK"));
+            SASSERT(!SQuery(_db, "rolling back db transaction", "ROLLBACK"));
             _rollbackElapsed += STimeNow() - before;
         }
 


### PR DESCRIPTION
### Details
Follow up to this:
https://github.com/Expensify/Bedrock/pull/2194/files

The `pragma schema_version` and `rollback` queries never seem to be slow and are nor very useful to look at.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/458560

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
