### PR TITLE
Decompress replicated transactions on followers.

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2338,7 +2338,8 @@ void SQLiteNode::_handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SDa
     }
 
     // Inside transaction; get ready to back out on error
-    if (!db.writeUnmodified(message.content)) {
+    //  decompress() is a no-op for non-zstd-framed input, so this works whether or not the leader is compressing.
+    if (!db.writeUnmodified(BedrockPlugin_Compression::decompress(message.content))) {
         STHROW("failed to write transaction");
     }
 }


### PR DESCRIPTION
### Details
Prerequisite for: https://github.com/Expensify/Bedrock/pull/2599

This turns on decompressing any compressed journal entries we receive from leader. We need this in place before we can start sending compressed journal entries.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/601964

### Tests
Existing tests.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
