### PR TITLE
Reconnect after setting priority

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1263,7 +1263,6 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                 _haveSeenPeerOnSameVersion = true;
                 if (_haveBeenWAITING) {
                     _priority = _originalPriority;
-                    SINFO("Setting priority to " << _originalPriority << " because we've seen a peer on the same version");
                     _reconnectAll();
                 }
             }
@@ -1947,7 +1946,6 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
             if (!_haveBeenWAITING) {
                 _haveBeenWAITING = true;
                 if (_haveSeenPeerOnSameVersion) {
-                    SINFO("Setting priority to " << _originalPriority << " because we're WAITING");
                     _priority = _originalPriority;
                     _reconnectAll();
                 }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1263,6 +1263,8 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                 _haveSeenPeerOnSameVersion = true;
                 if (_haveBeenWAITING) {
                     _priority = _originalPriority;
+                    SINFO("Setting priority to " << _originalPriority << " because we've seen a peer on the same version");
+                    _reconnectAll();
                 }
             }
 
@@ -1945,7 +1947,9 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
             if (!_haveBeenWAITING) {
                 _haveBeenWAITING = true;
                 if (_haveSeenPeerOnSameVersion) {
+                    SINFO("Setting priority to " << _originalPriority << " because we're WAITING");
                     _priority = _originalPriority;
+                    _reconnectAll();
                 }
             }
         }

--- a/test/clustertest/tests/ClusterUpgradeTest.cpp
+++ b/test/clustertest/tests/ClusterUpgradeTest.cpp
@@ -106,10 +106,6 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
     }
 
     void test() {
-        SLogSetThreadName("");
-        SLogSetThreadPrefix("");
-        SLogLevel(LOG_DEBUG);
-
         // Let the entire cluster come up on the production version.
         ASSERT_TRUE(tester->getTester(0).waitForState("LEADING"));
         ASSERT_TRUE(tester->getTester(1).waitForState("FOLLOWING"));
@@ -146,23 +142,18 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
         tester->getTester(0).stopServer();
 
         // We should now have a two-node cluster with 1 leading and 2 following.
-        SINFO("TYLER two node");
         ASSERT_TRUE(tester->getTester(1).waitForState("LEADING"));
         ASSERT_TRUE(tester->getTester(2).waitForState("FOLLOWING"));
-        SINFO("TYLER two node done");
 
         // Start up the old leader on the new version.
         tester->getTester(0).serverName = "bedrock";
         tester->getTester(0).updateArgs({{"-plugins", newTestPlugin}});
         tester->getTester(0).startServer();
-        SINFO("TYLER start old leader");
+
         // We should get the expected cluster state.
         ASSERT_TRUE(tester->getTester(0).waitForState("LEADING"));
-        SINFO("TYLER old leader done");
         ASSERT_TRUE(tester->getTester(1).waitForState("FOLLOWING"));
-        SINFO("TYLER old follower done");
         ASSERT_TRUE(tester->getTester(2).waitForState("FOLLOWING"));
-        SINFO("TYLER old follower done");
 
         // Now 0 and 2 are the new version, and 1 is the old version.
         versions = getVersions();

--- a/test/clustertest/tests/ClusterUpgradeTest.cpp
+++ b/test/clustertest/tests/ClusterUpgradeTest.cpp
@@ -106,6 +106,10 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
     }
 
     void test() {
+        SLogSetThreadName("");
+        SLogSetThreadPrefix("");
+        SLogLevel(LOG_DEBUG);
+
         // Let the entire cluster come up on the production version.
         ASSERT_TRUE(tester->getTester(0).waitForState("LEADING"));
         ASSERT_TRUE(tester->getTester(1).waitForState("FOLLOWING"));
@@ -142,18 +146,23 @@ struct ClusterUpgradeTest : tpunit::TestFixture {
         tester->getTester(0).stopServer();
 
         // We should now have a two-node cluster with 1 leading and 2 following.
+        SINFO("TYLER two node");
         ASSERT_TRUE(tester->getTester(1).waitForState("LEADING"));
         ASSERT_TRUE(tester->getTester(2).waitForState("FOLLOWING"));
+        SINFO("TYLER two node done");
 
         // Start up the old leader on the new version.
         tester->getTester(0).serverName = "bedrock";
         tester->getTester(0).updateArgs({{"-plugins", newTestPlugin}});
         tester->getTester(0).startServer();
-
+        SINFO("TYLER start old leader");
         // We should get the expected cluster state.
         ASSERT_TRUE(tester->getTester(0).waitForState("LEADING"));
+        SINFO("TYLER old leader done");
         ASSERT_TRUE(tester->getTester(1).waitForState("FOLLOWING"));
+        SINFO("TYLER old follower done");
         ASSERT_TRUE(tester->getTester(2).waitForState("FOLLOWING"));
+        SINFO("TYLER old follower done");
 
         // Now 0 and 2 are the new version, and 1 is the old version.
         versions = getVersions();


### PR DESCRIPTION
### Details
When working on other issues, I noticed that `ClusterUpgradeTest` had become unreliable.

Upon further investigation, we caused this with this change: https://github.com/Expensify/Bedrock/pull/2212

We only send our priority to peers either on login, or when we change state. This means that if a node sets its priority to -1 at startup and goes following (which it may do if it first connects to a leader on a different version), it may just sit there `FOLLOWING` even after it changes its priority after connecting to another node on the same version as it.

This change causes the node to reconnect once it's updated its priority, so it can resend messages to all peers advertising it's new priority, and start from scratch deciding if it should lead or not.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/520536

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
