### PR TITLE
Fix race condition and mutex timeout in `_upgradeDB`

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -141,7 +141,7 @@ void BedrockServer::sync()
     // Now we jump into our main command processing loop.
     uint64_t nextActivity = STimeNow();
     unique_ptr<BedrockCommand> command(nullptr);
-    bool committingCommand = false;
+    bool commitInProgress = false;
     bool upgradeInProgress = false;
 
     // Timer for S_poll performance logging. Created outside the loop because it's cumulative.
@@ -285,7 +285,7 @@ void BedrockServer::sync()
             _notifyDoneSync.postPoll(fdm);
         }
 
-        if (command && committingCommand) {
+        if (command && commitInProgress) {
             void (*onPrepareHandler)(SQLite& db, int64_t tableID) = nullptr;
             bool enabled = command->shouldEnableOnPrepareNotification(db, &onPrepareHandler);
             if (enabled) {
@@ -321,10 +321,10 @@ void BedrockServer::sync()
             // If we bailed out while doing a upgradeDB, clear state
             if (upgradeInProgress) {
                 upgradeInProgress = false;
-                if (committingCommand) {
+                if (commitInProgress) {
                     const string commandName = command ? command->getMethodName() : "No Command";
                     db.rollback(commandName);
-                    committingCommand = false; //NOLINT
+                    commitInProgress = false; //NOLINT
                 }
             }
 
@@ -362,20 +362,10 @@ void BedrockServer::sync()
             continue;
         }
 
-        // This first time we start LEADING, we will try and upgrade the DB.
-        // We then set _upgradeCompleted and will not attempt to upgrade again, there is no more work to do.
-        if (
-            // If we've aleady set that we've completed an upgrade, we can skip this block.
-            !_upgradeCompleted &&
-
-            // Run this block id we *JUST* switched
-            ((preUpdateState != SQLiteNodeState::LEADING && getState() == SQLiteNodeState::LEADING)
-             ||
-            (getState() == SQLiteNodeState::LEADING && upgradeInProgress && !committingCommand))
-        ) {
-            // Store this before we start writing to the DB, which can take a while depending on what changes were made
-            // (for instance, adding an index).
-            upgradeInProgress = true;
+        // If _upgradeCompleted is set, I.e., we're run at least one upgrade, we can skip this block.
+        // Otherwise, if we're leading, let's start the commit.
+        // Also, if a commit is in progress, skip it (it's the commit we started on the last loop iteration).
+        if (!_upgradeCompleted && getState() == SQLiteNodeState::LEADING && !commitInProgress) {
             if (!_syncNode->hasQuorum()) {
                 // Because we are going to commit the upgrade as a QUORUM commit (i.e., wait until over half of nodes
                 // approve it), we wait until `hasQuorum()` is true before we even attempt to start it.
@@ -392,7 +382,7 @@ void BedrockServer::sync()
                 continue;
             }
             if (_upgradeDB(db)) {
-                committingCommand = true;
+                commitInProgress = true;
                 _syncNode->startCommit(SQLiteNode::QUORUM);
                 _lastQuorumCommandTime = STimeNow();
 
@@ -405,7 +395,6 @@ void BedrockServer::sync()
             } else {
                 // If we're not doing an upgrade, we don't need to keep suppressing multi-write, and we're done with
                 // the upgradeInProgress flag.
-                upgradeInProgress = false;
                 _upgradeCompleted = true;
                 SINFO("UpgradeDB skipped, done.");
             }
@@ -413,17 +402,18 @@ void BedrockServer::sync()
 
         // If we started a commit, and one's not in progress, then we've finished it and we'll take that command and
         // stick it back in the appropriate queue.
-        if (committingCommand && !_syncNode->commitInProgress()) {
-            // Record the time spent, unless we were upgrading, in which case, there's no command to write to.
-            if (command) {
-                command->stopTiming(BedrockCommand::COMMIT_SYNC);
+        if (commitInProgress) {
+            // If the sync node's still working on the existing commit, just continue.
+            if (_syncNode->commitInProgress()) {
+                continue;
             }
-            committingCommand = false;
+            commitInProgress = false;
 
             // If we were upgrading, there's no response to send, we're just done.
-            if (upgradeInProgress) {
+            // But if we failed, we just try again. We have no real other options as this is required for
+            // the database to be in a usable state.
+            if (!_upgradeCompleted) {
                 if (_syncNode->commitSucceeded()) {
-                    upgradeInProgress = false;
                     _upgradeCompleted = true;
                     SINFO("UpgradeDB succeeded, done.");
                     _notifyDone.push(true);
@@ -433,23 +423,28 @@ void BedrockServer::sync()
                 continue;
             }
 
+            // We should only get here with a command existing.
+            if (!command) {
+                SWARN("Sync thread commit with no command!");
+                continue;
+            }
+
+            // Record the time spent, unless we were upgrading, in which case, there's no command to write to.
+            command->stopTiming(BedrockCommand::COMMIT_SYNC);
+
             if (command->shouldPostProcess() && command->response.methodLine == "200 OK") {
                 // PostProcess if the command should run postProcess, and there have been no errors thrown thus far.
                 core.postProcessCommand(command, false);
             }
 
             if (_syncNode->commitSucceeded()) {
-                if (command) {
-                    SINFO("[performance] Sync thread finished committing command " << command->request.methodLine);
-                    _conflictManager.recordTables(command->request.methodLine, db.getTablesUsed());
+                SINFO("[performance] Sync thread finished committing command " << command->request.methodLine);
+                _conflictManager.recordTables(command->request.methodLine, db.getTablesUsed());
 
-                    // Otherwise, save the commit count, mark this command as complete, and reply.
-                    command->response["commitCount"] = to_string(db.getCommitCount());
-                    command->complete = true;
-                    _reply(command);
-                } else {
-                    SINFO("Sync thread finished committing non-command");
-                }
+                // Otherwise, save the commit count, mark this command as complete, and reply.
+                command->response["commitCount"] = to_string(db.getCommitCount());
+                command->complete = true;
+                _reply(command);
             } else {
                 // This should only happen if the cluster becomes largely disconnected while we were in the process of
                 // committing a QUORUM command - if we no longer have enough peers to reach QUORUM, we'll fall out of
@@ -457,14 +452,10 @@ void BedrockServer::sync()
                 // state, because this loop is skipped except when LEADING, FOLLOWING, or STANDINGDOWN. It's also
                 // theoretically feasible for this to happen if a follower fails to commit a transaction, but that
                 // probably indicates a bug (or a follower disk failure).
-                if (command) {
-                    SINFO("requeueing command " << command->request.methodLine
-                          << " after failed sync commit. Sync thread has " << _syncNodeQueuedCommands.size()
-                          << " queued commands.");
-                    _syncNodeQueuedCommands.push(move(command));
-                } else {
-                    SERROR("Unexpected sync thread commit state.");
-                }
+                SINFO("requeueing command " << command->request.methodLine
+                        << " after failed sync commit. Sync thread has " << _syncNodeQueuedCommands.size()
+                        << " queued commands.");
+                _syncNodeQueuedCommands.push(move(command));
             }
         }
 
@@ -472,11 +463,6 @@ void BedrockServer::sync()
         // there could also be other finished work to handle while we wait for that to complete. Let's see if we can
         // handle any of that work.
         try {
-            // We don't start processing a new command until we've completed any existing ones.
-            if (committingCommand) {
-                continue;
-            }
-
             // Don't escalate, leader can't handle the command anyway. Don't even dequeue the command, just leave it
             // until one of these states changes. This prevents an endless loop of escalating commands, having
             // SQLiteNode re-queue them because leader is standing down, and then escalating them again until leader
@@ -575,7 +561,7 @@ void BedrockServer::sync()
                     BedrockCore::RESULT result = core.processCommand(command, true);
                     if (result == BedrockCore::RESULT::NEEDS_COMMIT) {
                         // The processor says we need to commit this, so let's start that process.
-                        committingCommand = true;
+                        commitInProgress = true;
                         SINFO("[performance] Sync thread beginning committing command " << command->request.methodLine);
                         // START TIMING.
                         command->startTiming(BedrockCommand::COMMIT_SYNC);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -778,7 +778,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
     // We specifically exclude `STANDINGDOWN` because even though we *can* process commands in this state, the intention
     // here is to shut the node down and so we want to stop building a backlog of in-process commands that prevent
     // standdown from completing. They will get blocked until we hit our final FOLLOWING state and then finished.
-    while (!dbReadyToHandleRequests() && getState() != SQLiteNodeState::STANDINGDOWN) {
+    while (!dbReadyToHandleRequests() || getState() == SQLiteNodeState::STANDINGDOWN) {
         // It's feasible that our command times out in this loop. In this case, we do not have a DB object to pass.
         // The only implication of this is the response does not get the commitCount attached to it.
         if (BedrockCore::isTimedOut(command, nullptr, this)) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -142,7 +142,6 @@ void BedrockServer::sync()
     uint64_t nextActivity = STimeNow();
     unique_ptr<BedrockCommand> command(nullptr);
     bool commitInProgress = false;
-    bool upgradeInProgress = false;
 
     // Timer for S_poll performance logging. Created outside the loop because it's cumulative.
     AutoTimer pollTimer("sync thread poll");
@@ -318,14 +317,9 @@ void BedrockServer::sync()
             (getState() != SQLiteNodeState::LEADING && getState() != SQLiteNodeState::STANDINGDOWN)) {
             shutdownTimer.safeNodeState = chrono::steady_clock::now();
 
-            // If we bailed out while doing a upgradeDB, clear state
-            if (upgradeInProgress) {
-                upgradeInProgress = false;
-                if (commitInProgress) {
-                    const string commandName = command ? command->getMethodName() : "No Command";
-                    db.rollback(commandName);
-                    commitInProgress = false; //NOLINT
-                }
+            if (commitInProgress) {
+                db.rollback(command ? command->getMethodName() : "upgradeDB");
+                commitInProgress = false;
             }
 
             // We should give up an any commands, and let them be re-escalated. If commands were initiated locally,

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -142,6 +142,7 @@ void BedrockServer::sync()
     uint64_t nextActivity = STimeNow();
     unique_ptr<BedrockCommand> command(nullptr);
     bool committingCommand = false;
+    bool upgradeInProgress = false;
 
     // Timer for S_poll performance logging. Created outside the loop because it's cumulative.
     AutoTimer pollTimer("sync thread poll");
@@ -318,17 +319,14 @@ void BedrockServer::sync()
             shutdownTimer.safeNodeState = chrono::steady_clock::now();
 
             // If we bailed out while doing a upgradeDB, clear state
-            if (_upgradeInProgress) {
-                _upgradeInProgress = false;
+            if (upgradeInProgress) {
+                upgradeInProgress = false;
                 if (committingCommand) {
                     const string commandName = command ? command->getMethodName() : "No Command";
                     db.rollback(commandName);
                     committingCommand = false; //NOLINT
                 }
             }
-
-            // If we're not leading, we're not upgrading, but we will need to check for upgrades again next time we go leading, so be ready for that.
-            _upgradeCompleted = false;
 
             // We should give up an any commands, and let them be re-escalated. If commands were initiated locally,
             // we can just re-queue them, they will get re-checked once things clear up, and then they'll get
@@ -364,22 +362,32 @@ void BedrockServer::sync()
             continue;
         }
 
-        // If we've just switched to the leading state, we want to upgrade the DB. We set a global `upgradeInProgress`
-        // flag to prevent workers from trying to use the DB while we do this.
-        // It's also possible for the upgrade to fail on the first try, in the case that our followers weren't ready to
-        // receive the transaction when we started. In this case, we'll try the upgrade again if we were already
-        // leading, and the upgrade is still in progress (because the first try failed), and we're not currently
-        // attempting to commit it.
-        if ((preUpdateState != SQLiteNodeState::LEADING && getState() == SQLiteNodeState::LEADING) ||
-            (getState() == SQLiteNodeState::LEADING && _upgradeInProgress && !committingCommand)) {
+        // This first time we start LEADING, we will try and upgrade the DB.
+        // We then set _upgradeCompleted and will not attempt to upgrade again, there is no more work to do.
+        if (
+            // If we've aleady set that we've completed an upgrade, we can skip this block.
+            !_upgradeCompleted &&
+
+            // Run this block id we *JUST* switched
+            ((preUpdateState != SQLiteNodeState::LEADING && getState() == SQLiteNodeState::LEADING)
+             ||
+            (getState() == SQLiteNodeState::LEADING && upgradeInProgress && !committingCommand))
+        ) {
             // Store this before we start writing to the DB, which can take a while depending on what changes were made
             // (for instance, adding an index).
-            _upgradeInProgress = true;
+            upgradeInProgress = true;
             if (!_syncNode->hasQuorum()) {
-                // We are now "upgrading" but we won't actually start the commit until the cluster is sufficiently
-                // connected. This is because if we need to roll back the commit, it disconnects the entire cluster,
-                // which is more likely to trigger the same thing to happen again, making cluster startup take
-                // significantly longer. In this case we'll just loop again, like if the upgrade failed.
+                // Because we are going to commit the upgrade as a QUORUM commit (i.e., wait until over half of nodes
+                // approve it), we wait until `hasQuorum()` is true before we even attempt to start it.
+                // You might ask "if we are LEADING, how do we not have QUORUM?" and the answer to that is that as soon as
+                // we become LEADING, we need nodes to subscribe to us in order to indicate that they are 100% caught up
+                // and ready to accept a transaction stream. basically we go LEADING, and then nodes go SUBSCRIBING for
+                // a second and then they go FOLLOWING.
+                // If we attempt this transaction before we wait for these nodes to go FOLLOWING, they will not participate in
+                // the transaction. This will cause the transaction to fail and be rolled back, but worse, it causes the whole
+                // cluster to reconnect, because a failed QUORUM transction throws the whole state of the cluster into
+                // question. This then takes a while to resolve as nodes all reconnect to one another, and is at risk for
+                // happening again on the next attempt as well.
                 SINFO("Waiting for quorum availability before running UpgradeDB.");
                 continue;
             }
@@ -397,7 +405,7 @@ void BedrockServer::sync()
             } else {
                 // If we're not doing an upgrade, we don't need to keep suppressing multi-write, and we're done with
                 // the upgradeInProgress flag.
-                _upgradeInProgress = false;
+                upgradeInProgress = false;
                 _upgradeCompleted = true;
                 SINFO("UpgradeDB skipped, done.");
             }
@@ -413,9 +421,9 @@ void BedrockServer::sync()
             committingCommand = false;
 
             // If we were upgrading, there's no response to send, we're just done.
-            if (_upgradeInProgress) {
+            if (upgradeInProgress) {
                 if (_syncNode->commitSucceeded()) {
-                    _upgradeInProgress = false;
+                    upgradeInProgress = false;
                     _upgradeCompleted = true;
                     SINFO("UpgradeDB succeeded, done.");
                     _notifyDone.push(true);
@@ -775,7 +783,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
 
     // We just spin until the node looks ready to go. Typically, this doesn't happen expect briefly at startup.
     size_t waitCount = 0;
-    while (_upgradeInProgress || (getState() != SQLiteNodeState::LEADING && getState() != SQLiteNodeState::FOLLOWING)) {
+    while (!isUpgradeComplete()) {
         // It's feasible that our command times out in this loop. In this case, we do not have a DB object to pass.
         // The only implication of this is the response does not get the commitCount attached to it.
         if (BedrockCore::isTimedOut(command, nullptr, this)) {
@@ -1215,7 +1223,6 @@ void BedrockServer::_resetServer()
     lock_guard<mutex> lock(_portMutex);
 
     _requestCount = 0;
-    _upgradeInProgress = false;
     if (_commandPortBlockReasons.size()) {
         SWARN("Clearing leftover command port blocks in resetServer (" << _commandPortBlockReasons.size() << " blocks remaining).");
         _commandPortBlockReasons.clear();
@@ -1243,7 +1250,6 @@ BedrockServer::BedrockServer(SQLiteNodeState state, const SData& args_)
 
 BedrockServer::BedrockServer(const SData& args_)
     : SQLiteServer(), shutdownWhileDetached(false), args(args_), _requestCount(0),
-    _upgradeInProgress(false),
     _isCommandPortLikelyBlocked(false),
     _syncLoopShouldBeRunning(true), _syncNode(nullptr), _clusterMessenger(nullptr), _shutdownState(RUNNING),
     _multiWriteEnabled(args.test("-enableMultiWrite")), _enableConflictPageLocks(args.test("-enableConflictPageLocks")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),
@@ -1693,7 +1699,20 @@ bool BedrockServer::isDetached()
 
 bool BedrockServer::isUpgradeComplete()
 {
-    return _upgradeCompleted;
+    auto state = getState();
+    if (state == SQLiteNodeState::FOLLOWING) {
+        // We are as upgraded as we can be, becuase someone else is controlling what the state of "upgraded" is,
+        // and they will broadcast those changes to us when appropriate.
+        return true;
+    }
+    if (state == SQLiteNodeState::STANDINGUP || state == SQLiteNodeState::LEADING || state == SQLiteNodeState::STANDINGDOWN) {
+        // We are upgraded if we have ever tried to run an upgrade. We are the authority so our schema is definitive,
+        // and so if it's applied, then the upgrade is done.
+        return _upgradeCompleted;
+    }
+
+    // In any other state, we can't really know if we're uprgaded, because we don't know what that means without a leader.
+    return false;
 }
 
 void BedrockServer::_status(unique_ptr<BedrockCommand>& command)

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -434,7 +434,7 @@ void BedrockServer::sync()
                 continue;
             }
 
-            // Record the time spent, unless we were upgrading, in which case, there's no command to write to.
+            // Record the time spent.
             command->stopTiming(BedrockCommand::COMMIT_SYNC);
 
             if (command->shouldPostProcess() && command->response.methodLine == "200 OK") {
@@ -772,9 +772,13 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
         return;
     }
 
-    // We just spin until the node looks ready to go. Typically, this doesn't happen expect briefly at startup.
     size_t waitCount = 0;
-    while (!isUpgradeComplete()) {
+
+    // We just spin until the node looks ready to go. Typically, this doesn't happen expect briefly at startup.
+    // We specifically exclude `STANDINGDOWN` because even though we *can* process commands in this state, the intention
+    // here is to shut the node down and so we want to stop building a backlog of in-process commands that prevent
+    // standdown from completing. They will get blocked until we hit our final FOLLOWING state and then finished.
+    while (!dbReadyToHandleRequests() && getState() != SQLiteNodeState::STANDINGDOWN) {
         // It's feasible that our command times out in this loop. In this case, we do not have a DB object to pass.
         // The only implication of this is the response does not get the commitCount attached to it.
         if (BedrockCore::isTimedOut(command, nullptr, this)) {
@@ -1688,16 +1692,16 @@ bool BedrockServer::isDetached()
     return _detach && !_syncLoopShouldBeRunning && _pluginsDetached;
 }
 
-bool BedrockServer::isUpgradeComplete()
+bool BedrockServer::dbReadyToHandleRequests()
 {
     auto state = getState();
     if (state == SQLiteNodeState::FOLLOWING) {
-        // We are as upgraded as we can be, becuase someone else is controlling what the state of "upgraded" is,
+        // We are as upgraded as we can be, because someone else is controlling what the state of "upgraded" is,
         // and they will broadcast those changes to us when appropriate.
         return true;
     }
     if (state == SQLiteNodeState::LEADING || state == SQLiteNodeState::STANDINGDOWN) {
-        // We are upgraded if we have ever completed an upgrade (including via no-oop).
+        // We are upgraded if we have ever completed an upgrade (including via no-op).
         // We are the authority so our schema is definitive, and so if it's applied, then the upgrade is done.
         return _upgradeCompleted;
     }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -382,7 +382,7 @@ void BedrockServer::sync()
                 // It's possible that _upgradeDB throws at least "512 Internal Lock Timeout".
                 // Because upgrading the DB is critical and needs to be completed before we can use the
                 // DB for anything, we attempt a retry here. A lock timeout should be retryable.
-                SWARN("Got exception: " << e.method << " attempting to upgrade DB, will retry.");
+                SWARN("Got exception when attempting to upgrade DB, will retry.", {{"command", e.method}, {"what", e.what()}});
                 db.rollback();
                 continue;
             }
@@ -443,7 +443,7 @@ void BedrockServer::sync()
             }
 
             if (_syncNode->commitSucceeded()) {
-                SINFO("[performance] Sync thread finished committing command " << command->request.methodLine);
+                SINFO("Sync thread finished committing command " << command->request.methodLine);
                 _conflictManager.recordTables(command->request.methodLine, db.getTablesUsed());
 
                 // Otherwise, save the commit count, mark this command as complete, and reply.
@@ -1696,17 +1696,17 @@ bool BedrockServer::dbReadyToHandleRequests()
 {
     auto state = getState();
     if (state == SQLiteNodeState::FOLLOWING) {
-        // We are as upgraded as we can be, because someone else is controlling what the state of "upgraded" is,
-        // and they will broadcast those changes to us when appropriate.
+        // If we are following someone else is in charge of upgrades, we can serve reqeusts.
         return true;
     }
     if (state == SQLiteNodeState::LEADING || state == SQLiteNodeState::STANDINGDOWN) {
         // We are upgraded if we have ever completed an upgrade (including via no-op).
-        // We are the authority so our schema is definitive, and so if it's applied, then the upgrade is done.
+        // If we have not yet completed an upgrade (the first thing we do when first going LEADING), we need
+        // to do that before we're ready to serve requests.
         return _upgradeCompleted;
     }
 
-    // In any other state, we can't really know if we're upgraded, because we don't know what that means without a leader.
+    // In any other state, we aren't ready.
     return false;
 }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -458,8 +458,8 @@ void BedrockServer::sync()
                 // theoretically feasible for this to happen if a follower fails to commit a transaction, but that
                 // probably indicates a bug (or a follower disk failure).
                 SINFO("requeueing command " << command->request.methodLine
-                        << " after failed sync commit. Sync thread has " << _syncNodeQueuedCommands.size()
-                        << " queued commands.");
+                      << " after failed sync commit. Sync thread has " << _syncNodeQueuedCommands.size()
+                      << " queued commands.");
                 _syncNodeQueuedCommands.push(move(command));
             }
         }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -356,7 +356,7 @@ void BedrockServer::sync()
             continue;
         }
 
-        // If _upgradeCompleted is set, I.e., we're run at least one upgrade, we can skip this block.
+        // If _upgradeCompleted is set, I.e., we've run at least one upgrade, we can skip this block.
         // Otherwise, if we're leading, let's start the commit.
         // Also, if a commit is in progress, skip it (it's the commit we started on the last loop iteration).
         if (!_upgradeCompleted && getState() == SQLiteNodeState::LEADING && !commitInProgress) {
@@ -369,13 +369,24 @@ void BedrockServer::sync()
                 // a second and then they go FOLLOWING.
                 // If we attempt this transaction before we wait for these nodes to go FOLLOWING, they will not participate in
                 // the transaction. This will cause the transaction to fail and be rolled back, but worse, it causes the whole
-                // cluster to reconnect, because a failed QUORUM transction throws the whole state of the cluster into
+                // cluster to reconnect, because a failed QUORUM transaction throws the whole state of the cluster into
                 // question. This then takes a while to resolve as nodes all reconnect to one another, and is at risk for
                 // happening again on the next attempt as well.
                 SINFO("Waiting for quorum availability before running UpgradeDB.");
                 continue;
             }
-            if (_upgradeDB(db)) {
+            bool dbHasChanges = false;
+            try {
+                dbHasChanges = _upgradeDB(db);
+            } catch (const SException& e) {
+                // It's possible that _upgradeDB throws at least "512 Internal Lock Timeout".
+                // Because upgrading the DB is critical and needs to be completed before we can use the
+                // DB for anything, we attempt a retry here. A lock timeout should be retryable.
+                SWARN("Got exception: " << e.method << " attempting to upgrade DB, will retry.");
+                db.rollback();
+                continue;
+            }
+            if (dbHasChanges) {
                 commitInProgress = true;
                 _syncNode->startCommit(SQLiteNode::QUORUM);
                 _lastQuorumCommandTime = STimeNow();
@@ -417,7 +428,7 @@ void BedrockServer::sync()
                 continue;
             }
 
-            // We should only get here with a command existing.
+            // This case is expected to be impossible but the warning is retained for now because the confidence in that is low.
             if (!command) {
                 SWARN("Sync thread commit with no command!");
                 continue;
@@ -1685,13 +1696,13 @@ bool BedrockServer::isUpgradeComplete()
         // and they will broadcast those changes to us when appropriate.
         return true;
     }
-    if (state == SQLiteNodeState::STANDINGUP || state == SQLiteNodeState::LEADING || state == SQLiteNodeState::STANDINGDOWN) {
-        // We are upgraded if we have ever tried to run an upgrade. We are the authority so our schema is definitive,
-        // and so if it's applied, then the upgrade is done.
+    if (state == SQLiteNodeState::LEADING || state == SQLiteNodeState::STANDINGDOWN) {
+        // We are upgraded if we have ever completed an upgrade (including via no-oop).
+        // We are the authority so our schema is definitive, and so if it's applied, then the upgrade is done.
         return _upgradeCompleted;
     }
 
-    // In any other state, we can't really know if we're uprgaded, because we don't know what that means without a leader.
+    // In any other state, we can't really know if we're upgraded, because we don't know what that means without a leader.
     return false;
 }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1696,7 +1696,7 @@ bool BedrockServer::dbReadyToHandleRequests()
 {
     auto state = getState();
     if (state == SQLiteNodeState::FOLLOWING) {
-        // If we are following someone else is in charge of upgrades, we can serve reqeusts.
+        // If we are following someone else is in charge of upgrades, we can serve requests.
         return true;
     }
     if (state == SQLiteNodeState::LEADING || state == SQLiteNodeState::STANDINGDOWN) {

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -220,7 +220,8 @@ public:
     bool dbReadyToHandleRequests();
 
     // Legacy name for dbReadyToHandleRequests, retained for backwards compatibility.
-    bool isUpgradeComplete() {
+    bool isUpgradeComplete()
+    {
         return dbReadyToHandleRequests();
     }
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -220,7 +220,7 @@ public:
     bool dbReadyToHandleRequests();
 
     // Legacy name for dbReadyToHandleRequests, retained for backwards compatibility.
-    bool isUpgradeComplete()
+    inline bool isUpgradeComplete()
     {
         return dbReadyToHandleRequests();
     }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -215,12 +215,11 @@ public:
     // Returns if we are detached and the sync thread has exited.
     bool isDetached();
 
-    // Returns if all plugins have completed calling UpgradeDB
-
-    // This probably makes sense to be called `isUpgraded`
-    // It should return true if:
-    // We are leading and have attempted an upgrade (we can only do one upgrade per deployed version).
-    // We are following
+    // FOLLOWING nodes are always upgraded. LEADING nodes are upgraded if they've run _upgradeDB()
+    // at least once (STANDINGUP AND STANDINGDOWN count at LEADING here).
+    // Nodes in any other state are not upgraded.
+    // This would really make more sense being called "dbReadyToHandleRequests" or similar, but this
+    // API is in use in plugins.
     bool isUpgradeComplete();
 
     // See if there's a plugin that can turn this request into a command.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -216,6 +216,11 @@ public:
     bool isDetached();
 
     // Returns if all plugins have completed calling UpgradeDB
+
+    // This probably makes sense to be called `isUpgraded`
+    // It should return true if:
+    // We are leading and have attempted an upgrade (we can only do one upgrade per deployed version).
+    // We are following
     bool isUpgradeComplete();
 
     // See if there's a plugin that can turn this request into a command.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -215,12 +215,14 @@ public:
     // Returns if we are detached and the sync thread has exited.
     bool isDetached();
 
-    // FOLLOWING nodes are always upgraded. LEADING nodes are upgraded if they've run _upgradeDB()
-    // at least once (STANDINGUP AND STANDINGDOWN count at LEADING here).
-    // Nodes in any other state are not upgraded.
-    // This would really make more sense being called "dbReadyToHandleRequests" or similar, but this
-    // API is in use in plugins.
-    bool isUpgradeComplete();
+    // If a node is LEADING (or STANDINGDOWN) and has, at some point, completed a DB upgrade,
+    // OR if the node is FOLLOWING, it is ready to handle requests.
+    bool dbReadyToHandleRequests();
+
+    // Legacy name for dbReadyToHandleRequests, retained for backwards compatibility.
+    bool isUpgradeComplete() {
+        return dbReadyToHandleRequests();
+    }
 
     // See if there's a plugin that can turn this request into a command.
     // If not, we'll create a command that returns `430 Unrecognized command`.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -264,9 +264,6 @@ private:
     // Each time we read a new request from a client, we give it a unique ID.
     atomic<uint64_t> _requestCount;
 
-    // This gets set to true when a database upgrade is in progress, letting workers know not to try to start any work.
-    atomic<bool> _upgradeInProgress;
-
     // This is the current version of the leader node, updated after every SQLiteNode::update() iteration. A
     // reference to this object is passed to the sync thread to allow this update.
     atomic<string> _leaderVersion;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1974,6 +1974,11 @@ void SQLiteNode::_changeState(SQLiteNodeState newState, uint64_t commitIDToCance
             // We send any unsent transactions here before we finish switching states, we need to make sure these are
             // all sent to the new leader before we complete the transition.
             _sendOutstandingTransactions();
+
+            // If we are not leading, then peers cannot be subscribed to us.
+            for (auto& peer : _peerList) {
+                peer->subscribed = false;
+            }
         }
 
         // Clear some state if we can

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -660,13 +660,17 @@ void BedrockPlugin_TestPlugin::stateChanged(SQLite& db, SQLiteNodeState newState
             return;
         }
         SINFO("Sleeping until the server is done upgrading.");
-        while (!server.isUpgradeComplete()) {
+        while (!server.dbReadyToHandleRequests()) {
             usleep(50'000);
         }
 
         SQResult result;
         db.read("SELECT count(*) FROM dbupgrade", result);
-        _maxID = SToInt64(result[0][0]);
+        // It's possible to fall out of leading and be following again, and if so, we don't want to
+        // set _maxID.
+        if (server.getState() == SQLiteNodeState::LEADING) {
+            _maxID = SToInt64(result[0][0]);
+        }
         SINFO("Server completed upgrade, _maxID " << _maxID);
     }).detach();
 }


### PR DESCRIPTION
### Details
This PR does a few things, some more related to the DB crash in the issue than others. I'll go through them in the order the files appear in the GH PR.

1. We reset `peer->subscribed` when we stop leading. This is maybe redundant but it's weird because otherwise this only ever gets reset if a peer disconnects or goes searching. That might cover every actual case but it's clearer to just do it when we stop leading.
2. Rename `committingCommand` to `commitInProgress`, as this is for any commit, not just commands (notably, DB upgrades).
3. There's a bunch of cleanup and refactoring around removing `_upgradeInProgress`. This is sort of redundant with `_upgradeCompleted` and so now we only use the latter. 
4. We simplified the check for when we can try and run an upgrade (we haven't already done it, we're leading, and we don't have a `commitInProgress`.
5. We wrap `_upgradeDB` in a try/catch to handle the actual crash we saw.
6. we replace `isUpgradeComplete` with `dbReadyToHandleRequests`. I'll talk about this for the rest of the PR here.

So, the old code has two different sorts of race conditions between where we do a DB upgrade and where we run commands.

We did this check:
```
if(LEADING) {
    if (hasQuorum()) {
        _upgradeInProgress = true;
```

So, first, let's talk about what it means to be be LEADING but not `hasQuorum()`:

LEADING really means "A quorum number nodes have told me that I can go LEADING".

And then `hasQuorum()` means "enough of those nodes that told me I could go LEADING are actually following".

There's a time period between these two where nodes that are attempting to follow are actually SUBSCRIBING, and this lasts at least one network round trip.

We do set _upgradeInProgress before that, but there's still a race condtion here where there's a window in which we are LEADING and `_upgradeInProgress` is false, but the upgrade hasn't happened.

So, the check in `runCommand` for whether we can start a command used to be:
```
while (_upgradeInProgress || (getState() != SQLiteNodeState::LEADING && getState() != SQLiteNodeState::FOLLOWING)) {
```

So you see there that it's possible to start a command thinking "upgrade is done" when we're leading but actually, the upgrade hasn't started yet. The logs for this crash show that happened for at least one command. It's possible some other command started in that window as well, and took over 5 seconds, and cause out lock to fail and resulting in what we saw:

```
2026-05-07T15:33:32.790976+00:00 db2.sjc bedrock: xxxxxx we@dont.know (SQLite.cpp:451) beginTransaction [sync] [warn] Failed to acquire commit lock in sync thread exclusive transaction!
2026-05-07T15:33:32.791032+00:00 db2.sjc bedrock: xxxxxx we@dont.know (libstuff.cpp:170) SException [sync] [info] Throwing exception with message: '512 Internal Lock Timeout' from sqlitecluster/SQLite.cpp:452
```

I don't actually have a concrete answer for what prevented us getting that lock in `_upgradeDB` for 5 seconds, but commands being able to start when they're supposed to be blocked seems like a good candidate.

So `dbReadyToHandleRequests` replaces this old check. This checks:

1. Are we FOLLOWING? We can serve requests.
2. Are we LEADING or STANDINGDOWN? We can serve requests if `_upgradeCompleted` is `true`, which is never `true` until an upgrade is true, so there's no race condition where you can check it before it's set and assume it's done.
3. Are we in some other state? We can't serve requests.

And then we augment this particularly in `runCommand` to exclude the STANDINGDOWN case, which just lets us shutdown more gracefully.

The main fix is the try/catch around `_upgradeDB` allowing a mutex that's blocked for 5 seconds to be retried in that case.

The secondary fix is to get rid of the race condition that allows commands to sneak in before `_upgradeDB` even runs, which hopefully (bot not provably) prevents the `Internal Lock Timeout` exception from ever happening.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/634788

### Tests
None
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
