### PR TITLE
Fix nodes getting stuck shutting down and slow replication.

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -826,6 +826,7 @@ int SQLite::commit(const string& description, const string& commandName, functio
     result = SQuery(_db, "COMMIT");
 
     // In HCTree mode, we log extra info for slow commits.
+    /* Currently disabled because the diagnostic query takes 30+s to run.
     if (_hctree) {
         uint64_t afterCommit = STimeNow();
         // log for any commit over 1 second.
@@ -840,6 +841,7 @@ int SQLite::commit(const string& description, const string& commandName, functio
             }
         }
     }
+    */
 
     _lastConflictPage = _conflictPage;
     _lastConflictLocation = _conflictLocation;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -802,7 +802,6 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash) {
     return true;
 }
 
-static atomic<bool> __SLOW_COMMIT_LOG{false};
 int SQLite::commit(const string& description, const string& commandName, function<void()>* preCheckpointCallback) {
     // If commits have been disabled, return an error without attempting the commit.
     if (!_sharedData._commitEnabled) {
@@ -827,13 +826,11 @@ int SQLite::commit(const string& description, const string& commandName, functio
     result = SQuery(_db, "COMMIT");
 
     // In HCTree mode, we log extra info for slow commits.
-    if (_hctree && !__SLOW_COMMIT_LOG) {
+    /* This is disabled because the diagnostic logging is unreasonably expensive (30+ seconds for the query).
+    if (_hctree) {
         uint64_t afterCommit = STimeNow();
         // log for any commit over 1 second.
         if ((afterCommit - beforeCommit) > 1'000'000) {
-            // We will log extra data about slow commits only once per invocation. This is enough to give us up-to-date
-            // diagnostic data, but mitigates the issue that this logging takes 30+ seconds blocking the replicaton thread.
-            __SLOW_COMMIT_LOG = true;
             SQResult slowCommitResult;
             SQuery(_db, "SELECT * FROM hctvalid", slowCommitResult);
             SINFO("SLOW HCTREE COMMIT " << (slowCommitResult.size() + 1) << " lines to follow");
@@ -844,6 +841,7 @@ int SQLite::commit(const string& description, const string& commandName, functio
             }
         }
     }
+    */
 
     _lastConflictPage = _conflictPage;
     _lastConflictLocation = _conflictLocation;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -130,7 +130,7 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, const shared_ptr<SQLitePool>& dbPoo
       _stateChangeCount(0),
       _stateTimeout(STimeNow() + firstTimeout),
       _syncPeer(nullptr),
-      _shouldReplicateThreadExit(false)
+      _replicateThreadShouldExitTime(0)
 {
     KILLABLE_SQLITE_NODE = this;
     SASSERT(_originalPriority >= 0);
@@ -173,16 +173,16 @@ void SQLiteNode::_replicate() {
     SQLitePeer* peer = nullptr;
     SData command;
     while (true) {
-        bool shouldExitWhenQueueEmpty = false;
+        uint64_t shouldExit = 0;
         bool isQueueEmpty = false;
         uint64_t dequeueTime = 0;
         {
             unique_lock<mutex> lock(_replicateMutex);
-            while (!_shouldReplicateThreadExit && _replicateQueue.empty()) {
+            while (!_replicateThreadShouldExitTime && _replicateQueue.empty()) {
                 _replicateCV.wait(lock);
             }
 
-            shouldExitWhenQueueEmpty = _shouldReplicateThreadExit;
+            shouldExit = _replicateThreadShouldExitTime;
             isQueueEmpty = _replicateQueue.empty();
             if (!isQueueEmpty) {
                 peer = _replicateQueue.front().first;
@@ -193,9 +193,9 @@ void SQLiteNode::_replicate() {
         }
 
         // If there was no work, we either wait again, or we can exit.
-        if (isQueueEmpty) {
+        if (isQueueEmpty || (shouldExit && shouldExit < STimeNow())) {
             // There are no commands to process.
-            if (shouldExitWhenQueueEmpty) {
+            if (shouldExit) {
                 if (db.insideTransaction()) {
                     SINFO("Finished replication mid-transaction, missing COMMIT_TRANSACTION, rolling back.");
                     db.rollback();
@@ -1628,7 +1628,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
             bool isReplicationRunning = false;
             {
                 lock_guard<mutex> lock(_replicateMutex);
-                if (!_shouldReplicateThreadExit) {
+                if (!_replicateThreadShouldExitTime) {
                     _replicateQueue.push(make_pair(peer, message));
                     isReplicationRunning = true;
                 }
@@ -1877,7 +1877,8 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
         if (_state == SQLiteNodeState::FOLLOWING) {
             {
                 lock_guard<mutex> lock(_replicateMutex);
-                _shouldReplicateThreadExit = true;
+                // Exit in 10 seconds.
+                _replicateThreadShouldExitTime = STimeNow() + 10'000'000;
             }
             if (_replicateThread) {
                 _replicateCV.notify_one();
@@ -1890,7 +1891,7 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
                 if (_replicateQueue.size()) {
                     SWARN("Replicate queue contains " << _replicateQueue.size() << " messages at thread shutdown.");
                 }
-                _shouldReplicateThreadExit = false;
+                _replicateThreadShouldExitTime = 0;
             }
 
             // We have no leader anymore.

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1885,12 +1885,11 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
                 delete _replicateThread;
                 _replicateThread = nullptr;
             }
-            // This is an unsafe access to _replicateQueue, it needs to be gaurded by _replicateMutex.
-            if (_replicateQueue.size()) {
-                SWARN("Replicate queue contains " << _replicateQueue.size() << " messages at thread shutdown.");
-            }
             {
                 lock_guard<mutex> lock(_replicateMutex);
+                if (_replicateQueue.size()) {
+                    SWARN("Replicate queue contains " << _replicateQueue.size() << " messages at thread shutdown.");
+                }
                 _shouldReplicateThreadExit = false;
             }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1889,7 +1889,8 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
             {
                 lock_guard<mutex> lock(_replicateMutex);
                 if (_replicateQueue.size()) {
-                    SWARN("Replicate queue contains " << _replicateQueue.size() << " messages at thread shutdown.");
+                    SWARN("Replicate queue contains " << _replicateQueue.size() << " messages at thread shutdown,  clearing.");
+                    _replicateQueue = queue<pair<SQLitePeer*, SData>>();
                 }
                 _replicateThreadShouldExitTime = 0;
             }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1885,6 +1885,7 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
                 delete _replicateThread;
                 _replicateThread = nullptr;
             }
+            // This is an unsafe access to _replicateQueue, it needs to be gaurded by _replicateMutex.
             if (_replicateQueue.size()) {
                 SWARN("Replicate queue contains " << _replicateQueue.size() << " messages at thread shutdown.");
             }

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -399,5 +399,5 @@ class SQLiteNode : public STCPManager {
     mutex _replicateMutex;
     condition_variable _replicateCV;
     queue<pair<SQLitePeer*, SData>> _replicateQueue;
-    atomic<bool> _shouldReplicateThreadExit;
+    atomic<uint64_t> _replicateThreadShouldExitTime;
 };


### PR DESCRIPTION
### Details
So this does two main things.

First, it limits the amount of time we'll spend waiting for the replication queue to finish before falling out of `FOLLOWING` to 10 seconds. This is sort of a floor, a single slow replicated transaction can go past this limit, but the next one will not start.

We intentionally try and complete the replication queue when we stop following. If leader crashes, we want to make sure that at least *some other node* has all the commits, so we don't want to abandon these immediately. However, this issue is the opposite case, where a follower is well behind, it currently keeps attempting to apply the entire queue until it times out. The 10 second timeout fix should still handle the case where followers are in sync, but leader dies, without losing leader's last commits. At the same time, this allows slow nodes to shut down without getting stuck. They will sync whatever they were missing when they come back up.

The second thing this change does is largely disable the extra logging for slow HC-Tree commits. ~~This will still allow exactly 1 of these log lines per run, which should be enough to keep supplying the sqlite team with diagnostic info.~~ Edit: I turned them off completely in a subsequent commit.

These can take a *crazy long time*:
<img width="1139" height="465" alt="Screenshot 2025-11-25 at 16 27 15" src="https://github.com/user-attachments/assets/3f48ccd5-64db-41c7-8384-9ba859d6f8c7" />

These cause replication backups, and I think are the primary problem causing https://github.com/Expensify/Expensify/issues/558782

To be clear, we do these because commits themselves are slow, but the slow commits take 1-2 seconds, and then the diagnostic queries take 30+ seconds. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/560525
Fixes https://github.com/Expensify/Expensify/issues/558782

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
