### PR TITLE
Add a few new member functions in preparation for making SQResult::rows private

### DIFF
--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -217,16 +217,8 @@ void SQResult::resize(size_t newSize) {
     }
 }
 
-void SQResult::push_back(const SQResultRow&& row) {
-    rows.push_back(row);
-}
-
 void SQResult::emplace_back(const SQResultRow&& row) {
     rows.emplace_back(move(row));
-}
-
-SQResultRow& SQResult::back() {
-    return rows.back();
 }
 
 const SQResultRow& SQResult::back() const {

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -185,14 +185,6 @@ SQResult& SQResult::operator=(const SQResult& other) {
     return *this;
 }
 
-vector<SQResultRow>::iterator SQResult::begin() {
-    return rows.begin();
-}
-
-vector<SQResultRow>::iterator SQResult::end() {
-    return rows.end();
-}
-
 vector<SQResultRow>::const_iterator SQResult::begin() const {
     return rows.begin();
 }

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -201,7 +201,7 @@ vector<SQResultRow>::const_iterator SQResult::cend() const {
     return rows.cend();
 }
 
-void SQResult::emplace_back(const SQResultRow&& row) {
+void SQResult::emplace_back(SQResultRow&& row) {
     rows.emplace_back(move(row));
 }
 

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -153,10 +153,6 @@ size_t SQResult::size() const {
     return rows.size();
 }
 
-const vector<SQResultRow>& SQResult::getRows() const {
-    return rows;
-}
-
 void SQResult::clear() {
     headers.clear();
     rows.clear();
@@ -221,16 +217,12 @@ void SQResult::resize(size_t newSize) {
     }
 }
 
-void SQResult::push_back(const SQResultRow& row) {
-    SQResultRow newRow = row;
-    newRow.result = this;
-    rows.push_back(newRow);
+void SQResult::push_back(const SQResultRow&& row) {
+    rows.push_back(row);
 }
 
-void SQResult::emplace_back(const SQResultRow& row) {
-    SQResultRow newRow = row;
-    newRow.result = this;
-    rows.emplace_back(newRow);
+void SQResult::emplace_back(const SQResultRow&& row) {
+    rows.emplace_back(move(row));
 }
 
 SQResultRow& SQResult::back() {

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -201,14 +201,6 @@ vector<SQResultRow>::const_iterator SQResult::cend() const {
     return rows.cend();
 }
 
-void SQResult::resize(size_t newSize) {
-    if (newSize > rows.size()) {
-        rows.resize(newSize, SQResultRow(*this));
-    } else {
-        rows.resize(newSize);
-    }
-}
-
 void SQResult::emplace_back(const SQResultRow&& row) {
     rows.emplace_back(move(row));
 }

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -214,9 +214,10 @@ vector<SQResultRow>::const_iterator SQResult::cend() const {
 }
 
 void SQResult::resize(size_t newSize) {
-    rows.resize(newSize);
-    for (auto& row : rows) {
-        row.result = this;
+    if (newSize > rows.size()) {
+        rows.resize(newSize, SQResultRow(*this));
+    } else {
+        rows.resize(newSize);
     }
 }
 

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -152,6 +152,10 @@ size_t SQResult::size() const {
     return rows.size();
 }
 
+const vector<SQResultRow>& SQResult::getRows() const {
+    return rows;
+}
+
 void SQResult::clear() {
     headers.clear();
     rows.clear();
@@ -182,4 +186,28 @@ SQResult& SQResult::operator=(const SQResult& other) {
         row.result = this;
     }
     return *this;
+}
+
+vector<SQResultRow>::iterator SQResult::begin() {
+    return rows.begin();
+}
+
+vector<SQResultRow>::iterator SQResult::end() {
+    return rows.end();
+}
+
+vector<SQResultRow>::const_iterator SQResult::begin() const {
+    return rows.begin();
+}
+
+vector<SQResultRow>::const_iterator SQResult::end() const {
+    return rows.end();
+}
+
+vector<SQResultRow>::const_iterator SQResult::cbegin() const {
+    return rows.cbegin();
+}
+
+vector<SQResultRow>::const_iterator SQResult::cend() const {
+    return rows.cend();
 }

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -1,5 +1,6 @@
 #include <libstuff/libstuff.h>
 #include "SQResult.h"
+#include <stdexcept>
 
 SQResultRow::SQResultRow(SQResult& result, size_t count) : vector<string>(count), result(&result) {
 }
@@ -211,3 +212,31 @@ vector<SQResultRow>::const_iterator SQResult::cbegin() const {
 vector<SQResultRow>::const_iterator SQResult::cend() const {
     return rows.cend();
 }
+
+void SQResult::resize(size_t newSize) {
+    rows.resize(newSize);
+    for (auto& row : rows) {
+        row.result = this;
+    }
+}
+
+void SQResult::push_back(const SQResultRow& row) {
+    SQResultRow newRow = row;
+    newRow.result = this;
+    rows.push_back(newRow);
+}
+
+void SQResult::emplace_back(const SQResultRow& row) {
+    SQResultRow newRow = row;
+    newRow.result = this;
+    rows.emplace_back(newRow);
+}
+
+SQResultRow& SQResult::back() {
+    return rows.back();
+}
+
+const SQResultRow& SQResult::back() const {
+    return rows.back();
+}
+

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -30,6 +30,9 @@ class SQResult {
 
     SQResult() = default;
     SQResult(SQResult const&) = default;
+    SQResult(vector<SQResultRow>&& rows, vector<string>&& headers)
+        : headers(move(headers)), rows(move(rows)) {
+    }
 
     // Accessors
     bool empty() const;
@@ -38,9 +41,7 @@ class SQResult {
     // Mutators
     void clear();
     void resize(size_t newSize);
-    void push_back(const SQResultRow&& row);
     void emplace_back(const SQResultRow&& row);
-    SQResultRow& back();
     const SQResultRow& back() const;
 
     // Operators

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -40,7 +40,7 @@ class SQResult {
 
     // Mutators
     void clear();
-    void emplace_back(const SQResultRow&& row);
+    void emplace_back(SQResultRow&& row);
     const SQResultRow& back() const;
 
     // Operators

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -40,7 +40,6 @@ class SQResult {
 
     // Mutators
     void clear();
-    void resize(size_t newSize);
     void emplace_back(const SQResultRow&& row);
     const SQResultRow& back() const;
 

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -38,6 +38,11 @@ class SQResult {
 
     // Mutators
     void clear();
+    void resize(size_t newSize);
+    void push_back(const SQResultRow& row);
+    void emplace_back(const SQResultRow& row);
+    SQResultRow& back();
+    const SQResultRow& back() const;
 
     // Operators
     SQResultRow& operator[](size_t rowNum);

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -34,6 +34,7 @@ class SQResult {
     // Accessors
     bool empty() const;
     size_t size() const;
+    const vector<SQResultRow>& getRows() const;
 
     // Mutators
     void clear();
@@ -50,4 +51,12 @@ class SQResult {
 
     // Deserializers
     bool deserialize(const string& json);
+
+    // Iterator support for range-based for loops
+    vector<SQResultRow>::iterator begin();
+    vector<SQResultRow>::iterator end();
+    vector<SQResultRow>::const_iterator begin() const;
+    vector<SQResultRow>::const_iterator end() const;
+    vector<SQResultRow>::const_iterator cbegin() const;
+    vector<SQResultRow>::const_iterator cend() const;
 };

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -34,13 +34,12 @@ class SQResult {
     // Accessors
     bool empty() const;
     size_t size() const;
-    const vector<SQResultRow>& getRows() const;
 
     // Mutators
     void clear();
     void resize(size_t newSize);
-    void push_back(const SQResultRow& row);
-    void emplace_back(const SQResultRow& row);
+    void push_back(const SQResultRow&& row);
+    void emplace_back(const SQResultRow&& row);
     SQResultRow& back();
     const SQResultRow& back() const;
 

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -58,8 +58,6 @@ class SQResult {
     bool deserialize(const string& json);
 
     // Iterator support for range-based for loops
-    vector<SQResultRow>::iterator begin();
-    vector<SQResultRow>::iterator end();
     vector<SQResultRow>::const_iterator begin() const;
     vector<SQResultRow>::const_iterator end() const;
     vector<SQResultRow>::const_iterator cbegin() const;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2640,21 +2640,21 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
                 }
 
                 if (error == SQLITE_ROW) {
-                    result.rows.emplace_back(SQResultRow(result, numColumns));
+                    result.emplace_back(SQResultRow(result, numColumns));
                     for (int i = 0; i < numColumns; i++) {
                         int colType = sqlite3_column_type(preparedStatement, i);
                         switch (colType) {
                             case SQLITE_INTEGER:
-                                result.rows.back()[i] = to_string(sqlite3_column_int64(preparedStatement, i));
+                                result.back()[i] = to_string(sqlite3_column_int64(preparedStatement, i));
                                 break;
                             case SQLITE_FLOAT:
-                                result.rows.back()[i] = to_string(sqlite3_column_double(preparedStatement, i));
+                                result.back()[i] = to_string(sqlite3_column_double(preparedStatement, i));
                                 break;
                             case SQLITE_TEXT:
-                                result.rows.back()[i] = reinterpret_cast<const char*>(sqlite3_column_text(preparedStatement, i));
+                                result.back()[i] = reinterpret_cast<const char*>(sqlite3_column_text(preparedStatement, i));
                                 break;
                             case SQLITE_BLOB:
-                                result.rows.back()[i] = string(static_cast<const char*>(sqlite3_column_blob(preparedStatement, i)), sqlite3_column_bytes(preparedStatement, i));
+                                result.back()[i] = string(static_cast<const char*>(sqlite3_column_blob(preparedStatement, i)), sqlite3_column_bytes(preparedStatement, i));
                                 break;
                             case SQLITE_NULL:
                                 // null string.

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2640,27 +2640,28 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
                 }
 
                 if (error == SQLITE_ROW) {
-                    result.emplace_back(SQResultRow(result, numColumns));
+                    SQResultRow row(result, numColumns);
                     for (int i = 0; i < numColumns; i++) {
                         int colType = sqlite3_column_type(preparedStatement, i);
                         switch (colType) {
                             case SQLITE_INTEGER:
-                                result.back()[i] = to_string(sqlite3_column_int64(preparedStatement, i));
+                                row[i] = to_string(sqlite3_column_int64(preparedStatement, i));
                                 break;
                             case SQLITE_FLOAT:
-                                result.back()[i] = to_string(sqlite3_column_double(preparedStatement, i));
+                                row[i] = to_string(sqlite3_column_double(preparedStatement, i));
                                 break;
                             case SQLITE_TEXT:
-                                result.back()[i] = reinterpret_cast<const char*>(sqlite3_column_text(preparedStatement, i));
+                                row[i] = reinterpret_cast<const char*>(sqlite3_column_text(preparedStatement, i));
                                 break;
                             case SQLITE_BLOB:
-                                result.back()[i] = string(static_cast<const char*>(sqlite3_column_blob(preparedStatement, i)), sqlite3_column_bytes(preparedStatement, i));
+                                row[i] = string(static_cast<const char*>(sqlite3_column_blob(preparedStatement, i)), sqlite3_column_bytes(preparedStatement, i));
                                 break;
                             case SQLITE_NULL:
                                 // null string.
                                 break;
                         }
                     }
+                    result.emplace_back(move(row));
                 } else {
                     if (error == SQLITE_DONE) {
                         // Treat "done" as just not-an-error.

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -796,7 +796,7 @@ void BedrockJobsCommand::process(SQLite& db) {
                 // Add arrays of children jobs to our response, 2 arrays to clearly distinguish between finished and cancelled children.
                 list<string> finishedChildJobArray;
                 list<string> cancelledChildJobArray;
-                for (auto row : childJobs.rows) {
+                for (auto row : childJobs) {
                     STable childJob;
                     childJob["jobID"] = row[0];
                     childJob["data"] = row[1];

--- a/plugins/MySQL.cpp
+++ b/plugins/MySQL.cpp
@@ -183,7 +183,7 @@ string MySQLPacket::serializeQueryResponse(int sequenceID, const SQResult& resul
     sendBuffer += eofPacket.serialize();
 
     // Add all the rows
-    for (const auto& row : result.rows) {
+    for (const auto& row : result) {
         // Now the row
         MySQLPacket rowPacket;
         rowPacket.sequenceID = ++sequenceID;
@@ -286,12 +286,12 @@ void BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
                     if (SIEquals(g_MySQLVariables[c][0], varName)) {
                         // Found it!
                         SINFO("Returning variable '" << varName << "'='" << g_MySQLVariables[c][1] << "'");
-                        result.rows.resize(1);
-                        result.rows[0].push_back(g_MySQLVariables[c][1]);
+                        result.resize(1);
+                        result[0].push_back(g_MySQLVariables[c][1]);
                         break;
                     }
                 }
-                if (result.rows.empty()) {
+                if (result.empty()) {
                     SHMMM("Couldn't find variable '" << varName << "', returning empty.");
                 }
                 s->send(MySQLPacket::serializeQueryResponse(packet.sequenceID, result));
@@ -302,10 +302,10 @@ void BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
                 result.headers.push_back("Variable Name");
                 result.headers.push_back("Value");
                 for (int c = 0; c < MYSQL_NUM_VARIABLES; ++c) {
-                    result.rows.resize(result.rows.size() + 1);
-                    result.rows.back().resize(2);
-                    result.rows.back()[0] = g_MySQLVariables[c][0];
-                    result.rows.back()[1] = g_MySQLVariables[c][1];
+                    result.resize(result.size() + 1);
+                    result.back().resize(2);
+                    result.back()[0] = g_MySQLVariables[c][0];
+                    result.back()[1] = g_MySQLVariables[c][1];
                 }
                 s->send(MySQLPacket::serializeQueryResponse(packet.sequenceID, result));
             } else if (SIEquals(query, "SHOW DATABASES;") ||
@@ -315,8 +315,8 @@ void BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
                 SINFO("Responding with fake database list");
                 SQResult result;
                 result.headers.push_back("Database");
-                result.rows.resize(1);
-                result.rows.back().push_back("main");
+                result.resize(1);
+                result.back().push_back("main");
                 s->send(MySQLPacket::serializeQueryResponse(packet.sequenceID, result));
             } else if (SIEquals(SToUpper(query), "SHOW /*!50002 FULL*/ TABLES;") ||
                        SIEquals(SToUpper(query), "SHOW FULL TABLES;")) {
@@ -378,8 +378,8 @@ void BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
                 SINFO("Responding fake version string");
                 SQResult result;
                 result.headers.push_back("version()");
-                result.rows.resize(1);
-                result.rows.back().push_back(BedrockPlugin_MySQL::mysqlVersion);
+                result.resize(1);
+                result.back().push_back(BedrockPlugin_MySQL::mysqlVersion);
                 s->send(MySQLPacket::serializeQueryResponse(packet.sequenceID, result));
             // Add SHOW KEYS() support
 

--- a/plugins/MySQL.cpp
+++ b/plugins/MySQL.cpp
@@ -280,43 +280,46 @@ void BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
             if (SREMatch(regExp, query, false, false, &matches)) {
                 string varName = matches[0];
                 // Loop across and look for it
-                SQResult result;
-                result.headers.push_back(varName);
+                vector<SQResultRow> rows;
                 for (int c = 0; c < MYSQL_NUM_VARIABLES; ++c) {
                     if (SIEquals(g_MySQLVariables[c][0], varName)) {
                         // Found it!
                         SINFO("Returning variable '" << varName << "'='" << g_MySQLVariables[c][1] << "'");
-                        result.resize(1);
-                        result[0].push_back(g_MySQLVariables[c][1]);
+                        SQResultRow row;
+                        row.push_back(g_MySQLVariables[c][1]);
+                        rows.push_back(row);
                         break;
                     }
                 }
-                if (result.empty()) {
+                if (rows.empty()) {
                     SHMMM("Couldn't find variable '" << varName << "', returning empty.");
                 }
+                vector<string> headers = {varName};
+                SQResult result(move(rows), move(headers));
                 s->send(MySQLPacket::serializeQueryResponse(packet.sequenceID, result));
             } else if (SIEquals(query, "SHOW VARIABLES;")) {
                 // Return the variable list
                 SINFO("Responding with fake variable list");
-                SQResult result;
-                result.headers.push_back("Variable Name");
-                result.headers.push_back("Value");
+                vector<SQResultRow> rows;
                 for (int c = 0; c < MYSQL_NUM_VARIABLES; ++c) {
-                    result.resize(result.size() + 1);
-                    result.back().resize(2);
-                    result.back()[0] = g_MySQLVariables[c][0];
-                    result.back()[1] = g_MySQLVariables[c][1];
+                    SQResultRow row;
+                    row.push_back(g_MySQLVariables[c][0]);
+                    row.push_back(g_MySQLVariables[c][1]);
+                    rows.push_back(row);
                 }
+                vector<string> headers = {"Variable Name", "Value"};
+                SQResult result(move(rows), move(headers));
                 s->send(MySQLPacket::serializeQueryResponse(packet.sequenceID, result));
             } else if (SIEquals(query, "SHOW DATABASES;") ||
                        SIEquals(SToUpper(query), "SELECT DATABASE();") ||
                        SIEquals(SToUpper(query), "SELECT * FROM (SELECT DATABASE() AS DATABASE_NAME) A WHERE A.DATABASE_NAME IS NOT NULL;")) {
                 // Return a fake "main" database
                 SINFO("Responding with fake database list");
-                SQResult result;
-                result.headers.push_back("Database");
-                result.resize(1);
-                result.back().push_back("main");
+                SQResultRow row;
+                row.push_back("main");
+                vector<SQResultRow> rows = {row};
+                vector<string> headers = {"Database"};
+                SQResult result(move(rows), move(headers));
                 s->send(MySQLPacket::serializeQueryResponse(packet.sequenceID, result));
             } else if (SIEquals(SToUpper(query), "SHOW /*!50002 FULL*/ TABLES;") ||
                        SIEquals(SToUpper(query), "SHOW FULL TABLES;")) {
@@ -376,10 +379,11 @@ void BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
             } else if (SIEquals(SToUpper(query), "SELECT VERSION();")) {
                 // Return our fake version
                 SINFO("Responding fake version string");
-                SQResult result;
-                result.headers.push_back("version()");
-                result.resize(1);
-                result.back().push_back(BedrockPlugin_MySQL::mysqlVersion);
+                SQResultRow row;
+                row.push_back(BedrockPlugin_MySQL::mysqlVersion);
+                vector<SQResultRow> rows = {row};
+                vector<string> headers = {"version()"};
+                SQResult result(move(rows), move(headers));
                 s->send(MySQLPacket::serializeQueryResponse(packet.sequenceID, result));
             // Add SHOW KEYS() support
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -67,7 +67,7 @@ SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, const string& file
         // Look up the existing wal setting for this DB.
         SQResult result;
         SQuery(db, "", "PRAGMA journal_mode;", result);
-        bool isDBCurrentlyUsingWAL2 = result.rows.size() && result.rows[0][0] == "wal2";
+        bool isDBCurrentlyUsingWAL2 = result.size() && result[0][0] == "wal2";
 
         // If the intended wal setting doesn't match the existing wal setting, change it.
         if (!hctree && !isDBCurrentlyUsingWAL2) {

--- a/test/clustertest/tests/FinishJobTest.cpp
+++ b/test/clustertest/tests/FinishJobTest.cpp
@@ -259,8 +259,8 @@ struct FinishJobTest : tpunit::TestFixture {
         SQResult result;
         list<string> ids = {parentID, finishedChildID, cancelledChildID};
         clusterTester->getTester(0).readDB("SELECT jobID, state FROM jobs WHERE jobID IN(" + SComposeList(ids) + ");", result);
-        ASSERT_EQUAL(result.rows.size(), 3);
-        for (auto& row : result.rows) {
+        ASSERT_EQUAL(result.size(), 3);
+        for (auto& row : result) {
             if (row[0] == parentID) {
                 ASSERT_EQUAL(row[1], "PAUSED");
             } else if (row[0] == finishedChildID) {

--- a/test/clustertest/tests/ForkCheckTest.cpp
+++ b/test/clustertest/tests/ForkCheckTest.cpp
@@ -17,7 +17,7 @@ struct ForkCheckTest : tpunit::TestFixture {
         tester.readDB("SELECT name FROM sqlite_schema WHERE type ='table' AND name LIKE 'journal%';", journals, online);
         uint64_t maxJournalCommit = 0;
         string maxJournalTable;
-        for (auto& row : journals.rows) {
+        for (auto& row : journals) {
             string maxID = tester.readDB("SELECT MAX(id) FROM " + row[0] + ";", online);
             try {
                 uint64_t maxCommitNum = stoull(maxID);

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -595,7 +595,7 @@ bool BedrockTester::readDB(const string& query, SQResult& result, bool online, i
             for (auto& v : vals) {
                 row.push_back(v);
             }
-            result.push_back(row);
+            result.push_back(move(row));
         }
         return true;
     } else {

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -558,11 +558,11 @@ string BedrockTester::readDB(const string& query, bool online, int64_t timeoutMS
         return "";
     }
 
-    if (result.rows[0].empty()) {
+    if (result[0].empty()) {
         return "";
     }
 
-    return result.rows[0][0];
+    return result[0][0];
 }
 
 bool BedrockTester::readDB(const string& query, SQResult& result, bool online, int64_t timeoutMS)
@@ -595,7 +595,7 @@ bool BedrockTester::readDB(const string& query, SQResult& result, bool online, i
             for (auto& v : vals) {
                 row.push_back(v);
             }
-            result.rows.push_back(row);
+            result.push_back(row);
         }
         return true;
     } else {

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -595,7 +595,7 @@ bool BedrockTester::readDB(const string& query, SQResult& result, bool online, i
             for (auto& v : vals) {
                 row.push_back(v);
             }
-            result.push_back(move(row));
+            result.emplace_back(move(row));
         }
         return true;
     } else {

--- a/test/tests/jobs/CreateJobsTest.cpp
+++ b/test/tests/jobs/CreateJobsTest.cpp
@@ -194,7 +194,7 @@ struct CreateJobsTest : tpunit::TestFixture {
         string query = "SELECT jobID, state FROM jobs WHERE jobID in (" + SQList(jobIDs) + ");";
         tester->readDB(query, result);
 
-        ASSERT_EQUAL(result.rows.size(), 0);
+        ASSERT_EQUAL(result.size(), 0);
     }
 
     void createUniqueChildWithWrongParent()

--- a/test/tests/jobs/GetJobsTest.cpp
+++ b/test/tests/jobs/GetJobsTest.cpp
@@ -79,7 +79,7 @@ struct GetJobsTest : tpunit::TestFixture {
         // `retryAfter`. We allow this to be within 3 seconds, because it's possible that the timestamps are generated
         // in sequential seconds, and so these can end up being, for instance, 5 minutes and 1 second different.
         SQResult jobData = getAllJobData(tester);
-        for (auto& row : jobData.rows) {
+        for (auto& row : jobData) {
             // Assert that the difference between "lastRun + 5min" and "nextRun" is less than 3 seconds.
             ASSERT_LESS_THAN(absoluteDiff(JobTestHelper::getTimestampForDateTimeString(row[2]) + 5 * 60, JobTestHelper::getTimestampForDateTimeString(row[3])), 3);
             ASSERT_EQUAL(row[1], "RUNQUEUED");
@@ -100,7 +100,7 @@ struct GetJobsTest : tpunit::TestFixture {
 
         // Now see what they look like.
         jobData = getAllJobData(tester);
-        for (auto& row : jobData.rows) {
+        for (auto& row : jobData) {
             // Should be queued again.
             ASSERT_EQUAL(row[1], "QUEUED");
 


### PR DESCRIPTION
### Details

These changes will also be used in https://github.com/Expensify/Auth/pull/16113 and https://github.com/Expensify/FuzzyBot/pull/310

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/522191

### Tests

Existing tests
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
