### PR TITLE
Add log paramater types to the whitelist

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -57,6 +57,10 @@ static set<string> PARAMS_WHITELIST = {
     "topic",
     "userID",
     "what",
+    "lastReportActionID",
+    "parentReportAction",
+    "lastReportActionID",
+    "parentReportActionType",
 };
 
 string addLogParams(string&& message, const STable& params) {


### PR DESCRIPTION
### Details

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/484579

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
