### PR TITLE
Update SQLite to branch hctree-bedrock-lcd-ex

### DIFF
--- a/libstuff/sqlite3.h
+++ b/libstuff/sqlite3.h
@@ -148,10 +148,10 @@ extern "C" {
 */
 #define SQLITE_VERSION        "3.54.0"
 #define SQLITE_VERSION_NUMBER 3054000
-#define SQLITE_SOURCE_ID      "2026-05-19 15:33:21 77323fe49ec9c658276dc9daa0965d4cd33d6f514784d652d41fa721c3bde4fd"
+#define SQLITE_SOURCE_ID      "2026-05-20 10:41:00 dd04962c126d3a6d33667eba84f390f36f04a07b93e6ddc494b5cbb63a237fb7"
 #define SQLITE_SCM_BRANCH     "hctree-bedrock-lcd-ex"
 #define SQLITE_SCM_TAGS       ""
-#define SQLITE_SCM_DATETIME   "2026-05-19T15:33:21.033Z"
+#define SQLITE_SCM_DATETIME   "2026-05-20T10:41:00.047Z"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers

--- a/libstuff/sqlite3.h
+++ b/libstuff/sqlite3.h
@@ -148,10 +148,10 @@ extern "C" {
 */
 #define SQLITE_VERSION        "3.54.0"
 #define SQLITE_VERSION_NUMBER 3054000
-#define SQLITE_SOURCE_ID      "2026-05-12 17:42:11 012a04edd0ab7001f2635eeb766089201cbe372d54e5008e7138a5dbe522bf06"
-#define SQLITE_SCM_BRANCH     "hctree-bedrock"
+#define SQLITE_SOURCE_ID      "2026-05-19 15:33:21 77323fe49ec9c658276dc9daa0965d4cd33d6f514784d652d41fa721c3bde4fd"
+#define SQLITE_SCM_BRANCH     "hctree-bedrock-lcd-ex"
 #define SQLITE_SCM_TAGS       ""
-#define SQLITE_SCM_DATETIME   "2026-05-12T17:42:11.503Z"
+#define SQLITE_SCM_DATETIME   "2026-05-19T15:33:21.033Z"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -2210,6 +2210,19 @@ struct sqlite3_mem_methods {
 ** recommended case) then the integer is always filled with zero, regardless
 ** if its initial value.
 ** </dl>
+**
+** [[SQLITE_CONFIG_SHAREDLOG_MAXSIZE]]
+** <dt>SQLITE_CONFIG_SHAREDLOG_MAXSIZE
+** <dd>This option is used to set the maximum size of a BEGIN CONCURRENT
+** shared-log in bytes. The default value is 1GiB (1*1024*1024*1024). The
+** argument to this configuration option must be a 64-bit signed integer
+** (type sqlite3_int64) to use as the new limit. A negative parameter
+** restores the default value, a value of zero disabled shared-logs
+** altogether. There is no way to configure unlimited memory usage, but
+** applications may instead configure a very large value (e.g. 1TiB).
+** Shared-log entries are automatically discarded when their associated
+** transactions are checkpointed, which prevents the shared-log from growing
+** indefinitely in this case.
 */
 #define SQLITE_CONFIG_SINGLETHREAD         1  /* nil */
 #define SQLITE_CONFIG_MULTITHREAD          2  /* nil */
@@ -2241,6 +2254,7 @@ struct sqlite3_mem_methods {
 #define SQLITE_CONFIG_SORTERREF_SIZE      28  /* int nByte */
 #define SQLITE_CONFIG_MEMDB_MAXSIZE       29  /* sqlite3_int64 */
 #define SQLITE_CONFIG_ROWID_IN_VIEW       30  /* int* */
+#define SQLITE_CONFIG_SHAREDLOG_MAXSIZE   31  /* sqlite3_int64 */
 
 /*
 ** CAPI3REF: Database Connection Configuration Options

--- a/libstuff/sqlite3ext.h
+++ b/libstuff/sqlite3ext.h
@@ -375,6 +375,9 @@ struct sqlite3_api_routines {
   void (*str_truncate)(sqlite3_str*,int);
   void (*str_free)(sqlite3_str*);
   int (*carray_bind)(sqlite3_stmt*,int,void*,int,int,void(*)(void*));
+  int (*carray_bind_v2)(sqlite3_stmt*,int,void*,int,int,void(*)(void*),void*);
+  /* Version 3.54.0 and later */
+  sqlite3_int64 (*incomplete)(const char*);
 };
 
 /*
@@ -717,6 +720,9 @@ typedef int (*sqlite3_loadext_entry)(
 #define sqlite3_str_truncate           sqlite3_api->str_truncate
 #define sqlite3_str_free               sqlite3_api->str_free
 #define sqlite3_carray_bind            sqlite3_api->carray_bind
+#define sqlite3_carray_bind_v2         sqlite3_api->carray_bind_v2
+/* Version 3.54.0 and later */
+#define sqlite3_incomplete             sqlite3_api->incomplete
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -348,13 +348,13 @@ void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg)
 
     // This is sort of hacky to parse this from the logging info. If it works we could ask sqlite for a better interface to get this info.
     if (SStartsWith(zMsg, "cannot commit")) {
-        // 17 is the length of "conflict at page" and the following space.
+        // Page conflicts are reported on SQLite versions which handle conflict at the page level.
+        // Other versions of SQLite report conflict at the row level, but we don't handle that yet. These versions are experimental as of May 2026.
         _conflictPage = 0;
         const char* conflictAt = strstr(zMsg, "conflict at page");
         if (conflictAt) {
+            // 17 is the length of "conflict at page" and the following space.
             _conflictPage = atol(conflictAt + 17);
-        } else {
-            SINFO("no conflict at page found");
         }
 
         // Sample conflict log lines:

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -349,8 +349,13 @@ void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg)
     // This is sort of hacky to parse this from the logging info. If it works we could ask sqlite for a better interface to get this info.
     if (SStartsWith(zMsg, "cannot commit")) {
         // 17 is the length of "conflict at page" and the following space.
-        const char* pageOffset = strstr(zMsg, "conflict at page") + 17;
-        _conflictPage = atol(pageOffset);
+        _conflictPage = 0;
+        const char* conflictAt = strstr(zMsg, "conflict at page");
+        if (conflictAt) {
+            _conflictPage = atol(conflictAt + 17);
+        } else {
+            SINFO("no conflict at page found");
+        }
 
         // Sample conflict log lines:
         // {SQLITE} Code: 0, Message: cannot commit CONCURRENT transaction - conflict at page 1854553 (read/write page; part of db table reports; content=0D00000009007100...)


### PR DESCRIPTION
### Details

This is to run this experiment: https://expensify.slack.com/archives/C05CBC62HGW/p1778516766941449?thread_ts=1778516627.946429&cid=C05CBC62HGW

> This branch is wal2 mode with falling back to logical-conflict detection if a page-level conflicts are detected. This allows it to commit transactions that would otherwise conflict in the same way as hctree does.

This PR includes 
- The SQLite version upgrade
- An update to `sqlitecluster/SQLite.cpp` so that new conflict detection doesn't segfault this code:
```
2026-05-22T13:13:12.316524+00:00 expensidev-2404 bedrock: 1nK8Ld we@dont.know (SQLite.cpp:347) _sqliteLogCallback [socket55_cmd] [info] {SQLITE} Code: 0, Message: cannot commit CONCURRENT transaction - conflict in table stuff - range (3,9223372036854775807) conflicts with write to rowid 4
```

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
