### PR TITLE
Add function to check if there is stacktrace stored

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -203,6 +203,10 @@ vector<string> SException::details() const noexcept {
     return stack;
 }
 
+bool SException::hasStackTrace() const noexcept {
+    return _depth > 0;
+}
+
 void SException::logStackTrace() const noexcept {
     for (const auto& frame : details()) {
         SINFO(frame);

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -147,6 +147,7 @@ class SException : public exception {
     const char* what() const noexcept;
     vector<string> details() const noexcept;
     void logStackTrace() const noexcept;
+    bool hasStackTrace() const noexcept;
 
     const string method;
     const STable headers;


### PR DESCRIPTION
### Details

Needed by this PR: https://github.com/Expensify/Auth/pull/15867

### Fixed Issues

Should help with finding the source of bad json parsing here: https://github.com/Expensify/Expensify/issues/507964

### Tests

See testing in https://github.com/Expensify/Auth/pull/15867

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
