### PR TITLE
Allow sending only BEGIN rather than BEGIN CONCURRENT

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -478,20 +478,9 @@ bool SQLite::beginTransaction(SQLite::TRANSACTION_TYPE type, bool beginOnly)
         SINFO("Beginning transaction - open transaction count: " << (_sharedData.openTransactionCount));
     }
     uint64_t before = STimeNow();
-<<<<<<< HEAD
 
     string beginQuery = (beginOnly && _hctree) ? "BEGIN" : "BEGIN CONCURRENT";
     _insideTransaction = !SQuery(_db, beginQuery);
-=======
-    _insideTransaction = !SQuery(_db, "BEGIN CONCURRENT");
-    if (_hctree) {
-        SQResult pageCountResult;
-        SQuery(_db, "PRAGMA page_count;", pageCountResult);
-        if (!pageCountResult.empty()) {
-            _pageCountDifference = SToUInt64(pageCountResult[0][0]) - _pageCountDifference;
-        }
-    }
->>>>>>> main
 
     // Because some other thread could commit once we've run `BEGIN CONCURRENT`, this value can be slightly behind
     // where we're actually able to start such that we know we shouldn't get a conflict if this commits successfully on

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -14,7 +14,8 @@
 // Tracing can only be enabled or disabled globally, not per object.
 atomic<bool> SQLite::enableTrace(false);
 
-sqlite3* SQLite::getDBHandle() {
+sqlite3* SQLite::getDBHandle()
+{
     return _db;
 }
 
@@ -22,11 +23,13 @@ thread_local string SQLite::_mostRecentSQLiteErrorLog;
 thread_local int64_t SQLite::_conflictPage;
 thread_local string SQLite::_conflictLocation;
 
-const string SQLite::getMostRecentSQLiteErrorLog() const {
+const string SQLite::getMostRecentSQLiteErrorLog() const
+{
     return _mostRecentSQLiteErrorLog;
 }
 
-string SQLite::initializeFilename(const string& filename) {
+string SQLite::initializeFilename(const string& filename)
+{
     // Canonicalize our filename and save that version.
     if (filename == ":memory:") {
         // This path is special, it exists in memory. This doesn't actually work correctly with journaling and such, as
@@ -46,14 +49,18 @@ string SQLite::initializeFilename(const string& filename) {
     }
 }
 
-const set<string>& SQLite::getTablesUsed() const {
+const set<string>& SQLite::getTablesUsed() const
+{
     return _tablesUsed;
 }
 
-SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames, bool hctree) {
-    static struct SharedDataLookupMapType {
+SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, const string& filename, const vector<string>& journalNames, bool hctree)
+{
+    static struct SharedDataLookupMapType
+    {
         map<string, SharedData*> m;
-        ~SharedDataLookupMapType() {
+        ~SharedDataLookupMapType()
+        {
             for (auto& p : m) {
                 delete(p.second);
             }
@@ -103,7 +110,8 @@ SQLite::SharedData& SQLite::initializeSharedData(sqlite3* db, const string& file
     }
 }
 
-bool SQLite::validateDBFormat(const string& filename, bool hctree) {
+bool SQLite::validateDBFormat(const string& filename, bool hctree)
+{
     // Open the DB in read-write mode.
     const bool fileExists = SFileExists(filename);
     const bool fileIsEmpty = !SFileSize(filename);
@@ -134,13 +142,14 @@ bool SQLite::validateDBFormat(const string& filename, bool hctree) {
         }
         SINFO("Opening database '" << filename << "'.");
     } else {
-        SINFO( "Creating database '" << filename << "'.");
+        SINFO("Creating database '" << filename << "'.");
     }
 
     return hctree;
 }
 
-sqlite3* SQLite::initializeDB(const string& filename, int64_t mmapSizeGB, bool hctree) {
+sqlite3* SQLite::initializeDB(const string& filename, int64_t mmapSizeGB, bool hctree)
+{
     sqlite3* db;
     string completeFilename = filename;
     if (hctree) {
@@ -160,7 +169,8 @@ sqlite3* SQLite::initializeDB(const string& filename, int64_t mmapSizeGB, bool h
     return db;
 }
 
-vector<string> SQLite::initializeJournal(sqlite3* db, int minJournalTables) {
+vector<string> SQLite::initializeJournal(sqlite3* db, int minJournalTables)
+{
     // Make sure we don't try and create more journals than we can name.
     SASSERT(minJournalTables < 10'000);
 
@@ -201,7 +211,8 @@ vector<string> SQLite::initializeJournal(sqlite3* db, int minJournalTables) {
     return journalNames;
 }
 
-void SQLite::commonConstructorInitialization(bool hctree) {
+void SQLite::commonConstructorInitialization(bool hctree)
+{
     // Perform sanity checks.
     SASSERT(!_filename.empty());
     SASSERT(_maxJournalSize > 0);
@@ -275,7 +286,8 @@ SQLite::SQLite(const SQLite& from) :
     commonConstructorInitialization(_hctree);
 }
 
-int SQLite::_progressHandlerCallback(void* arg) {
+int SQLite::_progressHandlerCallback(void* arg)
+{
     SQLite* sqlite = static_cast<SQLite*>(arg);
     uint64_t now = STimeNow();
     if (sqlite->_timeoutLimit && now > sqlite->_timeoutLimit) {
@@ -297,22 +309,26 @@ int SQLite::_progressHandlerCallback(void* arg) {
     return 0;
 }
 
-void SQLite::setAbortRef(atomic<bool>& abortVar) {
+void SQLite::setAbortRef(atomic<bool>& abortVar)
+{
     _shouldAbortPtr = &abortVar;
 }
 
-void SQLite::clearAbortRef() {
+void SQLite::clearAbortRef()
+{
     _shouldAbortPtr = nullptr;
 }
 
-int SQLite::_walHookCallback(void* sqliteObject, sqlite3* db, const char* name, int walFileSize) {
+int SQLite::_walHookCallback(void* sqliteObject, sqlite3* db, const char* name, int walFileSize)
+{
     SQLite* sqlite = static_cast<SQLite*>(sqliteObject);
     sqlite->_sharedData.outstandingFramesToCheckpoint = walFileSize;
     sqlite->_sharedData.knownOutstandingFramesToCheckpoint = walFileSize;
     return SQLITE_OK;
 }
 
-void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg) {
+void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg)
+{
     // Skip logging this as it generates a lot of noise and we don't use it.
     if (strstr(zMsg, "automatic index on")) {
         return;
@@ -338,18 +354,21 @@ void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg) {
     }
 }
 
-int SQLite::_sqliteTraceCallback(unsigned int traceCode, void* c, void* p, void* x) {
+int SQLite::_sqliteTraceCallback(unsigned int traceCode, void* c, void* p, void* x)
+{
     if (enableTrace && traceCode == SQLITE_TRACE_STMT) {
-        SINFO("NORMALIZED_SQL:" << sqlite3_normalized_sql((sqlite3_stmt*)p));
+        SINFO("NORMALIZED_SQL:" << sqlite3_normalized_sql((sqlite3_stmt*) p));
     }
     return 0;
 }
 
-string SQLite::_getJournalQuery(const list<string>& queryParts, bool append) {
+string SQLite::_getJournalQuery(const list<string>& queryParts, bool append)
+{
     return _getJournalQuery(_journalNames, queryParts, append);
 }
 
-string SQLite::_getJournalQuery(const vector<string>& journalNames, const list<string>& queryParts, bool append) {
+string SQLite::_getJournalQuery(const vector<string>& journalNames, const list<string>& queryParts, bool append)
+{
     list<string> queries;
     for (const string& name : journalNames) {
         queries.emplace_back(SComposeList(queryParts, " " + name + " ") + (append ? " " + name : ""));
@@ -358,7 +377,8 @@ string SQLite::_getJournalQuery(const vector<string>& journalNames, const list<s
     return query;
 }
 
-SQLite::~SQLite() {
+SQLite::~SQLite()
+{
     // First, rollback any incomplete transaction.
     if (!_uncommittedQuery.empty()) {
         SINFO("Rolling back in destructor.");
@@ -373,7 +393,8 @@ SQLite::~SQLite() {
     DBINFO("Database closed.");
 }
 
-void SQLite::exclusiveLockDB() {
+void SQLite::exclusiveLockDB()
+{
     // This order is important and not intuitive. It seems like we should lock `writeLock` before `commitLock` because that's the order these occur in a typical database operation,
     // however, there are two possible flows here. For a non-blocking transaction (i.e., one run in parallel with other transactions), the lock order is:
     // writeLock, commitLock, but importantly, in this case, these are not locked simultaneously. writeLock is only locked for the time of the actual DB write query, and then released.
@@ -394,22 +415,25 @@ void SQLite::exclusiveLockDB() {
         SINFO("Locking writeLock");
         _sharedData.writeLock.lock();
         SINFO("writeLock Locked");
-    } catch(const system_error& e) {
+    } catch (const system_error& e) {
         SWARN("Caught system_error calling _sharedData.writeLock, code: " << e.code() << ", message: " << e.what());
         throw;
     }
 }
 
-void SQLite::exclusiveUnlockDB() {
+void SQLite::exclusiveUnlockDB()
+{
     _sharedData.writeLock.unlock();
     _sharedData.commitLock.unlock();
 }
 
-SQLite::TRANSACTION_TYPE SQLite::getLastTransactionType() {
+SQLite::TRANSACTION_TYPE SQLite::getLastTransactionType()
+{
     return _lastTransactionType;
 }
 
-bool SQLite::beginTransaction(SQLite::TRANSACTION_TYPE type, bool beginOnly) {
+bool SQLite::beginTransaction(SQLite::TRANSACTION_TYPE type, bool beginOnly)
+{
     _lastTransactionType = type;
     _transactionTimer.start("BEGIN_TRANSACTION");
     if (type == TRANSACTION_TYPE::EXCLUSIVE) {
@@ -456,9 +480,6 @@ bool SQLite::beginTransaction(SQLite::TRANSACTION_TYPE type, bool beginOnly) {
     uint64_t before = STimeNow();
 
     string beginQuery = (beginOnly && _hctree) ? "BEGIN" : "BEGIN CONCURRENT";
-    if (beginQuery == "BEGIN") {
-        SINFO("Begin is BEGIN");
-    }
     _insideTransaction = !SQuery(_db, beginQuery);
 
     // Because some other thread could commit once we've run `BEGIN CONCURRENT`, this value can be slightly behind
@@ -485,7 +506,8 @@ bool SQLite::beginTransaction(SQLite::TRANSACTION_TYPE type, bool beginOnly) {
     return _insideTransaction;
 }
 
-bool SQLite::verifyTable(const string& tableName, const string& sql, bool& created, const string& type) {
+bool SQLite::verifyTable(const string& tableName, const string& sql, bool& created, const string& type)
+{
     // sqlite trims semicolon, so let's not supply it else we get confused later
     SASSERT(!SEndsWith(sql, ";"));
 
@@ -518,7 +540,8 @@ bool SQLite::verifyTable(const string& tableName, const string& sql, bool& creat
     }
 }
 
-bool SQLite::verifyIndex(const string& indexName, const string& tableName, const string& indexSQLDefinition, bool isUnique, bool createIfNotExists) {
+bool SQLite::verifyIndex(const string& indexName, const string& tableName, const string& indexSQLDefinition, bool isUnique, bool createIfNotExists)
+{
     SINFO("Verifying index", {{"indexName", indexName}, {"isUnique", to_string(isUnique)}});
     SQResult result;
     SASSERT(read("SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name=" + SQ(tableName) + " AND name=" + SQ(indexName) + ";", result));
@@ -539,7 +562,8 @@ bool SQLite::verifyIndex(const string& indexName, const string& tableName, const
     }
 }
 
-bool SQLite::addColumn(const string& tableName, const string& column, const string& columnType) {
+bool SQLite::addColumn(const string& tableName, const string& column, const string& columnType)
+{
     // Add a column to the table if it does not exist.  Totally freak out on error.
     const string& sql =
         SCollapse(read("SELECT sql FROM sqlite_master WHERE type='table' AND tbl_name='" + tableName + "';"));
@@ -553,7 +577,8 @@ bool SQLite::addColumn(const string& tableName, const string& column, const stri
     return false;
 }
 
-string SQLite::read(const string& query) const {
+string SQLite::read(const string& query) const
+{
     // Execute the read-only query
     SQResult result;
     if (!read(query, result)) {
@@ -565,7 +590,8 @@ string SQLite::read(const string& query) const {
     return result[0][0];
 }
 
-int SQLite::read(const string& query, sqlite3_qrf_spec* spec) const {
+int SQLite::read(const string& query, sqlite3_qrf_spec* spec) const
+{
     // Execute the read-only query. Skips caching.
     uint64_t before = STimeNow();
     int queryResult = SQuery(_db, query, spec);
@@ -574,7 +600,8 @@ int SQLite::read(const string& query, sqlite3_qrf_spec* spec) const {
     return queryResult;
 }
 
-bool SQLite::read(const string& query, SQResult& result, bool skipInfoWarn) const {
+bool SQLite::read(const string& query, SQResult& result, bool skipInfoWarn) const
+{
     uint64_t before = STimeNow();
     bool queryResult = false;
     _readQueryCount++;
@@ -595,8 +622,8 @@ bool SQLite::read(const string& query, SQResult& result, bool skipInfoWarn) cons
     return queryResult;
 }
 
-void SQLite::_checkInterruptErrors(const string& error) const {
-
+void SQLite::_checkInterruptErrors(const string& error) const
+{
     // Local error code.
     int errorCode = 0;
     uint64_t time = 0;
@@ -627,7 +654,8 @@ void SQLite::_checkInterruptErrors(const string& error) const {
     // Otherwise, no error.
 }
 
-bool SQLite::write(const string& query) {
+bool SQLite::write(const string& query)
+{
     if (_noopUpdateMode) {
         SALERT("Non-idempotent write in _noopUpdateMode. Query: " << query);
         return true;
@@ -638,7 +666,8 @@ bool SQLite::write(const string& query) {
     return _writeIdempotent(query, ignore);
 }
 
-bool SQLite::write(const string& query, SQResult& result) {
+bool SQLite::write(const string& query, SQResult& result)
+{
     if (_noopUpdateMode) {
         SALERT("Non-idempotent write in _noopUpdateMode. Query: " << query);
         return true;
@@ -648,21 +677,25 @@ bool SQLite::write(const string& query, SQResult& result) {
     return _writeIdempotent(query, result);
 }
 
-bool SQLite::writeIdempotent(const string& query) {
+bool SQLite::writeIdempotent(const string& query)
+{
     SQResult ignore;
     return _writeIdempotent(query, ignore);
 }
 
-bool SQLite::writeIdempotent(const string& query, SQResult& result) {
+bool SQLite::writeIdempotent(const string& query, SQResult& result)
+{
     return _writeIdempotent(query, result);
 }
 
-bool SQLite::writeUnmodified(const string& query) {
+bool SQLite::writeUnmodified(const string& query)
+{
     SQResult ignore;
     return _writeIdempotent(query, ignore, true);
 }
 
-bool SQLite::_writeIdempotent(const string& query, SQResult& result, bool alwaysKeepQueries) {
+bool SQLite::_writeIdempotent(const string& query, SQResult& result, bool alwaysKeepQueries)
+{
     if (!_insideTransaction) {
         STHROW("500 Attempted to write outside of transaction");
     }
@@ -730,7 +763,8 @@ bool SQLite::_writeIdempotent(const string& query, SQResult& result, bool always
     return true;
 }
 
-bool SQLite::prepare(uint64_t* transactionID, string* transactionhash) {
+bool SQLite::prepare(uint64_t* transactionID, string* transactionhash)
+{
     SASSERT(_insideTransaction);
 
     // Pick a journal for this transaction.
@@ -821,7 +855,8 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash) {
     return true;
 }
 
-int SQLite::commit(const string& description, const string& commandName, function<void()>* preCheckpointCallback) {
+int SQLite::commit(const string& description, const string& commandName, function<void()>* preCheckpointCallback)
+{
     // If commits have been disabled, return an error without attempting the commit.
     if (!_sharedData._commitEnabled) {
         return COMMIT_DISABLED;
@@ -842,7 +877,7 @@ int SQLite::commit(const string& description, const string& commandName, functio
     _conflictLocation = "";
     uint64_t before = STimeNow();
     uint64_t beforeCommit = STimeNow();
-    if(_hctree) {
+    if (_hctree) {
         SQResult pageCountResult;
         SQuery(_db, "PRAGMA page_count;", pageCountResult);
         if (!pageCountResult.empty()) {
@@ -850,7 +885,7 @@ int SQLite::commit(const string& description, const string& commandName, functio
         }
     }
     result = SQuery(_db, "COMMIT");
-    if(_hctree) {
+    if (_hctree) {
         SQResult pageCountResult;
         SQuery(_db, "PRAGMA page_count;", pageCountResult);
         if (!pageCountResult.empty()) {
@@ -859,22 +894,23 @@ int SQLite::commit(const string& description, const string& commandName, functio
     }
 
     // In HCTree mode, we log extra info for slow commits.
+
     /* This is disabled because the diagnostic logging is unreasonably expensive (30+ seconds for the query).
-    if (_hctree) {
-        uint64_t afterCommit = STimeNow();
-        // log for any commit over 1 second.
-        if ((afterCommit - beforeCommit) > 1'000'000) {
-            SQResult slowCommitResult;
-            SQuery(_db, "SELECT * FROM hctvalid", slowCommitResult);
-            SINFO("SLOW HCTREE COMMIT " << (slowCommitResult.size() + 1) << " lines to follow");
-            string headers = SComposeList(slowCommitResult.headers);
-            SINFO("SLOW HCTREE COMMIT HEADERS: " << headers);
-            for (size_t i = 0; i < slowCommitResult.size(); i++) {
-                SINFO("SLOW HCTREE COMMIT ROW: " << i << ": " << SComposeList(slowCommitResult[i]));
-            }
-        }
-    }
-    */
+     * if (_hctree) {
+     *  uint64_t afterCommit = STimeNow();
+     *  // log for any commit over 1 second.
+     *  if ((afterCommit - beforeCommit) > 1'000'000) {
+     *      SQResult slowCommitResult;
+     *      SQuery(_db, "SELECT * FROM hctvalid", slowCommitResult);
+     *      SINFO("SLOW HCTREE COMMIT " << (slowCommitResult.size() + 1) << " lines to follow");
+     *      string headers = SComposeList(slowCommitResult.headers);
+     *      SINFO("SLOW HCTREE COMMIT HEADERS: " << headers);
+     *      for (size_t i = 0; i < slowCommitResult.size(); i++) {
+     *          SINFO("SLOW HCTREE COMMIT ROW: " << i << ": " << SComposeList(slowCommitResult[i]));
+     *      }
+     *  }
+     * }
+     */
 
     _lastConflictPage = _conflictPage;
     _lastConflictLocation = _conflictLocation;
@@ -883,14 +919,14 @@ int SQLite::commit(const string& description, const string& commandName, functio
     SASSERT(result == SQLITE_OK || result == SQLITE_BUSY_SNAPSHOT);
     if (result == SQLITE_OK) {
         char time[16];
-        snprintf(time, 16, "%.2fms", (double)(STimeNow() - beforeCommit) / 1000.0);
+        snprintf(time, 16, "%.2fms", (double) (STimeNow() - beforeCommit) / 1000.0);
 
         // And record pages after the commit.
         int endPages;
         sqlite3_db_status(_db, SQLITE_DBSTATUS_CACHE_WRITE, &endPages, &dummy, 0);
 
         // Similarly, record WAL file size.
-        sqlite3_file *pWal = 0;
+        sqlite3_file* pWal = 0;
         sqlite3_int64 sz = 0;
         sqlite3_file_control(_db, "main", SQLITE_FCNTL_JOURNAL_POINTER, &pWal);
         if (pWal && pWal->pMethods) {
@@ -934,13 +970,13 @@ int SQLite::commit(const string& description, const string& commandName, functio
                 description,
                 SToStr(_sharedData.commitCount),
                 time,
-                (endPages - startPages),
+                   (endPages - startPages),
                 sz,
                 _readQueryCount,
                 _writeQueryCount,
                 _cacheHits,
                 _journalName,
-                (_hctree ? format(" HC-Tree pages added: {}", _pageCountDifference) : "")),
+                   (_hctree ? format(" HC-Tree pages added: {}", _pageCountDifference) : "")),
             commandName);
         _readQueryCount = 0;
         _writeQueryCount = 0;
@@ -957,7 +993,8 @@ int SQLite::commit(const string& description, const string& commandName, functio
     return result;
 }
 
-int SQLite::getCheckpointModeFromString(const string& checkpointModeString) {
+int SQLite::getCheckpointModeFromString(const string& checkpointModeString)
+{
     if (checkpointModeString == "PASSIVE") {
         return SQLITE_CHECKPOINT_PASSIVE;
     }
@@ -973,11 +1010,13 @@ int SQLite::getCheckpointModeFromString(const string& checkpointModeString) {
     SERROR("Invalid checkpoint type: " << checkpointModeString);
 }
 
-map<uint64_t, tuple<string, string, uint64_t>> SQLite::popCommittedTransactions() {
+map<uint64_t, tuple<string, string, uint64_t>> SQLite::popCommittedTransactions()
+{
     return _sharedData.popCommittedTransactions();
 }
 
-void SQLite::rollback(const string& commandName) {
+void SQLite::rollback(const string& commandName)
+{
     // Make sure we're actually inside a transaction
     if (_insideTransaction) {
         // Store the total transaction time only if we were inside one.
@@ -1027,29 +1066,32 @@ void SQLite::rollback(const string& commandName) {
     _dbCountAtStart = 0;
 }
 
-void SQLite::logLastTransactionTiming(const string& message, const string& commandName) {
+void SQLite::logLastTransactionTiming(const string& message, const string& commandName)
+{
     // We don't want to add `commitLockElapsed` and `totalTransactionElapsed` to the total elapsed time since they overlap with parts of the transaction
     // and that could double-count certain times (i.e. `commitElapsed` occurs simultaneously with `commitLockElapsed`)
     uint64_t totalElapsed = _beginElapsed + _readElapsed + _writeElapsed + _prepareElapsed + _commitElapsed + _rollbackElapsed;
     SINFO(message, {
         {"command", commandName},
-        {"totalElapsed", to_string(totalElapsed/1000)},
-        {"readElapsed", to_string(_readElapsed/1000)},
-        {"writeElapsed", to_string(_writeElapsed/1000)},
-        {"prepareElapsed", to_string(_prepareElapsed/1000)},
-        {"commitElapsed", to_string(_commitElapsed/1000)},
-        {"rollbackElapsed", to_string(_rollbackElapsed/1000)},
-        {"totalTransactionElapsed", to_string(_totalTransactionElapsed/1000)},
-        {"beginElapsed", to_string(_beginElapsed/1000)},
-        {"commitLockElapsed", to_string(_commitLockElapsed/1000)},
+        {"totalElapsed", to_string(totalElapsed / 1000)},
+        {"readElapsed", to_string(_readElapsed / 1000)},
+        {"writeElapsed", to_string(_writeElapsed / 1000)},
+        {"prepareElapsed", to_string(_prepareElapsed / 1000)},
+        {"commitElapsed", to_string(_commitElapsed / 1000)},
+        {"rollbackElapsed", to_string(_rollbackElapsed / 1000)},
+        {"totalTransactionElapsed", to_string(_totalTransactionElapsed / 1000)},
+        {"beginElapsed", to_string(_beginElapsed / 1000)},
+        {"commitLockElapsed", to_string(_commitLockElapsed / 1000)},
     });
 }
 
-bool SQLite::getCommit(uint64_t id, string& query, string& hash) {
+bool SQLite::getCommit(uint64_t id, string& query, string& hash)
+{
     return getCommit(_db, _journalNames, id, query, hash);
 }
 
-bool SQLite::getCommit(sqlite3* db, const vector<string>& journalNames, uint64_t id, string& query, string& hash) {
+bool SQLite::getCommit(sqlite3* db, const vector<string>& journalNames, uint64_t id, string& query, string& hash)
+{
     // TODO: This can fail if called after `BEGIN TRANSACTION`, if the id we want to look up was committed by another
     // thread. We may or may never need to handle this case.
     // Look up the query and hash for the given commit
@@ -1069,20 +1111,22 @@ bool SQLite::getCommit(sqlite3* db, const vector<string>& journalNames, uint64_t
     }
 
     // If we found a hash, we assume this was a good commit, as we'll allow an empty commit.
-    return (!hash.empty());
+    return !hash.empty();
 }
 
-string SQLite::getCommittedHash() {
+string SQLite::getCommittedHash()
+{
     return _sharedData.lastCommittedHash.load();
 }
 
-int SQLite::getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result, uint64_t timeoutLimitUS) {
+int SQLite::getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result, uint64_t timeoutLimitUS)
+{
     // Look up all the queries within that range
     SASSERTWARN(SWITHIN(1, fromIndex, toIndex));
     string query = _getJournalQuery({"SELECT id, hash, query FROM", "WHERE id >= " + SQ(fromIndex) +
-                                    (toIndex ? " AND id <= " + SQ(toIndex) : "")});
+                                     (toIndex ? " AND id <= " + SQ(toIndex) : "")});
     SDEBUG("Getting commits #" << fromIndex << "-" << toIndex);
-    query = "SELECT hash, query FROM (" + query  + ") ORDER BY id";
+    query = "SELECT hash, query FROM (" + query + ") ORDER BY id";
     if (timeoutLimitUS) {
         setTimeout(timeoutLimitUS);
     }
@@ -1091,40 +1135,48 @@ int SQLite::getCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result, u
     return queryResult;
 }
 
-int64_t SQLite::getLastInsertRowID() {
+int64_t SQLite::getLastInsertRowID()
+{
     // Make sure it *does* happen after an INSERT, but not with a IGNORE
     SASSERTWARN(SContains(_uncommittedQuery, "INSERT") || SContains(_uncommittedQuery, "REPLACE"));
     SASSERTWARN(!SContains(_uncommittedQuery, "IGNORE"));
-    int64_t sqliteRowID = (int64_t)sqlite3_last_insert_rowid(_db);
+    int64_t sqliteRowID = (int64_t) sqlite3_last_insert_rowid(_db);
     return sqliteRowID;
 }
 
-uint64_t SQLite::getCommitCount() const {
+uint64_t SQLite::getCommitCount() const
+{
     return _sharedData.commitCount;
 }
 
-uint64_t SQLite::getOutstandingFramesToCheckpoint() const {
+uint64_t SQLite::getOutstandingFramesToCheckpoint() const
+{
     return _sharedData.knownOutstandingFramesToCheckpoint;
 }
 
-size_t SQLite::getLastWriteChangeCount() {
+size_t SQLite::getLastWriteChangeCount()
+{
     int count = sqlite3_changes(_db);
-    return count > 0 ? (size_t)count : 0;
+    return count > 0 ? (size_t) count : 0;
 }
 
-void SQLite::enableRewrite(bool enable) {
+void SQLite::enableRewrite(bool enable)
+{
     _enableRewrite = enable;
 }
 
-void SQLite::setRewriteHandler(bool (*handler)(int, const char*, string&)) {
+void SQLite::setRewriteHandler(bool (*handler)(int, const char*, string&))
+{
     _rewriteHandler = handler;
 }
 
-void SQLite::enablePrepareNotifications(bool enable) {
+void SQLite::enablePrepareNotifications(bool enable)
+{
     _shouldNotifyPluginsOnPrepare = enable;
 }
 
-void SQLite::setOnPrepareHandler(void (*handler)(SQLite& _db, int64_t tableID)) {
+void SQLite::setOnPrepareHandler(void (*handler)(SQLite& _db, int64_t tableID))
+{
     _onPrepareHandler = handler;
 }
 
@@ -1135,7 +1187,8 @@ int SQLite::_sqliteAuthorizerCallback(void* pUserData, int actionCode, const cha
     return db->_authorize(actionCode, detail1, detail2, detail3, detail4);
 }
 
-int SQLite::_authorize(int actionCode, const char* detail1, const char* detail2, const char* detail3, const char* detail4) {
+int SQLite::_authorize(int actionCode, const char* detail1, const char* detail2, const char* detail3, const char* detail4)
+{
     // If we've enabled re-writing, see if we need to re-write this query.
     if (_enableRewrite && !_currentlyRunningRewritten && (*_rewriteHandler)(actionCode, detail1, _rewrittenQuery)) {
         // Deny the original query, we'll re-run on the re-written version.
@@ -1214,6 +1267,7 @@ int SQLite::_authorize(int actionCode, const char* detail1, const char* detail2,
         case SQLITE_COPY:
         case SQLITE_RECURSIVE:
             return SQLITE_DENY;
+
             break;
 
         // The following are *always* allowed in whitelist mode.
@@ -1221,7 +1275,9 @@ int SQLite::_authorize(int actionCode, const char* detail1, const char* detail2,
         case SQLITE_ANALYZE:
         case SQLITE_FUNCTION:
             return SQLITE_OK;
+
             break;
+
         case SQLITE_PRAGMA:
         {
             string normalizedTable = SToLower(detail1);
@@ -1237,6 +1293,7 @@ int SQLite::_authorize(int actionCode, const char* detail1, const char* detail2,
             }
             break;
         }
+
         case SQLITE_READ:
         {
             // See if there's an entry in the whitelist for this table.
@@ -1258,19 +1315,22 @@ int SQLite::_authorize(int actionCode, const char* detail1, const char* detail2,
     return SQLITE_DENY;
 }
 
-void SQLite::setTimeout(uint64_t timeLimitUS) {
+void SQLite::setTimeout(uint64_t timeLimitUS)
+{
     _timeoutStart = STimeNow();
     _timeoutLimit = _timeoutStart + timeLimitUS;
     _timeoutError = 0;
 }
 
-void SQLite::clearTimeout() {
+void SQLite::clearTimeout()
+{
     _timeoutLimit = 0;
     _timeoutStart = 0;
     _timeoutError = 0;
 }
 
-void SQLite::setUpdateNoopMode(bool enabled) {
+void SQLite::setUpdateNoopMode(bool enabled)
+{
     if (_noopUpdateMode == enabled) {
         return;
     }
@@ -1287,19 +1347,23 @@ void SQLite::setUpdateNoopMode(bool enabled) {
     }
 }
 
-bool SQLite::getUpdateNoopMode() const {
+bool SQLite::getUpdateNoopMode() const
+{
     return _noopUpdateMode;
 }
 
-uint64_t SQLite::getDBCountAtStart() const {
+uint64_t SQLite::getDBCountAtStart() const
+{
     return _dbCountAtStart;
 }
 
-void SQLite::setCommitEnabled(bool enable) {
+void SQLite::setCommitEnabled(bool enable)
+{
     _sharedData.setCommitEnabled(enable);
 }
 
-int SQLite::getPreparedStatements(const string& query, list<sqlite3_stmt*>& statements) {
+int SQLite::getPreparedStatements(const string& query, list<sqlite3_stmt*>& statements)
+{
     // We need a pointer to a prepared statement.
     sqlite3_stmt* ppStmt = nullptr;
 
@@ -1327,31 +1391,36 @@ int SQLite::getPreparedStatements(const string& query, list<sqlite3_stmt*>& stat
     return SQLITE_OK;
 }
 
-void SQLite::setQueryOnly(bool enabled) {
+void SQLite::setQueryOnly(bool enabled)
+{
     SQResult result;
     string query = "PRAGMA query_only = "s + (enabled ? "true" : "false") + ";";
     SQuery(_db, query, result);
 }
 
-int64_t SQLite::getLastConflictPage() const {
+int64_t SQLite::getLastConflictPage() const
+{
     return _lastConflictPage;
 }
 
-string SQLite::getLastConflictLocation() const {
+string SQLite::getLastConflictLocation() const
+{
     return _lastConflictLocation;
 }
 
 SQLite::SharedData::SharedData() :
-nextJournalCount(0),
-_commitEnabled(true),
-openTransactionCount(0),
-_commitLockTimer("commit lock timer", {
+    nextJournalCount(0),
+    _commitEnabled(true),
+    openTransactionCount(0),
+    _commitLockTimer("commit lock timer", {
     {"EXCLUSIVE", chrono::steady_clock::duration::zero()},
     {"SHARED", chrono::steady_clock::duration::zero()},
 })
-{ }
+{
+}
 
-void SQLite::SharedData::setCommitEnabled(bool enable) {
+void SQLite::SharedData::setCommitEnabled(bool enable)
+{
     if (_commitEnabled == enable) {
         // Exit early without grabbing the lock. It's possible during highly congested times for getting the lock to take long enough to time out the cluster.
         return;
@@ -1361,24 +1430,28 @@ void SQLite::SharedData::setCommitEnabled(bool enable) {
     _commitEnabled = enable;
 }
 
-void SQLite::SharedData::incrementCommit(const string& commitHash) {
+void SQLite::SharedData::incrementCommit(const string& commitHash)
+{
     lock_guard<decltype(_internalStateMutex)> lock(_internalStateMutex);
     commitCount++;
     commitTransactionInfo(commitCount);
     lastCommittedHash.store(commitHash);
 }
 
-void SQLite::SharedData::prepareTransactionInfo(uint64_t commitID, const string& query, const string& hash, uint64_t dbCountAtTransactionStart) {
+void SQLite::SharedData::prepareTransactionInfo(uint64_t commitID, const string& query, const string& hash, uint64_t dbCountAtTransactionStart)
+{
     lock_guard<decltype(_internalStateMutex)> lock(_internalStateMutex);
     _preparedTransactions.insert_or_assign(commitID, make_tuple(query, hash, dbCountAtTransactionStart));
 }
 
-void SQLite::SharedData::commitTransactionInfo(uint64_t commitID) {
+void SQLite::SharedData::commitTransactionInfo(uint64_t commitID)
+{
     lock_guard<decltype(_internalStateMutex)> lock(_internalStateMutex);
     _committedTransactions.insert(_preparedTransactions.extract(commitID));
 }
 
-map<uint64_t, tuple<string, string, uint64_t>> SQLite::SharedData::popCommittedTransactions() {
+map<uint64_t, tuple<string, string, uint64_t>> SQLite::SharedData::popCommittedTransactions()
+{
     lock_guard<decltype(_internalStateMutex)> lock(_internalStateMutex);
     decltype(_committedTransactions) result;
     result = move(_committedTransactions);

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -90,7 +90,7 @@ class SQLite {
 
     // Begins a new transaction. Returns true on success. If type is EXCLUSIVE, locks the commit mutex to guarantee
     // that this transaction cannot conflict with any others.
-    bool beginTransaction(TRANSACTION_TYPE type = TRANSACTION_TYPE::SHARED);
+    bool beginTransaction(TRANSACTION_TYPE type = TRANSACTION_TYPE::SHARED, bool beginOnly = false);
 
     // Verifies a table exists and has a particular definition. If the database is left with the right schema, it
     // returns true. If it had to create a new table (ie, the table was missing), it also sets created to true. If the

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -6,15 +6,27 @@
 #include <shared_mutex>
 
 class SQLite {
-  public:
+public:
 
     class timeout_error : public exception {
-      public :
-        timeout_error(const string& e, uint64_t time) : _what(e), _time(time) {};
-        virtual ~timeout_error() {};
-        const char* what() const noexcept { return _what.c_str(); }
-        const uint64_t time() const noexcept { return _time; }
-      private:
+public:
+        timeout_error(const string& e, uint64_t time) : _what(e), _time(time)
+        {
+        };
+        virtual ~timeout_error()
+        {
+        };
+        const char* what() const noexcept
+        {
+            return _what.c_str();
+        }
+
+        const uint64_t time() const noexcept
+        {
+            return _time;
+        }
+
+private:
         string _what;
         uint64_t _time;
     };
@@ -40,10 +52,17 @@ class SQLite {
     // normal `process` phase of a command on leader, but is treated similarly to a commit conflict in replication, and
     // re-runs the command after the other command (the `DELETE`) has finished.
     class constraint_error : public exception {
-      public :
-        constraint_error() {};
-        virtual ~constraint_error() {};
-        const char* what() const noexcept { return "constraint_error"; }
+public:
+        constraint_error()
+        {
+        };
+        virtual ~constraint_error()
+        {
+        };
+        const char* what() const noexcept
+        {
+            return "constraint_error";
+        }
     };
 
     // Constant to use like a sqlite result code when commits are disabled (see: https://www.sqlite.org/rescode.html)
@@ -68,7 +87,10 @@ class SQLite {
     ~SQLite();
 
     // Returns the canonicalized filename for this database
-    const string& getFilename() { return _filename; }
+    const string& getFilename()
+    {
+        return _filename;
+    }
 
     sqlite3* getDBHandle();
 
@@ -83,7 +105,8 @@ class SQLite {
     int read(const string& query, sqlite3_qrf_spec* spec) const;
 
     // Types of transactions that we can begin.
-    enum class TRANSACTION_TYPE {
+    enum class TRANSACTION_TYPE
+    {
         SHARED,
         EXCLUSIVE
     };
@@ -188,7 +211,10 @@ class SQLite {
     void rollback(const string& commandName = "");
 
     // Returns the total number of changes on this database
-    int getChangeCount() { return sqlite3_total_changes(_db); }
+    int getChangeCount()
+    {
+        return sqlite3_total_changes(_db);
+    }
 
     // Returns the timing of the last command
     void logLastTransactionTiming(const string& message, const string& commandName);
@@ -209,23 +235,35 @@ class SQLite {
     string getCommittedHash();
 
     // Returns what the new state will be of the database if the current transaction is committed.
-    string getUncommittedHash() { return _uncommittedHash; }
+    string getUncommittedHash()
+    {
+        return _uncommittedHash;
+    }
 
     // Returns a concatenated string containing all the 'write' queries executed within the current, uncommitted
     // transaction.
-    string getUncommittedQuery() { return _uncommittedQuery; }
+    string getUncommittedQuery()
+    {
+        return _uncommittedQuery;
+    }
 
     // Gets the ROWID of the last insertion (for auto-increment indexes)
     int64_t getLastInsertRowID();
 
     // Gets any error message associated with the previous query
-    string getLastError() { return sqlite3_errmsg(_db); }
+    string getLastError()
+    {
+        return sqlite3_errmsg(_db);
+    }
 
     // Returns the most recent error string from sqlite.
     const string getMostRecentSQLiteErrorLog() const;
 
     // Returns true if we're inside an uncommitted transaction.
-    bool insideTransaction() const { return _insideTransaction; }
+    bool insideTransaction() const
+    {
+        return _insideTransaction;
+    }
 
     // Looks up the exact SQL of a paricular commit to the database, as well as gets the SHA1 hash of the database
     // immediately following tha commit.
@@ -254,7 +292,7 @@ class SQLite {
     // This atomically removes and returns committed transactions from our internal list. SQLiteNode can call this, and
     // it will return a map of transaction IDs to tuples of (query, hash, dbCountAtTransactionStart), so that those
     // transactions can be replicated out to peers.
-    map<uint64_t, tuple<string,string, uint64_t>> popCommittedTransactions();
+    map<uint64_t, tuple<string, string, uint64_t>> popCommittedTransactions();
 
     // The whitelist is either nullptr, in which case the feature is disabled, or it's a map of table names to sets of
     // column names that are allowed for reading. Using whitelist at all put the database handle into a more
@@ -295,11 +333,11 @@ class SQLite {
     void exclusiveLockDB();
     void exclusiveUnlockDB();
 
-  private:
+private:
     // This structure contains all of the data that's shared between a set of SQLite objects that share the same
     // underlying database file.
     class SharedData {
-      public:
+public:
         // Constructor.
         SharedData();
 
@@ -359,7 +397,7 @@ class SQLite {
         // This can be locked in exclusive mode to prevent all writes. This exists to support the `BlockWrites` command.
         shared_mutex writeLock;
 
-      private:
+private:
         // The data required to replicate transactions, in two lists, depending on whether this has only been prepared
         // or if it's been committed.
         map<uint64_t, tuple<string, string, uint64_t>> _preparedTransactions;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -103,7 +103,7 @@ const vector<SQLitePeer*> SQLiteNode::_initPeers(const string& peerListString)
 
     // Sort the peerList by name so we can get peers by name efficiently with binary search
     sort(peerList.begin(), peerList.end(),
-              [](const SQLitePeer* peer1, const SQLitePeer* peer2) {
+         [](const SQLitePeer* peer1, const SQLitePeer* peer2) {
         return peer1->name < peer2->name;
                                                                                                        });
 
@@ -1356,7 +1356,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
             _server.onNodeLogin(peer);
         } else if (!peer->loggedIn) {
             STHROW("not logged in");
-        } else if (SIEquals(message.methodLine, "STATE"))   {
+        } else if (SIEquals(message.methodLine, "STATE")) {
             // STATE: Broadcast to all peers whenever a node's state changes. Also sent whenever a node commits a new query
             // (and thus has a new commit count and hash). A peer can react or respond to a peer's state change as follows:
             if (!message.isSet("State")) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -65,15 +65,16 @@ SQLiteNode* SQLiteNode::KILLABLE_SQLITE_NODE{0};
 atomic<bool> SQLiteNode::NODE_KILLED{false};
 
 // Initializations for static vars.
-const uint64_t SQLiteNode::RECV_TIMEOUT{STIME_US_PER_S * 30};
+const uint64_t SQLiteNode::RECV_TIMEOUT{STIME_US_PER_S* 30};
 
 const string SQLiteNode::CONSISTENCY_LEVEL_NAMES[] = {"ASYNC",
-                                                    "ONE",
-                                                    "QUORUM"};
+                                                      "ONE",
+                                                      "QUORUM"};
 
 const size_t SQLiteNode::MIN_APPROVE_FREQUENCY{10};
 
-const vector<SQLitePeer*> SQLiteNode::_initPeers(const string& peerListString) {
+const vector<SQLitePeer*> SQLiteNode::_initPeers(const string& peerListString)
+{
     // Make the logging macro work in the static initializer.
     auto _name = "init";
     SQLiteNodeState _state = SQLiteNodeState::UNKNOWN;
@@ -101,8 +102,10 @@ const vector<SQLitePeer*> SQLiteNode::_initPeers(const string& peerListString) {
     }
 
     // Sort the peerList by name so we can get peers by name efficiently with binary search
-    std::sort(peerList.begin(), peerList.end(),
-              [](const SQLitePeer* peer1, const SQLitePeer* peer2) { return peer1->name < peer2->name; });
+    sort(peerList.begin(), peerList.end(),
+              [](const SQLitePeer* peer1, const SQLitePeer* peer2) {
+        return peer1->name < peer2->name;
+                                                                                                       });
 
     return peerList;
 }
@@ -111,26 +114,26 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, const shared_ptr<SQLitePool>& dbPoo
                        const string& host, const string& peerList, int priority, uint64_t firstTimeout,
                        const string& version, const string& commandPort)
     : STCPManager(),
-      _commandAddress(commandPort),
-      _name(name),
-      _host(host),
-      _peerList(_initPeers(peerList)),
-      _originalPriority(priority),
-      _port(_host.empty() ? nullptr : openPort(_host)),
-      _version(version),
-      _commitState(CommitState::UNINITIALIZED),
-      _db(dbPool->getBase()),
-      _dbPool(dbPool),
-      _isShuttingDown(false),
-      _lastSentTransactionID(0),
-      _leadPeer(nullptr),
-      _priority(-1),
-      _server(server),
-      _state(SQLiteNodeState::UNKNOWN),
-      _stateChangeCount(0),
-      _stateTimeout(STimeNow() + firstTimeout),
-      _syncPeer(nullptr),
-      _replicateThreadShouldExitTime(0)
+    _commandAddress(commandPort),
+    _name(name),
+    _host(host),
+    _peerList(_initPeers(peerList)),
+    _originalPriority(priority),
+    _port(_host.empty() ? nullptr : openPort(_host)),
+    _version(version),
+    _commitState(CommitState::UNINITIALIZED),
+    _db(dbPool->getBase()),
+    _dbPool(dbPool),
+    _isShuttingDown(false),
+    _lastSentTransactionID(0),
+    _leadPeer(nullptr),
+    _priority(-1),
+    _server(server),
+    _state(SQLiteNodeState::UNKNOWN),
+    _stateChangeCount(0),
+    _stateTimeout(STimeNow() + firstTimeout),
+    _syncPeer(nullptr),
+    _replicateThreadShouldExitTime(0)
 {
     KILLABLE_SQLITE_NODE = this;
     SASSERT(_originalPriority >= 0);
@@ -145,7 +148,8 @@ SQLiteNode::SQLiteNode(SQLiteServer& server, const shared_ptr<SQLitePool>& dbPoo
     _changeState(SQLiteNodeState::SEARCHING);
 }
 
-SQLiteNode::~SQLiteNode() {
+SQLiteNode::~SQLiteNode()
+{
     // Make sure it's a clean shutdown
     SASSERTWARN(!commitInProgress());
 
@@ -164,7 +168,8 @@ SQLiteNode::~SQLiteNode() {
     }
 }
 
-void SQLiteNode::_replicate() {
+void SQLiteNode::_replicate()
+{
     SInitialize("replication");
     // Allow the DB handle to be returned regardless of how this function exits.
     SQLiteScopedHandle dbScope(*_dbPool, _dbPool->getIndex(false));
@@ -229,13 +234,14 @@ void SQLiteNode::_replicate() {
     }
 }
 
-void SQLiteNode::startCommit(ConsistencyLevel consistency) {
+void SQLiteNode::startCommit(ConsistencyLevel consistency)
+{
     unique_lock<decltype(_stateMutex)> uniqueLock(_stateMutex);
 
     // Verify we're not already committing something, and then record that we have begun. This doesn't actually *do*
     // anything, but `update()` will pick up the state in its next invocation and start the actual commit.
     SASSERT(_commitState == CommitState::UNINITIALIZED ||
-            _commitState == CommitState::SUCCESS       ||
+            _commitState == CommitState::SUCCESS ||
             _commitState == CommitState::FAILED);
     _commitState = CommitState::WAITING;
     _commitConsistency = consistency;
@@ -244,7 +250,8 @@ void SQLiteNode::startCommit(ConsistencyLevel consistency) {
     }
 }
 
-bool SQLiteNode::beginShutdown() {
+bool SQLiteNode::beginShutdown()
+{
     unique_lock<decltype(_stateMutex)> uniqueLock(_stateMutex);
     // Ignore redundant
     if (!_isShuttingDown) {
@@ -257,10 +264,12 @@ bool SQLiteNode::beginShutdown() {
     return false;
 }
 
-bool SQLiteNode::_isNothingBlockingShutdown() const {
+bool SQLiteNode::_isNothingBlockingShutdown() const
+{
     // Don't shutdown if in the middle of a transaction
-    if (_db.insideTransaction())
+    if (_db.insideTransaction()) {
         return false;
+    }
 
     // If we're doing a commit, don't shut down.
     if (commitInProgress()) {
@@ -281,7 +290,8 @@ bool SQLiteNode::_isNothingBlockingShutdown() const {
     return true;
 }
 
-bool SQLiteNode::shutdownComplete() const {
+bool SQLiteNode::shutdownComplete() const
+{
     shared_lock<decltype(_stateMutex)> sharedLock(_stateMutex);
 
     // First even see if we're shutting down
@@ -307,19 +317,22 @@ bool SQLiteNode::shutdownComplete() const {
     }
 }
 
-SQLiteNodeState SQLiteNode::getState() const {
+SQLiteNodeState SQLiteNode::getState() const
+{
     // Note: this can skip locking because it only accesses a single atomic variable, which makes it safe to call in
     // private methods.
     return _state;
 }
 
-int SQLiteNode::getPriority() const {
+int SQLiteNode::getPriority() const
+{
     // Note: this can skip locking because it only accesses a single atomic variable, which makes it safe to call in
     // private methods.
     return _priority;
 }
 
-void SQLiteNode::setShutdownPriority() {
+void SQLiteNode::setShutdownPriority()
+{
     SINFO("Setting priority to 1.");
     unique_lock<decltype(_stateMutex)> uniqueLock(_stateMutex);
     _priority = 1;
@@ -336,7 +349,8 @@ void SQLiteNode::setShutdownPriority() {
     SINFO("SHUTDOWN Priority changed");
 }
 
-const string SQLiteNode::getLeaderVersion() const {
+const string SQLiteNode::getLeaderVersion() const
+{
     shared_lock<decltype(_stateMutex)> sharedLock(_stateMutex);
     if (_state == SQLiteNodeState::LEADING || _state == SQLiteNodeState::STANDINGDOWN) {
         return _version;
@@ -346,32 +360,37 @@ const string SQLiteNode::getLeaderVersion() const {
     return "";
 }
 
-uint64_t SQLiteNode::getCommitCount() const {
+uint64_t SQLiteNode::getCommitCount() const
+{
     // Note: this can skip locking because it only accesses a single atomic variable, which makes it safe to call in
     // private methods. (Yes, SQLite::SharedData::getCommitCount is atomic, go check).
     return _db.getCommitCount();
 }
 
-uint64_t SQLiteNode::getOutstandingFramesToCheckpoint() const {
+uint64_t SQLiteNode::getOutstandingFramesToCheckpoint() const
+{
     // Note: this can skip locking because it only accesses a single atomic variable, which makes it safe to call in
     // private methods.
     return _db.getOutstandingFramesToCheckpoint();
 }
 
-bool SQLiteNode::commitInProgress() const {
+bool SQLiteNode::commitInProgress() const
+{
     // Note: this can skip locking because it only accesses a single atomic variable, which makes it safe to call in
     // private methods.
     CommitState commitState = _commitState.load();
-    return (commitState == CommitState::WAITING || commitState == CommitState::COMMITTING);
+    return commitState == CommitState::WAITING || commitState == CommitState::COMMITTING;
 }
 
-bool SQLiteNode::commitSucceeded() const {
+bool SQLiteNode::commitSucceeded() const
+{
     // Note: this can skip locking because it only accesses a single atomic variable, which makes it safe to call in
     // private methods.
     return _commitState == CommitState::SUCCESS;
 }
 
-void SQLiteNode::_sendOutstandingTransactions(const set<uint64_t>& commitOnlyIDs) {
+void SQLiteNode::_sendOutstandingTransactions(const set<uint64_t>& commitOnlyIDs)
+{
     auto transactions = _db.popCommittedTransactions();
     if (transactions.empty()) {
         // Nothing to do.
@@ -420,7 +439,8 @@ void SQLiteNode::_sendOutstandingTransactions(const set<uint64_t>& commitOnlyIDs
     }
 }
 
-list<STable> SQLiteNode::getPeerInfo() const {
+list<STable> SQLiteNode::getPeerInfo() const
+{
     // This does not lock _stateMutex. It follows the rule in `SQLiteNode.h` that says:
     //  * Alternatively, a public `const` method that is a simple getter for an atomic property can skip the lock.
     // peer->getData is atomic internally, so we can treat `peer->getData()` as a simple getter for an atomic property.
@@ -434,7 +454,8 @@ list<STable> SQLiteNode::getPeerInfo() const {
     return peerData;
 }
 
-string SQLiteNode::getEligibleFollowerForForwardingAddress() const {
+string SQLiteNode::getEligibleFollowerForForwardingAddress() const
+{
     vector<string> validPeers;
     const string leaderVersion = getLeaderVersion();
     if (leaderVersion.empty()) {
@@ -486,7 +507,8 @@ string SQLiteNode::getEligibleFollowerForForwardingAddress() const {
 // State Transitions
 // -----------------
 // Each state transitions according to the following events and operates as follows:
-bool SQLiteNode::update() {
+bool SQLiteNode::update()
+{
     if (NODE_KILLED) {
         SWARN("Killed, skipping update");
         return false;
@@ -500,467 +522,448 @@ bool SQLiteNode::update() {
 
     // Process the database state machine
     switch (_state) {
-    /// - SEARCHING: Wait for a period and try to connect to all known
-    ///     peers.  After a timeout, give up and go ahead with whoever
-    ///     we were able to successfully connect to -- if anyone.  The
-    ///     logic for this state is as follows:
-    ///
-    ///         if( no peers configured )             goto LEADING
-    ///         if( !timeout )                        keep waiting
-    ///         if( no peers connected )              goto LEADING
-    ///         if( nobody has more commits than us ) goto WAITING
-    ///         else send SYNCHRONIZE and goto SYNCHRONIZING
-    ///
-    case SQLiteNodeState::SEARCHING: {
-        SASSERTWARN(!_syncPeer);
-        SASSERTWARN(!_leadPeer);
-        SASSERTWARN(_db.getUncommittedHash().empty());
+        /// - SEARCHING: Wait for a period and try to connect to all known
+        ///     peers.  After a timeout, give up and go ahead with whoever
+        ///     we were able to successfully connect to -- if anyone.  The
+        ///     logic for this state is as follows:
+        ///
+        ///         if( no peers configured )             goto LEADING
+        ///         if( !timeout )                        keep waiting
+        ///         if( no peers connected )              goto LEADING
+        ///         if( nobody has more commits than us ) goto WAITING
+        ///         else send SYNCHRONIZE and goto SYNCHRONIZING
+        ///
+        case SQLiteNodeState::SEARCHING: {
+            SASSERTWARN(!_syncPeer);
+            SASSERTWARN(!_leadPeer);
+            SASSERTWARN(_db.getUncommittedHash().empty());
 
-        // If we're trying to shut down, just do nothing, especially don't jump directly to leading and get stuck in an endless loop.
-        if (_isShuttingDown) {
+            // If we're trying to shut down, just do nothing, especially don't jump directly to leading and get stuck in an endless loop.
+            if (_isShuttingDown) {
+                // We need to exit here.
+                return false; // Don't re-update
+            }
 
-            // We need to exit here.
-            return false; // Don't re-update
-        }
+            // If no peers, we're the leader, unless we're shutting down.
+            if (_peerList.empty()) {
+                SHMMM("No peers configured, jumping to LEADING");
+                _priority = _originalPriority;
+                _changeState(SQLiteNodeState::LEADING);
 
-        // If no peers, we're the leader, unless we're shutting down.
-        if (_peerList.empty()) {
-            SHMMM("No peers configured, jumping to LEADING");
-            _priority = _originalPriority;
-            _changeState(SQLiteNodeState::LEADING);
+                // Run `update` again immediately.
+                return true;
+            }
 
-            // Run `update` again immediately.
-            return true;
-        }
+            // How many peers have we logged in to?
+            size_t numFullPeers = 0;
+            size_t numLoggedInFullPeers = 0;
+            list<string> loggedInPeers;
+            SQLitePeer* freshestPeer = nullptr;
+            for (const auto& peer : _peerList) {
+                // Count how many full peers (non-permafollowers) we have, and how many are logged in.
+                // Note that the `permaFollower` property is const and this value will always be the same for a given peer.
+                if (!peer->permaFollower) {
+                    numFullPeers++;
+                    if (peer->loggedIn) {
+                        numLoggedInFullPeers++;
+                    }
+                }
 
-        // How many peers have we logged in to?
-        size_t numFullPeers = 0;
-        size_t numLoggedInFullPeers = 0;
-        list<string> loggedInPeers;
-        SQLitePeer* freshestPeer = nullptr;
-        for (const auto& peer : _peerList) {
-            // Count how many full peers (non-permafollowers) we have, and how many are logged in.
-            // Note that the `permaFollower` property is const and this value will always be the same for a given peer.
-            if (!peer->permaFollower) {
-                numFullPeers++;
+                // Find the freshest non-broken peer (including permafollowers).
                 if (peer->loggedIn) {
-                    numLoggedInFullPeers++;
+                    loggedInPeers.push_back(peer->name);
+                    if (peer->forked) {
+                        SWARN("Hash mismatch. Forked from peer " << peer->name << " so not considering it." << _getLostQuorumLogMessage());
+                        continue;
+                    }
+
+                    // The freshest peer is the one that has the most commits. There can be ties here, they don't matter.
+                    if (!freshestPeer || peer->commitCount > freshestPeer->commitCount) {
+                        freshestPeer = peer;
+                    }
                 }
             }
 
-            // Find the freshest non-broken peer (including permafollowers).
-            if (peer->loggedIn) {
-                loggedInPeers.push_back(peer->name);
-                if (peer->forked) {
-                    SWARN("Hash mismatch. Forked from peer " << peer->name << " so not considering it." << _getLostQuorumLogMessage());
+            SINFO("Signed in to " << numLoggedInFullPeers << " of " << numFullPeers << " full peers (plus " << (_peerList.size() - numFullPeers) << " permafollowers): " << SComposeList(loggedInPeers));
+
+            // We just keep searching until we are connected to at least half the full peers.
+            // Note that `numLoggedInFullPeers == numFullPeers` is adequate to satisfy the cluster size, because we do not include ourselves in the cluster size.
+            // For example, for a cluster of size 5, we have 4 peers. If we are logged into two of them, that means we are a group of three connected peers,
+            // which is sufficient for quorum. In this case `if (2 * 2 < 4)` will return `false` and we will skip the `return false`.
+            if (numLoggedInFullPeers * 2 < numFullPeers) {
+                return false;
+            }
+
+            // The only way to not have a freshest peer, given that we've already checked that there should be peers, and that we're connected to at least half of
+            // them, is if all of the peers that we're connected to have forked from us. In this case, the best course of action is to wait for a non-forked peer
+            // to connect. If we have forked from too many peers, we can't get here, we'll have crashed.
+            if (!freshestPeer) {
+                SHMMM("Not connected to any non-forked peer. Retrying.");
+                return false;
+            }
+
+            // If we're at or ahead of the freshest peer, we can move forward towards LEADING or FOLLOWING.
+            if (_db.getCommitCount() >= freshestPeer->commitCount) {
+                SINFO("Synchronized with the freshest peer '" << freshestPeer->name << "', WAITING.");
+                _changeState(SQLiteNodeState::WAITING);
+
+                // Run `update` again immediately.
+                return true;
+            }
+
+            // Otherwise, the peer has a higher commit count than us, synchronize from it.
+            SASSERTWARN(!_syncPeer);
+            _updateSyncPeer();
+            if (_syncPeer) {
+                _sendToPeer(_syncPeer, SData("SYNCHRONIZE"));
+                _changeState(SQLiteNodeState::SYNCHRONIZING);
+
+                // Run `update` again immediately.
+                return true;
+            }
+
+            // Wait on some network activity to see if we can fix this with a new peer login.
+            SWARN("We have a fresher peer but couldn't get a sync peer, SEARCHING again.");
+            return false;
+        }
+
+        /// - SYNCHRONIZING: We only stay in this state while waiting for
+        ///     the SYNCHRONIZE_RESPONSE.  When we receive it, we'll enter
+        ///     the WAITING state.  Alternately, give up waitng after a
+        ///     period and go SEARCHING.
+        ///
+        case SQLiteNodeState::SYNCHRONIZING: {
+            if (_isShuttingDown) {
+                _changeState(SQLiteNodeState::SEARCHING);
+                return false;
+            }
+
+            SASSERTWARN(_syncPeer);
+            SASSERTWARN(!_leadPeer);
+            SASSERTWARN(_db.getUncommittedHash().empty());
+            // Nothing to do but wait
+            if (STimeNow() > _stateTimeout) {
+                // Give up on synchronization; reconnect that peer and go searching
+                SHMMM("Timed out while waiting for SYNCHRONIZE_RESPONSE, searching.");
+                _reconnectPeer(_syncPeer);
+                _syncPeer = nullptr;
+                _changeState(SQLiteNodeState::SEARCHING);
+                return true; // Re-update
+            }
+            break;
+        }
+
+        /// - WAITING: As the name implies, wait until something happens.  The
+        ///     logic for this state is as follows:
+        ///
+        ///         loop across "LoggedIn" peers to find the following:
+        ///             - freshest peer (most commits)
+        ///             - highest priority peer
+        ///             - current leader (might be STANDINGUP or STANDINGDOWN)
+        ///         if( no peers logged in )
+        ///             goto SEARCHING
+        ///         if( a higher-priority LEADING leader exists )
+        ///             send SUBSCRIBE and go SUBSCRIBING
+        ///         if( the freshest peer has more commits han us )
+        ///             goto SEARCHING
+        ///         if( no leader and we're the highest prioriy )
+        ///             clear "StandupResponse" on all peers
+        ///             goto STANDINGUP
+        ///
+        case SQLiteNodeState::WAITING: {
+            SASSERTWARN(!_syncPeer);
+            SASSERTWARN(!_leadPeer);
+            SASSERTWARN(_db.getUncommittedHash().empty());
+
+            if (_isShuttingDown) {
+                // This can happen because of fast stand down.
+                // If there are commands in `peek` when we start stand down, we will need to escalate those after stand down to the new leader.
+                // So the sync node starts the process of going through:
+                // LEADING -> STANDINGDOWN -> SEARCHING -> SYNCHRONIZING -> WAITING -> FOLLLOWING -> SEARCHING
+                // However, if we complete the first part of this and get through STANDINGDOWN and there are *no* commands
+                // left to handle, the node could be in any of SEARCHING, SYNCHRONIZING, WAITING, or FOLLOWING.
+                // We switch to SEARCHING just for consistency, and exit.
+                _changeState(SQLiteNodeState::SEARCHING);
+
+                return false;
+            }
+
+            // Loop across peers and find the highest priority and leader
+            int numFullPeers = 0;
+            int numLoggedInFullPeers = 0;
+            SQLitePeer* highestPriorityPeer = nullptr;
+            SQLitePeer* freshestPeer = nullptr;
+            SQLitePeer* currentLeader = nullptr;
+            for (auto peer : _peerList) {
+                if (peer->permaFollower) {
+                    // Permafollowers are treated as ineligible for leader, etc.
                     continue;
                 }
 
-                // The freshest peer is the one that has the most commits. There can be ties here, they don't matter.
-                if (!freshestPeer || peer->commitCount > freshestPeer->commitCount) {
-                    freshestPeer = peer;
-                }
-            }
-        }
-
-        SINFO("Signed in to " << numLoggedInFullPeers << " of " << numFullPeers << " full peers (plus " << (_peerList.size() - numFullPeers) << " permafollowers): " << SComposeList(loggedInPeers));
-
-        // We just keep searching until we are connected to at least half the full peers.
-        // Note that `numLoggedInFullPeers == numFullPeers` is adequate to satisfy the cluster size, because we do not include ourselves in the cluster size.
-        // For example, for a cluster of size 5, we have 4 peers. If we are logged into two of them, that means we are a group of three connected peers,
-        // which is sufficient for quorum. In this case `if (2 * 2 < 4)` will return `false` and we will skip the `return false`.
-        if (numLoggedInFullPeers * 2 < numFullPeers) {
-            return false;
-        }
-
-        // The only way to not have a freshest peer, given that we've already checked that there should be peers, and that we're connected to at least half of
-        // them, is if all of the peers that we're connected to have forked from us. In this case, the best course of action is to wait for a non-forked peer
-        // to connect. If we have forked from too many peers, we can't get here, we'll have crashed.
-        if (!freshestPeer) {
-            SHMMM("Not connected to any non-forked peer. Retrying.");
-            return false;
-        }
-
-        // If we're at or ahead of the freshest peer, we can move forward towards LEADING or FOLLOWING.
-        if (_db.getCommitCount() >= freshestPeer->commitCount) {
-            SINFO("Synchronized with the freshest peer '" << freshestPeer->name << "', WAITING.");
-            _changeState(SQLiteNodeState::WAITING);
-
-            // Run `update` again immediately.
-            return true;
-        }
-
-        // Otherwise, the peer has a higher commit count than us, synchronize from it.
-        SASSERTWARN(!_syncPeer);
-        _updateSyncPeer();
-        if (_syncPeer) {
-            _sendToPeer(_syncPeer, SData("SYNCHRONIZE"));
-            _changeState(SQLiteNodeState::SYNCHRONIZING);
-
-            // Run `update` again immediately.
-            return true;
-        }
-
-        // Wait on some network activity to see if we can fix this with a new peer login.
-        SWARN("We have a fresher peer but couldn't get a sync peer, SEARCHING again.");
-        return false;
-    }
-
-    /// - SYNCHRONIZING: We only stay in this state while waiting for
-    ///     the SYNCHRONIZE_RESPONSE.  When we receive it, we'll enter
-    ///     the WAITING state.  Alternately, give up waitng after a
-    ///     period and go SEARCHING.
-    ///
-    case SQLiteNodeState::SYNCHRONIZING: {
-        if (_isShuttingDown) {
-            _changeState(SQLiteNodeState::SEARCHING);
-            return false;
-        }
-
-        SASSERTWARN(_syncPeer);
-        SASSERTWARN(!_leadPeer);
-        SASSERTWARN(_db.getUncommittedHash().empty());
-        // Nothing to do but wait
-        if (STimeNow() > _stateTimeout) {
-            // Give up on synchronization; reconnect that peer and go searching
-            SHMMM("Timed out while waiting for SYNCHRONIZE_RESPONSE, searching.");
-            _reconnectPeer(_syncPeer);
-            _syncPeer = nullptr;
-            _changeState(SQLiteNodeState::SEARCHING);
-            return true; // Re-update
-        }
-        break;
-    }
-
-    /// - WAITING: As the name implies, wait until something happens.  The
-    ///     logic for this state is as follows:
-    ///
-    ///         loop across "LoggedIn" peers to find the following:
-    ///             - freshest peer (most commits)
-    ///             - highest priority peer
-    ///             - current leader (might be STANDINGUP or STANDINGDOWN)
-    ///         if( no peers logged in )
-    ///             goto SEARCHING
-    ///         if( a higher-priority LEADING leader exists )
-    ///             send SUBSCRIBE and go SUBSCRIBING
-    ///         if( the freshest peer has more commits han us )
-    ///             goto SEARCHING
-    ///         if( no leader and we're the highest prioriy )
-    ///             clear "StandupResponse" on all peers
-    ///             goto STANDINGUP
-    ///
-    case SQLiteNodeState::WAITING: {
-        SASSERTWARN(!_syncPeer);
-        SASSERTWARN(!_leadPeer);
-        SASSERTWARN(_db.getUncommittedHash().empty());
-
-        if (_isShuttingDown) {
-            // This can happen because of fast stand down.
-            // If there are commands in `peek` when we start stand down, we will need to escalate those after stand down to the new leader.
-            // So the sync node starts the process of going through:
-            // LEADING -> STANDINGDOWN -> SEARCHING -> SYNCHRONIZING -> WAITING -> FOLLLOWING -> SEARCHING
-            // However, if we complete the first part of this and get through STANDINGDOWN and there are *no* commands
-            // left to handle, the node could be in any of SEARCHING, SYNCHRONIZING, WAITING, or FOLLOWING.
-            // We switch to SEARCHING just for consistency, and exit.
-            _changeState(SQLiteNodeState::SEARCHING);
-
-            return false;
-        }
-
-        // Loop across peers and find the highest priority and leader
-        int numFullPeers = 0;
-        int numLoggedInFullPeers = 0;
-        SQLitePeer* highestPriorityPeer = nullptr;
-        SQLitePeer* freshestPeer = nullptr;
-        SQLitePeer* currentLeader = nullptr;
-        for (auto peer : _peerList) {
-            if (peer->permaFollower) {
-                // Permafollowers are treated as ineligible for leader, etc.
-                continue;
-            }
-
-            if (peer->forked) {
-                // Forked nodes are treated as ineligible for leader, etc.
-                SHMMM("Not counting forked peer " << peer->name << " for freshest, highestPriority, or currentLeader.");
-                continue;
-            }
-
-            // Verify we're logged in
-            ++numFullPeers;
-            if (peer->loggedIn) {
-                // Verify we're still fresh
-                ++numLoggedInFullPeers;
-                if (!freshestPeer || peer->commitCount > freshestPeer->commitCount) {
-                    freshestPeer = peer;
+                if (peer->forked) {
+                    // Forked nodes are treated as ineligible for leader, etc.
+                    SHMMM("Not counting forked peer " << peer->name << " for freshest, highestPriority, or currentLeader.");
+                    continue;
                 }
 
-                // See if it's the highest priority
-                if (!highestPriorityPeer || peer->priority > highestPriorityPeer->priority) {
-                    highestPriorityPeer = peer;
-                }
-
-                // See if it is currently the leader (or standing up/down)
-                if (peer->state == SQLiteNodeState::STANDINGUP || peer->state == SQLiteNodeState::LEADING || peer->state == SQLiteNodeState::STANDINGDOWN) {
-                    // Found the current leader
-                    if (currentLeader) {
-                        PHMMM("Multiple peers trying to stand up (also '" << currentLeader->name << "'), let's hope they sort it out.");
-                    }
-                    currentLeader = peer;
-                }
-            }
-        }
-
-        // If there are no logged in peers, then go back to SEARCHING.
-        if (!highestPriorityPeer) {
-            // Not connected to any other peers
-            SHMMM("Configured to have peers but can't connect to any, re-SEARCHING.");
-            _changeState(SQLiteNodeState::SEARCHING);
-            return true; // Re-update
-        }
-        SASSERT(highestPriorityPeer);
-        SASSERT(freshestPeer);
-
-        SDEBUG("Dumping evaluated cluster state: numLoggedInFullPeers=" << numLoggedInFullPeers << " freshestPeer=" << freshestPeer->name << " highestPriorityPeer=" << highestPriorityPeer->name << " currentLeader=" << (currentLeader ? currentLeader->name : "none"));
-
-        // If there is already a leader that is higher priority than us,
-        // subscribe -- even if we're not in sync with it.  (It'll bring
-        // us back up to speed while subscribing.)
-        if (currentLeader && _priority < highestPriorityPeer->priority && currentLeader->state == SQLiteNodeState::LEADING) {
-            // Subscribe to the leader
-            SINFO("Subscribing to leader '" << currentLeader->name << "'");
-            _leadPeer = currentLeader;
-            _sendToPeer(currentLeader, SData("SUBSCRIBE"));
-            _changeState(SQLiteNodeState::SUBSCRIBING);
-            return true; // Re-update
-        }
-
-        // No leader to subscribe to, let's see if there's anybody else
-        // out there with commits we don't have.  Might as well synchronize
-        // while waiting.
-        if (freshestPeer->commitCount > _db.getCommitCount()) {
-            // Out of sync with a peer -- resynchronize
-            SHMMM("Lost synchronization while waiting; re-SEARCHING.");
-            _changeState(SQLiteNodeState::SEARCHING);
-            return true; // Re-update
-        }
-
-        // No leader and we're in sync, perhaps everybody is waiting for us
-        // to stand up?  If we're higher than the highest priority, are using
-        // a real priority and are not a permafollower, and are connected to
-        // enough full peers to achieve quorum, we should be leader.
-        if (!currentLeader && numLoggedInFullPeers * 2 >= numFullPeers &&
-            _priority > 0 && _priority > highestPriorityPeer->priority) {
-            // Yep -- time for us to stand up -- clear everyone's
-            // last approval status as they're about to send them.
-            SINFO("No leader and we're highest priority (over " << highestPriorityPeer->name << "), STANDINGUP");
-            for (auto peer : _peerList) {
-                peer->standupResponse = SQLitePeer::Response::NONE;
-            }
-            _changeState(SQLiteNodeState::STANDINGUP);
-            return true; // Re-update
-        }
-
-        // Otherwise, Keep waiting
-        SDEBUG("Connected to " << numLoggedInFullPeers << " of " << numFullPeers << " full peers (" << _peerList.size()
-                               << " with permafollowers), priority=" << _priority);
-        break;
-    }
-
-    /// - STANDINGUP: We're waiting for peers to approve or deny our standup
-    ///     request.  The logic for this state is:
-    ///
-    ///         if( at least one peer has denied standup )
-    ///             goto SEARCHING
-    ///         if( everybody has responded and approved )
-    ///             goto LEADING
-    ///         if( somebody hasn't responded but we're timing out )
-    ///             goto SEARCHING
-    ///
-    case SQLiteNodeState::STANDINGUP: {
-        SASSERTWARN(!_syncPeer);
-        SASSERTWARN(!_leadPeer);
-        SASSERTWARN(_db.getUncommittedHash().empty());
-        size_t numFullPeers = 0;
-        size_t numLoggedInFullPeers = 0;
-        size_t approveCount = 0;
-        if (_isShuttingDown) {
-            SINFO("Shutting down while standing up, setting state to SEARCHING");
-            _changeState(SQLiteNodeState::SEARCHING);
-            return true; // Re-update
-        }
-
-        for (auto peer : _peerList) {
-            // Check this peer; if not logged in, tacit approval
-            if (!peer->permaFollower) {
+                // Verify we're logged in
                 ++numFullPeers;
                 if (peer->loggedIn) {
-                    // Connected and logged in.
-                    numLoggedInFullPeers++;
+                    // Verify we're still fresh
+                    ++numLoggedInFullPeers;
+                    if (!freshestPeer || peer->commitCount > freshestPeer->commitCount) {
+                        freshestPeer = peer;
+                    }
 
-                    // Has it responded yet?
-                    if (peer->standupResponse == SQLitePeer::Response::NONE) {
-                        // This peer hasn't yet responded. We do nothing with it in this case, maybe it will have responded by the next check.
-                    } else if (peer->standupResponse == SQLitePeer::Response::DENY) {
-                        // It responeded, but didn't approve -- abort
-                        PHMMM("Refused our STANDUP, cancel and RE-SEARCH");
-                        _changeState(SQLiteNodeState::SEARCHING);
-                        return true; // Re-update
-                    } else if (peer->standupResponse == SQLitePeer::Response::APPROVE) {
-                        approveCount++;
+                    // See if it's the highest priority
+                    if (!highestPriorityPeer || peer->priority > highestPriorityPeer->priority) {
+                        highestPriorityPeer = peer;
+                    }
+
+                    // See if it is currently the leader (or standing up/down)
+                    if (peer->state == SQLiteNodeState::STANDINGUP || peer->state == SQLiteNodeState::LEADING || peer->state == SQLiteNodeState::STANDINGDOWN) {
+                        // Found the current leader
+                        if (currentLeader) {
+                            PHMMM("Multiple peers trying to stand up (also '" << currentLeader->name << "'), let's hope they sort it out.");
+                        }
+                        currentLeader = peer;
                     }
                 }
             }
+
+            // If there are no logged in peers, then go back to SEARCHING.
+            if (!highestPriorityPeer) {
+                // Not connected to any other peers
+                SHMMM("Configured to have peers but can't connect to any, re-SEARCHING.");
+                _changeState(SQLiteNodeState::SEARCHING);
+                return true; // Re-update
+            }
+            SASSERT(highestPriorityPeer);
+            SASSERT(freshestPeer);
+
+            SDEBUG("Dumping evaluated cluster state: numLoggedInFullPeers=" << numLoggedInFullPeers << " freshestPeer=" << freshestPeer->name << " highestPriorityPeer=" << highestPriorityPeer->name << " currentLeader=" << (currentLeader ? currentLeader->name : "none"));
+
+            // If there is already a leader that is higher priority than us,
+            // subscribe -- even if we're not in sync with it.  (It'll bring
+            // us back up to speed while subscribing.)
+            if (currentLeader && _priority < highestPriorityPeer->priority && currentLeader->state == SQLiteNodeState::LEADING) {
+                // Subscribe to the leader
+                SINFO("Subscribing to leader '" << currentLeader->name << "'");
+                _leadPeer = currentLeader;
+                _sendToPeer(currentLeader, SData("SUBSCRIBE"));
+                _changeState(SQLiteNodeState::SUBSCRIBING);
+                return true; // Re-update
+            }
+
+            // No leader to subscribe to, let's see if there's anybody else
+            // out there with commits we don't have.  Might as well synchronize
+            // while waiting.
+            if (freshestPeer->commitCount > _db.getCommitCount()) {
+                // Out of sync with a peer -- resynchronize
+                SHMMM("Lost synchronization while waiting; re-SEARCHING.");
+                _changeState(SQLiteNodeState::SEARCHING);
+                return true; // Re-update
+            }
+
+            // No leader and we're in sync, perhaps everybody is waiting for us
+            // to stand up?  If we're higher than the highest priority, are using
+            // a real priority and are not a permafollower, and are connected to
+            // enough full peers to achieve quorum, we should be leader.
+            if (!currentLeader && numLoggedInFullPeers * 2 >= numFullPeers &&
+                _priority > 0 && _priority > highestPriorityPeer->priority) {
+                // Yep -- time for us to stand up -- clear everyone's
+                // last approval status as they're about to send them.
+                SINFO("No leader and we're highest priority (over " << highestPriorityPeer->name << "), STANDINGUP");
+                for (auto peer : _peerList) {
+                    peer->standupResponse = SQLitePeer::Response::NONE;
+                }
+                _changeState(SQLiteNodeState::STANDINGUP);
+                return true; // Re-update
+            }
+
+            // Otherwise, Keep waiting
+            SDEBUG("Connected to " << numLoggedInFullPeers << " of " << numFullPeers << " full peers (" << _peerList.size()
+                   << " with permafollowers), priority=" << _priority);
+            break;
         }
 
-        // If everyone's responded with approval and we form a majority, then finish standup.
-        bool majorityConnected = numLoggedInFullPeers * 2 >= numFullPeers;
-        bool quorumApproved = approveCount * 2 >= numFullPeers;
-        if (majorityConnected && quorumApproved) {
-            // Complete standup
-            SINFO("Enough peers responded, going LEADING.");
-            _changeState(SQLiteNodeState::LEADING);
-            return true; // Re-update
-        }
+        /// - STANDINGUP: We're waiting for peers to approve or deny our standup
+        ///     request.  The logic for this state is:
+        ///
+        ///         if( at least one peer has denied standup )
+        ///             goto SEARCHING
+        ///         if( everybody has responded and approved )
+        ///             goto LEADING
+        ///         if( somebody hasn't responded but we're timing out )
+        ///             goto SEARCHING
+        ///
+        case SQLiteNodeState::STANDINGUP: {
+            SASSERTWARN(!_syncPeer);
+            SASSERTWARN(!_leadPeer);
+            SASSERTWARN(_db.getUncommittedHash().empty());
+            size_t numFullPeers = 0;
+            size_t numLoggedInFullPeers = 0;
+            size_t approveCount = 0;
+            if (_isShuttingDown) {
+                SINFO("Shutting down while standing up, setting state to SEARCHING");
+                _changeState(SQLiteNodeState::SEARCHING);
+                return true; // Re-update
+            }
 
-        // See if we're taking too long
-        if (STimeNow() > _stateTimeout) {
-            // Timed out
-            SHMMM("Timed out waiting for STANDUP approval; re-SEARCHING.");
-            _changeState(SQLiteNodeState::SEARCHING);
-            return true; // Re-update
-        }
-        break;
-    }
-
-    /// - LEADING / STANDINGDOWN : These are the states where the magic
-    ///     happens.  In both states, the node will execute distributed
-    ///     transactions.  However, new transactions are only
-    ///     started in the LEADING state (while existing transactions are
-    ///     concluded in the STANDINGDOWN) state.  The logic for this state
-    ///     is as follows:
-    ///
-    ///         if( we're processing a transaction )
-    ///             if( all subscribed followers have responded/approved )
-    ///                 commit this transaction to the local DB
-    ///                 broadcast COMMIT_TRANSACTION to all subscribed followers
-    ///                 send a STATE to show we've committed a new transaction
-    ///                 notify the caller that the command is complete
-    ///         if( we're LEADING and not processing a command )
-    ///             if( there is another LEADER )         goto STANDINGDOWN
-    ///             if( there is a higher priority peer ) goto STANDINGDOWN
-    ///             if( a command is queued )
-    ///                 if( processing the command affects the database )
-    ///                    clear the transactionResponse of all peers
-    ///                    broadcast BEGIN_TRANSACTION to subscribed followers
-    ///         if( we're standing down and all followers have unsubscribed )
-    ///             goto SEARCHING
-    ///
-    case SQLiteNodeState::LEADING:
-    case SQLiteNodeState::STANDINGDOWN: {
-        SASSERTWARN(!_syncPeer);
-        SASSERTWARN(!_leadPeer);
-
-        // NOTE: This block very carefully will not try and call _changeState() while holding SQLite::g_commitLock,
-        // because that could cause a deadlock when called by an outside caller!
-
-        // If there's no commit in progress, we'll send any outstanding transactions that exist. We won't send them
-        // mid-commit, as they'd end up as nested transactions interleaved with the one in progress. However, there
-        // should never be any commits in here while a commit is in progress anyway, since all commits except the one
-        // running are blocked until that one finishes.
-        if (!commitInProgress()) {
-            _sendOutstandingTransactions();
-        }
-
-        // This means we've started a distributed transaction and need to decide if we should commit it, which can mean
-        // waiting on peers to approve the transaction. We can do this even after we've begun standing down.
-        if (_commitState == CommitState::COMMITTING) {
-            // Loop across all peers configured to see how many are:
-            int numFullPeers = 0;     // Num non-permafollowers configured
-            int numFullFollowers = 0; // Num full peers that are "subscribed"
-            int numFullResponded = 0; // Num full peers that have responded approve/deny
-            int numFullApproved = 0;  // Num full peers that have approved
-            int numFullDenied = 0;    // Num full peers that have denied
             for (auto peer : _peerList) {
-                // Check this peer to see if it's full or a permafollower
+                // Check this peer; if not logged in, tacit approval
                 if (!peer->permaFollower) {
-                    // It's a full peer -- is it subscribed, and if so, how did it respond?
                     ++numFullPeers;
-                    if (peer->subscribed) {
-                        // Subscribed, did it respond?
-                        numFullFollowers++;
-                        if (peer->transactionResponse == SQLitePeer::Response::NONE) {
-                            continue;
-                        }
-                        numFullResponded++;
-                        if (peer->transactionResponse == SQLitePeer::Response::APPROVE) {
-                            SDEBUG("Peer '" << peer->name << "' has approved transaction.");
-                            ++numFullApproved;
-                        } else {
-                            SWARN("Peer '" << peer->name << "' denied transaction.");
-                            ++numFullDenied;
+                    if (peer->loggedIn) {
+                        // Connected and logged in.
+                        numLoggedInFullPeers++;
+
+                        // Has it responded yet?
+                        if (peer->standupResponse == SQLitePeer::Response::NONE) {
+                            // This peer hasn't yet responded. We do nothing with it in this case, maybe it will have responded by the next check.
+                        } else if (peer->standupResponse == SQLitePeer::Response::DENY) {
+                            // It responeded, but didn't approve -- abort
+                            PHMMM("Refused our STANDUP, cancel and RE-SEARCH");
+                            _changeState(SQLiteNodeState::SEARCHING);
+                            return true; // Re-update
+                        } else if (peer->standupResponse == SQLitePeer::Response::APPROVE) {
+                            approveCount++;
                         }
                     }
                 }
             }
 
-            // Figure out if we have enough consistency
-            bool consistentEnough = false;
-            switch (_commitConsistency) {
-                case ASYNC:
-                    // Always consistent enough if we don't care!
-                    consistentEnough = true;
-                    break;
-                case ONE:
-                    // So long at least one full approved (if we have any peers, that is), we're good.
-                    consistentEnough = !numFullPeers || (numFullApproved > 0);
-                    break;
-                case QUORUM:
-                    // This one requires a majority
-                    consistentEnough = (numFullApproved * 2 >= numFullPeers);
-                    break;
-                default:
-                    SERROR("Invalid write consistency.");
-                    break;
+            // If everyone's responded with approval and we form a majority, then finish standup.
+            bool majorityConnected = numLoggedInFullPeers * 2 >= numFullPeers;
+            bool quorumApproved = approveCount * 2 >= numFullPeers;
+            if (majorityConnected && quorumApproved) {
+                // Complete standup
+                SINFO("Enough peers responded, going LEADING.");
+                _changeState(SQLiteNodeState::LEADING);
+                return true; // Re-update
             }
 
-            // See if all active non-permafollowers have responded.
-            // NOTE: This can be true if nobody responds if there are no full followers - this includes machines that
-            // should be followers that are disconnected.
-            bool everybodyResponded = numFullResponded >= numFullFollowers;
+            // See if we're taking too long
+            if (STimeNow() > _stateTimeout) {
+                // Timed out
+                SHMMM("Timed out waiting for STANDUP approval; re-SEARCHING.");
+                _changeState(SQLiteNodeState::SEARCHING);
+                return true; // Re-update
+            }
+            break;
+        }
 
-            // If anyone denied this transaction, roll this back. Alternatively, roll it back if everyone we're
-            // currently connected to has responded, but that didn't generate enough consistency. This could happen, in
-            // theory, if we were disconnected from enough of the cluster that we could no longer reach QUORUM, but
-            // this should have been detected earlier and forced us out of leading.
-            // TODO: we might want to remove the `numFullDenied` condition here. A single failure shouldn't cause the
-            // entire cluster to break. Imagine a scenario where a follower disk was full, and every write operation
-            // failed with an sqlite3 error.
-            if (numFullDenied || (everybodyResponded && !consistentEnough)) {
-                SINFO("Rolling back transaction because everybody currently connected responded "
+        /// - LEADING / STANDINGDOWN : These are the states where the magic
+        ///     happens.  In both states, the node will execute distributed
+        ///     transactions.  However, new transactions are only
+        ///     started in the LEADING state (while existing transactions are
+        ///     concluded in the STANDINGDOWN) state.  The logic for this state
+        ///     is as follows:
+        ///
+        ///         if( we're processing a transaction )
+        ///             if( all subscribed followers have responded/approved )
+        ///                 commit this transaction to the local DB
+        ///                 broadcast COMMIT_TRANSACTION to all subscribed followers
+        ///                 send a STATE to show we've committed a new transaction
+        ///                 notify the caller that the command is complete
+        ///         if( we're LEADING and not processing a command )
+        ///             if( there is another LEADER )         goto STANDINGDOWN
+        ///             if( there is a higher priority peer ) goto STANDINGDOWN
+        ///             if( a command is queued )
+        ///                 if( processing the command affects the database )
+        ///                    clear the transactionResponse of all peers
+        ///                    broadcast BEGIN_TRANSACTION to subscribed followers
+        ///         if( we're standing down and all followers have unsubscribed )
+        ///             goto SEARCHING
+        ///
+        case SQLiteNodeState::LEADING:
+        case SQLiteNodeState::STANDINGDOWN: {
+            SASSERTWARN(!_syncPeer);
+            SASSERTWARN(!_leadPeer);
+
+            // NOTE: This block very carefully will not try and call _changeState() while holding SQLite::g_commitLock,
+            // because that could cause a deadlock when called by an outside caller!
+
+            // If there's no commit in progress, we'll send any outstanding transactions that exist. We won't send them
+            // mid-commit, as they'd end up as nested transactions interleaved with the one in progress. However, there
+            // should never be any commits in here while a commit is in progress anyway, since all commits except the one
+            // running are blocked until that one finishes.
+            if (!commitInProgress()) {
+                _sendOutstandingTransactions();
+            }
+
+            // This means we've started a distributed transaction and need to decide if we should commit it, which can mean
+            // waiting on peers to approve the transaction. We can do this even after we've begun standing down.
+            if (_commitState == CommitState::COMMITTING) {
+                // Loop across all peers configured to see how many are:
+                int numFullPeers = 0; // Num non-permafollowers configured
+                int numFullFollowers = 0; // Num full peers that are "subscribed"
+                int numFullResponded = 0; // Num full peers that have responded approve/deny
+                int numFullApproved = 0; // Num full peers that have approved
+                int numFullDenied = 0; // Num full peers that have denied
+                for (auto peer : _peerList) {
+                    // Check this peer to see if it's full or a permafollower
+                    if (!peer->permaFollower) {
+                        // It's a full peer -- is it subscribed, and if so, how did it respond?
+                        ++numFullPeers;
+                        if (peer->subscribed) {
+                            // Subscribed, did it respond?
+                            numFullFollowers++;
+                            if (peer->transactionResponse == SQLitePeer::Response::NONE) {
+                                continue;
+                            }
+                            numFullResponded++;
+                            if (peer->transactionResponse == SQLitePeer::Response::APPROVE) {
+                                SDEBUG("Peer '" << peer->name << "' has approved transaction.");
+                                ++numFullApproved;
+                            } else {
+                                SWARN("Peer '" << peer->name << "' denied transaction.");
+                                ++numFullDenied;
+                            }
+                        }
+                    }
+                }
+
+                // Figure out if we have enough consistency
+                bool consistentEnough = false;
+                switch (_commitConsistency) {
+                    case ASYNC:
+                        // Always consistent enough if we don't care!
+                        consistentEnough = true;
+                        break;
+
+                    case ONE:
+                        // So long at least one full approved (if we have any peers, that is), we're good.
+                        consistentEnough = !numFullPeers || (numFullApproved > 0);
+                        break;
+
+                    case QUORUM:
+                        // This one requires a majority
+                        consistentEnough = (numFullApproved * 2 >= numFullPeers);
+                        break;
+
+                    default:
+                        SERROR("Invalid write consistency.");
+                        break;
+                }
+
+                // See if all active non-permafollowers have responded.
+                // NOTE: This can be true if nobody responds if there are no full followers - this includes machines that
+                // should be followers that are disconnected.
+                bool everybodyResponded = numFullResponded >= numFullFollowers;
+
+                // If anyone denied this transaction, roll this back. Alternatively, roll it back if everyone we're
+                // currently connected to has responded, but that didn't generate enough consistency. This could happen, in
+                // theory, if we were disconnected from enough of the cluster that we could no longer reach QUORUM, but
+                // this should have been detected earlier and forced us out of leading.
+                // TODO: we might want to remove the `numFullDenied` condition here. A single failure shouldn't cause the
+                // entire cluster to break. Imagine a scenario where a follower disk was full, and every write operation
+                // failed with an sqlite3 error.
+                if (numFullDenied || (everybodyResponded && !consistentEnough)) {
+                    SINFO("Rolling back transaction because everybody currently connected responded "
                       "but not consistent enough. Num denied: " << numFullDenied << ". Follower write failure?");
 
-                // Notify everybody to rollback
-                SData rollback("ROLLBACK_TRANSACTION");
-                rollback.set("ID", _lastSentTransactionID + 1);
-                _sendToAllPeers(rollback, true); // true: Only to subscribed peers.
-                _db.rollback();
-
-                // Finished, but failed.
-                _commitState = CommitState::FAILED;
-            } else if (consistentEnough) {
-                // Commit this distributed transaction. Either we have quorum, or we don't need it.
-                SDEBUG("Committing current transaction because consistentEnough: " << _db.getUncommittedQuery());
-                uint64_t beforeCommit = STimeNow();
-                // Only other intersting place we commit and would care about node state.
-                int result = _db.commit(stateName(_state));
-                SINFO("SQLite::commit in SQLiteNode took " << ((STimeNow() - beforeCommit)/1000) << "ms.");
-
-                // If this is the case, there was a commit conflict.
-                if (result == SQLITE_BUSY_SNAPSHOT) {
-                    // We already asked everyone to commit this (even if it was async), so we'll have to tell them to
-                    // roll back.
-                    SINFO("[performance] Conflict committing " << CONSISTENCY_LEVEL_NAMES[_commitConsistency]
-                          << " commit, rolling back.");
+                    // Notify everybody to rollback
                     SData rollback("ROLLBACK_TRANSACTION");
                     rollback.set("ID", _lastSentTransactionID + 1);
                     _sendToAllPeers(rollback, true); // true: Only to subscribed peers.
@@ -968,9 +971,30 @@ bool SQLiteNode::update() {
 
                     // Finished, but failed.
                     _commitState = CommitState::FAILED;
-                } else {
-                    // Hey, our commit succeeded! Record how long it took.
-                    _db.logLastTransactionTiming(
+                } else if (consistentEnough) {
+                    // Commit this distributed transaction. Either we have quorum, or we don't need it.
+                    SDEBUG("Committing current transaction because consistentEnough: " << _db.getUncommittedQuery());
+                    uint64_t beforeCommit = STimeNow();
+                    // Only other intersting place we commit and would care about node state.
+                    int result = _db.commit(stateName(_state));
+                    SINFO("SQLite::commit in SQLiteNode took " << ((STimeNow() - beforeCommit) / 1000) << "ms.");
+
+                    // If this is the case, there was a commit conflict.
+                    if (result == SQLITE_BUSY_SNAPSHOT) {
+                        // We already asked everyone to commit this (even if it was async), so we'll have to tell them to
+                        // roll back.
+                        SINFO("[performance] Conflict committing " << CONSISTENCY_LEVEL_NAMES[_commitConsistency]
+                              << " commit, rolling back.");
+                        SData rollback("ROLLBACK_TRANSACTION");
+                        rollback.set("ID", _lastSentTransactionID + 1);
+                        _sendToAllPeers(rollback, true); // true: Only to subscribed peers.
+                        _db.rollback();
+
+                        // Finished, but failed.
+                        _commitState = CommitState::FAILED;
+                    } else {
+                        // Hey, our commit succeeded! Record how long it took.
+                        _db.logLastTransactionTiming(
                         format(
                             "Committed leader transaction for '{} ({}). (consistencyRequired={}), {} of {} approved ({} total).",
                             _lastSentTransactionID + 1,
@@ -979,210 +1003,210 @@ bool SQLiteNode::update() {
                             numFullApproved,
                             numFullPeers,
                             _peerList.size()
-                        ),
+                            ),
                         "SQLiteNode::update"
-                    );
-                    SINFO("[performance] Successfully committed " << CONSISTENCY_LEVEL_NAMES[_commitConsistency]
-                          << " transaction. Sending COMMIT_TRANSACTION to peers.");
+                        );
+                        SINFO("[performance] Successfully committed " << CONSISTENCY_LEVEL_NAMES[_commitConsistency]
+                              << " transaction. Sending COMMIT_TRANSACTION to peers.");
 
-                    // Send our outstanding transactions. Note that this particular transaction will send a COMMIT
-                    // only, although if any other transactions have completed since we released a commit lock, we will
-                    // send those ass well.
-                    _sendOutstandingTransactions({_lastSentTransactionID + 1});
+                        // Send our outstanding transactions. Note that this particular transaction will send a COMMIT
+                        // only, although if any other transactions have completed since we released a commit lock, we will
+                        // send those ass well.
+                        _sendOutstandingTransactions({_lastSentTransactionID + 1});
 
-                    // Done!
-                    _commitState = CommitState::SUCCESS;
+                        // Done!
+                        _commitState = CommitState::SUCCESS;
+                    }
+                } else {
+                    // Not consistent enough, but not everyone's responded yet, so we'll wait.
+                    SINFO("Waiting to commit. consistencyRequired=" << CONSISTENCY_LEVEL_NAMES[_commitConsistency]);
+
+                    // We're going to need to read from the network to finish this.
+                    return false;
                 }
-            } else {
-                // Not consistent enough, but not everyone's responded yet, so we'll wait.
-                SINFO("Waiting to commit. consistencyRequired=" << CONSISTENCY_LEVEL_NAMES[_commitConsistency]);
-
-                // We're going to need to read from the network to finish this.
-                return false;
-            }
-        }
-
-        // If there's a transaction that's waiting, we'll start it. We do this *before* we check to see if we should
-        // stand down, and since we return true, we'll never stand down as long as we keep adding new transactions
-        // here. It's up to the server to stop giving us transactions to process if it wants us to stand down.
-        if (_commitState == CommitState::WAITING) {
-            _commitState = CommitState::COMMITTING;
-            SINFO("[performance] Beginning " << CONSISTENCY_LEVEL_NAMES[_commitConsistency] << " commit.");
-
-            // We should already have locked the DB before getting here, we can safely clear out any outstanding
-            // transactions, no new ones can be added until we release the lock.
-            _sendOutstandingTransactions();
-
-            // We'll send the commit count to peers.
-            uint64_t commitCount = _db.getCommitCount();
-
-            // There's no handling for a failed prepare. This should only happen if the DB has been corrupted or
-            // something catastrophic like that.
-            {
-                AutoScopeOnPrepare onPrepare(onPrepareHandlerEnabled, _db, onPrepareHandler);
-                SASSERT(_db.prepare());
             }
 
-            // Begin the distributed transaction
-            SData transaction("BEGIN_TRANSACTION");
-            SINFO("beginning distributed transaction for commit #" << commitCount + 1 << " ("
-                  << _db.getUncommittedHash() << ")");
-            transaction.set("NewCount", commitCount + 1);
-            transaction.set("NewHash", _db.getUncommittedHash());
-            transaction.set("leaderSendTime", to_string(STimeNow()));
-            transaction.set("dbCountAtStart", to_string(_db.getDBCountAtStart()));
-            if (_commitConsistency == ASYNC) {
-                transaction.set("ID", "ASYNC_" + to_string(_lastSentTransactionID + 1));
-            } else {
-                transaction.set("ID", _lastSentTransactionID + 1);
-            }
-            transaction.content = _db.getUncommittedQuery();
+            // If there's a transaction that's waiting, we'll start it. We do this *before* we check to see if we should
+            // stand down, and since we return true, we'll never stand down as long as we keep adding new transactions
+            // here. It's up to the server to stop giving us transactions to process if it wants us to stand down.
+            if (_commitState == CommitState::WAITING) {
+                _commitState = CommitState::COMMITTING;
+                SINFO("[performance] Beginning " << CONSISTENCY_LEVEL_NAMES[_commitConsistency] << " commit.");
 
-            for (auto peer : _peerList) {
-                // Clear the response flag from the last transaction
-                peer->transactionResponse = SQLitePeer::Response::NONE;
-            }
+                // We should already have locked the DB before getting here, we can safely clear out any outstanding
+                // transactions, no new ones can be added until we release the lock.
+                _sendOutstandingTransactions();
 
-            // And send it to everyone who's subscribed.
-            uint64_t beforeSend = STimeNow();
-            _sendToAllPeers(transaction, true);
-            SINFO("[performance] SQLite::_sendToAllPeers in SQLiteNode took " << ((STimeNow() - beforeSend)/1000) << "ms.");
+                // We'll send the commit count to peers.
+                uint64_t commitCount = _db.getCommitCount();
 
-            // We return `true` here to immediately re-update and thus commit this transaction immediately if it was
-            // asynchronous.
-            return true;
-        }
+                // There's no handling for a failed prepare. This should only happen if the DB has been corrupted or
+                // something catastrophic like that.
+                {
+                    AutoScopeOnPrepare onPrepare(onPrepareHandlerEnabled, _db, onPrepareHandler);
+                    SASSERT(_db.prepare());
+                }
 
-        // Check to see if we should stand down. We'll finish any outstanding commits before we actually do.
-        if (_state == SQLiteNodeState::LEADING) {
-            string standDownReason;
-            if (_priority == 1) {
-                standDownReason = "Priority changed to 1, standing down.";
-            } else if (_isShuttingDown) {
-                // Graceful shutdown. Set priority 1 and stand down so we'll re-connect to the new leader and finish
-                // up our commands.
-                standDownReason = "Shutting down, setting priority 1 and STANDINGDOWN.";
-                _priority = 1;
-            } else {
-                // Loop across peers
+                // Begin the distributed transaction
+                SData transaction("BEGIN_TRANSACTION");
+                SINFO("beginning distributed transaction for commit #" << commitCount + 1 << " ("
+                      << _db.getUncommittedHash() << ")");
+                transaction.set("NewCount", commitCount + 1);
+                transaction.set("NewHash", _db.getUncommittedHash());
+                transaction.set("leaderSendTime", to_string(STimeNow()));
+                transaction.set("dbCountAtStart", to_string(_db.getDBCountAtStart()));
+                if (_commitConsistency == ASYNC) {
+                    transaction.set("ID", "ASYNC_" + to_string(_lastSentTransactionID + 1));
+                } else {
+                    transaction.set("ID", _lastSentTransactionID + 1);
+                }
+                transaction.content = _db.getUncommittedQuery();
+
                 for (auto peer : _peerList) {
-                    // Check this peer
-                    if (peer->state == SQLiteNodeState::LEADING) {
-                        // Hm... somehow we're in a multi-leader scenario -- not good.
-                        // Let's get out of this as soon as possible.
-                        standDownReason = "Found another LEADER (" + peer->name + "), STANDINGDOWN to clean it up.";
-                    } else if (peer->state == SQLiteNodeState::WAITING) {
-                        // We have a WAITING peer; is it waiting to STANDUP?
-                        if (peer->priority > _priority) {
-                            // We've got a higher priority peer in the works; stand down so it can stand up.
-                            standDownReason = "Found higher priority WAITING peer (" + peer->name
-                                              + ") while LEADING, STANDINGDOWN";
-                        } else if (peer->commitCount > _db.getCommitCount()) {
-                            // It's got data that we don't, stand down so we can get it.
-                            standDownReason = "Found WAITING peer (" + peer->name +
-                                              ") with more data than us (we have " + SToStr(_db.getCommitCount()) +
-                                              ", it has " + to_string(peer->commitCount) + ") while LEADING, STANDINGDOWN";
+                    // Clear the response flag from the last transaction
+                    peer->transactionResponse = SQLitePeer::Response::NONE;
+                }
+
+                // And send it to everyone who's subscribed.
+                uint64_t beforeSend = STimeNow();
+                _sendToAllPeers(transaction, true);
+                SINFO("[performance] SQLite::_sendToAllPeers in SQLiteNode took " << ((STimeNow() - beforeSend) / 1000) << "ms.");
+
+                // We return `true` here to immediately re-update and thus commit this transaction immediately if it was
+                // asynchronous.
+                return true;
+            }
+
+            // Check to see if we should stand down. We'll finish any outstanding commits before we actually do.
+            if (_state == SQLiteNodeState::LEADING) {
+                string standDownReason;
+                if (_priority == 1) {
+                    standDownReason = "Priority changed to 1, standing down.";
+                } else if (_isShuttingDown) {
+                    // Graceful shutdown. Set priority 1 and stand down so we'll re-connect to the new leader and finish
+                    // up our commands.
+                    standDownReason = "Shutting down, setting priority 1 and STANDINGDOWN.";
+                    _priority = 1;
+                } else {
+                    // Loop across peers
+                    for (auto peer : _peerList) {
+                        // Check this peer
+                        if (peer->state == SQLiteNodeState::LEADING) {
+                            // Hm... somehow we're in a multi-leader scenario -- not good.
+                            // Let's get out of this as soon as possible.
+                            standDownReason = "Found another LEADER (" + peer->name + "), STANDINGDOWN to clean it up.";
+                        } else if (peer->state == SQLiteNodeState::WAITING) {
+                            // We have a WAITING peer; is it waiting to STANDUP?
+                            if (peer->priority > _priority) {
+                                // We've got a higher priority peer in the works; stand down so it can stand up.
+                                standDownReason = "Found higher priority WAITING peer (" + peer->name
+                                    + ") while LEADING, STANDINGDOWN";
+                            } else if (peer->commitCount > _db.getCommitCount()) {
+                                // It's got data that we don't, stand down so we can get it.
+                                standDownReason = "Found WAITING peer (" + peer->name +
+                                    ") with more data than us (we have " + SToStr(_db.getCommitCount()) +
+                                    ", it has " + to_string(peer->commitCount) + ") while LEADING, STANDINGDOWN";
+                            }
                         }
                     }
                 }
-            }
 
-            // Do we want to stand down, and can we?
-            if (!standDownReason.empty()) {
-                SHMMM(standDownReason);
-                _changeState(SQLiteNodeState::STANDINGDOWN);
-                SINFO("Standing down: " << standDownReason);
-            }
-        }
-
-        // At this point, we're no longer committing. We'll have returned false above, or we'll have completed any
-        // outstanding transaction, we can complete standing down if that's what we're doing.
-        if (_state == SQLiteNodeState::STANDINGDOWN) {
-            // See if we're done
-            // We can only switch to SEARCHING if the server has no outstanding write work to do.
-            if (_standDownTimeout.ringing()) {
-                SWARN("Timeout STANDINGDOWN, giving up on server and continuing.");
-            }
-            // Standdown complete
-            SINFO("STANDDOWN complete, SEARCHING");
-            if (_isShuttingDown) {
-                for (const auto& peer : _peerList) {
-                    peer->shutdownSocket();
+                // Do we want to stand down, and can we?
+                if (!standDownReason.empty()) {
+                    SHMMM(standDownReason);
+                    _changeState(SQLiteNodeState::STANDINGDOWN);
+                    SINFO("Standing down: " << standDownReason);
                 }
             }
-            _changeState(SQLiteNodeState::SEARCHING);
 
-            // We're no longer waiting on responses from peers, we can re-update immediately and start becoming a
-            // follower node instead.
-            return true;
-        }
-        break;
-    }
+            // At this point, we're no longer committing. We'll have returned false above, or we'll have completed any
+            // outstanding transaction, we can complete standing down if that's what we're doing.
+            if (_state == SQLiteNodeState::STANDINGDOWN) {
+                // See if we're done
+                // We can only switch to SEARCHING if the server has no outstanding write work to do.
+                if (_standDownTimeout.ringing()) {
+                    SWARN("Timeout STANDINGDOWN, giving up on server and continuing.");
+                }
+                // Standdown complete
+                SINFO("STANDDOWN complete, SEARCHING");
+                if (_isShuttingDown) {
+                    for (const auto& peer : _peerList) {
+                        peer->shutdownSocket();
+                    }
+                }
+                _changeState(SQLiteNodeState::SEARCHING);
 
-    /// - SUBSCRIBING: We're waiting for a SUBSCRIPTION_APPROVED from the
-    ///     leader.  When we receive it, we'll go FOLLOWING. Otherwise, if we
-    ///     timeout, go SEARCHING.
-    ///
-    case SQLiteNodeState::SUBSCRIBING:
-        if (_isShuttingDown) {
-            _changeState(SQLiteNodeState::SEARCHING);
-            return false;
-        }
-        SASSERTWARN(!_syncPeer);
-        SASSERTWARN(_leadPeer);
-        SASSERTWARN(_db.getUncommittedHash().empty());
-        // Nothing to do but wait
-        if (STimeNow() > _stateTimeout) {
-            // Give up
-            SHMMM("Timed out waiting for SUBSCRIPTION_APPROVED, reconnecting to leader and re-SEARCHING.");
-            _reconnectPeer(_leadPeer);
-            _leadPeer = nullptr;
-            _changeState(SQLiteNodeState::SEARCHING);
-            return true; // Re-update
-        }
-        break;
-
-    /// - FOLLOWING: This is where the other half of the magic happens.  Most
-    ///     nodes will (hopefully) spend 99.999% of their time in this state.
-    ///     FOLLOWING nodes simply begin and commit transactions with the
-    ///     following logic:
-    ///
-    ///         if( leader steps down or disconnects ) goto SEARCHING
-    ///
-    case SQLiteNodeState::FOLLOWING:
-        SASSERTWARN(!_syncPeer);
-        // If graceful shutdown requested, stop following once there is
-        // nothing blocking shutdown.  We stop listening for new commands
-        // immediately upon TERM.)
-        if (_isShuttingDown && _isNothingBlockingShutdown()) {
-            // Go searching so we stop following
-            SINFO("Stopping FOLLOWING in order to gracefully shut down, SEARCHING.");
-            _changeState(SQLiteNodeState::SEARCHING);
-            return false; // Don't update
-        }
-
-        // If the leader stops leading (or standing down), we'll go SEARCHING, which allows us to look for a new
-        // leader. We don't want to go searching before that, because we won't know when leader is done sending its
-        // final transactions.
-        SASSERT(_leadPeer);
-        if (_leadPeer.load()->state != SQLiteNodeState::LEADING && _leadPeer.load()->state != SQLiteNodeState::STANDINGDOWN) {
-            // Leader stepping down
-            SHMMM("Leader stepping down.");
-
-            // Are we in the middle of a commit? This should only happen if we received a `BEGIN_TRANSACTION` without a
-            // corresponding `COMMIT` or `ROLLBACK`, this isn't supposed to happen.
-            if (!_db.getUncommittedHash().empty()) {
-                SWARN("Leader stepped down with transaction in progress, rolling back.");
-                _db.rollback();
+                // We're no longer waiting on responses from peers, we can re-update immediately and start becoming a
+                // follower node instead.
+                return true;
             }
-            _changeState(SQLiteNodeState::SEARCHING);
-            return true; // Re-update
+            break;
         }
 
-        break;
+        /// - SUBSCRIBING: We're waiting for a SUBSCRIPTION_APPROVED from the
+        ///     leader.  When we receive it, we'll go FOLLOWING. Otherwise, if we
+        ///     timeout, go SEARCHING.
+        ///
+        case SQLiteNodeState::SUBSCRIBING:
+            if (_isShuttingDown) {
+                _changeState(SQLiteNodeState::SEARCHING);
+                return false;
+            }
+            SASSERTWARN(!_syncPeer);
+            SASSERTWARN(_leadPeer);
+            SASSERTWARN(_db.getUncommittedHash().empty());
+            // Nothing to do but wait
+            if (STimeNow() > _stateTimeout) {
+                // Give up
+                SHMMM("Timed out waiting for SUBSCRIPTION_APPROVED, reconnecting to leader and re-SEARCHING.");
+                _reconnectPeer(_leadPeer);
+                _leadPeer = nullptr;
+                _changeState(SQLiteNodeState::SEARCHING);
+                return true; // Re-update
+            }
+            break;
 
-    default:
-        SERROR("Invalid state #" << stateName(_state));
+        /// - FOLLOWING: This is where the other half of the magic happens.  Most
+        ///     nodes will (hopefully) spend 99.999% of their time in this state.
+        ///     FOLLOWING nodes simply begin and commit transactions with the
+        ///     following logic:
+        ///
+        ///         if( leader steps down or disconnects ) goto SEARCHING
+        ///
+        case SQLiteNodeState::FOLLOWING:
+            SASSERTWARN(!_syncPeer);
+            // If graceful shutdown requested, stop following once there is
+            // nothing blocking shutdown.  We stop listening for new commands
+            // immediately upon TERM.)
+            if (_isShuttingDown && _isNothingBlockingShutdown()) {
+                // Go searching so we stop following
+                SINFO("Stopping FOLLOWING in order to gracefully shut down, SEARCHING.");
+                _changeState(SQLiteNodeState::SEARCHING);
+                return false; // Don't update
+            }
+
+            // If the leader stops leading (or standing down), we'll go SEARCHING, which allows us to look for a new
+            // leader. We don't want to go searching before that, because we won't know when leader is done sending its
+            // final transactions.
+            SASSERT(_leadPeer);
+            if (_leadPeer.load()->state != SQLiteNodeState::LEADING && _leadPeer.load()->state != SQLiteNodeState::STANDINGDOWN) {
+                // Leader stepping down
+                SHMMM("Leader stepping down.");
+
+                // Are we in the middle of a commit? This should only happen if we received a `BEGIN_TRANSACTION` without a
+                // corresponding `COMMIT` or `ROLLBACK`, this isn't supposed to happen.
+                if (!_db.getUncommittedHash().empty()) {
+                    SWARN("Leader stepped down with transaction in progress, rolling back.");
+                    _db.rollback();
+                }
+                _changeState(SQLiteNodeState::SEARCHING);
+                return true; // Re-update
+            }
+
+            break;
+
+        default:
+            SERROR("Invalid state #" << stateName(_state));
     }
 
     // Don't update immediately
@@ -1191,7 +1215,8 @@ bool SQLiteNode::update() {
 
 // Messages
 // Here are the messages that can be received, and how a cluster node will respond to each based on its state:
-void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
+void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
+{
     try {
         SASSERT(peer);
         SASSERTWARN(!message.empty());
@@ -1208,7 +1233,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
         } else if (SIEquals(message.methodLine, "PONG")) {
             // Latency must be > 0 because we treat 0 as "not connected".
             peer->latency = max(STimeNow() - message.calc64("Timestamp"), 1ul);
-            SINFO("Received PONG from peer '" << peer->name << "' (" << peer->latency/1000 << "ms latency)");
+            SINFO("Received PONG from peer '" << peer->name << "' (" << peer->latency / 1000 << "ms latency)");
             return;
         }
 
@@ -1234,7 +1259,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
         // represents ~30s of commits. If we're behind, let's close the command port
         // so we can catch up with the cluster before processing new commands.
         const string blockReason = "COMMITS_LAGGING_BEHIND";
-        const int64_t currentCommitDifference =  peer->commitCount - getCommitCount();
+        const int64_t currentCommitDifference = peer->commitCount - getCommitCount();
         if (peer == _leadPeer && currentCommitDifference >= 12'500 && !_blockedCommandPortForBeingBehind) {
             SINFO("Node is behind by " + SToStr(currentCommitDifference) + " commits, closing command port so it can catch up.");
             _server.blockCommandPort(blockReason);
@@ -1308,7 +1333,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
 
             if (hashesMatch) {
                 PINFO("Peer logged in at '" << message["State"] << "', priority #" << message["Priority"] << " commit #"
-                    << message["CommitCount"] << " (" << message["Hash"] << ")");
+                      << message["CommitCount"] << " (" << message["Hash"] << ")");
                 peer->loggedIn = true;
             } else {
                 PINFO("Peer is forked, marking as bad, will ignore.");
@@ -1331,8 +1356,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
             _server.onNodeLogin(peer);
         } else if (!peer->loggedIn) {
             STHROW("not logged in");
-        }
-        else if (SIEquals(message.methodLine, "STATE")) {
+        } else if (SIEquals(message.methodLine, "STATE"))   {
             // STATE: Broadcast to all peers whenever a node's state changes. Also sent whenever a node commits a new query
             // (and thus has a new commit count and hash). A peer can react or respond to a peer's state change as follows:
             if (!message.isSet("State")) {
@@ -1363,32 +1387,40 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                 // Make sure transition states are an approved pair
                 bool okTransition = false;
                 switch (from) {
-                case SQLiteNodeState::UNKNOWN:
-                    break;
-                case SQLiteNodeState::SEARCHING:
-                    okTransition = (to == SQLiteNodeState::SYNCHRONIZING || to == SQLiteNodeState::WAITING || to == SQLiteNodeState::LEADING);
-                    break;
-                case SQLiteNodeState::SYNCHRONIZING:
-                    okTransition = (to == SQLiteNodeState::SEARCHING || to == SQLiteNodeState::WAITING);
-                    break;
-                case SQLiteNodeState::WAITING:
-                    okTransition = (to == SQLiteNodeState::SEARCHING || to == SQLiteNodeState::STANDINGUP || to == SQLiteNodeState::SUBSCRIBING);
-                    break;
-                case SQLiteNodeState::STANDINGUP:
-                    okTransition = (to == SQLiteNodeState::SEARCHING || to == SQLiteNodeState::LEADING);
-                    break;
-                case SQLiteNodeState::LEADING:
-                    okTransition = (to == SQLiteNodeState::SEARCHING || to == SQLiteNodeState::STANDINGDOWN);
-                    break;
-                case SQLiteNodeState::STANDINGDOWN:
-                    okTransition = (to == SQLiteNodeState::SEARCHING);
-                    break;
-                case SQLiteNodeState::SUBSCRIBING:
-                    okTransition = (to == SQLiteNodeState::SEARCHING || to == SQLiteNodeState::FOLLOWING);
-                    break;
-                case SQLiteNodeState::FOLLOWING:
-                    okTransition = (to == SQLiteNodeState::SEARCHING);
-                    break;
+                    case SQLiteNodeState::UNKNOWN:
+                        break;
+
+                    case SQLiteNodeState::SEARCHING:
+                        okTransition = (to == SQLiteNodeState::SYNCHRONIZING || to == SQLiteNodeState::WAITING || to == SQLiteNodeState::LEADING);
+                        break;
+
+                    case SQLiteNodeState::SYNCHRONIZING:
+                        okTransition = (to == SQLiteNodeState::SEARCHING || to == SQLiteNodeState::WAITING);
+                        break;
+
+                    case SQLiteNodeState::WAITING:
+                        okTransition = (to == SQLiteNodeState::SEARCHING || to == SQLiteNodeState::STANDINGUP || to == SQLiteNodeState::SUBSCRIBING);
+                        break;
+
+                    case SQLiteNodeState::STANDINGUP:
+                        okTransition = (to == SQLiteNodeState::SEARCHING || to == SQLiteNodeState::LEADING);
+                        break;
+
+                    case SQLiteNodeState::LEADING:
+                        okTransition = (to == SQLiteNodeState::SEARCHING || to == SQLiteNodeState::STANDINGDOWN);
+                        break;
+
+                    case SQLiteNodeState::STANDINGDOWN:
+                        okTransition = (to == SQLiteNodeState::SEARCHING);
+                        break;
+
+                    case SQLiteNodeState::SUBSCRIBING:
+                        okTransition = (to == SQLiteNodeState::SEARCHING || to == SQLiteNodeState::FOLLOWING);
+                        break;
+
+                    case SQLiteNodeState::FOLLOWING:
+                        okTransition = (to == SQLiteNodeState::SEARCHING);
+                        break;
                 }
                 if (!okTransition) {
                     PWARN("Peer making invalid transition from '" << stateName(from) << "' to '" << stateName(to) << "'");
@@ -1472,8 +1504,8 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                         // This is the same handling as at the bottom of _onMESSAGE.
                         SWARN("Error processing message, reconnecting", {
                             {"peer", peer ? peer->name : "unknown"},
-                              {"message", !message.empty()? message.methodLine : ""},
-                              {"reason", e.what()}
+                            {"message", !message.empty()? message.methodLine : ""},
+                            {"reason", e.what()}
                         });
                         SData reconnect("RECONNECT");
                         reconnect["Reason"] = e.what();
@@ -1671,7 +1703,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
                     if (hashMatch && to_string(_lastSentTransactionID + 1) == message["ID"]) {
                         if (message.calcU64("NewCount") != _db.getCommitCount() + 1) {
                             STHROW("commit count mismatch. Expected: " + message["NewCount"] + ", but would actually be: "
-                                  + to_string(_db.getCommitCount() + 1));
+                                   + to_string(_db.getCommitCount() + 1));
                         }
                         if (peer->permaFollower) {
                             STHROW("permafollowers shouldn't approve/deny");
@@ -1728,7 +1760,8 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message) {
     }
 }
 
-void SQLiteNode::_onConnect(SQLitePeer* peer) {
+void SQLiteNode::_onConnect(SQLitePeer* peer)
+{
     SASSERT(peer);
     SASSERTWARN(!peer->loggedIn);
     SData login("LOGIN");
@@ -1749,7 +1782,8 @@ void SQLiteNode::_onConnect(SQLitePeer* peer) {
 // Whenever a peer disconnects, the following checks are made to verify no
 // internal consistency has been lost:  (Technically these checks need only be
 // made in certain states, but we'll check them in all states just to be sure.)
-void SQLiteNode::_onDisconnect(SQLitePeer* peer) {
+void SQLiteNode::_onDisconnect(SQLitePeer* peer)
+{
     SASSERT(peer);
 
     /// - Verify we didn't just lose contact with our leader.  This should
@@ -1769,8 +1803,8 @@ void SQLiteNode::_onDisconnect(SQLitePeer* peer) {
             // approve or deny, but we'll never get its response.  Roll it
             // back and synchronize when we reconnect.
             PHMMM("Was expecting a response for transaction #" << _db.getCommitCount() + 1 << " ("
-                                                               << _db.getUncommittedHash()
-                                                               << ") but disconnected prematurely; rolling back.");
+                  << _db.getUncommittedHash()
+                  << ") but disconnected prematurely; rolling back.");
             _db.rollback();
         }
         _changeState(SQLiteNodeState::SEARCHING);
@@ -1829,7 +1863,8 @@ void SQLiteNode::_onDisconnect(SQLitePeer* peer) {
     }
 }
 
-SData SQLiteNode::_addPeerHeaders(SData message) {
+SData SQLiteNode::_addPeerHeaders(SData message)
+{
     if (!message.isSet("CommitCount")) {
         message["CommitCount"] = SToStr(_db.getCommitCount());
     }
@@ -1840,7 +1875,8 @@ SData SQLiteNode::_addPeerHeaders(SData message) {
     return message;
 }
 
-void SQLiteNode::_sendToPeer(SQLitePeer* peer, const SData& message) {
+void SQLiteNode::_sendToPeer(SQLitePeer* peer, const SData& message)
+{
     // We can treat this whole function as atomic and thread-safe as it sends data to a peer with it's own atomic
     // `sendMessage` and the peer itself (assuming it's something from _peerList, which, if not, don't do that) is
     // const and will exist without changing until destruction.
@@ -1851,7 +1887,8 @@ void SQLiteNode::_sendToPeer(SQLitePeer* peer, const SData& message) {
     peer->sendMessage(_addPeerHeaders(message));
 }
 
-void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly) {
+void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly)
+{
     const SData messageWithHeaders = _addPeerHeaders(message);
 
     // Loop across all connected peers and send the message. _peerList is const so this is thread-safe.
@@ -1868,7 +1905,8 @@ void SQLiteNode::_sendToAllPeers(const SData& message, bool subscribedOnly) {
     }
 }
 
-void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCancelAfter) {
+void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCancelAfter)
+{
     if (newState != _state) {
         // First, we notify all plugins about the state change
         _server.notifyStateChangeToPlugins(*pluginDB, newState);
@@ -1999,7 +2037,8 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
     }
 }
 
-void SQLiteNode::_queueSynchronize(const SQLiteNode* const node, SQLitePeer* peer, SQLite& db, SData& response, bool sendAll, uint64_t timeoutAfterUS) {
+void SQLiteNode::_queueSynchronize(const SQLiteNode* const node, SQLitePeer* peer, SQLite& db, SData& response, bool sendAll, uint64_t timeoutAfterUS)
+{
     // We need this to check the state of the node, and we also need `name` to make the logging macros work in a static
     // function. However, if you pass a null pointer here, we can't set these, so we'll fail. We also can't log that,
     // so we are just going to rely on the signal handling for sigsegv to log that for you. Don't do that.
@@ -2009,8 +2048,9 @@ void SQLiteNode::_queueSynchronize(const SQLiteNode* const node, SQLitePeer* pee
     uint64_t peerCommitCount = 0;
     string peerHash;
     peer->getCommit(peerCommitCount, peerHash);
-    if (peerCommitCount > db.getCommitCount())
+    if (peerCommitCount > db.getCommitCount()) {
         STHROW("you have more data than me");
+    }
     if (peerCommitCount) {
         // It has some data -- do we agree on what we share?
         string myHash, ignore;
@@ -2062,7 +2102,7 @@ void SQLiteNode::_queueSynchronize(const SQLiteNode* const node, SQLitePeer* pee
             }
         }
 
-        if ((uint64_t)result.size() != toIndex - fromIndex + 1) {
+        if ((uint64_t) result.size() != toIndex - fromIndex + 1) {
             STHROW("mismatched commit count");
         }
 
@@ -2081,7 +2121,8 @@ void SQLiteNode::_queueSynchronize(const SQLiteNode* const node, SQLitePeer* pee
     }
 }
 
-void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message) {
+void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message)
+{
     if (message.isSet("ShuttingDown")) {
         STHROW("Sync peer is shutting down");
     }
@@ -2094,7 +2135,7 @@ void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message) {
     SData commit;
     const char* content = message.content.c_str();
     int messageSize = 0;
-    int remaining = (int)message.content.size();
+    int remaining = (int) message.content.size();
     while ((messageSize = commit.deserialize(content, remaining))) {
         // Consume this message and process
         // **FIXME: This could be optimized to commit in one huge transaction
@@ -2132,14 +2173,16 @@ void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message) {
         SDEBUG("Committing current transaction because _recvSynchronize: " << _db.getUncommittedQuery());
         _db.commit(stateName(_state));
 
-        if (_db.getCommittedHash() != commit["Hash"])
+        if (_db.getCommittedHash() != commit["Hash"]) {
             STHROW("potential hash mismatch");
+        }
         --commitsRemaining;
     }
 
     // Did we get all our commits?
-    if (commitsRemaining)
+    if (commitsRemaining) {
         STHROW("commits remaining at end");
+    }
 }
 
 void SQLiteNode::_updateSyncPeer()
@@ -2199,13 +2242,13 @@ void SQLiteNode::_updateSyncPeer()
         string from, to;
         if (_syncPeer) {
             from = _syncPeer->name + " (commit count=" + to_string(_syncPeer->commitCount) + "), latency="
-                                   + to_string(_syncPeer->latency/1000) + "ms";
+                + to_string(_syncPeer->latency / 1000) + "ms";
         } else {
             from = "(NONE)";
         }
         if (newSyncPeer) {
             to = newSyncPeer->name + " (commit count=" + to_string(newSyncPeer->commitCount) + "), latency="
-                                   + to_string(newSyncPeer->latency/1000) + "ms";
+                + to_string(newSyncPeer->latency / 1000) + "ms";
         } else {
             to = "(NONE)";
         }
@@ -2221,7 +2264,7 @@ void SQLiteNode::_updateSyncPeer()
             } else if (peer->commitCount <= commitCount) {
                 nonChosenPeers.push_back(peer->name + ":commit=" + to_string(peer->commitCount));
             } else {
-                nonChosenPeers.push_back(peer->name + ":" + to_string(peer->latency/1000) + "ms");
+                nonChosenPeers.push_back(peer->name + ":" + to_string(peer->latency / 1000) + "ms");
             }
         }
         SINFO("Updating SYNCHRONIZING peer from " << from << " to " << to << ". Not chosen: " << SComposeList(nonChosenPeers));
@@ -2231,20 +2274,23 @@ void SQLiteNode::_updateSyncPeer()
     }
 }
 
-void SQLiteNode::_reconnectPeer(SQLitePeer* peer) {
+void SQLiteNode::_reconnectPeer(SQLitePeer* peer)
+{
     SHMMM("Reconnecting to '" << peer->name << "'");
     peer->loggedIn = false;
     peer->shutdownSocket();
 }
 
-void SQLiteNode::_reconnectAll() {
+void SQLiteNode::_reconnectAll()
+{
     // Loop across and reconnect
     for (auto peer : _peerList) {
         _reconnectPeer(peer);
     }
 }
 
-bool SQLiteNode::_majoritySubscribed() const {
+bool SQLiteNode::_majoritySubscribed() const
+{
     // Count up how may full and subscribed peers we have (A "full" peer is one that *isn't* a permafollower).
     int numFullPeers = 0;
     int numFullFollowers = 0;
@@ -2258,10 +2304,11 @@ bool SQLiteNode::_majoritySubscribed() const {
     }
 
     // Done!
-    return (numFullFollowers * 2 >= numFullPeers);
+    return numFullFollowers * 2 >= numFullPeers;
 }
 
-void SQLiteNode::_handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SData& message) {
+void SQLiteNode::_handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SData& message)
+{
     // BEGIN_TRANSACTION: Sent by the LEADER to all subscribed followers to begin a new distributed transaction. Each
     // follower begins a local transaction with this query and responds APPROVE_TRANSACTION. If the follower cannot start
     // the transaction for any reason, it is broken somehow -- disconnect from the leader.
@@ -2286,7 +2333,8 @@ void SQLiteNode::_handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SDa
     }
 }
 
-void SQLiteNode::_handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const SData& message, uint64_t dequeueTime) {
+void SQLiteNode::_handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const SData& message, uint64_t dequeueTime)
+{
     uint64_t prepareStartTime = STimeNow();
     // BEGIN_TRANSACTION: Sent by the LEADER to all subscribed followers to begin a new distributed transaction. Each
     // follower begins a local transaction with this query and responds APPROVE_TRANSACTION. If the follower cannot start
@@ -2345,13 +2393,14 @@ void SQLiteNode::_handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const S
     uint64_t leaderSentTimestamp = message.calcU64("leaderSendTime");
     uint64_t transitTimeUS = dequeueTime - leaderSentTimestamp;
     uint64_t applyTimeUS = STimeNow() - prepareStartTime;
-    float transitTimeMS = (float)transitTimeUS / 1000.0;
-    float applyTimeMS = (float)applyTimeUS / 1000.0;
+    float transitTimeMS = (float) transitTimeUS / 1000.0;
+    float applyTimeMS = (float) applyTimeUS / 1000.0;
     PINFO("[performance] Replicated transaction " << message.calcU64("NewCount") << ", sent by leader at " << leaderSentTimestamp
           << ", transit/dequeue time: " << transitTimeMS << "ms, applied in: " << applyTimeMS << "ms, should COMMIT next.");
 }
 
-int SQLiteNode::_handleCommitTransaction(SQLite& db, SQLitePeer* peer, const uint64_t commandCommitCount, const string& commandCommitHash) {
+int SQLiteNode::_handleCommitTransaction(SQLite& db, SQLitePeer* peer, const uint64_t commandCommitCount, const string& commandCommitHash)
+{
     // COMMIT_TRANSACTION: Sent to all subscribed followers by the leader when it determines that the current
     // outstanding transaction should be committed to the database. This completes a given distributed transaction.
     if (_state != SQLiteNodeState::FOLLOWING) {
@@ -2362,7 +2411,7 @@ int SQLiteNode::_handleCommitTransaction(SQLite& db, SQLitePeer* peer, const uin
     }
     if (commandCommitCount != db.getCommitCount() + 1) {
         STHROW("commit count mismatch. Expected: " + to_string(commandCommitCount) + ", but would actually be: "
-              + to_string(db.getCommitCount() + 1));
+               + to_string(db.getCommitCount() + 1));
     }
     if (commandCommitHash != db.getUncommittedHash()) {
         STHROW("hash mismatch:" + commandCommitHash + "!=" + db.getUncommittedHash() + ";");
@@ -2391,7 +2440,8 @@ int SQLiteNode::_handleCommitTransaction(SQLite& db, SQLitePeer* peer, const uin
     return result;
 }
 
-void SQLiteNode::_handleRollbackTransaction(SQLite& db, SQLitePeer* peer, const SData& message) {
+void SQLiteNode::_handleRollbackTransaction(SQLite& db, SQLitePeer* peer, const SData& message)
+{
     // ROLLBACK_TRANSACTION: Sent to all subscribed followers by the leader when it determines that the current
     // outstanding transaction should be rolled back. This completes a given distributed transaction.
     if (!message.isSet("ID")) {
@@ -2406,7 +2456,8 @@ void SQLiteNode::_handleRollbackTransaction(SQLite& db, SQLitePeer* peer, const 
     db.rollback();
 }
 
-SQLiteNodeState SQLiteNode::leaderState() const {
+SQLiteNodeState SQLiteNode::leaderState() const
+{
     shared_lock<decltype(_stateMutex)> sharedLock(_stateMutex);
     if (_leadPeer) {
         return _leadPeer.load()->state;
@@ -2414,7 +2465,8 @@ SQLiteNodeState SQLiteNode::leaderState() const {
     return SQLiteNodeState::UNKNOWN;
 }
 
-string SQLiteNode::leaderCommandAddress() const {
+string SQLiteNode::leaderCommandAddress() const
+{
     // Note: this can skip locking because it only accesses atomic variables in a predicatable order.
     // If there's a _leadPeer, we atomically get a copy of it. Because these can only point to our const list of peers,
     // once we have this value, we know that `_leadPeerCopy` is safe. It's either pointing at null, or a valid Peer
@@ -2433,7 +2485,8 @@ string SQLiteNode::leaderCommandAddress() const {
     return "";
 }
 
-bool SQLiteNode::hasQuorum() const {
+bool SQLiteNode::hasQuorum() const
+{
     shared_lock<decltype(_stateMutex)> sharedLock(_stateMutex);
     if (_state != SQLiteNodeState::LEADING && _state != SQLiteNodeState::STANDINGDOWN) {
         return false;
@@ -2448,10 +2501,11 @@ bool SQLiteNode::hasQuorum() const {
             }
         }
     }
-    return (numFullFollowers * 2 >= numFullPeers);
+    return numFullFollowers * 2 >= numFullPeers;
 }
 
-void SQLiteNode::prePoll(fd_map& fdm) const {
+void SQLiteNode::prePoll(fd_map& fdm) const
+{
     shared_lock<decltype(_stateMutex)> sharedLock(_stateMutex);
     if (_port) {
         SFDset(fdm, _port->s, SREADEVTS);
@@ -2465,7 +2519,8 @@ void SQLiteNode::prePoll(fd_map& fdm) const {
     _commitsToSend.prePoll(fdm);
 }
 
-STCPManager::Socket* SQLiteNode::_acceptSocket() {
+STCPManager::Socket* SQLiteNode::_acceptSocket()
+{
     // Initialize to 0 in case we don't accept anything. Note that this *does* overwrite the passed-in pointer.
     Socket* socket = nullptr;
 
@@ -2487,7 +2542,8 @@ STCPManager::Socket* SQLiteNode::_acceptSocket() {
     return socket;
 }
 
-void SQLiteNode::_processPeerMessages(uint64_t& nextActivity, SQLitePeer* peer, bool unlimited) {
+void SQLiteNode::_processPeerMessages(uint64_t& nextActivity, SQLitePeer* peer, bool unlimited)
+{
     try {
         size_t messagesDeqeued = 0;
         while (true) {
@@ -2505,7 +2561,8 @@ void SQLiteNode::_processPeerMessages(uint64_t& nextActivity, SQLitePeer* peer, 
     }
 }
 
-void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
+void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity)
+{
     if (NODE_KILLED) {
         SWARN("Killed, skipping postPoll");
         return;
@@ -2587,6 +2644,7 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 _processPeerMessages(nextActivity, peer);
             }
             break;
+
             case SQLitePeer::PeerPostPollStatus::SOCKET_ERROR:
             {
                 _processPeerMessages(nextActivity, peer, true);
@@ -2596,6 +2654,7 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 peer->shutdownSocket();
             }
             break;
+
             case SQLitePeer::PeerPostPollStatus::SOCKET_CLOSED:
             {
                 _processPeerMessages(nextActivity, peer, true);
@@ -2603,6 +2662,7 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
                 _onDisconnect(peer);
             }
             break;
+
             case SQLitePeer::PeerPostPollStatus::OK:
             {
                 auto lastRecvTime = peer->lastRecvTime();
@@ -2628,13 +2688,15 @@ void SQLiteNode::postPoll(fd_map& fdm, uint64_t& nextActivity) {
     _commitsToSend.clear();
 }
 
-void SQLiteNode::notifyCommit() const {
+void SQLiteNode::notifyCommit() const
+{
     // Note: this can skip locking because it only accesses a single atomic variable, which makes it safe to call in
     // private methods.
     _commitsToSend.push(true);
 }
 
-void SQLiteNode::_sendPING(SQLitePeer* peer) {
+void SQLiteNode::_sendPING(SQLitePeer* peer)
+{
     // Send a PING message, including our current timestamp
     SASSERT(peer);
     SData ping("PING");
@@ -2642,17 +2704,21 @@ void SQLiteNode::_sendPING(SQLitePeer* peer) {
     peer->sendMessage(ping);
 }
 
-SQLitePeer* SQLiteNode::getPeerByName(const string& name) const {
+SQLitePeer* SQLiteNode::getPeerByName(const string& name) const
+{
     // Binary search for the peer by name
     SQLitePeer searchPeer(name, "", STable(), 1);
-    auto it = lower_bound(_peerList.begin(), _peerList.end(), &searchPeer, [](const SQLitePeer* peer1, const SQLitePeer* peer2) { return peer1->name < peer2->name; });
+    auto it = lower_bound(_peerList.begin(), _peerList.end(), &searchPeer, [](const SQLitePeer* peer1, const SQLitePeer* peer2) {
+        return peer1->name < peer2->name;
+                                                                                                                                                                    });
     if (it != _peerList.end() && (*it)->name == name) {
         return *it;
     }
     return nullptr;
 }
 
-const string& SQLiteNode::stateName(SQLiteNodeState state) {
+const string& SQLiteNode::stateName(SQLiteNodeState state)
+{
     static string placeholder = "";
     static map<SQLiteNodeState, string> lookup = {
         {SQLiteNodeState::UNKNOWN, "UNKNOWN"},
@@ -2673,7 +2739,8 @@ const string& SQLiteNode::stateName(SQLiteNodeState state) {
     }
 }
 
-SQLiteNodeState SQLiteNode::stateFromName(const string& name) {
+SQLiteNodeState SQLiteNode::stateFromName(const string& name)
+{
     const string normalizedName = SToUpper(name);
     static map<string, SQLiteNodeState> lookup = {
         {"SEARCHING", SQLiteNodeState::SEARCHING},
@@ -2693,7 +2760,8 @@ SQLiteNodeState SQLiteNode::stateFromName(const string& name) {
     }
 }
 
-void SQLiteNode::kill() {
+void SQLiteNode::kill()
+{
     NODE_KILLED = true;
     for (SQLitePeer* peer : _peerList) {
         SWARN("Killing peer: " << peer->name);
@@ -2704,17 +2772,19 @@ void SQLiteNode::kill() {
     _port = nullptr;
 }
 
-string SQLiteNode::_getLostQuorumLogMessage() const {
+string SQLiteNode::_getLostQuorumLogMessage() const
+{
     string lostQuorumMessage;
     if (_lastLostQuorum) {
         lostQuorumMessage = " Lost Quorum at: " + STIMESTAMP_MS(_lastLostQuorum) + " (" +
-        to_string((double)(STimeNow() - _lastLostQuorum) / 1000000.0) + " seconds ago).";
+            to_string((double) (STimeNow() - _lastLostQuorum) / 1000000.0) + " seconds ago).";
     }
 
     return lostQuorumMessage;
 }
 
-void SQLiteNode::_sendStandupResponse(SQLitePeer* peer, const SData& message) {
+void SQLiteNode::_sendStandupResponse(SQLitePeer* peer, const SData& message)
+{
     // STANDINGUP: When a peer announces it intends to stand up, we immediately respond with approval or
     // denial. We determine this by checking to see if there is any  other peer who is already leader or
     // also trying to stand up.
@@ -2800,7 +2870,8 @@ void SQLiteNode::_sendStandupResponse(SQLitePeer* peer, const SData& message) {
     _sendToPeer(peer, response);
 }
 
-void SQLiteNode::_dieIfForkedFromCluster() {
+void SQLiteNode::_dieIfForkedFromCluster()
+{
     size_t quorumNodeCount = 0;
     size_t forkedFullPeerCount = 0;
     for (const auto& p : _peerList) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -972,14 +972,14 @@ bool SQLiteNode::update() {
                     // Hey, our commit succeeded! Record how long it took.
                     _db.logLastTransactionTiming(
                         format(
-                            "Committed leader transaction for '{} ({}). (consistencyRequired={}), {} of {} approved ({} total).", 
-                            _lastSentTransactionID + 1, 
-                            _db.getCommittedHash(), 
-                            CONSISTENCY_LEVEL_NAMES[_commitConsistency], 
-                            numFullApproved, 
-                            numFullPeers, 
+                            "Committed leader transaction for '{} ({}). (consistencyRequired={}), {} of {} approved ({} total).",
+                            _lastSentTransactionID + 1,
+                            _db.getCommittedHash(),
+                            CONSISTENCY_LEVEL_NAMES[_commitConsistency],
+                            numFullApproved,
+                            numFullPeers,
                             _peerList.size()
-                        ), 
+                        ),
                         "SQLiteNode::update"
                     );
                     SINFO("[performance] Successfully committed " << CONSISTENCY_LEVEL_NAMES[_commitConsistency]
@@ -2276,7 +2276,7 @@ void SQLiteNode::_handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SDa
 
     // Shared with single-threaded replication because this is the only thread writing, and thus we can't get conflicts,
     // and using SHARED prevents us from blocking or being blocked by readers.
-    if (!db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED)) {
+    if (!db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED, true)) {
         STHROW("failed to begin transaction");
     }
 


### PR DESCRIPTION
### Details
Latest request from Dan to diagnose slow commits on followers.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/337537

### Tests
Tested that the logs print 
```2026-01-09T18:35:21.639763+00:00 expensidev-2404 bedrock10007: xxxxxx (SQLite.cpp:460) beginTransaction [replication] [info] Begin is BEGIN```
A bunch of time in tests with `-enableHCTree` enabled, and do not without it. Will remove the logline in the next commit.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
