### PR TITLE
Handle `HTTP 204 No Content` responses

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -110,11 +110,11 @@ void SStandaloneHTTPSManager::postPoll(fd_map& fdm, SStandaloneHTTPSManager::Tra
         // Shut down the socket, we're done with it.
         transaction.s->shutdown(Socket::CLOSED);
 
-        // This is supposed to check for a "200" response, which it does very poorly. It also checks for message
+        // This is supposed to check for a "200" or "204 No Content"response, which it does very poorly. It also checks for message
         // content. Why this is the what constitutes a valid response is lost to time. Any well-formed response should
         // be valid here, and this should get cleaned up. However, this requires testing anything that might rely on
         // the existing behavior, which is an exercise for later.
-        if (SContains(transaction.fullResponse.methodLine, " 200") || transaction.fullResponse.content.size()) {
+        if (SContains(transaction.fullResponse.methodLine, " 200") || SContains(transaction.fullResponse.methodLine, "204") || transaction.fullResponse.content.size()) {
             // Pass the transaction down to the subclass.
             _onRecv(&transaction);
         } else {


### PR DESCRIPTION
### Details

Creating/updating a PIN returns a `HTTP 204 No Content` with our existing logic, that is treated as a failure. I've updated the logic to handle a successful request with no response content. Related Auth PR: https://github.com/Expensify/Auth/pull/16812

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/530543

### Tests

Tested in: https://github.com/Expensify/Auth/pull/16812

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
