### PR TITLE
Protect pointer delete

### DIFF
--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -534,6 +534,7 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
 
 SQLite& BedrockTester::getSQLiteDB()
 {
+    lock_guard<decltype(_dbMutex)> lock(_dbMutex);
     if (!_db) {
         // Assumes wal2 mode.
         _db = new SQLite(_args["-db"], 1000000, 3000000, -1, 0, ENABLE_HCTREE);
@@ -542,10 +543,7 @@ SQLite& BedrockTester::getSQLiteDB()
 }
 
 void BedrockTester::freeDB() {
-    if (_db == nullptr) {
-        return;
-    }
-    lock_guard<decltype(_testersMutex)> lock(_testersMutex);
+    lock_guard<decltype(_dbMutex)> lock(_dbMutex);
     delete _db;
     _db = nullptr;
 }

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -542,6 +542,10 @@ SQLite& BedrockTester::getSQLiteDB()
 }
 
 void BedrockTester::freeDB() {
+    if (_db == nullptr) {
+        return;
+    }
+    lock_guard<decltype(_testersMutex)> lock(_testersMutex);
     delete _db;
     _db = nullptr;
 }

--- a/test/lib/BedrockTester.h
+++ b/test/lib/BedrockTester.h
@@ -124,6 +124,9 @@ class BedrockTester {
     // This is the underlying storage for `getSQLiteDB` and will only be initialized once per tester.
     SQLite* _db = nullptr;
 
+    // Locks around initializing and deleting _db in case a tester is being used concurrently
+    mutex _dbMutex;
+
     // The ports the server will listen on.
     uint16_t _serverPort;
     uint16_t _nodePort;


### PR DESCRIPTION
### Details

My PR here seems to have made it much more likely to make this race condition fail: https://github.com/Expensify/Auth/pull/16131#issuecomment-3050749255

~I think this is the source of our random segmentation faults we get in github when running Auth tests.~ (don't think this is the case anymore.. this seems to be a new segmentation fault that we can have thanks to the changes I'm proposing in Auth)

The fix is trying to make sure there can't be two threads calling `delete _db` before we make `_db = nullptr`

I'm not sure if there are other areas where we assign `_db` that should be protected, but at least this seems to be enough to fix the problem.

### Fixed Issues
Fixes https://github.com/Expensify/Auth/pull/16131#issuecomment-3050749255

### Tests

To make it easier to fail, you can check out https://github.com/Expensify/Auth/pull/16131

1. Run tests with `./authtest -only BatchTopUpCredits` many times and confirm that the test passes without crashing.

Without this bedrock PR, I get a lot this crash:

```
expensidev-2404->Auth/test (aldo_wait-for-tables-in-cluster-to-be-ready) > ./authtest -only BatchTopUpCredits
Aborted (core dumped)
```

specially if you checkout the mentioned Auth PR.



_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
