### PR TITLE
Only load SSL certs once at startup

### DIFF
--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -79,10 +79,8 @@ SSSLState::SSSLState(const string& hostname, int socket) {
         STHROW("Invalid host: " + hostname);
     }
 
-    // Do a bunch of TLS initialization.
     int lastResult = 0;
     char errorBuffer[500] = {0};
-
     lastResult = mbedtls_ssl_set_hostname(&ssl, domain.c_str());
     if (lastResult) {
         mbedtls_strerror(lastResult, errorBuffer, sizeof(errorBuffer));

--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -28,7 +28,7 @@ void SSSLState::initConfig() {
     const char* envCertPath = getenv("CERT_PATH");
     const string certPath = envCertPath ? envCertPath : "/etc/ssl/certs/";
     lastResult = mbedtls_x509_crt_parse_path(&_cacert, certPath.c_str());
-    bool certificatesLoaded = false;
+    bool successfullyLoadedCACerts = false;
     if (lastResult < 0) {
 
         mbedtls_strerror(lastResult, errorBuffer, sizeof(errorBuffer));
@@ -42,13 +42,13 @@ void SSSLState::initConfig() {
         }
     } else if (lastResult > 0) {
         SWARN("Loaded CA certificates from " + certPath + " directory, but " + to_string(lastResult) + " certificates failed to parse");
-        certificatesLoaded = true;
+        successfullyLoadedCACerts = true;
     } else {
-        certificatesLoaded = true;
+        successfullyLoadedCACerts = true;
     }
 
     // These calls do not return error codes.
-    mbedtls_ssl_conf_authmode(&_conf, certificatesLoaded ? MBEDTLS_SSL_VERIFY_REQUIRED : MBEDTLS_SSL_VERIFY_OPTIONAL);
+    mbedtls_ssl_conf_authmode(&_conf, successfullyLoadedCACerts ? MBEDTLS_SSL_VERIFY_REQUIRED : MBEDTLS_SSL_VERIFY_OPTIONAL);
     mbedtls_ssl_conf_rng(&_conf, mbedtls_ctr_drbg_random, &_ctr_drbg);
     mbedtls_ssl_conf_ca_chain(&_conf, &_cacert, nullptr);
 

--- a/libstuff/SSSLState.cpp
+++ b/libstuff/SSSLState.cpp
@@ -16,8 +16,8 @@ void SSSLState::initConfig() {
     mbedtls_ctr_drbg_init(&_ctr_drbg);
     mbedtls_ssl_config_init(&_conf);
 
-    int lastResult = mbedtls_ctr_drbg_seed(&_ctr_drbg, mbedtls_entropy_func, &_ec, nullptr, 0);
     char errorBuffer[500] = {0};
+    int lastResult = mbedtls_ctr_drbg_seed(&_ctr_drbg, mbedtls_entropy_func, &_ec, nullptr, 0);
     if (lastResult) {
         mbedtls_strerror(lastResult, errorBuffer, sizeof(errorBuffer));
         STHROW("mbedtls_ctr_drbg_seed failed with error " + to_string(lastResult) + ": " + errorBuffer);

--- a/libstuff/SSSLState.h
+++ b/libstuff/SSSLState.h
@@ -6,6 +6,8 @@
 #include <mbedtls/net_sockets.h>
 #include <mbedtls/x509_crt.h>
 #include <string>
+#include <mutex>
+#include <atomic>
 
 using namespace std;
 class SFastBuffer;
@@ -28,5 +30,11 @@ class SSSLState {
     mbedtls_ssl_config conf;
     mbedtls_ssl_context ssl;
     mbedtls_net_context net_ctx;
-    mbedtls_x509_crt cacert;
+    static mbedtls_x509_crt _cacert;
+
+  private:
+    static mutex _certificateMutex;
+    static atomic<bool> _certificatesLoadingComplete;
+    static atomic<bool> _certificatesLoaded;
+    static void _loadCerts();
 };

--- a/libstuff/SSSLState.h
+++ b/libstuff/SSSLState.h
@@ -6,18 +6,18 @@
 #include <mbedtls/net_sockets.h>
 #include <mbedtls/x509_crt.h>
 #include <string>
-#include <mutex>
-#include <atomic>
 
 using namespace std;
 class SFastBuffer;
 
 class SSSLState {
   public:
-
     SSSLState(const string& hostname);
     SSSLState(const string& hostname, int socket);
     ~SSSLState();
+
+    static void initConfig();
+    static void freeConfig();
 
     int send(const char* buffer, int length);
     int send(const SFastBuffer& buffer);
@@ -25,16 +25,12 @@ class SSSLState {
     int recv(char* buffer, int length);
     bool recvAppend(SFastBuffer& recvBuffer);
 
-    mbedtls_entropy_context ec;
-    mbedtls_ctr_drbg_context ctr_drbg;
-    mbedtls_ssl_config conf;
     mbedtls_ssl_context ssl;
     mbedtls_net_context net_ctx;
-    static mbedtls_x509_crt _cacert;
 
   private:
-    static mutex _certificateMutex;
-    static atomic<bool> _certificatesLoadingComplete;
-    static atomic<bool> _certificatesLoaded;
-    static void _loadCerts();
+    static mbedtls_entropy_context _ec;
+    static mbedtls_ctr_drbg_context _ctr_drbg;
+    static mbedtls_ssl_config _conf;
+    static mbedtls_x509_crt _cacert;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,7 @@
 #include <plugins/Jobs.h>
 #include <plugins/MySQL.h>
 #include <libstuff/libstuff.h>
+#include <libstuff/SSSLState.h>
 #include <sqlitecluster/SQLite.h>
 #include <VMTouch.h>
 
@@ -339,6 +340,9 @@ int main(int argc, char* argv[]) {
     // Log stack traces if we have unhandled exceptions.
     set_terminate(STerminateHandler);
 
+    // Set up SSL configuration
+    SSSLState::initConfig();
+
     // Create our BedrockServer object so we can keep it for the life of the
     // program.
     SINFO("Starting bedrock server");
@@ -398,6 +402,9 @@ int main(int argc, char* argv[]) {
     SINFO("Deleting BedrockServer");
     delete _server;
     SINFO("BedrockServer deleted");
+
+    // Tear down SSL configuration
+    SSSLState::freeConfig();
 
     // Finished with our signal handler.
     SStopSignalThread();

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3,6 +3,7 @@
 #include <libstuff/SData.h>
 #include <libstuff/libstuff.h>
 #include <test/lib/BedrockTester.h>
+#include <libstuff/SSSLState.h>
 
 /*
  * Command line args to support:
@@ -24,6 +25,9 @@ int main(int argc, char* argv[]) {
 
     // Catch sigint.
     signal(SIGINT, sigclean);
+
+    // Set up SSL configuration
+    SSSLState::initConfig();
 
     // Tests to run (or skip);
     set<string> include;
@@ -95,6 +99,9 @@ int main(int argc, char* argv[]) {
             retval = 1;
         }
     }
+
+    // Tear down SSL configuration
+    SSSLState::freeConfig();
 
     return retval;
 }


### PR DESCRIPTION
### Details
This moves all of the configuration of SSL options out of the initialization for each connection and does it exactly once at startup. The linked issue has a bit more detail about this. It seems that parsing the certificate chain on each connection may be slowing backups down significantly. In any case, it should be more efficient to do it this way.

This is basically all the same code as before, with some of it moved to two new static methods, and a few variables made private.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/523601

### Tests
All auth tests pass (with https://github.com/Expensify/Auth/pull/16176)
All fuzzybot tests pass (no FuzzyBot PR needed)
All EBM tests pass (no EBM PR needed)
Edited EBM tests to have a 10x bigger database to backup to exercise SSL some more and it worked fine.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
