### PR TITLE
Enable sending compressed journal entries over the network.

### DIFF
--- a/plugins/Compression.cpp
+++ b/plugins/Compression.cpp
@@ -260,6 +260,44 @@ void BedrockPlugin_Compression::registerSQLite(sqlite3* db)
                                nullptr, ::sqliteDecompress, nullptr, nullptr, nullptr);
 }
 
+string BedrockPlugin_Compression::compress(const string& input, size_t dictID)
+{
+    if (dictID == 0 || input.empty()) {
+        return input;
+    }
+
+    ZSTD_CDict* cdict = getCompressionDictionary(dictID);
+    if (!cdict) {
+        SWARN("compress(): no dictionary found for ID " << dictID);
+        return input;
+    }
+
+    ZSTD_CCtx* cctx = ZSTD_createCCtx();
+    if (!cctx) {
+        SWARN("compress(): failed to create compression context");
+        return input;
+    }
+
+    // Match the SQL UDF's frame parameters so on-disk and on-wire bytes are interchangeable.
+    ZSTD_CCtx_setParameter(cctx, ZSTD_c_dictIDFlag, 1);
+    ZSTD_CCtx_setParameter(cctx, ZSTD_c_checksumFlag, 0);
+
+    size_t dstCap = ZSTD_compressBound(input.size());
+    string output(dstCap, '\0');
+
+    size_t compressedSize = ZSTD_compress_usingCDict(cctx, output.data(), dstCap,
+                                                     input.data(), input.size(), cdict);
+    ZSTD_freeCCtx(cctx);
+
+    if (ZSTD_isError(compressedSize)) {
+        SWARN("compress(): " << ZSTD_getErrorName(compressedSize));
+        return input;
+    }
+
+    output.resize(compressedSize);
+    return output;
+}
+
 string BedrockPlugin_Compression::decompress(const string& input)
 {
     if (input.empty()) {

--- a/plugins/Compression.cpp
+++ b/plugins/Compression.cpp
@@ -268,14 +268,12 @@ string BedrockPlugin_Compression::compress(const string& input, size_t dictID)
 
     ZSTD_CDict* cdict = getCompressionDictionary(dictID);
     if (!cdict) {
-        SWARN("compress(): no dictionary found for ID " << dictID);
-        return input;
+        SERROR("compress(): no dictionary found for ID " << dictID << " — configured dictionary is missing from the database");
     }
 
     ZSTD_CCtx* cctx = ZSTD_createCCtx();
     if (!cctx) {
-        SWARN("compress(): failed to create compression context");
-        return input;
+        SERROR("compress(): failed to create compression context");
     }
 
     // Match the SQL UDF's frame parameters so on-disk and on-wire bytes are interchangeable.
@@ -290,8 +288,7 @@ string BedrockPlugin_Compression::compress(const string& input, size_t dictID)
     ZSTD_freeCCtx(cctx);
 
     if (ZSTD_isError(compressedSize)) {
-        SWARN("compress(): " << ZSTD_getErrorName(compressedSize));
-        return input;
+        SERROR("compress(): " << ZSTD_getErrorName(compressedSize));
     }
 
     output.resize(compressedSize);

--- a/plugins/Compression.h
+++ b/plugins/Compression.h
@@ -30,6 +30,10 @@ public:
     // Register the compress(data, dictID) and decompress(data) SQLite UDFs.
     static void registerSQLite(sqlite3* db);
 
+    // Returns input compressed with the given dictionary ID. If dictID is 0 or input is empty,
+    // returns input unchanged. Produces a byte-identical zstd frame to the compress() SQL UDF.
+    static string compress(const string& input, size_t dictID);
+
     // Returns decompressed data if input is a zstd frame, otherwise returns input unchanged.
     static string decompress(const string& input);
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -846,10 +846,6 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash)
         *transactionhash = _uncommittedHash;
     }
 
-    // Compress _uncommittedQuery in place so the same bytes can be written to the journal and shipped to peers in
-    // BEGIN_TRANSACTION, avoiding a second compression on the wire. Skip when empty so an empty transaction stays
-    // an empty string rather than a zstd frame. After this point _uncommittedQuery may be a binary zstd frame, so
-    // anything that needs the raw SQL (hash, keyword checks) must have run before now.
     if (!_uncommittedQuery.empty()) {
         _uncommittedQuery = BedrockPlugin_Compression::compress(_uncommittedQuery, journalZstdDictionaryID.load());
     } else {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -846,17 +846,32 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash)
         *transactionhash = _uncommittedHash;
     }
 
-    // Create our query. Wrap _uncommittedQuery with compress() for zstd compression.
-    // When journalZstdDictionaryID is 0 (the default), compress() returns data unchanged.
-    string query = "INSERT INTO " + _journalName + " VALUES (" + SQ(commitCount + 1) + ", compress(" + SQ(_uncommittedQuery) + ", " + SQ(journalZstdDictionaryID.load()) + "), " + SQ(_uncommittedHash) + " )";
-
-    // These are the values we're currently operating on, until we either commit or rollback.
-    _sharedData.prepareTransactionInfo(commitCount + 1, _uncommittedQuery, _uncommittedHash, _dbCountAtStart);
-    if (_uncommittedQuery.empty()) {
+    // Compress _uncommittedQuery in place so the same bytes can be written to the journal and shipped to peers in
+    // BEGIN_TRANSACTION, avoiding a second compression on the wire. Skip when empty so an empty transaction stays
+    // an empty string rather than a zstd frame. After this point _uncommittedQuery may be a binary zstd frame, so
+    // anything that needs the raw SQL (hash, keyword checks) must have run before now.
+    if (!_uncommittedQuery.empty()) {
+        _uncommittedQuery = BedrockPlugin_Compression::compress(_uncommittedQuery, journalZstdDictionaryID.load());
+    } else {
         SINFO("Will commmit blank query");
     }
 
-    int result = SQuery(_db, query);
+    // Stash the (now possibly compressed) query so SQLiteNode can ship it to peers without re-compressing.
+    _sharedData.prepareTransactionInfo(commitCount + 1, _uncommittedQuery, _uncommittedHash, _dbCountAtStart);
+
+    string query = "INSERT INTO " + _journalName + " VALUES (?, ?, ?)";
+    sqlite3_stmt* stmt = nullptr;
+    int result = sqlite3_prepare_v2(_db, query.c_str(), -1, &stmt, nullptr);
+    if (result == SQLITE_OK) {
+        sqlite3_bind_int64(stmt, 1, commitCount + 1);
+        sqlite3_bind_blob(stmt, 2, _uncommittedQuery.data(),
+                          _uncommittedQuery.size(), SQLITE_STATIC);
+        sqlite3_bind_text(stmt, 3, _uncommittedHash.data(),
+                          _uncommittedHash.size(), SQLITE_STATIC);
+        int stepResult = sqlite3_step(stmt);
+        result = (stepResult == SQLITE_DONE) ? SQLITE_OK : stepResult;
+    }
+    sqlite3_finalize(stmt);
     _prepareElapsed += STimeNow() - before;
     if (result) {
         // Couldn't insert into the journal; roll back the original commit

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -241,7 +241,9 @@ public:
     }
 
     // Returns a concatenated string containing all the 'write' queries executed within the current, uncommitted
-    // transaction.
+    // transaction. Before prepare() runs this is the raw SQL; after prepare() runs it holds the same bytes that were
+    // written to the journal — a zstd frame when journalZstdDictionaryID is non-zero, or the raw SQL otherwise. The
+    // post-prepare form is what gets shipped to followers in BEGIN_TRANSACTION.
     string getUncommittedQuery()
     {
         return _uncommittedQuery;
@@ -288,7 +290,8 @@ public:
 
     // This atomically removes and returns committed transactions from our internal list. SQLiteNode can call this, and
     // it will return a map of transaction IDs to tuples of (query, hash, dbCountAtTransactionStart), so that those
-    // transactions can be replicated out to peers.
+    // transactions can be replicated out to peers. The query is in its post-prepare() form (a zstd frame when
+    // journalZstdDictionaryID is non-zero, otherwise the raw SQL) and is shipped to followers as-is.
     map<uint64_t, tuple<string, string, uint64_t>> popCommittedTransactions();
 
     // The whitelist is either nullptr, in which case the feature is disabled, or it's a map of table names to sets of
@@ -362,7 +365,9 @@ public:
         atomic<int64_t> nextJournalCount;
 
         // When `SQLite::prepare` is called, we need to save a set of info that will be broadcast to peers when the
-        // transaction is ultimately committed. This should be cleared out if the transaction is rolled back.
+        // transaction is ultimately committed. This should be cleared out if the transaction is rolled back. The
+        // query is in its post-prepare() form (a zstd frame when compression is enabled, raw SQL otherwise) and is
+        // shipped directly to followers in BEGIN_TRANSACTION.
         void prepareTransactionInfo(uint64_t commitID, const string& query, const string& hash, uint64_t dbCountAtTransactionStart);
 
         // When a transaction that was prepared is committed, we move the data from the prepared list to the committed
@@ -450,7 +455,9 @@ private:
     bool _insideTransaction = false;
 
     // The new query and new hash to add to the journal for a transaction that's nearing completion, before we commit
-    // it.
+    // it. During query execution _uncommittedQuery is the raw concatenated SQL; prepare() replaces it in place with
+    // the same bytes that are written to the journal — a zstd frame when journalZstdDictionaryID is non-zero,
+    // otherwise unchanged. This single representation is then both stored on disk and shipped to followers.
     string _uncommittedQuery;
     string _uncommittedHash;
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2338,7 +2338,8 @@ void SQLiteNode::_handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SDa
     }
 
     // Inside transaction; get ready to back out on error
-    if (!db.writeUnmodified(message.content)) {
+    //  decompress() is a no-op for non-zstd-framed input, so this works whether or not the leader is compressing.
+    if (!db.writeUnmodified(BedrockPlugin_Compression::decompress(message.content))) {
         STHROW("failed to write transaction");
     }
 }


### PR DESCRIPTION
### Details
HOLD for https://github.com/Expensify/Bedrock/pull/2609

When compressing journal entries on leader, we currently send the original plaintext to followers. This allows us to send compressed queries to followers, saving network bandwidth.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/601964

### Tests
Existing compression tests handle this case.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
