### PR TITLE
Don't die on index corruption

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2692,7 +2692,11 @@ int SQuery(sqlite3* db, const char* e, const string& sql, SQResult& result, int6
     }
 
     if (error == SQLITE_CORRUPT) {
-        SERROR("Database corruption was detected, cannot continue, bedrock will exit immediately.");
+        if (extErr == SQLITE_CORRUPT_INDEX) {
+            SALERT("Database index corruption was detected on query: " << sql);
+        } else {
+            SERROR("Database corruption was detected, cannot continue, bedrock will exit immediately.");
+        }
     }
 
     uint64_t elapsed = STimeNow() - startTime;


### PR DESCRIPTION
### Details
Per Richard Hipp, this particular case of this error is recoverable and we don't need to crash. We still want to warn in a way that keeps us investigating the problem, though.

I read the SQlite source and this error is only used for this specific case:
```
** If P5 is not zero, then raise an SQLITE_CORRUPT_INDEX error
** if no matching index entry is found.  This happens when running
** an UPDATE or DELETE statement and the index entry to be updated
** or deleted is not found.  For some uses of IdxDelete
** (example:  the EXCEPT operator) it does not matter that no matching
** entry is found.  For those cases, P5 is zero.  Also, do not raise
** this (self-correcting and non-critical) error if in writable_schema mode.
```

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
