### PR TITLE
Add validation for method line

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1297,7 +1297,7 @@ void SComposeHTTP(string& buffer, const string& methodLine, const STable& nameVa
 
     // Validate methodLine before adding it to the buffer to avoid control characters
     for (const unsigned char c : methodLine) {
-        if (c < 32 || c == 127) {
+        if (c != 9 && (c < 32 || c == 127)) {
             STHROW("Invalid control character ascii(" + to_string(static_cast<int>(c)) + ") in methodLine");
         }
     }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1294,6 +1294,12 @@ void SComposeHTTP(string& buffer, const string& methodLine, const STable& nameVa
 
     // Just walk across and compose a valid HTTP-like message
     buffer.clear();
+
+    // Validate methodLine before adding it to the buffer to avoid control characters
+    if (any_of(methodLine.cbegin(), methodLine.cend(), [](auto c) { return c < 32 || c == 127; })) {
+        STHROW("Invalid non-printable character detected in methodLine");
+    }
+
     buffer += methodLine + "\r\n";
     for (pair<string, string> item : nameValueMap) {
         if (SIEquals("Set-Cookie", item.first)) {

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1296,8 +1296,10 @@ void SComposeHTTP(string& buffer, const string& methodLine, const STable& nameVa
     buffer.clear();
 
     // Validate methodLine before adding it to the buffer to avoid control characters
-    if (any_of(methodLine.cbegin(), methodLine.cend(), [](auto c) { return c < 32 || c == 127; })) {
-        STHROW("Invalid non-printable character detected in methodLine");
+    for (const unsigned char c : methodLine) {
+        if (c < 32 || c == 127) {
+            STHROW("Invalid control character ascii(" + to_string(static_cast<int>(c)) + ") in methodLine");
+        }
     }
 
     buffer += methodLine + "\r\n";

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -991,6 +991,5 @@ struct LibStuff : tpunit::TestFixture
         // Verify that control characters are not allowed in methodLine
         string methodLineWithControlChars = "500 Internal Server Error\r\nContent-Type: application/json";
         ASSERT_THROW(SComposeHTTP(methodLineWithControlChars, {}, ""), SException);
-        ASSERT_EQUAL(buffer, "500 Internal Server Error\r\nContent-Length: 0\r\n\r\n");
     }
 } __LibStuff;

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -40,7 +40,8 @@ struct LibStuff : tpunit::TestFixture
                                      TEST(LibStuff::testSReplaceAllBut),
                                      TEST(LibStuff::SQResultTest),
                                      TEST(LibStuff::testReturningClause),
-                                     TEST(LibStuff::SRedactSensitiveValuesTest)
+                                     TEST(LibStuff::SRedactSensitiveValuesTest),
+                                     TEST(LibStuff::SComposeHTTPTest)
     )
     {
     }
@@ -979,5 +980,17 @@ struct LibStuff : tpunit::TestFixture
         logValue = R"({"html":"private conversation happens here"})";
         SRedactSensitiveValues(logValue);
         ASSERT_EQUAL(R"({"html":"<REDACTED>"})", logValue);
+    }
+
+    void SComposeHTTPTest()
+    {
+        string methodLine = "500 Internal Server Error";
+        string buffer = SComposeHTTP(methodLine, {}, "");
+        ASSERT_EQUAL(buffer, "500 Internal Server Error\r\nContent-Length: 0\r\n\r\n");
+
+        // Verify that control characters are not allowed in methodLine
+        string methodLineWithControlChars = "500 Internal Server Error\r\nContent-Type: application/json";
+        ASSERT_THROW(SComposeHTTP(methodLineWithControlChars, {}, ""), SException);
+        ASSERT_EQUAL(buffer, "500 Internal Server Error\r\nContent-Length: 0\r\n\r\n");
     }
 } __LibStuff;


### PR DESCRIPTION
### Details

Controls characters can be a problem in method line. 
Add validation for methodLine in SComposeHTTP.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/601890

### Tests
```
✅ LibStuff::SComposeHTTPTest (0ms)
```
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
