### PR TITLE
Add detached state to status command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1676,7 +1676,7 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         content["version"] = _version;
         content["host"] = args["-nodeHost"];
         content["commandCount"] = BedrockCommand::getCommandCount();
-        content["detached"] = isDetached() ? "true" : "false";
+        content["isDetached"] = isDetached() ? "true" : "false";
 
         {
             // Make it known if anything is known to cause crashes.


### PR DESCRIPTION
### Details
Add detached state to bedrock status command. 

### Fixed Issues
Related to: https://github.com/Expensify/Expensify/issues/519907

### Tests
<img width="1101" height="205" alt="image" src="https://github.com/user-attachments/assets/5d824175-c175-42d4-aa8e-7bbbbbedb0b7" />

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
