### PR TITLE
Add outstandingFramesToCommit to _status output

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1677,6 +1677,8 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         content["host"] = args["-nodeHost"];
         content["commandCount"] = BedrockCommand::getCommandCount();
         content["isDetached"] = isDetached() ? "true" : "false";
+        content["detached"] = isDetached() ? "true" : "false";
+        content["outstandingFramesToCheckpoint"] = _syncNode->getOutstandingFramesToCheckpoint();
 
         {
             // Make it known if anything is known to cause crashes.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1677,7 +1677,6 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         content["host"] = args["-nodeHost"];
         content["commandCount"] = BedrockCommand::getCommandCount();
         content["isDetached"] = isDetached() ? "true" : "false";
-        content["detached"] = isDetached() ? "true" : "false";
         content["outstandingFramesToCheckpoint"] = _syncNode->getOutstandingFramesToCheckpoint();
 
         {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1677,7 +1677,6 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
         content["host"] = args["-nodeHost"];
         content["commandCount"] = BedrockCommand::getCommandCount();
         content["isDetached"] = isDetached() ? "true" : "false";
-        content["outstandingFramesToCheckpoint"] = _syncNode->getOutstandingFramesToCheckpoint();
 
         {
             // Make it known if anything is known to cause crashes.
@@ -1739,6 +1738,7 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command) {
             // Set some information about this node.
             content["CommitCount"] = to_string(_syncNodeCopy->getCommitCount());
             content["priority"] = to_string(_syncNodeCopy->getPriority());
+            content["outstandingFramesToCheckpoint"] = to_string(_syncNodeCopy->getOutstandingFramesToCheckpoint());
             _syncNodeCopy = nullptr;
         } else {
             content["syncNodeAvailable"] = "false";

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -284,6 +284,7 @@ int SQLite::_progressHandlerCallback(void* arg) {
 int SQLite::_walHookCallback(void* sqliteObject, sqlite3* db, const char* name, int walFileSize) {
     SQLite* sqlite = static_cast<SQLite*>(sqliteObject);
     sqlite->_sharedData.outstandingFramesToCheckpoint = walFileSize;
+    sqlite->_sharedData.knownOutstandingFramesToCheckpoint = walFileSize;
     return SQLITE_OK;
 }
 
@@ -1024,7 +1025,7 @@ uint64_t SQLite::getCommitCount() const {
 }
 
 uint64_t SQLite::getOutstandingFramesToCheckpoint() const {
-    return _sharedData.outstandingFramesToCheckpoint;
+    return _sharedData.knownOutstandingFramesToCheckpoint;
 }
 
 size_t SQLite::getLastWriteChangeCount() {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1018,9 +1018,13 @@ int64_t SQLite::getLastInsertRowID() {
     int64_t sqliteRowID = (int64_t)sqlite3_last_insert_rowid(_db);
     return sqliteRowID;
 }
-
+ 
 uint64_t SQLite::getCommitCount() const {
     return _sharedData.commitCount;
+}
+
+uint64_t SQLite::getOutstandingFramesToCheckpoint() const {
+    return _sharedData.outstandingFramesToCheckpoint;
 }
 
 size_t SQLite::getLastWriteChangeCount() {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1018,7 +1018,7 @@ int64_t SQLite::getLastInsertRowID() {
     int64_t sqliteRowID = (int64_t)sqlite3_last_insert_rowid(_db);
     return sqliteRowID;
 }
- 
+
 uint64_t SQLite::getCommitCount() const {
     return _sharedData.commitCount;
 }

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -342,6 +342,10 @@ class SQLite {
         // no ill effects, but currently we use it to set a floor on the number of frames we will try and checkpoint.
         atomic<size_t> outstandingFramesToCheckpoint = 0;
 
+        // Like above, this records the number of frames that we know are currently waiting to be checkpointed, however it
+        // is not reset at the end of each checkpoint. This was the graph that relies on this value won't dip to 0
+        atomic<size_t> knownOutstandingFramesToCheckpoint = 0;
+
         // This can be locked in exclusive mode to prevent all writes. This exists to support the `BlockWrites` command.
         shared_mutex writeLock;
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -200,6 +200,9 @@ class SQLite {
     // database.
     uint64_t getCommitCount() const;
 
+    // Returns the number of WAL frames that are currently waiting to be checkpointed.
+    uint64_t getOutstandingFramesToCheckpoint() const;
+
     // Returns the current state of the database, as a SHA1 hash of all queries committed.
     string getCommittedHash();
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -343,7 +343,7 @@ class SQLite {
         atomic<size_t> outstandingFramesToCheckpoint = 0;
 
         // Like above, this records the number of frames that we know are currently waiting to be checkpointed, however it
-        // is not reset at the end of each checkpoint. This was the graph that relies on this value won't dip to 0
+        // is not reset at the end of each checkpoint. This way the graph that relies on this value won't dip to 0
         atomic<size_t> knownOutstandingFramesToCheckpoint = 0;
 
         // This can be locked in exclusive mode to prevent all writes. This exists to support the `BlockWrites` command.

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -346,8 +346,14 @@ const string SQLiteNode::getLeaderVersion() const {
 
 uint64_t SQLiteNode::getCommitCount() const {
     // Note: this can skip locking because it only accesses a single atomic variable, which makes it safe to call in
-    // private methods. (Yes, SQLite::SharedData::commitCount is atomic, go check).
+    // private methods.
     return _db.getCommitCount();
+}
+
+uint64_t SQLiteNode::getOutstandingFramesToCheckpoint() const {
+    // Note: this can skip locking because it only accesses a single atomic variable, which makes it safe to call in
+    // private methods. (Yes, SQLite::SharedData::outstandingFramesToCheckpoint is atomic, go check).
+    return _db.getOutstandingFramesToCheckpoint();
 }
 
 bool SQLiteNode::commitInProgress() const {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -346,13 +346,13 @@ const string SQLiteNode::getLeaderVersion() const {
 
 uint64_t SQLiteNode::getCommitCount() const {
     // Note: this can skip locking because it only accesses a single atomic variable, which makes it safe to call in
-    // private methods.
+    // private methods. (Yes, SQLite::SharedData::getCommitCount is atomic, go check).
     return _db.getCommitCount();
 }
 
 uint64_t SQLiteNode::getOutstandingFramesToCheckpoint() const {
     // Note: this can skip locking because it only accesses a single atomic variable, which makes it safe to call in
-    // private methods. (Yes, SQLite::SharedData::outstandingFramesToCheckpoint is atomic, go check).
+    // private methods.
     return _db.getOutstandingFramesToCheckpoint();
 }
 

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -115,6 +115,9 @@ class SQLiteNode : public STCPManager {
     // Does not block.
     uint64_t getCommitCount() const;
 
+    // Get's the number of WAL frames that are currently waiting to be checkpointed.
+    uint64_t getOutstandingFramesToCheckpoint() const;
+
     // Get's the current leader version (our own version if we're leading)
     // Can block.
     const string getLeaderVersion() const;

--- a/test/tests/StatusTest.cpp
+++ b/test/tests/StatusTest.cpp
@@ -11,6 +11,7 @@ struct StatusTest : tpunit::TestFixture {
         string response = tester.executeWaitMultipleData({status})[0].content;
         ASSERT_TRUE(SContains(response, "plugins"));
         ASSERT_TRUE(SContains(response, "multiWriteManualBlacklist"));
+        ASSERT_TRUE(SContains(response, "outstandingFramesToCheckpoint"));
     }
 
 } __StatusTest;


### PR DESCRIPTION
### Details
We need to graph the outstanding frames to commit; to do that, we need a reliable way to get that count.
Currently, we rely on logs, which may be delayed. This PR adds the ability to query Bedrock directly for its WAL frame count.

### Fixed Issues
Related to: https://github.com/Expensify/Expensify/issues/527326

### Tests
<img width="1275" height="770" alt="image" src="https://github.com/user-attachments/assets/7777197f-fb40-435a-b2f5-abfefed74e8c" />
