### PR TITLE
Demote request failure log to HMMM

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -162,7 +162,7 @@ void SStandaloneHTTPSManager::postPoll(fd_map& fdm, SStandaloneHTTPSManager::Tra
                 transaction.s = nullptr;
             } else {
                 // No response data at all - this is a genuine failure
-                SWARN("Connection " << ((transaction.s->state.load() > Socket::CONNECTED) ? "died prematurely" : "timed out"));
+                SHMMM("Connection " << ((transaction.s->state.load() > Socket::CONNECTED) ? "died prematurely" : "timed out"));
                 transaction.response = transaction.s->sendBufferEmpty() ? 501 : 500;
             }
         } else {


### PR DESCRIPTION
### Details

If because of network blip, multiple socket connection dies, then this logs warning for each of the request.
The log proved to be noisy during network blips and not helpful because commands handle request failures(50X) response at the command level. So demoting the log to HMMM

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/608833

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
