### PR TITLE
Revert "Remove ability to set custom processTimeout per command"

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -40,8 +40,8 @@ uint64_t BedrockCore::_getRemainingTime(const unique_ptr<BedrockCommand>& comman
     // This is what's left for the "absolute" time. If it's negative, we've already timed out.
     int64_t adjustedTimeout = timeout - now;
 
-    // processTimeout caps how long any single process phase can run. It is not configurable per-command.
-    int64_t processTimeout = BedrockCommand::DEFAULT_PROCESS_TIMEOUT;
+    // We also want to know the processTimeout, because we'll return early if we get stuck processing for too long.
+    int64_t processTimeout = command->request.isSet("processTimeout") ? command->request.calc("processTimeout") : BedrockCommand::DEFAULT_PROCESS_TIMEOUT;
 
     // Since timeouts are specified in ms, we convert to us.
     processTimeout *= 1000;

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -468,7 +468,7 @@ void TestPluginCommand::process(SQLite& db)
         const string value = "THIS IS A TEST STRING WITH EXACTLY 48 CHARACTERS";
         db.write("INSERT INTO TEST VALUES(" + SQ(nextID) + ", " + SQ(value) + ");");
         size_t querySize = 0;
-        for (size_t i = 0; i < 2'000; i++) {
+        for (size_t i = 0; i < 2'000'000; i++) {
             string nq = "UPDATE TEST SET VALUE = " + SQ(value) + " WHERE id = " + SQ(nextID) + ";";
             db.write(nq);
             querySize += nq.size();

--- a/test/clustertest/tests/MassiveQueryTest.cpp
+++ b/test/clustertest/tests/MassiveQueryTest.cpp
@@ -13,6 +13,7 @@ struct MassiveQueryTest : tpunit::TestFixture
         // We're going to send a command to a follower, it should run on leader and get replicated.
         BedrockTester& brtester = tester.getTester(1);
         SData cmd("bigquery");
+        cmd["processTimeout"] = "290000";
         cmd["writeConsistency"] = "ASYNC";
         auto r1 = brtester.executeWaitMultipleData({cmd})[0];
         uint64_t commitCount = 0;

--- a/test/clustertest/tests/TimeoutTest.cpp
+++ b/test/clustertest/tests/TimeoutTest.cpp
@@ -75,15 +75,16 @@ struct TimeoutTest : tpunit::TestFixture
         // Test write commands.
         BedrockTester& brtester = tester->getTester(0);
 
-        // One large INSERT that exceeds the default 5s processTimeout on its own.
+        // Run one long query.
         SData slow("slowprocessquery");
-        slow["size"] = "100000000";
+        slow["processTimeout"] = "200"; // 0.2s
+        slow["size"] = "1000000";
         slow["count"] = "1";
         brtester.executeWaitVerifyContent(slow, "555 Timeout processing command");
 
-        // Many medium INSERTs that cumulatively exceed the default 5s processTimeout.
-        slow["size"] = "100000";
-        slow["count"] = "1000";
+        // And a bunch of faster ones.
+        slow["size"] = "100";
+        slow["count"] = "10000";
         brtester.executeWaitVerifyContent(slow, "555 Timeout processing command");
     }
 


### PR DESCRIPTION
Reverts Expensify/Bedrock#2594

Coming from: https://expensify.slack.com/archives/C094TGUTZ/p1779235583008719?thread_ts=1779231319.722659&cid=C094TGUTZ

This PR broke BatchReimbursements