### PR TITLE
Reply to timed out commands without requeuing them

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -751,8 +751,8 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
     // This functionality will go away as we remove the queues from bedrock, and so this can be removed at that time.
     {
         auto _syncNodeCopy = atomic_load(&_syncNode);
-        if (!_syncNodeCopy || _command->request.calcU64("commandExecuteTime") > STimeNow()) {
-            _commandQueue.push(move(_command));
+        if (!_syncNodeCopy || command->request.calcU64("commandExecuteTime") > STimeNow()) {
+            _commandQueue.push(move(command));
             return;
         }
     }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -736,8 +736,18 @@ bool BedrockServer::isShuttingDown()
 
 void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlocking, bool hasDedicatedThread)
 {
-    // If there's no sync node (because we're detaching/attaching), we can only queue a command for later.
-    // Also,if this command is scheduled in the future, we can't just run it, we need to enqueue it to run at that point.
+    // This takes ownership of the passed command. By calling the move constructor, the caller's unique_ptr is now empty, and so when the one here goes out of scope (i.e., this function
+    // returns), the command is destroyed.
+    unique_ptr<BedrockCommand> command(move(_command));
+
+    // If the command has already timed out, reply as such.
+    if (BedrockCore::isTimedOut(command, nullptr, this)) {
+        _reply(command);
+        return;
+    }
+
+    // If there's no sync node (because we're detaching/attaching), we can't run a command right now.
+    // Also, if this command is scheduled in the future, we can't run it either, we need to enqueue it to run at that point.
     // This functionality will go away as we remove the queues from bedrock, and so this can be removed at that time.
     {
         auto _syncNodeCopy = atomic_load(&_syncNode);
@@ -746,10 +756,6 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
             return;
         }
     }
-
-    // This takes ownership of the passed command. By calling the move constructor, the caller's unique_ptr is now empty, and so when the one here goes out of scope (i.e., this function
-    // returns), the command is destroyed.
-    unique_ptr<BedrockCommand> command(move(_command));
 
     SAUTOPREFIX(command->request);
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -740,24 +740,13 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
     // returns), the command is destroyed.
     unique_ptr<BedrockCommand> command(move(_command));
 
+    SAUTOPREFIX(command->request);
+
     // If the command has already timed out, reply as such.
     if (BedrockCore::isTimedOut(command, nullptr, this)) {
         _reply(command);
         return;
     }
-
-    // If there's no sync node (because we're detaching/attaching), we can't run a command right now.
-    // Also, if this command is scheduled in the future, we can't run it either, we need to enqueue it to run at that point.
-    // This functionality will go away as we remove the queues from bedrock, and so this can be removed at that time.
-    {
-        auto _syncNodeCopy = atomic_load(&_syncNode);
-        if (!_syncNodeCopy || command->request.calcU64("commandExecuteTime") > STimeNow()) {
-            _commandQueue.push(move(command));
-            return;
-        }
-    }
-
-    SAUTOPREFIX(command->request);
 
     // Set the function that lets the signal handler know which command caused a problem, in case that happens.
     // If a signal is caught on this thread, which should only happen for unrecoverable, yet synchronous
@@ -780,6 +769,17 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
         command->complete = true;
         _reply(command);
         return;
+    }
+
+    // If there's no sync node (because we're detaching/attaching), we can't run a command right now.
+    // Also, if this command is scheduled in the future, we can't run it either, we need to enqueue it to run at that point.
+    // This functionality will go away as we remove the queues from bedrock, and so this can be removed at that time.
+    {
+        auto _syncNodeCopy = atomic_load(&_syncNode);
+        if (!_syncNodeCopy || command->request.calcU64("commandExecuteTime") > STimeNow()) {
+            _commandQueue.push(move(command));
+            return;
+        }
     }
 
     size_t waitCount = 0;


### PR DESCRIPTION
### Details
Fixes the bug we saw where a command that was scheduled in the future with a timeout in the past would get into an infinite loop of being pulled off the command queue and re-queued immediately because it wasn't scheduled to run yet. This change makes these time out at the timeout* point, regardless of the scheduled run time.


### Fixed Issues
Fixes https://expensify.enterprise.slack.com/archives/C0B4AUG3FU7

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
