### PR TITLE
Add try_lock_for on commit lock to respect the total command timeout

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -32,7 +32,7 @@ private:
     bool (*_handler)(int, const char*, string&);
 };
 
-uint64_t BedrockCore::getRemainingTime(const unique_ptr<BedrockCommand>& command, bool isProcessing)
+chrono::microseconds BedrockCore::getRemainingTime(const unique_ptr<BedrockCommand>& command, bool isProcessing)
 {
     int64_t timeout = command->timeout();
     int64_t now = STimeNow();
@@ -53,7 +53,7 @@ uint64_t BedrockCore::getRemainingTime(const unique_ptr<BedrockCommand>& command
     }
 
     // Both of these are positive, return the lowest remaining.
-    return isProcessing ? min(processTimeout, adjustedTimeout) : adjustedTimeout;
+    return chrono::microseconds(isProcessing ? min(processTimeout, adjustedTimeout) : adjustedTimeout);
 }
 
 bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command, SQLite* db, const BedrockServer* server)
@@ -444,11 +444,11 @@ void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, c
 
 void BedrockCore::decreaseCommandTimeout(unique_ptr<BedrockCommand>& command, uint64_t timeoutMS)
 {
-    const uint64_t remainingTimeUS = getRemainingTime(command, false);
-    if ((timeoutMS * 1000ull) < remainingTimeUS) {
+    const auto remainingTimeUS = getRemainingTime(command, false);
+    if (chrono::microseconds(timeoutMS * 1000ull) < remainingTimeUS) {
         command->setTimeout(timeoutMS);
-        const int64_t newRemainingTimeUS = getRemainingTime(command, false);
+        const auto newRemainingTimeUS = getRemainingTime(command, false);
         _db.setTimeout(newRemainingTimeUS);
-        SINFO("Decreased command timeout from " << STIMESTAMP(STimeNow() + remainingTimeUS) << " to " << STIMESTAMP(STimeNow() + newRemainingTimeUS));
+        SINFO("Decreased command timeout from " << STIMESTAMP(STimeNow() + remainingTimeUS.count()) << " to " << STIMESTAMP(STimeNow() + newRemainingTimeUS.count()));
     }
 }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -32,7 +32,7 @@ private:
     bool (*_handler)(int, const char*, string&);
 };
 
-uint64_t BedrockCore::_getRemainingTime(const unique_ptr<BedrockCommand>& command, bool isProcessing)
+uint64_t BedrockCore::getRemainingTime(const unique_ptr<BedrockCommand>& command, bool isProcessing)
 {
     int64_t timeout = command->timeout();
     int64_t now = STimeNow();
@@ -59,7 +59,7 @@ uint64_t BedrockCore::_getRemainingTime(const unique_ptr<BedrockCommand>& comman
 bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command, SQLite* db, const BedrockServer* server)
 {
     try {
-        _getRemainingTime(command, false);
+        getRemainingTime(command, false);
     } catch (const SException& e) {
         // Yep, timed out.
         _handleCommandException(command, e, db, server);
@@ -82,7 +82,7 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlo
         try {
             SDEBUG("prePeeking at '" << request.methodLine << "'");
             command->prePeekCount++;
-            _db.setTimeout(_getRemainingTime(command, false));
+            _db.setTimeout(getRemainingTime(command, false));
             _db.setAbortRef(command->shouldAbort);
 
             // Make sure no writes happen while in prePeek command
@@ -142,7 +142,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
     try {
         SDEBUG("Peeking at '" << request.methodLine << "'");
         command->peekCount++;
-        _db.setTimeout(_getRemainingTime(command, false));
+        _db.setTimeout(getRemainingTime(command, false));
         _db.setAbortRef(command->shouldAbort);
 
         try {
@@ -240,7 +240,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
     try {
         SDEBUG("Processing '" << request.methodLine << "'");
         command->processCount++;
-        _db.setTimeout(_getRemainingTime(command, true));
+        _db.setTimeout(getRemainingTime(command, true));
         _db.setAbortRef(command->shouldAbort);
         if (!_db.insideTransaction()) {
             // If a transaction was already begun in `peek`, then this won't run. We call it here to support the case where
@@ -352,7 +352,7 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool i
         try {
             SDEBUG("postProcessing at '" << request.methodLine << "'");
             command->postProcessCount++;
-            _db.setTimeout(_getRemainingTime(command, false));
+            _db.setTimeout(getRemainingTime(command, false));
             _db.setAbortRef(command->shouldAbort);
 
             // Make sure no writes happen while in postProcess command
@@ -444,10 +444,10 @@ void BedrockCore::_handleCommandException(unique_ptr<BedrockCommand>& command, c
 
 void BedrockCore::decreaseCommandTimeout(unique_ptr<BedrockCommand>& command, uint64_t timeoutMS)
 {
-    const uint64_t remainingTimeUS = _getRemainingTime(command, false);
+    const uint64_t remainingTimeUS = getRemainingTime(command, false);
     if ((timeoutMS * 1000ull) < remainingTimeUS) {
         command->setTimeout(timeoutMS);
-        const int64_t newRemainingTimeUS = _getRemainingTime(command, false);
+        const int64_t newRemainingTimeUS = getRemainingTime(command, false);
         _db.setTimeout(newRemainingTimeUS);
         SINFO("Decreased command timeout from " << STIMESTAMP(STimeNow() + remainingTimeUS) << " to " << STIMESTAMP(STimeNow() + newRemainingTimeUS));
     }

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -73,7 +73,7 @@ private:
     // Gets the amount of time remaining until this command times out. This is the difference between the command's
     // 'timeout' value (or the default timeout, if not set) and the time the command was initially scheduled to run. If
     // this time is already expired, this throws `555 Timeout`
-    static uint64_t getRemainingTime(const unique_ptr<BedrockCommand>& command, bool isProcessing);
+    static chrono::microseconds getRemainingTime(const unique_ptr<BedrockCommand>& command, bool isProcessing);
 
 private:
     // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -70,14 +70,14 @@ private:
     // otherwise, nothing happens
     void decreaseCommandTimeout(unique_ptr<BedrockCommand>& command, uint64_t timeoutMS);
 
-private:
-    // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.
-    string _getExceptionName();
-
     // Gets the amount of time remaining until this command times out. This is the difference between the command's
     // 'timeout' value (or the default timeout, if not set) and the time the command was initially scheduled to run. If
     // this time is already expired, this throws `555 Timeout`
-    static uint64_t _getRemainingTime(const unique_ptr<BedrockCommand>& command, bool isProcessing);
+    static uint64_t getRemainingTime(const unique_ptr<BedrockCommand>& command, bool isProcessing);
+
+private:
+    // When called in the context of handling an exception, returns the demangled (if possible) name of the exception.
+    string _getExceptionName();
 
     static void _handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e, SQLite* db = nullptr, const BedrockServer* server = nullptr);
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1021,11 +1021,23 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                         bool commitSuccess = false;
                         uint64_t transactionID = 0;
                         string transactionHash;
+                        chrono::microseconds timeToCommit = chrono::microseconds::max();
                         {
                             BedrockCore::AutoTimer timer(command, isBlocking ? BedrockCommand::BLOCKING_COMMIT_WORKER : BedrockCommand::COMMIT_WORKER);
                             void (* onPrepareHandler)(SQLite& db, int64_t tableID) = nullptr;
                             bool enableOnPrepareNotifications = command->shouldEnableOnPrepareNotification(db, &onPrepareHandler);
-                            commitSuccess = core.commit(*_syncNode, transactionID, transactionHash, command->getMethodName(), enableOnPrepareNotifications, onPrepareHandler);
+                            
+                            // We want to calculate the remaining time for this command before we try to commit. It's possible that it will throw.
+                            // If that's the case, we will still allow the commit flow to happen passing a 0 timeout, which will cause it to fail
+                            // immediately and we'll deal with the consequences below instead of creating new if/else flows here.
+                            try {
+                                // We can use false for isProcessing here since we want to use the total command timeout.
+                                timeToCommit = chrono::microseconds(core.getRemainingTime(command, false));
+                            } catch (const SException& e) {
+                                SINFO("Command '" << command->getMethodName() << "' timed out before commit.");
+                                timeToCommit = chrono::microseconds(0);
+                            }
+                            commitSuccess = core.commit(*_syncNode, transactionID, transactionHash, command->getMethodName(), enableOnPrepareNotifications, onPrepareHandler, timeToCommit);
 
                             if (getState() != SQLiteNodeState::LEADING) {
                                 SINFO("Stopped leading while trying to commit, will retry.");
@@ -1047,7 +1059,9 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                             // mark it as complete. We add the currentCommit count here as well.
                             command->response["commitCount"] = to_string(db.getCommitCount());
                             command->complete = true;
-                        } else {
+                        } else if (!core.isTimedOut(command, &db, this)) {
+                            // One of the reasons the commit failed might be because of a timeout. If that's the case,
+                            // then we skip this part since everything will be done in the method call above.
                             SINFO("Conflict or state change committing " << command->request.methodLine);
                             if (_enableConflictPageLocks) {
                                 lastConflictLocation = db.getLastConflictLocation();

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1034,7 +1034,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                             // and still commit it if there's no wait time for the mutex.
                             try {
                                 // We can use false for isProcessing here since we want to use the total command timeout.
-                                timeToCommit = chrono::microseconds(core.getRemainingTime(command, false));
+                                timeToCommit = core.getRemainingTime(command, false);
                             } catch (const SException& e) {
                                 SINFO("Command '" << command->getMethodName() << "' timed out before commit.");
                             }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1021,14 +1021,14 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                         bool commitSuccess = false;
                         uint64_t transactionID = 0;
                         string transactionHash;
-                        
+
                         // Let's use a default value of 0 for the time to acquire the lock, which would work as a try_lock.
                         chrono::microseconds timeToCommit = chrono::microseconds(0);
                         {
                             BedrockCore::AutoTimer timer(command, isBlocking ? BedrockCommand::BLOCKING_COMMIT_WORKER : BedrockCommand::COMMIT_WORKER);
                             void (* onPrepareHandler)(SQLite& db, int64_t tableID) = nullptr;
                             bool enableOnPrepareNotifications = command->shouldEnableOnPrepareNotification(db, &onPrepareHandler);
-                            
+
                             // We want to calculate the remaining time for this command before we try to commit. It's possible that it will throw.
                             // If that's the case, we will still allow the commit flow to happen passing a 0 timeout, making it behave as a try_lock
                             // and still commit it if there's no wait time for the mutex.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1021,21 +1021,22 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                         bool commitSuccess = false;
                         uint64_t transactionID = 0;
                         string transactionHash;
-                        chrono::microseconds timeToCommit = chrono::microseconds::max();
+                        
+                        // Let's use a default value of 0 for the time to acquire the lock, which would work as a try_lock.
+                        chrono::microseconds timeToCommit = chrono::microseconds(0);
                         {
                             BedrockCore::AutoTimer timer(command, isBlocking ? BedrockCommand::BLOCKING_COMMIT_WORKER : BedrockCommand::COMMIT_WORKER);
                             void (* onPrepareHandler)(SQLite& db, int64_t tableID) = nullptr;
                             bool enableOnPrepareNotifications = command->shouldEnableOnPrepareNotification(db, &onPrepareHandler);
                             
                             // We want to calculate the remaining time for this command before we try to commit. It's possible that it will throw.
-                            // If that's the case, we will still allow the commit flow to happen passing a 0 timeout, which will cause it to fail
-                            // immediately and we'll deal with the consequences below instead of creating new if/else flows here.
+                            // If that's the case, we will still allow the commit flow to happen passing a 0 timeout, making it behave as a try_lock
+                            // and still commit it if there's no wait time for the mutex.
                             try {
                                 // We can use false for isProcessing here since we want to use the total command timeout.
                                 timeToCommit = chrono::microseconds(core.getRemainingTime(command, false));
                             } catch (const SException& e) {
                                 SINFO("Command '" << command->getMethodName() << "' timed out before commit.");
-                                timeToCommit = chrono::microseconds(0);
                             }
                             commitSuccess = core.commit(*_syncNode, transactionID, transactionHash, command->getMethodName(), enableOnPrepareNotifications, onPrepareHandler, timeToCommit);
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -865,7 +865,7 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
         if (!_sharedData.commitLock.try_lock_for(commitLockTimeout)) {
             // Couldn't get the lock in time. Roll back the open transaction.
             SINFO("Timed out after " << chrono::duration_cast<chrono::microseconds>(commitLockTimeout).count()
-                << "us waiting for commit lock.");
+                  << "us waiting for commit lock.");
             return false;
         }
         auto end = STimeNow();

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1413,6 +1413,11 @@ int SQLite::_authorize(int actionCode, const char* detail1, const char* detail2,
     return SQLITE_DENY;
 }
 
+void SQLite::setTimeout(chrono::microseconds timeLimit)
+{
+    setTimeout(timeLimit.count());
+}
+
 void SQLite::setTimeout(uint64_t timeLimitUS)
 {
     _timeoutStart = STimeNow();

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -828,7 +828,7 @@ bool SQLite::_writeIdempotent(const string& query, const map<string, Parameter>&
     return true;
 }
 
-bool SQLite::prepare(uint64_t* transactionID, string* transactionhash)
+bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::microseconds commitLockTimeout)
 {
     SASSERT(_insideTransaction);
 
@@ -862,7 +862,13 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash)
     // We lock this here, so that we can guarantee the order in which commits show up in the database.
     if (!_mutexLocked) {
         auto start = STimeNow();
-        _sharedData.commitLock.lock();
+        if (!_sharedData.commitLock.try_lock_for(commitLockTimeout)) {
+            // Couldn't get the lock in time. Roll back the open transaction.
+            SINFO("Timed out after " << chrono::duration_cast<chrono::microseconds>(commitLockTimeout).count()
+                << "us waiting for commit lock; rolling back.");
+            rollback();
+            return false;
+        }
         auto end = STimeNow();
         if (end - start > 5'000) {
             SINFO("Waited " << (end - start) << "us for commit lock.");

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -865,8 +865,7 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
         if (!_sharedData.commitLock.try_lock_for(commitLockTimeout)) {
             // Couldn't get the lock in time. Roll back the open transaction.
             SINFO("Timed out after " << chrono::duration_cast<chrono::microseconds>(commitLockTimeout).count()
-                << "us waiting for commit lock; rolling back.");
-            rollback();
+                << "us waiting for commit lock.");
             return false;
         }
         auto end = STimeNow();

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -171,6 +171,8 @@ public:
     // Prepare to commit or rollback the transaction. This also inserts the current uncommitted query into the
     // journal; no additional writes are allowed until the next transaction has begun.
     // The transactionID and transactionHash, if passed, will be updated with the values prepared for this transaction.
+    // The commitLockTimeout, if passed, will limit the time we wait for the lock. If not, we'll use the max value, which
+    // is effectively no timeout.
     // Note that if this transaction fails to commit, these will not ultimately be accurate.
     bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr, chrono::microseconds commitLockTimeout = chrono::microseconds::max());
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -285,8 +285,13 @@ public:
     // Looks up a range of commits. Returns raw query data which may be compressed.
     int getCompressedCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result, uint64_t timeoutLimitUS = 0);
 
+    
+    
     // Set a time limit for this transaction, in US from the current time.
     void setTimeout(uint64_t timeLimitUS);
+
+    // Overload of function above to accept microseconds directly.
+    void setTimeout(chrono::microseconds timeLimit);
 
     // Reset all timeout information to 0, to be ready for the next operation.
     void clearTimeout();

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -285,8 +285,6 @@ public:
     // Looks up a range of commits. Returns raw query data which may be compressed.
     int getCompressedCommits(uint64_t fromIndex, uint64_t toIndex, SQResult& result, uint64_t timeoutLimitUS = 0);
 
-    
-    
     // Set a time limit for this transaction, in US from the current time.
     void setTimeout(uint64_t timeLimitUS);
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -172,7 +172,7 @@ public:
     // journal; no additional writes are allowed until the next transaction has begun.
     // The transactionID and transactionHash, if passed, will be updated with the values prepared for this transaction.
     // Note that if this transaction fails to commit, these will not ultimately be accurate.
-    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr);
+    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr, chrono::microseconds commitLockTimeout = chrono::microseconds::max());
 
     // This enables or disables automatic re-writing. This feature is to support mocked requests and load testing. This
     // overloads set_authorizer to allow a plugin to deny certain queries from running (currently based only on the

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -15,8 +15,8 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
     {
         AutoScopeOnPrepare onPrepare(needsPluginNotification, _db, notificationHandler);
 
-        // This will fail only if we can't acquire the commit lock respecting the command timeout, which 
-        // likely means our cluster health is not optimal. In this case, we want to roll back and 
+        // This will fail only if we can't acquire the commit lock respecting the command timeout, which
+        // likely means our cluster health is not optimal. In this case, we want to roll back and
         // return false, which will make the caller return the appropriate exception.
         if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout)) {
             _db.rollback(commandName);

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -17,9 +17,9 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
 
         // This will fail only if we can't acquire the commit lock respecting the command timeout, which 
         // likely means our cluster health is not optimal. In this case, we want to roll back and 
-        // return a failure, which will cause SQLiteNode to re-run the command and return the
-        // appropriate timeout exception.
+        // return false, which will make the caller return the appropriate exception.
         if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout)) {
+            _db.rollback(commandName);
             return false;
         }
     }

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -19,7 +19,7 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
         // likely means our cluster health is not optimal. In this case, we want to roll back and 
         // return a failure, which will cause SQLiteNode to re-run the command and return the
         // appropriate timeout exception.
-        if (_db.prepare(&commitID, &transactionHash, commitLockTimeout)) {
+        if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout)) {
             return false;
         }
     }

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -8,14 +8,20 @@ SQLiteCore::SQLiteCore(SQLite& db) : _db(db)
 {
 }
 
-bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, const string& commandName, bool needsPluginNotification, void (*notificationHandler)(SQLite& _db, int64_t tableID)) noexcept
+bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, const string& commandName, bool needsPluginNotification, void (*notificationHandler)(SQLite& _db, int64_t tableID), chrono::microseconds commitLockTimeout) noexcept
 {
     // This handler only needs to exist in prepare so we scope it here to automatically unset
     // the handler function once we are done with prepare.
     {
         AutoScopeOnPrepare onPrepare(needsPluginNotification, _db, notificationHandler);
-        // This should always succeed.
-        SASSERT(_db.prepare(&commitID, &transactionHash));
+
+        // This will fail only if we can't acquire the commit lock respecting the command timeout, which 
+        // likely means our cluster health is not optimal. In this case, we want to roll back and 
+        // return a failure, which will cause SQLiteNode to re-run the command and return the
+        // appropriate timeout exception.
+        if (_db.prepare(&commitID, &transactionHash, commitLockTimeout)) {
+            return false;
+        }
     }
 
     // Check for any state other than leading and refuse.

--- a/sqlitecluster/SQLiteCore.h
+++ b/sqlitecluster/SQLiteCore.h
@@ -14,7 +14,7 @@ public:
 
     // Commit the outstanding transaction on the DB.
     // Returns true on successful commit, false on conflict.
-    bool commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, const string& commandName, bool needsPluginNotifiation, void (*notificationHandler)(SQLite& _db, int64_t tableID) = nullptr) noexcept;
+    bool commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, const string& commandName, bool needsPluginNotifiation, void (*notificationHandler)(SQLite& _db, int64_t tableID) = nullptr, chrono::microseconds commitLockTimeout = chrono::microseconds::max()) noexcept;
 
     // Roll back a transaction if we've decided not to commit it.
     void rollback(const string& commandName = "NONE");


### PR DESCRIPTION
### Details

We saw a behavior where we were holding transactions for a long time, longer than our timeout for any command.

Considering a timeout of 110s, this is what was happening:

- Command executed peek/process in 2s. But waited for the commit lock for 45s, and it conflicted, so we ran it again.
- Command executed again in 2s. Waited for the commit lock for 45s, and conflicted again, so it went to the third try
- Command finished in 2s, but waited for the commit lock for 130s. in this case, it should have timed out after 14 seconds, but it didn't. It conflicted again.
- Before sending it to the blocking queue, we checked if it was timed out, and returned an error to the caller.

That means that we held that command transaction open for over 110s without need. With enough parallel transactions, this will increase WAL file size and make all other db reads/writes slow.

This PR changes the commit lock to wait for a maximum of the remaining command timeout.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/640539

### Tests

I had a script that ran 60 parallels command locally with a high timeout, and one "victim" command with a short timeout (50ms). Ran the script several times, and confrmed that sometimes the victim timed out early:

```
=== Victim response ===
555 Timeout
commitCount: 425318
Connection: close
nodeName: bedrock
peekTime: 52
processTime: 396
totalTime: 51473
unaccountedTime: 5020
Content-Length: 0


=== Victim status line ===
555 Timeout

=== Relevant log lines written after the victim was sent ===
2026-05-27T12:29:42.110203+00:00 expensidev-2404 bedrock: lHQMD1 we@dont.know (SQLite.cpp:868) prepare [socket32089_cmd] [info] Timed out after 23625us waiting for commit lock.
```
It's important to note that since the order in try_lock_for is not FIFO, this script might return success sometimes. 

<details><summary>Script</summary>
<p>

This script failed to shutdown it's own processes in the second run, so do `pkill -f "script_name.sh"

```bash
set -uo pipefail

HOST="${HOST:-127.0.0.1}"
PORT="${PORT:-8888}"
WORKERS="${WORKERS:-50}"
WARMUP_SECS="${WARMUP_SECS:-2}"
VICTIM_TIMEOUT_MS="${VICTIM_TIMEOUT_MS:-50}"
WORKER_TIMEOUT_MS="${WORKER_TIMEOUT_MS:-60000}"
VALUE_BYTES="${VALUE_BYTES:-262144}"
LOG_FILE="${LOG_FILE:-/var/log/syslog}"

cleanup() {
    [[ ${#WORKER_PIDS[@]:-0} -gt 0 ]] && kill "${WORKER_PIDS[@]}" 2>/dev/null
    pkill -P $$ 2>/dev/null
    wait 2>/dev/null
}
trap cleanup EXIT INT TERM
WORKER_PIDS=()

# Detect nc flavor (GNU has -q, BSD/macOS does not).
if nc -h 2>&1 | grep -q -- " -q "; then
    NC=(nc -q 1 -w 5)
else
    NC=(nc -w 5)
fi

# A single, in-memory value reused by all workers and the victim.
VALUE="$(head -c "$VALUE_BYTES" /dev/urandom | base64 | head -c "$VALUE_BYTES")"

send_writecache() {
    local name="$1" timeout_ms="$2"
    printf 'WriteCache\r\nname: %s\r\nvalue: %s\r\nTimeout: %s\r\nConnection: close\r\n\r\n' \
        "$name" "$VALUE" "$timeout_ms" | "${NC[@]}" "$HOST" "$PORT"
}

worker_loop() {
    local id="$1" i=0
    while :; do
        send_writecache "worker_${id}_$((i++))" "$WORKER_TIMEOUT_MS" >/dev/null 2>&1
    done
}

# 1. Confirm the target is leading. The new code path only runs on the leader
#    (followers escalate writes to the sync thread).
STATUS="$(printf 'Status\r\nConnection: close\r\n\r\n' | "${NC[@]}" "$HOST" "$PORT")"
if ! grep -q '"state"[[:space:]]*:[[:space:]]*"LEADING"' <<<"$STATUS"; then
    echo "ERROR: $HOST:$PORT is not LEADING; aborting." >&2
    echo "First 40 lines of Status response:" >&2
    head -40 <<<"$STATUS" >&2
    exit 1
fi

# 2. Spawn contention.
echo "Spawning $WORKERS WriteCache workers against $HOST:$PORT (value=${VALUE_BYTES}B)..."
for i in $(seq 1 "$WORKERS"); do
    worker_loop "$i" &
    WORKER_PIDS+=($!)
done

# 3. Warm up so the commit lock is consistently held by a worker.
sleep "$WARMUP_SECS"

# 4. Mark log position (if accessible) so we can isolate the victim's lines.
LOG_START_BYTES=0
if [[ -r "$LOG_FILE" ]]; then
    LOG_START_BYTES=$(wc -c <"$LOG_FILE")
fi

# 5. Fire the victim.
VICTIM_NAME="victim_$(date +%s%N)"
echo "Sending victim: name=$VICTIM_NAME Timeout=${VICTIM_TIMEOUT_MS}ms"
VICTIM_RESPONSE="$(send_writecache "$VICTIM_NAME" "$VICTIM_TIMEOUT_MS" || true)"

# 6. Let a few more commits flush through the log, then stop workers.
sleep "$WARMUP_SECS"
cleanup
trap - EXIT INT TERM

# 7. Report.
echo
echo "=== Victim response ==="
echo "$VICTIM_RESPONSE"

VICTIM_STATUS="$(printf '%s' "$VICTIM_RESPONSE" | head -1)"
echo
echo "=== Victim status line ==="
echo "$VICTIM_STATUS"

if [[ -r "$LOG_FILE" ]]; then
    echo
    echo "=== Relevant log lines written after the victim was sent ==="
    tail -c +"$((LOG_START_BYTES + 1))" "$LOG_FILE" | \
        grep -E "Timed out after .* waiting for commit lock|Command 'WriteCache' timed out before commit" || \
        echo "(no matching log lines found)"
else
    echo
    echo "(LOG_FILE=$LOG_FILE not readable; export LOG_FILE=... or read via 'docker logs ...')"
fi

# 8. Pass/fail. A `555` victim status is the contract for path 4.
echo
if [[ "$VICTIM_STATUS" == *"555"* ]]; then
    echo "PASS: victim returned 555 Timeout."
    exit 0
else
    echo "FAIL: victim did not return 555."
    exit 1
fi
```

</p>
</details> 

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
