### PR TITLE
Double char limit in logs

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2700,7 +2700,7 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
     uint64_t elapsed = STimeNow() - startTime;
     if (!skipInfoWarn && ((int64_t)elapsed > warnThreshold || (int64_t)elapsed > 10000)) {
         // Avoid logging queries so long that we need dozens of lines to log them.
-        string sqlToLog = sql.substr(0, 20000);
+        string sqlToLog = sql.substr(0, 40000);
         SRedactSensitiveValues(sqlToLog);
 
         if ((int64_t)elapsed > warnThreshold) {


### PR DESCRIPTION
### Details
Doubling string char limit so queries don't show cut off in logs.

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
