### PR TITLE
Return early if socket is not connected through proxy

### DIFF
--- a/libstuff/SHTTPSProxySocket.cpp
+++ b/libstuff/SHTTPSProxySocket.cpp
@@ -33,6 +33,11 @@ SHTTPSProxySocket::~SHTTPSProxySocket() {
 bool SHTTPSProxySocket::send(size_t* bytesSentCount) {
     lock_guard<decltype(sendRecvMutex)> lock(sendRecvMutex);
 
+    // Don't try to send if we're still connecting to the proxy - wait for postPoll to transition to CONNECTED
+    if (state.load() == Socket::State::CONNECTING) {
+        return true;
+    }
+
     bool result = false;
     size_t oldSize = sendBuffer.size();
     size_t oldPreSendSize = preSendBuffer.size();


### PR DESCRIPTION
### Details
If a socket is not connected to the proxy, return early which will cause the poll loop to wait for a connection

### Fixed Issues
relates to https://github.com/Expensify/Expensify/issues/578735

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
