### PR TITLE
Add rowNum to params whitelist

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -53,6 +53,7 @@ static set<string> PARAMS_WHITELIST = {
     "peer",
     "reason",
     "requestID",
+    "rowNum",
     "status",
     "topic",
     "userID",


### PR DESCRIPTION
### Details

cc @danieldoglas @aldo-expensify 

We forgot this here: https://github.com/Expensify/Bedrock/pull/2224

### Fixed Issues
```
2025-09-30T12:13:21.823848+00:00 expensidev-2404 bedrock: V0cBxG florent@expensify.com (libstuff.cpp:162) SException [socket0] [info] Throwing exception with message: '500 Log param rowNum not in the whitelist, either do not log that or add it to PARAMS_WHITELIST if it's not sensitive' from libstuff/SLog.cpp:73
```

### Tests
```
2025-09-30T12:16:13.208531+00:00 expensidev-2404 bedrock: 6DDdt7 florent@expensify.com (SQResult.cpp:195) operator[] [socket0] [info] SQResult::operator[] out of range ~~ rowNum: '0'
```

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
