### PR TITLE
Use STHROW_STACK to collect stacktrace

### DIFF
--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -38,7 +38,7 @@ string& SQResultRow::operator[](const string& key) {
             }
         }
     }
-    throw out_of_range("No column named " + key);
+    STHROW_STACK("No column named " + key);
 }
 
 const string& SQResultRow::operator[](const string& key) const {
@@ -55,7 +55,7 @@ const string& SQResultRow::operator[](const string& key) const {
             }
         }
     }
-    throw out_of_range("No column named " + key);
+    STHROW_STACK("No column named " + key);
 }
 
 string SQResult::serializeToJSON() const {
@@ -151,7 +151,8 @@ SQResultRow& SQResult::operator[](size_t rowNum) {
     try {
         return rows.at(rowNum);
     } catch (const out_of_range& e) {
-        STHROW("Out of range");
+        SINFO("SQResult::operator out of range", {{"rowNum", to_string(rowNum)}});
+        STHROW_STACK("Out of range");
     }
 }
 
@@ -159,7 +160,8 @@ const SQResultRow& SQResult::operator[](size_t rowNum) const {
     try {
         return rows.at(rowNum);
     } catch (const out_of_range& e) {
-        STHROW("Out of range");
+        SINFO("SQResult::operator out of range", {{"rowNum", to_string(rowNum)}});
+        STHROW_STACK("Out of range");
     }
 }
 

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -734,7 +734,7 @@ struct LibStuff : tpunit::TestFixture {
         bool threw = false;
         try {
             string s = result[0]["notacolumn"];
-        } catch (const out_of_range& e) {
+        } catch (const SException& e) {
             threw = true;
         }
         ASSERT_TRUE(threw);


### PR DESCRIPTION
### Details

When we try to access a column that doesn't exist in SQResult, it is currently throwing an `out_of_range` if the access was by key (string) or a `SException` if the access was by index.

This is inconsistent and it also makes it hard to track where this happened, for example this one: https://github.com/Expensify/Expensify/issues/519077

```
95638cf6bcc608e5-LAX	db2.lax	2025-06-27 08:24:53 696	toiyeucuocsong99+50@gmail.com	Caught unexpected exception: No column named parentReportID in command Search
95638cf6bcc608e5-LAX	db2.lax	2025-06-27 08:24:53 696	toiyeucuocsong99+50@gmail.com	Throwing exception with message: 'No column named parentReportID' from N/A:0
95638cf6bcc608e5-LAX	db2.lax	2025-06-27 08:24:53 696	toiyeucuocsong99+50@gmail.com	Unhandled exception typename: (mangled) St12out_of_range, command: Search
```

(there is no stack trace)

I'm changing the code to `STHROW_STACK` because that collects the stack, and if the exception is not caught in the command, the stack trace will be automatically logged here:

https://github.com/Expensify/Auth/blob/28ea25d4010344eb1053df9d86ba6c0bf2e24bfa/auth/AuthCommand.cpp#L709-L711

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/519077

### Tests

You can test this by modifying your code somewhere in Auth accessing a column that doesn't exist in a SQResult. Check your logs for the request and you should find the stack trace. For example:



_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
