### PR TITLE
Track max transaction elapsed time across multiple transactions

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -142,7 +142,6 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
     try {
         SDEBUG("Peeking at '" << request.methodLine << "' with priority: " << command->priority);
         command->peekCount++;
-        _db.resetMaxTransactionElapsed();
         _db.setTimeout(_getRemainingTime(command, false));
         _db.setAbortRef(command->shouldAbort);
 
@@ -241,7 +240,6 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
     try {
         SDEBUG("Processing '" << request.methodLine << "'");
         command->processCount++;
-        _db.resetMaxTransactionElapsed();
         _db.setTimeout(_getRemainingTime(command, true));
         _db.setAbortRef(command->shouldAbort);
         if (!_db.insideTransaction()) {

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -142,6 +142,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
     try {
         SDEBUG("Peeking at '" << request.methodLine << "' with priority: " << command->priority);
         command->peekCount++;
+        _db.resetMaxTransactionElapsed();
         _db.setTimeout(_getRemainingTime(command, false));
         _db.setAbortRef(command->shouldAbort);
 
@@ -240,6 +241,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
     try {
         SDEBUG("Processing '" << request.methodLine << "'");
         command->processCount++;
+        _db.resetMaxTransactionElapsed();
         _db.setTimeout(_getRemainingTime(command, true));
         _db.setAbortRef(command->shouldAbort);
         if (!_db.insideTransaction()) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -510,6 +510,10 @@ void BedrockServer::sync()
                     return addLogParams("CRASHING from BedrockServer::sync, command:" + command->request.methodLine, command->request.nameValueMap);
                 });
 
+                // Reset the max transaction elapsed time for this new command on the shared sync thread db handle,
+                // so we don't carry over stale timing from the previous command that used this handle.
+                db.resetMaxTransactionElapsed();
+
                 // And now we'll decide how to handle it.
                 if (getState() == SQLiteNodeState::LEADING || getState() == SQLiteNodeState::STANDINGDOWN) {
                     // We peek commands here in the sync thread to be able to run peek and process as part of the same

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -210,6 +210,13 @@ public:
     // Cancels the current transaction and rolls it back.
     void rollback(const string& commandName = "");
 
+    // Resets the max transaction elapsed time. Call this at command boundaries to avoid
+    // carrying over timing from a previous command on the same db handle.
+    void resetMaxTransactionElapsed()
+    {
+        _totalTransactionElapsed = 0;
+    }
+
     // Returns the total number of changes on this database
     int getChangeCount()
     {

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -212,6 +212,10 @@ public:
 
     // Resets the max transaction elapsed time. Call this at command boundaries to avoid
     // carrying over timing from a previous command on the same db handle.
+    // This is intentionally not reset in beginTransaction like other timing counters, because a single
+    // command may run multiple transactions (e.g., when peek makes httpsRequests, the transaction is
+    // closed and reopened after the requests complete), and we want to track the highest transaction
+    // time across all of them.
     void resetMaxTransactionElapsed()
     {
         _totalTransactionElapsed = 0;

--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -78,6 +78,9 @@ SQLite& SQLitePool::initializeIndex(size_t index)
     if (_objects[index] == nullptr) {
         _objects[index] = new SQLite(_baseDB);
     }
+    // Reset the max transaction elapsed time when handing out a db handle to a new command, so we don't
+    // carry over stale timing from the previous command that used this handle.
+    _objects[index]->resetMaxTransactionElapsed();
     return *_objects[index];
 }
 


### PR DESCRIPTION
## Summary
- `_totalTransactionElapsed` was only storing the last transaction's time when a command ran multiple transactions (e.g., when peek makes httpsRequests and the transaction is closed and reopened). This meant the slowest transaction could be silently lost in timing logs.
- Changed rollback and commit to use `max()` so the highest transaction time is preserved across all transactions within a single command.
- Added `resetMaxTransactionElapsed()` and call it at db assignment boundaries (pool handle initialization and sync thread command loop) so stale timing doesn't carry over between commands on the same db handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)