### PR TITLE
Internally store `SQResult` data with SQLite types.

### DIFF
--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -34,6 +34,14 @@ size_t SQResultRow::size() const {
     return data.size();
 }
 
+string& SQResultRow::at(size_t index) {
+    return data.at(index);
+}
+
+const string& SQResultRow::at(size_t index) const {
+    return data.at(index);
+}
+
 string& SQResultRow::operator[](const size_t& rowNum) {
     try {
         return data.at(rowNum);
@@ -89,6 +97,10 @@ const string& SQResultRow::operator[](const string& key) const {
         }
     }
     STHROW_STACK("No column named " + key);
+}
+
+SQResultRow::operator const std::vector<std::string>&() const {
+    return data;
 }
 
 string SQResult::serializeToJSON() const {

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -3,19 +3,23 @@
 #include "libstuff/SQResultFormatter.h"
 #include <stdexcept>
 
-SQResultRow::SQResultRow(SQResult& result, size_t count) : vector<string>(count), result(&result) {
+SQResultRow::SQResultRow(SQResult& result, size_t count) : result(&result) {
 }
 
-SQResultRow::SQResultRow() : vector<string>(), result(nullptr) {
+SQResultRow::SQResultRow() : result(nullptr) {
 }
 
 void SQResultRow::push_back(const string& s) {
-    vector<string>::push_back(s);
+    data.push_back(s);
+}
+
+vector<string>::iterator SQResultRow::end() {
+    return data.end();
 }
 
 string& SQResultRow::operator[](const size_t& rowNum) {
     try {
-        return at(rowNum);
+        return data.at(rowNum);
     } catch (const out_of_range& e) {
         SINFO("SQResultRow::operator[] out of range", {{"rowNum", to_string(rowNum)}});
         STHROW_STACK("Out of range");
@@ -23,7 +27,7 @@ string& SQResultRow::operator[](const size_t& rowNum) {
 }
 const string& SQResultRow::operator[](const size_t& rowNum) const {
     try {
-        return at(rowNum);
+        return data.at(rowNum);
     } catch (const out_of_range& e) {
         SINFO("SQResultRow::operator[] out of range", {{"rowNum", to_string(rowNum)}});
         STHROW_STACK("Out of range");
@@ -31,7 +35,7 @@ const string& SQResultRow::operator[](const size_t& rowNum) const {
 }
 
 SQResultRow& SQResultRow::operator=(const SQResultRow& other) {
-    vector<string>::operator=(other);
+    data = other.data;
     result = other.result;
     return *this;
 }
@@ -41,7 +45,7 @@ string& SQResultRow::operator[](const string& key) {
         for (size_t i = 0; i < result->headers.size(); i++) {
 
             // If the headers have more entries than the row (they really shouldn't), break early instead of segfaulting.
-            if (i >= size()) {
+            if (i >= data.size()) {
                 break;
             }
 
@@ -58,7 +62,7 @@ const string& SQResultRow::operator[](const string& key) const {
         for (size_t i = 0; i < result->headers.size(); i++) {
 
             // If the headers have more entries than the row (they really shouldn't), break early instead of segfaulting.
-            if (i >= size()) {
+            if (i >= data.size()) {
                 break;
             }
 
@@ -117,7 +121,7 @@ bool SQResult::deserialize(const string& json) {
             }
 
             // Insert the values
-            vector<string>& row = rows[rowIndex++];
+            SQResultRow& row = rows[rowIndex++];
             row.insert(row.end(), jsonRow.begin(), jsonRow.end());
         }
 

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -171,11 +171,15 @@ string SQResultRow::at(size_t index) {
     return data.at(index);
 }
 
+SQResultRow::ColVal& SQResultRow::get(size_t index) {
+    return data.at(index);
+}
+
 const string SQResultRow::at(size_t index) const {
     return data.at(index);
 }
 
-SQResultRow::ColVal::operator std::string() const {
+SQResultRow::ColVal::operator string() const {
     switch (type) {
         case TYPE::TEXT:
         case TYPE::BLOB:

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 
 SQResultRow::SQResultRow(SQResult& result, size_t count) : result(&result) {
+    data.resize(count);
 }
 
 SQResultRow::SQResultRow() : result(nullptr) {

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -17,6 +17,14 @@ SQResultRow::ColVal& SQResultRow::ColVal::operator=(string&& val) {
     return *this;
 }
 
+SQResultRow::ColVal::ColVal(const char* val) : type(SQResultRow::ColVal::TYPE::TEXT), text(val ? val : "") {}
+
+SQResultRow::ColVal& SQResultRow::ColVal::operator=(const char* val) {
+    type = TYPE::TEXT;
+    text = val ? val : "";
+    return *this;
+}
+
 SQResultRow::SQResultRow(SQResult& result, size_t count) : result(&result) {
     data.resize(count);
 }
@@ -54,6 +62,10 @@ string operator+(const char* lhs, const SQResultRow::ColVal& rhs) {
 
 string operator+(const SQResultRow::ColVal& lhs, const char* rhs) {
     return static_cast<string>(lhs) + string(rhs);
+}
+
+string operator+(const SQResultRow::ColVal& lhs, const SQResultRow::ColVal& rhs) {
+    return static_cast<string>(lhs) + static_cast<string>(rhs);
 }
 
 bool operator==(const SQResultRow::ColVal& a, const string& b) {
@@ -121,6 +133,10 @@ bool SQResultRow::ColVal::empty() const {
     return false;
 }
 
+size_t SQResultRow::ColVal::size() const {
+    return static_cast<string>(*this).size();
+}
+
 ostream& operator<<(ostream& os, const SQResultRow::ColVal& v) {
     // Reuse the string conversion which already formats REAL reasonably.
     os << static_cast<string>(v);
@@ -176,7 +192,7 @@ SQResultRow::ColVal::operator std::string() const {
     }
 }
 
-SQResultRow::ColVal& SQResultRow::operator[](const size_t& rowNum) {
+string SQResultRow::operator[](const size_t& rowNum) {
     try {
         return data.at(rowNum);
     } catch (const out_of_range& e) {
@@ -184,7 +200,7 @@ SQResultRow::ColVal& SQResultRow::operator[](const size_t& rowNum) {
         STHROW_STACK("Out of range");
     }
 }
-const SQResultRow::ColVal& SQResultRow::operator[](const size_t& rowNum) const {
+const string SQResultRow::operator[](const size_t& rowNum) const {
     try {
         return data.at(rowNum);
     } catch (const out_of_range& e) {
@@ -199,7 +215,7 @@ SQResultRow& SQResultRow::operator=(const SQResultRow& other) {
     return *this;
 }
 
-SQResultRow::ColVal& SQResultRow::operator[](const string& key) {
+string SQResultRow::operator[](const string& key) {
     if (result) {
         for (size_t i = 0; i < result->headers.size(); i++) {
 
@@ -216,7 +232,7 @@ SQResultRow::ColVal& SQResultRow::operator[](const string& key) {
     STHROW_STACK("No column named " + key);
 }
 
-const SQResultRow::ColVal& SQResultRow::operator[](const string& key) const {
+const string SQResultRow::operator[](const string& key) const {
     if (result) {
         for (size_t i = 0; i < result->headers.size(); i++) {
 

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -17,6 +17,22 @@ vector<string>::iterator SQResultRow::end() {
     return data.end();
 }
 
+vector<string>::const_iterator SQResultRow::end() const {
+    return data.end();
+}
+
+vector<string>::const_iterator SQResultRow::begin() const {
+    return data.begin();
+}
+
+bool SQResultRow::empty() const {
+    return data.empty();
+}
+
+size_t SQResultRow::size() const {
+    return data.size();
+}
+
 string& SQResultRow::operator[](const size_t& rowNum) {
     try {
         return data.at(rowNum);

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -253,7 +253,7 @@ const string SQResultRow::operator[](const string& key) const {
     STHROW_STACK("No column named " + key);
 }
 
-SQResultRow::operator const std::vector<std::string>() const {
+SQResultRow::operator vector<string>() const {
     vector<string> out(data.size());
     for (size_t i = 0; i < data.size(); i++) {
         out[i] = data[i];

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -159,7 +159,9 @@ bool SQResult::deserialize(const string& json) {
 
             // Insert the values
             SQResultRow& row = rows[rowIndex++];
-            row.insert(row.end(), jsonRow.begin(), jsonRow.end());
+            for (const string& s : jsonRow) {
+                row.push_back(s);
+            }
         }
 
         // Success!

--- a/libstuff/SQResult.cpp
+++ b/libstuff/SQResult.cpp
@@ -1,29 +1,7 @@
 #include <libstuff/libstuff.h>
 #include "SQResult.h"
 #include "libstuff/SQResultFormatter.h"
-#include <libstuff/sqlite3.h>
 #include <stdexcept>
-#include <cmath>
-
-SQResultRow::ColVal& SQResultRow::ColVal::operator=(const string& val) {
-    type = TYPE::TEXT;
-    text = val;
-    return *this;
-}
-
-SQResultRow::ColVal& SQResultRow::ColVal::operator=(string&& val) {
-    type = TYPE::TEXT;
-    text = std::move(val);
-    return *this;
-}
-
-SQResultRow::ColVal::ColVal(const char* val) : type(SQResultRow::ColVal::TYPE::TEXT), text(val ? val : "") {}
-
-SQResultRow::ColVal& SQResultRow::ColVal::operator=(const char* val) {
-    type = TYPE::TEXT;
-    text = val ? val : "";
-    return *this;
-}
 
 SQResultRow::SQResultRow(SQResult& result, size_t count) : result(&result) {
     data.resize(count);
@@ -32,130 +10,19 @@ SQResultRow::SQResultRow(SQResult& result, size_t count) : result(&result) {
 SQResultRow::SQResultRow() : result(nullptr) {
 }
 
-SQResultRow::ColVal::ColVal() : type(SQResultRow::ColVal::TYPE::NONE) {
-}
-
-SQResultRow::ColVal::ColVal(int64_t val) : type(SQResultRow::ColVal::TYPE::INTEGER), integer(val) {
-}
-
-SQResultRow::ColVal::ColVal(double val) : type(SQResultRow::ColVal::TYPE::REAL), real(val) {
-}
-
-SQResultRow::ColVal::ColVal(const string& val) : type(SQResultRow::ColVal::TYPE::TEXT), text(val) {
-}
-
-SQResultRow::ColVal::ColVal(TYPE t, const string& val) : type(t), text(val) {
-}
-
-string operator+(string lhs, const SQResultRow::ColVal& rhs) {
-    lhs += static_cast<string>(rhs);
-    return lhs;
-}
-
-string operator+(const SQResultRow::ColVal& lhs, string rhs) {
-    return static_cast<string>(lhs) + rhs;
-}
-
-string operator+(const char* lhs, const SQResultRow::ColVal& rhs) {
-    return string(lhs) + static_cast<string>(rhs);
-}
-
-string operator+(const SQResultRow::ColVal& lhs, const char* rhs) {
-    return static_cast<string>(lhs) + string(rhs);
-}
-
-string operator+(const SQResultRow::ColVal& lhs, const SQResultRow::ColVal& rhs) {
-    return static_cast<string>(lhs) + static_cast<string>(rhs);
-}
-
-bool operator==(const SQResultRow::ColVal& a, const string& b) {
-    return static_cast<string>(a) == b;
-}
-
-bool operator==(const string& a, const SQResultRow::ColVal& b) {
-    return a == static_cast<string>(b);
-}
-
-bool operator==(const SQResultRow::ColVal& a, const char* b) {
-    return static_cast<string>(a) == string(b ? b : "");
-}
-
-bool operator==(const char* a, const SQResultRow::ColVal& b) {
-    return string(a ? a : "") == static_cast<string>(b);
-}
-
-bool operator==(const SQResultRow::ColVal& a, const SQResultRow::ColVal& b) {
-    // Types must match
-    if (a.type != b.type) {
-        return false;
-    }
-
-    switch (a.type) {
-        case SQResultRow::ColVal::TYPE::NONE:
-            // Consider two NONEs equal
-            return true;
-
-        case SQResultRow::ColVal::TYPE::INTEGER:
-            return a.integer == b.integer;
-
-        case SQResultRow::ColVal::TYPE::REAL: {
-            // Reasonable floating-point equality: combined abs/rel tolerance
-            double da = a.real;
-            double db = b.real;
-            double diff = da - db;
-            if (diff < 0) diff = -diff;
-
-            const double absTol = 1e-12;
-            const double relTol = 1e-9;
-
-            double aad = da; if (aad < 0) aad = -aad;
-            double abd = db; if (abd < 0) abd = -abd;
-            double scale = (aad > abd) ? aad : abd;
-
-            return diff <= absTol + relTol * scale;
-        }
-
-        case SQResultRow::ColVal::TYPE::TEXT:
-        case SQResultRow::ColVal::TYPE::BLOB:
-            return a.text == b.text;
-    }
-
-    return false;
-}
-
-bool SQResultRow::ColVal::empty() const {
-    if (type == TYPE::NONE) {
-        return true;
-    }
-    if ((type == TYPE::TEXT || type == TYPE::BLOB) && text.empty()) {
-        return true;
-    }
-    return false;
-}
-
-size_t SQResultRow::ColVal::size() const {
-    return static_cast<string>(*this).size();
-}
-
-ostream& operator<<(ostream& os, const SQResultRow::ColVal& v) {
-    // Reuse the string conversion which already formats REAL reasonably.
-    os << static_cast<string>(v);
-    return os;
-}
-
 void SQResultRow::push_back(const string& s) {
-    data.push_back(ColVal(ColVal::TYPE::TEXT, s));
+    data.push_back(SQValue(SQValue::TYPE::TEXT, s));
 }
 
-vector<SQResultRow::ColVal>::iterator SQResultRow::end() {
+vector<SQValue>::iterator SQResultRow::end() {
     return data.end();
 }
 
-vector<SQResultRow::ColVal>::const_iterator SQResultRow::end() const {
+vector<SQValue>::const_iterator SQResultRow::end() const {
     return data.end();
 }
 
-vector<SQResultRow::ColVal>::const_iterator SQResultRow::begin() const {
+vector<SQValue>::const_iterator SQResultRow::begin() const {
     return data.begin();
 }
 
@@ -171,29 +38,12 @@ string SQResultRow::at(size_t index) {
     return data.at(index);
 }
 
-SQResultRow::ColVal& SQResultRow::get(size_t index) {
+SQValue& SQResultRow::get(size_t index) {
     return data.at(index);
 }
 
 const string SQResultRow::at(size_t index) const {
     return data.at(index);
-}
-
-SQResultRow::ColVal::operator string() const {
-    switch (type) {
-        case TYPE::TEXT:
-        case TYPE::BLOB:
-            return text;
-        case TYPE::INTEGER:
-            return std::to_string(integer);
-        case TYPE::REAL:
-            char buf[64];
-            sqlite3_snprintf(sizeof(buf), buf, "%!.15g", real);
-            return string(buf);
-        case TYPE::NONE:
-        default:
-            return "";
-    }
 }
 
 string SQResultRow::operator[](const size_t& rowNum) {

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -9,25 +9,61 @@ class SQResultRow {
     friend class SQResult;
   public:
 
-    class COLVAL {
-      enum class TYPES {
-        NONE, // because NULL is overloaded.
-        INTEGER,
-        REAL,
-        TEXT,
-        BLOB,
+    class ColVal {
+      public:
+        enum class TYPE {
+            NONE, // because NULL is overloaded.
+            INTEGER,
+            REAL,
+            TEXT,
+            BLOB,
+        };
+
+      operator string() const;
+
+      // Constructors;
+      ColVal();
+      ColVal(int64_t val);
+      ColVal(double val);
+      explicit ColVal(const string& val);
+      explicit ColVal(TYPE t, const string& val);
+
+      ColVal& operator=(const string& val);
+      ColVal& operator=(string&& val);
+
+      // Allow string concatenation.
+      friend string operator+(string lhs, const ColVal& rhs);
+      friend string operator+(const ColVal& lhs, string rhs);
+      friend string operator+(const char* lhs, const ColVal& rhs);
+      friend string operator+(const ColVal& lhs, const char* rhs);
+
+      // And string comparison
+      friend bool operator==(const ColVal& a, const string& b);
+      friend bool operator==(const string& a, const ColVal& b);
+      friend bool operator==(const ColVal& a, const char* b);
+      friend bool operator==(const char* a, const ColVal& b);
+
+      friend bool operator==(const ColVal& a, const ColVal& b);
+      friend bool operator!=(const ColVal& a, const ColVal& b) { return !(a == b); }
+
+      bool empty() const;
+
+      friend ostream& operator<<(ostream& os, const ColVal& v);
+
+      private:
+          TYPE type;
+
+          // Treat these as a union.
+          int64_t integer{0};
+          double real{0.0};
+          string text;
+          // Not used, we simply store this in `text` as they're stored the same way.
+          // This is left here to make it clear it's not accidentally omitted.
+          // string blob;
       };
-      union DATA {
-        int64_t none;
-        int64_t integer;
-        double real;
-        string text;
-        string blob;
-      };
-    };
 
     template <class InputIt>
-    vector<string>::iterator insert(vector<string>::const_iterator pos, InputIt first, InputIt last) {
+    vector<ColVal>::iterator insert(vector<ColVal>::const_iterator pos, InputIt first, InputIt last) {
         return data.insert(pos, first, last);
     }
 
@@ -35,24 +71,24 @@ class SQResultRow {
     SQResultRow(SQResult& result, size_t count = 0);
     SQResultRow(SQResultRow const&) = default;
     void push_back(const string& s);
-    string& operator[](const size_t& key);
-    const string& operator[](const size_t& key) const;
-    string& operator[](const string& key);
-    const string& operator[](const string& key) const;
-    vector<string>::const_iterator begin() const;
-    vector<string>::iterator end();
-    vector<string>::const_iterator end() const;
+    ColVal& operator[](const size_t& key);
+    const ColVal& operator[](const size_t& key) const;
+    ColVal& operator[](const string& key);
+    const ColVal& operator[](const string& key) const;
+    vector<ColVal>::const_iterator begin() const;
+    vector<ColVal>::iterator end();
+    vector<ColVal>::const_iterator end() const;
     bool empty() const;
     size_t size() const;
     SQResultRow& operator=(const SQResultRow& other);
-    string& at(size_t index);
-    const string& at(size_t index) const;
+    string at(size_t index);
+    const string at(size_t index) const;
 
-    operator const std::vector<std::string>&() const;
+    operator const std::vector<std::string>() const;
 
   private:
     SQResult* result = nullptr;
-    vector<string> data;
+    vector<ColVal> data;
 };
 
 class SQResult {

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -45,6 +45,10 @@ class SQResultRow {
     bool empty() const;
     size_t size() const;
     SQResultRow& operator=(const SQResultRow& other);
+    string& at(size_t index);
+    const string& at(size_t index) const;
+
+    operator const std::vector<std::string>&() const;
 
   private:
     SQResult* result = nullptr;

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -25,17 +25,20 @@ class SQResultRow {
       ColVal();
       ColVal(int64_t val);
       ColVal(double val);
+      ColVal(const char* val);
       explicit ColVal(const string& val);
       explicit ColVal(TYPE t, const string& val);
 
       ColVal& operator=(const string& val);
       ColVal& operator=(string&& val);
+      ColVal& operator=(const char* val);
 
       // Allow string concatenation.
       friend string operator+(string lhs, const ColVal& rhs);
       friend string operator+(const ColVal& lhs, string rhs);
       friend string operator+(const char* lhs, const ColVal& rhs);
       friend string operator+(const ColVal& lhs, const char* rhs);
+      friend string operator+(const ColVal& lhs, const ColVal& rhs);
 
       // And string comparison
       friend bool operator==(const ColVal& a, const string& b);
@@ -47,6 +50,7 @@ class SQResultRow {
       friend bool operator!=(const ColVal& a, const ColVal& b) { return !(a == b); }
 
       bool empty() const;
+      size_t size() const;
 
       friend ostream& operator<<(ostream& os, const ColVal& v);
 
@@ -71,10 +75,10 @@ class SQResultRow {
     SQResultRow(SQResult& result, size_t count = 0);
     SQResultRow(SQResultRow const&) = default;
     void push_back(const string& s);
-    ColVal& operator[](const size_t& key);
-    const ColVal& operator[](const size_t& key) const;
-    ColVal& operator[](const string& key);
-    const ColVal& operator[](const string& key) const;
+    string operator[](const size_t& key);
+    const string operator[](const size_t& key) const;
+    string operator[](const string& key);
+    const string operator[](const string& key) const;
     vector<ColVal>::const_iterator begin() const;
     vector<ColVal>::iterator end();
     vector<ColVal>::const_iterator end() const;

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -5,9 +5,34 @@
 using namespace std;
 class SQResult;
 
-class SQResultRow : public vector<string> {
+class SQResultRow {
     friend class SQResult;
   public:
+
+    class COLVAL {
+      enum class TYPES {
+        NONE, // because NULL is overloaded.
+        INTEGER,
+        REAL,
+        TEXT,
+        BLOB,
+      };
+      union DATA {
+        int64_t none;
+        int64_t integer;
+        double real;
+        string text;
+        string blob;
+      };
+    };
+
+    using iterator = vector<string>::iterator;
+    using const_iterator = vector<string>::const_iterator;
+    template <class InputIt>
+    iterator insert(const_iterator pos, InputIt first, InputIt last) {
+        return data.insert(pos, first, last);
+    }
+
     SQResultRow();
     SQResultRow(SQResult& result, size_t count = 0);
     SQResultRow(SQResultRow const&) = default;
@@ -16,10 +41,12 @@ class SQResultRow : public vector<string> {
     const string& operator[](const size_t& key) const;
     string& operator[](const string& key);
     const string& operator[](const string& key) const;
+    vector<string>::iterator end();
     SQResultRow& operator=(const SQResultRow& other);
 
   private:
     SQResult* result = nullptr;
+    vector<string> data;
 };
 
 class SQResult {

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -1,75 +1,14 @@
 #pragma once
-// Can't include libstuff.h here because it'd be circular.
 #include <string>
 #include <vector>
+#include <libstuff/SQValue.h>
 using namespace std;
+
 class SQResult;
 
 class SQResultRow {
     friend class SQResult;
   public:
-
-    class ColVal {
-      public:
-        enum class TYPE {
-            NONE, // because NULL is overloaded.
-            INTEGER,
-            REAL,
-            TEXT,
-            BLOB,
-        };
-
-      operator string() const;
-
-      // Constructors;
-      ColVal();
-      ColVal(int64_t val);
-      ColVal(double val);
-      ColVal(const char* val);
-      explicit ColVal(const string& val);
-      explicit ColVal(TYPE t, const string& val);
-
-      ColVal& operator=(const string& val);
-      ColVal& operator=(string&& val);
-      ColVal& operator=(const char* val);
-
-      // Allow string concatenation.
-      friend string operator+(string lhs, const ColVal& rhs);
-      friend string operator+(const ColVal& lhs, string rhs);
-      friend string operator+(const char* lhs, const ColVal& rhs);
-      friend string operator+(const ColVal& lhs, const char* rhs);
-      friend string operator+(const ColVal& lhs, const ColVal& rhs);
-
-      // And string comparison
-      friend bool operator==(const ColVal& a, const string& b);
-      friend bool operator==(const string& a, const ColVal& b);
-      friend bool operator==(const ColVal& a, const char* b);
-      friend bool operator==(const char* a, const ColVal& b);
-
-      friend bool operator==(const ColVal& a, const ColVal& b);
-      friend bool operator!=(const ColVal& a, const ColVal& b) { return !(a == b); }
-
-      bool empty() const;
-      size_t size() const;
-
-      friend ostream& operator<<(ostream& os, const ColVal& v);
-
-      private:
-          TYPE type;
-
-          // Treat these as a union.
-          int64_t integer{0};
-          double real{0.0};
-          string text;
-          // Not used, we simply store this in `text` as they're stored the same way.
-          // This is left here to make it clear it's not accidentally omitted.
-          // string blob;
-      };
-
-    template <class InputIt>
-    vector<ColVal>::iterator insert(vector<ColVal>::const_iterator pos, InputIt first, InputIt last) {
-        return data.insert(pos, first, last);
-    }
 
     SQResultRow();
     SQResultRow(SQResult& result, size_t count = 0);
@@ -79,21 +18,26 @@ class SQResultRow {
     const string operator[](const size_t& key) const;
     string operator[](const string& key);
     const string operator[](const string& key) const;
-    vector<ColVal>::const_iterator begin() const;
-    vector<ColVal>::iterator end();
-    vector<ColVal>::const_iterator end() const;
+    vector<SQValue>::const_iterator begin() const;
+    vector<SQValue>::iterator end();
+    vector<SQValue>::const_iterator end() const;
     bool empty() const;
     size_t size() const;
     SQResultRow& operator=(const SQResultRow& other);
     string at(size_t index);
-    ColVal& get(size_t index);
+    SQValue& get(size_t index);
     const string at(size_t index) const;
 
     operator vector<string>() const;
 
+    template <class InputIt>
+    vector<SQValue>::iterator insert(vector<SQValue>::const_iterator pos, InputIt first, InputIt last) {
+        return data.insert(pos, first, last);
+    }
+
   private:
     SQResult* result = nullptr;
-    vector<ColVal> data;
+    vector<SQValue> data;
 };
 
 class SQResult {

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -26,10 +26,8 @@ class SQResultRow {
       };
     };
 
-    using iterator = vector<string>::iterator;
-    using const_iterator = vector<string>::const_iterator;
     template <class InputIt>
-    iterator insert(const_iterator pos, InputIt first, InputIt last) {
+    vector<string>::iterator insert(vector<string>::const_iterator pos, InputIt first, InputIt last) {
         return data.insert(pos, first, last);
     }
 
@@ -41,7 +39,11 @@ class SQResultRow {
     const string& operator[](const size_t& key) const;
     string& operator[](const string& key);
     const string& operator[](const string& key) const;
+    vector<string>::const_iterator begin() const;
     vector<string>::iterator end();
+    vector<string>::const_iterator end() const;
+    bool empty() const;
+    size_t size() const;
     SQResultRow& operator=(const SQResultRow& other);
 
   private:

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -8,8 +8,8 @@ class SQResult;
 
 class SQResultRow {
     friend class SQResult;
-  public:
 
+  public:
     SQResultRow();
     SQResultRow(SQResult& result, size_t count = 0);
     SQResultRow(SQResultRow const&) = default;
@@ -27,13 +27,7 @@ class SQResultRow {
     string at(size_t index);
     SQValue& get(size_t index);
     const string at(size_t index) const;
-
     operator vector<string>() const;
-
-    template <class InputIt>
-    vector<SQValue>::iterator insert(vector<SQValue>::const_iterator pos, InputIt first, InputIt last) {
-        return data.insert(pos, first, last);
-    }
 
   private:
     SQResult* result = nullptr;

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -89,7 +89,7 @@ class SQResultRow {
     ColVal& get(size_t index);
     const string at(size_t index) const;
 
-    operator const std::vector<std::string>() const;
+    operator vector<string>() const;
 
   private:
     SQResult* result = nullptr;

--- a/libstuff/SQResult.h
+++ b/libstuff/SQResult.h
@@ -86,6 +86,7 @@ class SQResultRow {
     size_t size() const;
     SQResultRow& operator=(const SQResultRow& other);
     string at(size_t index);
+    ColVal& get(size_t index);
     const string at(size_t index) const;
 
     operator const std::vector<std::string>() const;

--- a/libstuff/SQValue.cpp
+++ b/libstuff/SQValue.cpp
@@ -1,0 +1,150 @@
+#include <libstuff/SQValue.h>
+#include <libstuff/sqlite3.h>
+
+SQValue& SQValue::operator=(const string& val) {
+    type = TYPE::TEXT;
+    text = val;
+    return *this;
+}
+
+SQValue& SQValue::operator=(string&& val) {
+    type = TYPE::TEXT;
+    text = std::move(val);
+    return *this;
+}
+
+SQValue::SQValue(const char* val) : type(SQValue::TYPE::TEXT), text(val ? val : "") {}
+
+SQValue& SQValue::operator=(const char* val) {
+    type = TYPE::TEXT;
+    text = val ? val : "";
+    return *this;
+}
+
+SQValue::SQValue() : type(SQValue::TYPE::NONE) {
+}
+
+SQValue::SQValue(int64_t val) : type(SQValue::TYPE::INTEGER), integer(val) {
+}
+
+SQValue::SQValue(double val) : type(SQValue::TYPE::REAL), real(val) {
+}
+
+SQValue::SQValue(const string& val) : type(SQValue::TYPE::TEXT), text(val) {
+}
+
+SQValue::SQValue(TYPE t, const string& val) : type(t), text(val) {
+}
+
+string operator+(string lhs, const SQValue& rhs) {
+    lhs += static_cast<string>(rhs);
+    return lhs;
+}
+
+string operator+(const SQValue& lhs, string rhs) {
+    return static_cast<string>(lhs) + rhs;
+}
+
+string operator+(const char* lhs, const SQValue& rhs) {
+    return string(lhs) + static_cast<string>(rhs);
+}
+
+string operator+(const SQValue& lhs, const char* rhs) {
+    return static_cast<string>(lhs) + string(rhs);
+}
+
+string operator+(const SQValue& lhs, const SQValue& rhs) {
+    return static_cast<string>(lhs) + static_cast<string>(rhs);
+}
+
+bool operator==(const SQValue& a, const string& b) {
+    return static_cast<string>(a) == b;
+}
+
+bool operator==(const string& a, const SQValue& b) {
+    return a == static_cast<string>(b);
+}
+
+bool operator==(const SQValue& a, const char* b) {
+    return static_cast<string>(a) == string(b ? b : "");
+}
+
+bool operator==(const char* a, const SQValue& b) {
+    return string(a ? a : "") == static_cast<string>(b);
+}
+
+bool operator==(const SQValue& a, const SQValue& b) {
+    // Types must match
+    if (a.type != b.type) {
+        return false;
+    }
+
+    switch (a.type) {
+        case SQValue::TYPE::NONE:
+            // Consider two NONEs equal
+            return true;
+
+        case SQValue::TYPE::INTEGER:
+            return a.integer == b.integer;
+
+        case SQValue::TYPE::REAL: {
+            // Reasonable floating-point equality: combined abs/rel tolerance
+            double da = a.real;
+            double db = b.real;
+            double diff = da - db;
+            if (diff < 0) diff = -diff;
+
+            const double absTol = 1e-12;
+            const double relTol = 1e-9;
+
+            double aad = da; if (aad < 0) aad = -aad;
+            double abd = db; if (abd < 0) abd = -abd;
+            double scale = (aad > abd) ? aad : abd;
+
+            return diff <= absTol + relTol * scale;
+        }
+
+        case SQValue::TYPE::TEXT:
+        case SQValue::TYPE::BLOB:
+            return a.text == b.text;
+    }
+
+    return false;
+}
+
+bool SQValue::empty() const {
+    if (type == TYPE::NONE) {
+        return true;
+    }
+    if ((type == TYPE::TEXT || type == TYPE::BLOB) && text.empty()) {
+        return true;
+    }
+    return false;
+}
+
+size_t SQValue::size() const {
+    return static_cast<string>(*this).size();
+}
+
+SQValue::operator string() const {
+    switch (type) {
+        case TYPE::TEXT:
+        case TYPE::BLOB:
+            return text;
+        case TYPE::INTEGER:
+            return std::to_string(integer);
+        case TYPE::REAL:
+            char buf[64];
+            sqlite3_snprintf(sizeof(buf), buf, "%!.15g", real);
+            return string(buf);
+        case TYPE::NONE:
+        default:
+            return "";
+    }
+}
+
+ostream& operator<<(ostream& os, const SQValue& v) {
+    // Reuse the string conversion which already formats REAL reasonably.
+    os << static_cast<string>(v);
+    return os;
+}

--- a/libstuff/SQValue.cpp
+++ b/libstuff/SQValue.cpp
@@ -2,7 +2,7 @@
 #include <libstuff/SQValue.h>
 #include <libstuff/sqlite3.h>
 
-// All of our connstructor bodies are emtpy, we just use member initializer lists.
+// All of our constructor bodies are empty, we just use member initializer lists.
 SQValue::SQValue() : type(SQValue::TYPE::NONE) {}
 SQValue::SQValue(int64_t val) : type(SQValue::TYPE::INTEGER), integer(val) {}
 SQValue::SQValue(double val) : type(SQValue::TYPE::REAL), real(val) {}

--- a/libstuff/SQValue.cpp
+++ b/libstuff/SQValue.cpp
@@ -49,35 +49,35 @@ string operator+(const SQValue& lhs, const SQValue& rhs) {
     return static_cast<string>(lhs) + static_cast<string>(rhs);
 }
 
-bool operator==(const SQValue& a, const string& b) {
-    return static_cast<string>(a) == b;
+bool operator==(const SQValue& lhs, const string& rhs) {
+    return static_cast<string>(lhs) == rhs;
 }
 
-bool operator==(const string& a, const SQValue& b) {
-    return a == static_cast<string>(b);
+bool operator==(const string& lhs, const SQValue& rhs) {
+    return lhs == static_cast<string>(rhs);
 }
 
-bool operator==(const SQValue& a, const char* b) {
-    return static_cast<string>(a) == string(b ? b : "");
+bool operator==(const SQValue& lhs, const char* rhs) {
+    return static_cast<string>(lhs) == string(rhs ? rhs : "");
 }
 
-bool operator==(const char* a, const SQValue& b) {
-    return string(a ? a : "") == static_cast<string>(b);
+bool operator==(const char* lhs, const SQValue& rhs) {
+    return string(lhs ? lhs : "") == static_cast<string>(rhs);
 }
 
-bool operator==(const SQValue& a, const SQValue& b) {
+bool operator==(const SQValue& lhs, const SQValue& rhs) {
     // Types must match
-    if (a.type != b.type) {
+    if (lhs.type != rhs.type) {
         return false;
     }
 
-    switch (a.type) {
+    switch (lhs.type) {
         case SQValue::TYPE::NONE:
             // Consider two NONEs equal
             return true;
 
         case SQValue::TYPE::INTEGER:
-            return a.integer == b.integer;
+            return lhs.integer == rhs.integer;
 
         case SQValue::TYPE::REAL:
         {
@@ -94,17 +94,17 @@ bool operator==(const SQValue& a, const SQValue& b) {
             // we've set `absTolerance` to, and this accounts for that as well.
             const double absTolerance = 1e-12;
             const double relTolerance = 1e-9;
-            return fabs(a.real - b.real) <= absTolerance + relTolerance * max(fabs(a.real), fabs(b.real));
+            return fabs(lhs.real - rhs.real) <= absTolerance + relTolerance * max(fabs(lhs.real), fabs(rhs.real));
         }
 
         case SQValue::TYPE::TEXT:
         case SQValue::TYPE::BLOB:
-            return a.text == b.text;
+            return lhs.text == rhs.text;
     }
 }
 
-bool operator!=(const SQValue& a, const SQValue& b) {
-    return !(a == b);
+bool operator!=(const SQValue& lhs, const SQValue& rhs) {
+    return !(lhs == rhs);
 }
 
 bool SQValue::empty() const {

--- a/libstuff/SQValue.cpp
+++ b/libstuff/SQValue.cpp
@@ -101,8 +101,6 @@ bool operator==(const SQValue& a, const SQValue& b) {
         case SQValue::TYPE::BLOB:
             return a.text == b.text;
     }
-
-    return false;
 }
 
 bool operator!=(const SQValue& a, const SQValue& b) {

--- a/libstuff/SQValue.h
+++ b/libstuff/SQValue.h
@@ -39,14 +39,14 @@ public:
     friend string operator+(const SQValue& lhs, const SQValue& rhs);
 
     // Support comparison with strings.
-    friend bool operator==(const SQValue& a, const string& b);
-    friend bool operator==(const string& a, const SQValue& b);
-    friend bool operator==(const SQValue& a, const char* b);
-    friend bool operator==(const char* a, const SQValue& b);
+    friend bool operator==(const SQValue& lhs, const string& rhs);
+    friend bool operator==(const string& lhs, const SQValue& rhs);
+    friend bool operator==(const SQValue& lhs, const char* rhs);
+    friend bool operator==(const char* lhs, const SQValue& rhs);
 
     // Support comparison with another SQValue.
-    friend bool operator==(const SQValue& a, const SQValue& b);
-    friend bool operator!=(const SQValue& a, const SQValue& b);
+    friend bool operator==(const SQValue& lhs, const SQValue& rhs);
+    friend bool operator!=(const SQValue& lhs, const SQValue& rhs);
 
     // Calling either of these acts like the aame function call on `string`.
     bool empty() const;

--- a/libstuff/SQValue.h
+++ b/libstuff/SQValue.h
@@ -1,0 +1,63 @@
+
+#pragma once
+
+#include <string>
+#include <vector>
+using namespace std;
+
+class SQValue {
+public:
+    enum class TYPE {
+        NONE, // because NULL is overloaded.
+        INTEGER,
+        REAL,
+        TEXT,
+        BLOB,
+    };
+
+    operator string() const;
+
+    // Constructors;
+    SQValue();
+    SQValue(int64_t val);
+    SQValue(double val);
+    SQValue(const char* val);
+    explicit SQValue(const string& val);
+    explicit SQValue(TYPE t, const string& val);
+
+    SQValue& operator=(const string& val);
+    SQValue& operator=(string&& val);
+    SQValue& operator=(const char* val);
+
+    // Allow string concatenation.
+    friend string operator+(string lhs, const SQValue& rhs);
+    friend string operator+(const SQValue& lhs, string rhs);
+    friend string operator+(const char* lhs, const SQValue& rhs);
+    friend string operator+(const SQValue& lhs, const char* rhs);
+    friend string operator+(const SQValue& lhs, const SQValue& rhs);
+
+    // And string comparison
+    friend bool operator==(const SQValue& a, const string& b);
+    friend bool operator==(const string& a, const SQValue& b);
+    friend bool operator==(const SQValue& a, const char* b);
+    friend bool operator==(const char* a, const SQValue& b);
+
+    friend bool operator==(const SQValue& a, const SQValue& b);
+    friend bool operator!=(const SQValue& a, const SQValue& b) { return !(a == b); }
+
+    bool empty() const;
+    size_t size() const;
+
+    friend ostream& operator<<(ostream& os, const SQValue& v);
+
+private:
+    TYPE type;
+
+    // Treat these as a union.
+    int64_t integer{0};
+    double real{0.0};
+    string text;
+    // Not used, we simply store this in `text` as they're stored the same way.
+    // This is left here to make it clear it's not accidentally omitted.
+    // string blob;
+};

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2768,7 +2768,7 @@ bool SQVerifyTable(sqlite3* db, const string& tableName, const string& sql) {
     } else {
         // Table exists, verify it's correct
         SINFO("'" << tableName << "' already exists, verifying. ");
-        SASSERT((string)result[0][4] == sql);
+        SASSERT(result[0][4] == sql);
         return false; // Table already exists with correct definition
     }
 }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2648,19 +2648,19 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
                         int colType = sqlite3_column_type(preparedStatement, i);
                         switch (colType) {
                             case SQLITE_INTEGER:
-                                row[i] = (int64_t)sqlite3_column_int64(preparedStatement, i);
+                                row.get(i) = (int64_t)sqlite3_column_int64(preparedStatement, i);
                                 break;
                             case SQLITE_FLOAT:
-                                row[i] = sqlite3_column_double(preparedStatement, i);
+                                row.get(i) = sqlite3_column_double(preparedStatement, i);
                                 break;
                             case SQLITE_TEXT:
-                                row[i] = SQResultRow::ColVal(SQResultRow::ColVal::TYPE::TEXT, string(reinterpret_cast<const char*>(sqlite3_column_text(preparedStatement, i))));
+                                row.get(i) = SQResultRow::ColVal(SQResultRow::ColVal::TYPE::TEXT, string(reinterpret_cast<const char*>(sqlite3_column_text(preparedStatement, i))));
                                 break;
                             case SQLITE_BLOB:
-                                row[i] = SQResultRow::ColVal(SQResultRow::ColVal::TYPE::BLOB, string(static_cast<const char*>(sqlite3_column_blob(preparedStatement, i)), sqlite3_column_bytes(preparedStatement, i)));
+                                row.get(i) = SQResultRow::ColVal(SQResultRow::ColVal::TYPE::BLOB, string(static_cast<const char*>(sqlite3_column_blob(preparedStatement, i)), sqlite3_column_bytes(preparedStatement, i)));
                                 break;
                             case SQLITE_NULL:
-                                // null string.
+                                row.get(i) = SQResultRow::ColVal();
                                 break;
                         }
                     }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2648,18 +2648,16 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
                         int colType = sqlite3_column_type(preparedStatement, i);
                         switch (colType) {
                             case SQLITE_INTEGER:
-                                row[i] = to_string(sqlite3_column_int64(preparedStatement, i));
+                                row[i] = (int64_t)sqlite3_column_int64(preparedStatement, i);
                                 break;
                             case SQLITE_FLOAT:
-                                char buf[64];
-                                sqlite3_snprintf(sizeof(buf), buf, "%!.15g", sqlite3_column_double(preparedStatement, i));
-                                row[i] = buf;
+                                row[i] = sqlite3_column_double(preparedStatement, i);
                                 break;
                             case SQLITE_TEXT:
-                                row[i] = reinterpret_cast<const char*>(sqlite3_column_text(preparedStatement, i));
+                                row[i] = SQResultRow::ColVal(SQResultRow::ColVal::TYPE::TEXT, string(reinterpret_cast<const char*>(sqlite3_column_text(preparedStatement, i))));
                                 break;
                             case SQLITE_BLOB:
-                                row[i] = string(static_cast<const char*>(sqlite3_column_blob(preparedStatement, i)), sqlite3_column_bytes(preparedStatement, i));
+                                row[i] = SQResultRow::ColVal(SQResultRow::ColVal::TYPE::BLOB, string(static_cast<const char*>(sqlite3_column_blob(preparedStatement, i)), sqlite3_column_bytes(preparedStatement, i)));
                                 break;
                             case SQLITE_NULL:
                                 // null string.
@@ -2770,7 +2768,7 @@ bool SQVerifyTable(sqlite3* db, const string& tableName, const string& sql) {
     } else {
         // Table exists, verify it's correct
         SINFO("'" << tableName << "' already exists, verifying. ");
-        SASSERT(result[0][4] == sql);
+        SASSERT((string)result[0][4] == sql);
         return false; // Table already exists with correct definition
     }
 }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2654,13 +2654,13 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
                                 row.get(i) = sqlite3_column_double(preparedStatement, i);
                                 break;
                             case SQLITE_TEXT:
-                                row.get(i) = SQResultRow::ColVal(SQResultRow::ColVal::TYPE::TEXT, string(reinterpret_cast<const char*>(sqlite3_column_text(preparedStatement, i))));
+                                row.get(i) = SQValue(SQValue::TYPE::TEXT, string(reinterpret_cast<const char*>(sqlite3_column_text(preparedStatement, i))));
                                 break;
                             case SQLITE_BLOB:
-                                row.get(i) = SQResultRow::ColVal(SQResultRow::ColVal::TYPE::BLOB, string(static_cast<const char*>(sqlite3_column_blob(preparedStatement, i)), sqlite3_column_bytes(preparedStatement, i)));
+                                row.get(i) = SQValue(SQValue::TYPE::BLOB, string(static_cast<const char*>(sqlite3_column_blob(preparedStatement, i)), sqlite3_column_bytes(preparedStatement, i)));
                                 break;
                             case SQLITE_NULL:
-                                row.get(i) = SQResultRow::ColVal();
+                                row.get(i) = SQValue();
                                 break;
                         }
                     }

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -132,8 +132,8 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
         ASSERT_EQUAL(originalJob[0][3], jobName);
         // nextRun and created should be equal or higher to the time we started the test
-        ASSERT_TRUE(originalJob[0][0].compare(startTime) >= 0);
-        ASSERT_TRUE(originalJob[0][4].compare(startTime) >= 0);
+        ASSERT_TRUE(string(originalJob[0][0]).compare(startTime) >= 0);
+        ASSERT_TRUE(string(originalJob[0][4]).compare(startTime) >= 0);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], data);

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -132,8 +132,8 @@ struct CreateJobTest : tpunit::TestFixture {
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
         ASSERT_EQUAL(originalJob[0][3], jobName);
         // nextRun and created should be equal or higher to the time we started the test
-        ASSERT_TRUE(string(originalJob[0][0]).compare(startTime) >= 0);
-        ASSERT_TRUE(string(originalJob[0][4]).compare(startTime) >= 0);
+        ASSERT_TRUE(originalJob[0][0].compare(startTime) >= 0);
+        ASSERT_TRUE(originalJob[0][4].compare(startTime) >= 0);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], data);


### PR DESCRIPTION
### Details

This changes the internal representation of `SQResult` to use typed data rather than plain strings for everything. This will allow us to resolve ambiguity between NULL and the empty string, for example, or between actual numbers and strings containing numbers.

What this actually does changes `SQResultRow` from being a child class of `vector<string>` to containing a member that is `vector<SQValue>`. Because `SQResultRow` is no longer a vector itself, we needed to add a variety of simple `vector` methods (`size`, `at`, `empty`, etc) that are called in various places.

We also created the new `SQValue` class, which is just one of `NULL`, `int_64`, `double` or `string`, but with a bunch of convenience functions in place such that it is always convertible to `string`, and all existing code will continue to use it as `string`.

This does not actually add methods to get any of these values as their expected type. This will be added in a future PR. The point of this PR is that we validate we haven't broken anything.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/337537

### Tests

Auth tests pass:
```
[ TEST RESULTS ] Passed: 5223, Failed: 0
```

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
