### PR TITLE
Add request context to SHTTPSManager 'Message failed' warning

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -126,7 +126,27 @@ void SStandaloneHTTPSManager::postPoll(fd_map& fdm, SStandaloneHTTPSManager::Tra
             _onRecv(transaction);
         } else {
             // Coercing anything that's not 200 to 500 makes no sense, and should be abandoned with the above.
-            SWARN("Message failed: '" << transaction.fullResponse.methodLine << "'");
+
+            // Build a single-line, bounded snippet of the response body to aid diagnosis without flooding logs.
+            // Avoid logging the full request URL because external service paths can carry auth tokens; the Host
+            // header plus the request methodLine (verb + path) is usually enough to identify the upstream call.
+            string bodySnippet = transaction.fullResponse.content.substr(0, 256);
+            for (char& c : bodySnippet) {
+                if (c == '\n' || c == '\r' || c == '\t') {
+                    c = ' ';
+                }
+            }
+            if (transaction.fullResponse.content.size() > 256) {
+                bodySnippet += "...";
+            }
+            const string& host = transaction.fullRequest.nameValueMap.contains("Host") ? transaction.fullRequest.nameValueMap.at("Host") : "(unknown)";
+            SWARN("Message failed: response='" << transaction.fullResponse.methodLine
+                  << "' statusCode=" << statusCode
+                  << " requestHost='" << host
+                  << "' requestLine='" << transaction.fullRequest.methodLine
+                  << "' requestID='" << transaction.requestID
+                  << "' bodySnippet='" << bodySnippet
+                  << "' bodySize=" << transaction.fullResponse.content.size());
             transaction.response = getHTTPResponseCode(transaction.fullResponse.methodLine, 500);
         }
 


### PR DESCRIPTION
### Details

This is purely an observability change. The current SWARN at `libstuff/SHTTPSManager.cpp:129` looks like this:

```cpp
SWARN("Message failed: '" << transaction.fullResponse.methodLine << "'");
```

which gives us log lines like `Message failed: ' Internal Server Error'` with no indication of which upstream service or call actually failed. I hit this trying to investigate https://github.com/Expensify/Expensify/issues/634514 and there's nothing to go on.

This adds the request methodLine (verb + path), the `Host` header, the parsed status code, the requestID, and a bounded single-line snippet of the response body (first 256 chars with newlines/tabs squashed to spaces). I deliberately didn't log the full request URL because external service paths can sometimes carry auth tokens in query strings — Host + methodLine is enough to identify the upstream call without that risk.

The issue should stay open until the warning fires again with the new context so we can actually diagnose it.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/634514

### Tests
No behavior change — only the SWARN string changes. Compiled `libstuff/SHTTPSManager.o` cleanly against the existing Bedrock tree.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes