### PR TITLE
Log an alert when we fail to create a job for any reason

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -42,25 +42,21 @@ void SLogStackTrace(int level) {
 
 // If the param name is not in this whitelist, we will log <REDACTED> in addLogParams.
 static set<string> PARAMS_WHITELIST = {
-    "approver",
-    "approvers",
     "command",
     "Connection",
     "Content-Length",
     "count",
-    "employeeEmail",
-    "employees",
     "indexName",
     "isUnique",
     "logParam",
     "message",
     "peer",
-    "policyID",
     "reason",
     "requestID",
     "status",
     "topic",
     "userID",
+    "what",
 };
 
 string addLogParams(string&& message, const STable& params) {


### PR DESCRIPTION
### Details

### Fixed Issues
In https://github.com/Expensify/Web-Expensify/pull/47929, we saw that we had been failing to create jobs for a long while. This PR intends to make such cases more obvious in the future by logging an alert.

### Tests
Run this command:
```
CreateJob
asdf
```

Check logs:
```
2025-08-04T12:03:42.897613+00:00 expensidev-2404 bedrock: P9m2ok (Jobs.cpp:324) peek [socket0] [alrt] {Jobs} Failed creating job ~~ what: '402 Missing name'
```
