### PR TITLE
Make PARAMS_WHITELIST thread-safe via atomic snapshot

### DIFF
--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -1,5 +1,6 @@
 #include "libstuff.h"
 #include <execinfo.h> // for backtrace*
+#include <memory>
 
 // Global logging state shared between all threads
 atomic<int> _g_SLogMask(LOG_INFO);
@@ -48,34 +49,38 @@ void SLogStackTrace(int level)
 }
 
 // If the param name is not in this whitelist, we will log <REDACTED> in addLogParams.
-static set<string> PARAMS_WHITELIST = {
-    "beginElapsed",
-    "chatID",
-    "command",
-    "commitElapsed",
-    "commitLockElapsed",
-    "Connection",
-    "Content-Length",
-    "count",
-    "indexName",
-    "isUnique",
-    "logParam",
-    "message",
-    "peer",
-    "prepareElapsed",
-    "query",
-    "readElapsed",
-    "reason",
-    "requestID",
-    "rollbackElapsed",
-    "rowNum",
-    "status",
-    "topic",
-    "totalElapsed",
-    "totalTransactionElapsed",
-    "userID",
-    "what",
-    "writeElapsed",
+// Held as an immutable snapshot so readers (every parameterized log call) are lock-free;
+// SWhitelistLogParams swaps in a new snapshot via copy-on-write CAS.
+static atomic<shared_ptr<const set<string>>> PARAMS_WHITELIST{
+    make_shared<const set<string>>(set<string>{
+        "beginElapsed",
+        "chatID",
+        "command",
+        "commitElapsed",
+        "commitLockElapsed",
+        "Connection",
+        "Content-Length",
+        "count",
+        "indexName",
+        "isUnique",
+        "logParam",
+        "message",
+        "peer",
+        "prepareElapsed",
+        "query",
+        "readElapsed",
+        "reason",
+        "requestID",
+        "rollbackElapsed",
+        "rowNum",
+        "status",
+        "topic",
+        "totalElapsed",
+        "totalTransactionElapsed",
+        "userID",
+        "what",
+        "writeElapsed",
+    })
 };
 
 string addLogParams(string&& message, const STable& params)
@@ -85,10 +90,11 @@ string addLogParams(string&& message, const STable& params)
     }
 
     message += " ~~";
+    auto whitelist = PARAMS_WHITELIST.load();
     for (const auto& [key, value] : params) {
         message += " ";
         string valueToLog = value;
-        if (!SContains(PARAMS_WHITELIST, key)) {
+        if (!SContains(*whitelist, key)) {
             if (!GLOBAL_IS_LIVE) {
                 STHROW("500 Log param " + key + " not in the whitelist, either do not log that or add it to PARAMS_WHITELIST if it's not sensitive");
             }
@@ -102,10 +108,17 @@ string addLogParams(string&& message, const STable& params)
 
 void SWhitelistLogParams(const set<string>& params)
 {
-    PARAMS_WHITELIST.insert(params.begin(), params.end());
+    auto current = PARAMS_WHITELIST.load();
+    while (true) {
+        auto next = make_shared<set<string>>(*current);
+        next->insert(params.begin(), params.end());
+        if (PARAMS_WHITELIST.compare_exchange_weak(current, next)) {
+            return;
+        }
+    }
 }
 
 bool SIsLogParamWhitelisted(const string& key)
 {
-    return SContains(PARAMS_WHITELIST, key);
+    return SContains(*PARAMS_WHITELIST.load(), key);
 }

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -112,7 +112,7 @@ void SWhitelistLogParams(const set<string>& params)
     while (true) {
         auto next = make_shared<set<string>>(*current);
         next->insert(params.begin(), params.end());
-        if (PARAMS_WHITELIST.compare_exchange_weak(current, next)) {
+        if (PARAMS_WHITELIST.compare_exchange_strong(current, next)) {
             return;
         }
     }


### PR DESCRIPTION
### Details

`PARAMS_WHITELIST` in `libstuff/SLog.cpp` was a bare `static set<string>` with no synchronization between `SWhitelistLogParams` (writer, currently called once during Auth plugin init) and the readers — `addLogParams` and `SIsLogParamWhitelisted` — which fire from every parameterized log call site. Today's startup ordering happens to make this safe by construction (writes complete before any worker thread starts, and `std::thread` creation establishes a happens-before edge), but the API doesn't enforce that, so any future runtime caller of `SWhitelistLogParams` would silently introduce a data race on a `std::set`.

This swaps the storage for `atomic<shared_ptr<const set<string>>>`. Readers do a single atomic load and dereference an immutable snapshot — no lock acquisition on the read path, which matters because `addLogParams` is one of the hottest reads in the binary (every `SINFO`/`SWARN`/etc. with params hits the whitelist N+1 times: once for syslog, once per key for the Fluentd path). The writer builds a new snapshot via copy-on-write and swaps it in with `compare_exchange_weak`, which keeps the function correct even under concurrent writers (the structural fragility the issue calls out).

I considered the `shared_timed_mutex` pattern that `BedrockServer::_blacklistedParallelCommands` uses, but that pattern fits incremental runtime mutation (its writers add commands via the control port) — whereas `PARAMS_WHITELIST` is read-mostly, write-once-at-startup, and the snapshot semantics are natural.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/602617

### Tests
No new tests added.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes