### PR TITLE
Fix Message failed: ' Timeout' SWARN in SHTTPSManager::postPoll

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -113,23 +113,16 @@ void SStandaloneHTTPSManager::postPoll(fd_map& fdm, SStandaloneHTTPSManager::Tra
         transaction.s->recvBuffer.consumeFront(size);
         transaction.finished = now;
 
-        // This is supposed to check for a "200" or "204 No Content"response, which it does very poorly. It also checks for message
-        // content. Why this is the what constitutes a valid response is lost to time. Any well-formed response should
-        // be valid here, and this should get cleaned up. However, this requires testing anything that might rely on
-        // the existing behavior, which is an exercise for later.
-        if (
-            SContains(transaction.fullResponse.methodLine, " 200") ||
-            SContains(transaction.fullResponse.methodLine, "204") ||
-            SContains(transaction.fullResponse.methodLine, "202") ||
-            transaction.fullResponse.content.size()
-        ) {
-            // Pass the transaction down to the subclass.
-            _onRecv(transaction);
-        } else {
-            // Coercing anything that's not 200 to 500 makes no sense, and should be abandoned with the above.
-            SWARN("Message failed: '" << transaction.fullResponse.methodLine << "'");
-            transaction.response = 500;
+        // Log a hint for non-standard responses that don't follow HTTP format (e.g., a load balancer
+        // returning a plain-text " Timeout" instead of a proper "HTTP/1.1 504 Gateway Timeout").
+        // These are not errors in our code, but they are unexpected from the remote service.
+        if (!SStartsWith(transaction.fullResponse.methodLine, "HTTP/")) {
+            SHMMM("Received non-standard response: '" << transaction.fullResponse.methodLine << "'");
         }
+
+        // Pass the transaction down to the subclass for all complete responses. Each subclass's _onRecv
+        // is responsible for parsing the response code and handling errors appropriately.
+        _onRecv(transaction);
 
         // Finished with the socket, free it up.
         delete transaction.s;

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -115,6 +115,8 @@ void SStandaloneHTTPSManager::postPoll(fd_map& fdm, SStandaloneHTTPSManager::Tra
         // Log a hint for non-standard responses that don't follow HTTP format (e.g., a load balancer
         // returning a plain-text " Timeout" instead of a proper "HTTP/1.1 504 Gateway Timeout").
         // These are not errors in our code, but they are unexpected from the remote service.
+        // Note: non-standard responses have no Content-Length and an unparseable statusCode, so they
+        // only reach this branch once the socket is closed (making completeRequest true via CLOSED state).
         if (!SStartsWith(transaction.fullResponse.methodLine, "HTTP/")) {
             SHMMM("Received non-standard response: '" << transaction.fullResponse.methodLine << "'");
         }
@@ -148,6 +150,10 @@ void SStandaloneHTTPSManager::postPoll(fd_map& fdm, SStandaloneHTTPSManager::Tra
                 transaction.finished = now;
                 if (!transaction.fullResponse.methodLine.empty()) {
                     _onRecv(transaction);
+                } else {
+                    // Got bytes but no parseable methodLine (e.g., bare "\r\n\r\n"). Use a safe
+                    // fallback rather than leaving response == 0, which would stall wait loops.
+                    transaction.response = 400;
                 }
 
                 // Clean up the socket

--- a/test/lib/TestHTTPS.cpp
+++ b/test/lib/TestHTTPS.cpp
@@ -21,6 +21,9 @@ bool TestHTTPS::_onRecv(Transaction& transaction)
             transaction.response = status;
         }
     }
+    if (!transaction.response) {
+        transaction.response = 400;
+    }
 
     return false;
 }

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -2,6 +2,7 @@
 
 #include <libstuff/libstuff.h>
 #include <libstuff/SData.h>
+#include <libstuff/SHTTPSManager.h>
 #include <libstuff/SQResult.h>
 #include <libstuff/SRandom.h>
 #include <sqlitecluster/SQLite.h>
@@ -10,6 +11,7 @@
 struct LibStuff : tpunit::TestFixture
 {
     LibStuff() : tpunit::TestFixture(true, "LibStuff",
+                                     TEST(LibStuff::testGetHTTPResponseCode),
                                      TEST(LibStuff::testEncryptDecrpyt),
                                      TEST(LibStuff::testSHMACSHA1),
                                      TEST(LibStuff::testSHMACSHA256),
@@ -991,5 +993,22 @@ struct LibStuff : tpunit::TestFixture
         // Verify that control characters are not allowed in methodLine
         string methodLineWithControlChars = "500 Internal Server Error\r\nContent-Type: application/json";
         ASSERT_THROW(SComposeHTTP(methodLineWithControlChars, {}, ""), SException);
+    }
+
+    void testGetHTTPResponseCode()
+    {
+        // Standard HTTP response lines parse correctly.
+        ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode("HTTP/1.1 200 OK"), 200);
+        ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode("HTTP/1.1 204 No Content"), 204);
+        ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode("HTTP/1.1 202 Accepted"), 202);
+        ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode("HTTP/1.1 400 Bad Request"), 400);
+        ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode("HTTP/1.1 500 Internal Server Error"), 500);
+        ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode("HTTP/1.1 504 Gateway Timeout"), 504);
+
+        // Non-standard responses (e.g., from a load balancer sending " Timeout" instead of a proper
+        // HTTP status line) fall back to 400 rather than crashing or producing a misleading result.
+        ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode(" Timeout"), 400);
+        ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode("Timeout"), 400);
+        ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode(""), 400);
     }
 } __LibStuff;

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -1010,5 +1010,9 @@ struct LibStuff : tpunit::TestFixture
         ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode(" Timeout"), 400);
         ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode("Timeout"), 400);
         ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode(""), 400);
+
+        // Explicit defaultStatusCode is used when parsing fails.
+        ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode("garbage", 502), 502);
+        ASSERT_EQUAL(SStandaloneHTTPSManager::getHTTPResponseCode("", 500), 500);
     }
 } __LibStuff;


### PR DESCRIPTION
### Explanation of Change

`SHTTPSManager::postPoll()` was only calling `_onRecv()` for responses containing `" 200"`, `"204"`, or `"202"` in the methodLine, or responses with body content. Any other complete response (including non-standard methodLines like `" Timeout"` from load balancers) fell into an else branch that fired `SWARN("Message failed: '...")` and coerced the response to 500.

The existing code comment even called this out explicitly: *"Coercing anything that's not 200 to 500 makes no sense, and should be abandoned with the above."*

**Before:** Non-standard HTTP responses (e.g., load balancer returning `" Timeout"` instead of `HTTP/1.1 504 Gateway Timeout`) triggered `SWARN("Message failed: '...'")` and forced response=500, bypassing all `_onRecv()` subclass handling.

**After:** All complete responses are passed to `_onRecv()` for proper subclass handling. Non-standard methodLines (not starting with `HTTP/`) log at `SHMMM` severity instead of `SWARN`. Subclasses (Stripe, Hubspot, etc.) parse response codes as designed.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/610175

### Tests

Added `testGetHTTPResponseCode` to `LibStuffTest` verifying:
- Standard HTTP responses (200, 204, 202, 400, 500, 504) parse correctly
- Non-standard methodLines (`" Timeout"`, `"Timeout"`, `""`) return 400 as a safe default
- Explicit `defaultStatusCode` parameter is used when parsing fails

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
