### PR TITLE
Add support for querying connection id in MySQL plugin

### DIFF
--- a/plugins/MySQL.cpp
+++ b/plugins/MySQL.cpp
@@ -387,7 +387,7 @@ void BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
                 s->send(MySQLPacket::serializeQueryResponse(packet.sequenceID, result));
             // Add SHOW KEYS() support
 
-            } else if (SREMatch("^SELECT\\s+CONNECTION_ID\\(\\s*\\)(?:\\s+AS\\s+(\\w+))?\\s*;?$", SToUpper(query), false, false, nullptr)) {
+            } else if (SREMatch("^SELECT\\s+CONNECTION_ID\\(\\s*\\)(?:\\s+AS\\s+(\\w+))?\\s*;?$", SToUpper(query), false, false, &matches)) {
                 // Return connection ID - handles SELECT connection_id(); and SELECT connection_id() AS alias;
                 SINFO("Responding with connection ID");
                 SQResultRow row;
@@ -395,10 +395,9 @@ void BedrockPlugin_MySQL::onPortRecv(STCPManager::Socket* s, SData& request) {
                 vector<SQResultRow> rows = {row};
                 
                 // Extract the alias if present, otherwise use default column name
-                vector<string> matches;
                 string columnName = "connection_id()";
-                if (SREMatch("^SELECT\\s+CONNECTION_ID\\(\\s*\\)(?:\\s+AS\\s+(\\w+))?\\s*;?$", SToUpper(query), false, false, &matches) && matches.size() > 1) {
-                    columnName = SToLower(matches[1]); // Use the alias if provided (matches[1] is the captured group)
+                if (!matches.empty()) {
+                    columnName = SToLower(matches[0]); // Use the alias if provided
                 }
                 
                 vector<string> headers = {columnName};


### PR DESCRIPTION
### Details

Implements a shim for `SELECT connection_id()`, which is the only missing feature that I couldn't figure out how to easily work around in my Beekeeper Studio fork

This PR is a subset of https://github.com/Expensify/Bedrock/pull/2262

### Fixed Issues
Fixes GH_LINK

### Tests
1. Check out my [Expensidev PR](https://github.com/Expensify/Expensidev/pull/966) and do `vagrant reload`
2. Check out and build this PR
3. Build and run [my fork of Beekeeper Studio](https://github.com/beekeeper-studio/beekeeper-studio/pull/3478)
4. Create a new connection in Beekeeper, select Bedrock, then in the connection details, use expensify.com.dev as the host and port 3307 for the Bedrock db and 3308 for the Auth db
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
