### PR TITLE
Check that followers actually have the new table

### DIFF
--- a/test/clustertest/tests/UpgradeDBTest.cpp
+++ b/test/clustertest/tests/UpgradeDBTest.cpp
@@ -35,7 +35,7 @@ struct UpgradeDBTest : tpunit::TestFixture
         // replicate asynchronously, so without waiting they might not yet have the row.
         string leaderCommitCount = SParseJSONObject(
             tester->getTester(0).executeWaitVerifyContent(SData("Status"), "200", true)
-        )["CommitCount"];
+            )["CommitCount"];
         for (auto i : {1, 2}) {
             ASSERT_TRUE(tester->getTester(i).waitForStatusTerm("CommitCount", leaderCommitCount));
         }

--- a/test/clustertest/tests/UpgradeDBTest.cpp
+++ b/test/clustertest/tests/UpgradeDBTest.cpp
@@ -25,13 +25,27 @@ struct UpgradeDBTest : tpunit::TestFixture
 
     void test()
     {
-        for (auto i : {0, 1, 2}) {
-            BedrockTester& brtester = tester->getTester(i);
+        // Write one row on the leader. Write commands always run on the leader regardless of
+        // which node they're sent to, so this only confirms the table exists on the leader.
+        SData insert("Query");
+        insert["Query"] = "INSERT INTO dbupgrade VALUES(1, " + SQ("val") + ");";
+        tester->getTester(0).executeWaitVerifyContent(insert, "200");
 
-            // This just verifies that the dbupgrade table was created by TestPlugin.
-            SData query("Query");
-            query["Query"] = "INSERT INTO dbupgrade VALUES(" + SQ(1 + i) + ", " + SQ("val") + ");";
-            brtester.executeWaitVerifyContent(query, "200");
+        // Capture the leader's commit count now that the INSERT has landed. Followers
+        // replicate asynchronously, so without waiting they might not yet have the row.
+        string leaderCommitCount = SParseJSONObject(
+            tester->getTester(0).executeWaitVerifyContent(SData("Status"), "200", true)
+        )["CommitCount"];
+        for (auto i : {1, 2}) {
+            ASSERT_TRUE(tester->getTester(i).waitForStatusTerm("CommitCount", leaderCommitCount));
+        }
+
+        // Read the same row back on every node, including both followers. Unlike writes,
+        // read queries are processed locally on the receiving node without being escalated to
+        // the leader. If upgradeDatabase's CREATE TABLE was not replicated to a follower, the
+        // SELECT will fail on that node, catching incomplete schema replication.
+        for (auto i : {0, 1, 2}) {
+            ASSERT_EQUAL(tester->getTester(i).readDB("SELECT value FROM dbupgrade WHERE id = 1;"), "val");
         }
     }
 } __UpgradeDBTest;


### PR DESCRIPTION
### Details

When investigating this comment:
https://github.com/Expensify/Bedrock/pull/2578#discussion_r3118831602

I noticed that `UpgradeDBTest` verifies that the table exists with a write command. However, that will always run on leader, which doesn't actually mean the new table gets replicated to followers. This changes the test to write one row to leader, and then check that it exists on followers. If it succeeds, it means the table itself was replicated.

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/601964

### Tests
Is test
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
