### PR TITLE
Socket pool liveness check

### DIFF
--- a/libstuff/SSocketPool.cpp
+++ b/libstuff/SSocketPool.cpp
@@ -51,16 +51,26 @@ void SSocketPool::_timeoutThreadFunc()
 unique_ptr<STCPManager::Socket> SSocketPool::getSocket()
 {
     {
-        // If there's an existing socket, return it.
         lock_guard<mutex> lock(_poolMutex);
-        if (_sockets.size()) {
-            pair<chrono::steady_clock::time_point, unique_ptr<STCPManager::Socket>> s = move(_sockets.front());
+        while (_sockets.size()) {
+            auto s = move(_sockets.front());
             _sockets.pop_front();
-            return move(s.second);
+
+            // Verify the socket is still alive before returning it.
+            if (s.second->state.load() == STCPManager::Socket::CONNECTED) {
+                struct pollfd pfd = {s.second->s, POLLIN | POLLOUT, 0};
+                int ret = poll(&pfd, 1, 0);
+                if (ret >= 0 && !(pfd.revents & (POLLERR | POLLHUP | POLLNVAL))) {
+                    return move(s.second);
+                }
+            }
+
+            // Socket is dead, discard it (destructor closes fd).
+            SINFO("[SOCKET] Discarding stale socket from pool for host '" << host << "'.");
         }
     }
 
-    // If we get here, we need to create a socket to return. No need to hold the lock, so it goes out of scope.
+    // No live pooled socket available, create a new one. No need to hold the lock, so it goes out of scope.
     try {
         // TODO: Allow S_socket to take a parsed address instead of redoing all the parsing each time.
         return unique_ptr<STCPManager::Socket>(new STCPManager::Socket(host));

--- a/libstuff/SSocketPool.cpp
+++ b/libstuff/SSocketPool.cpp
@@ -50,24 +50,28 @@ void SSocketPool::_timeoutThreadFunc()
 
 unique_ptr<STCPManager::Socket> SSocketPool::getSocket()
 {
-    {
-        lock_guard<mutex> lock(_poolMutex);
-        while (_sockets.size()) {
-            auto s = move(_sockets.front());
-            _sockets.pop_front();
-
-            // Verify the socket is still alive before returning it.
-            if (s.second->state.load() == STCPManager::Socket::CONNECTED) {
-                struct pollfd pfd = {s.second->s, POLLIN | POLLOUT, 0};
-                int ret = poll(&pfd, 1, 0);
-                if (ret >= 0 && !(pfd.revents & (POLLERR | POLLHUP | POLLNVAL))) {
-                    return move(s.second);
-                }
+    while (true) {
+        unique_ptr<STCPManager::Socket> socket;
+        {
+            lock_guard<mutex> lock(_poolMutex);
+            if (_sockets.empty()) {
+                break;
             }
-
-            // Socket is dead, discard it (destructor closes fd).
-            SINFO("[SOCKET] Discarding stale socket from pool for host '" << host << "'.");
+            socket = move(_sockets.front().second);
+            _sockets.pop_front();
         }
+
+        // Verify the socket is still alive before returning it.
+        if (socket->state.load() == STCPManager::Socket::CONNECTED) {
+            struct pollfd pfd = {socket->s, POLLIN | POLLOUT, 0};
+            int ret = poll(&pfd, 1, 0);
+            if (ret >= 0 && !(pfd.revents & (POLLERR | POLLHUP | POLLNVAL))) {
+                return socket;
+            }
+        }
+
+        // Socket is dead, discard it (destructor closes fd).
+        SINFO("[SOCKET] Discarding stale socket from pool for host '" << host << "'.");
     }
 
     // No live pooled socket available, create a new one. No need to hold the lock, so it goes out of scope.

--- a/libstuff/SSocketPool.cpp
+++ b/libstuff/SSocketPool.cpp
@@ -65,7 +65,7 @@ unique_ptr<STCPManager::Socket> SSocketPool::getSocket()
         if (socket->state.load() != STCPManager::Socket::CLOSED) {
             struct pollfd pfd = {socket->s, POLLIN | POLLOUT, 0};
             int ret = poll(&pfd, 1, 0);
-            if (ret >= 0 && !(pfd.revents & (POLLERR | POLLHUP | POLLNVAL))) {
+            if (ret >= 0 && !(pfd.revents & (POLLERR | POLLHUP | POLLNVAL | POLLIN))) {
                 return socket;
             }
         }

--- a/libstuff/SSocketPool.cpp
+++ b/libstuff/SSocketPool.cpp
@@ -62,7 +62,7 @@ unique_ptr<STCPManager::Socket> SSocketPool::getSocket()
         }
 
         // Verify the socket is still alive before returning it.
-        if (socket->state.load() == STCPManager::Socket::CONNECTED) {
+        if (socket->state.load() != STCPManager::Socket::CLOSED) {
             struct pollfd pfd = {socket->s, POLLIN | POLLOUT, 0};
             int ret = poll(&pfd, 1, 0);
             if (ret >= 0 && !(pfd.revents & (POLLERR | POLLHUP | POLLNVAL))) {


### PR DESCRIPTION
### Details
This uses `poll()` to check if a socket has died when removing it from the pool, returning a different one if it has.

It was previously possible for a socket to die while sitting in the pool unused until we tried to write to it, at which point we'd notice the error. This checks for errors before returning the socket to the caller.

Note that it's still possible for a socket to die at any time, including after we have done this check but before the caller acts on the socket, but the exposure is now greatly reduced.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/613505#event-24230562693

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
