### PR TITLE
Verify that a hash matches before we actually commit

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2168,17 +2168,19 @@ void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message)
         if (!_db.writeUnmodified(BedrockPlugin_Compression::decompress(commit.content))) {
             STHROW("failed to write transaction");
         }
-        if (!_db.prepare()) {
+        string newHash;
+        if (!_db.prepare(nullptr, &newHash)) {
             STHROW("failed to prepare transaction");
+        }
+        if (newHash != commit["Hash"]) {
+            STHROW("potential hash mismatch");
         }
 
         // Transaction succeeded, commit and go to the next
         SDEBUG("Committing current transaction because _recvSynchronize: " << _db.getUncommittedQuery());
         _db.commit(stateName(_state));
 
-        if (_db.getCommittedHash() != commit["Hash"]) {
-            STHROW("potential hash mismatch");
-        }
+
         --commitsRemaining;
     }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2180,7 +2180,6 @@ void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message)
         SDEBUG("Committing current transaction because _recvSynchronize: " << _db.getUncommittedQuery());
         _db.commit(stateName(_state));
 
-
         --commitsRemaining;
     }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2173,6 +2173,7 @@ void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message)
             STHROW("failed to prepare transaction");
         }
         if (newHash != commit["Hash"]) {
+            _db.rollback();
             STHROW("potential hash mismatch");
         }
 


### PR DESCRIPTION
### Details
We currently don't check the hash of a new commit until after we commit it, so the DB could already be corrupted by the time we verify it.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/633962

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes