### PR TITLE
Combine duplicated logs

### DIFF
--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -35,16 +35,13 @@ void BedrockBlockingCommandQueue::push(unique_ptr<BedrockCommand>&& command)
 
         if (count > maxPerIdentifier) {
             SINFO("Blocking queue rate limit: rejecting '" << command->request.methodLine
-                  << "' for identifier '" << identifier << "'");
+                  << "' for identifier '" << identifier << "' (count=" << count
+                  << ", threshold=" << maxPerIdentifier << ")");
             // TODO: enable enforcement after monitoring confirms thresholds are correct in production.
             // STHROW("503 Blocking queue rate limited");
         }
 
         count++;
-        if (count > maxPerIdentifier) {
-            SWARN("Blocking queue rate limit: blocking identifier '" << identifier
-                  << "' with " << count << " commands in blocking queue (threshold: " << maxPerIdentifier << ")");
-        }
     }
 
     // A command is entering the queue, so it is no longer empty. Clear the empty timestamp so

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -32,16 +32,16 @@ void BedrockBlockingCommandQueue::push(unique_ptr<BedrockCommand>&& command)
         }
 
         size_t& count = _identifierCounts[identifier];
+        count++;
 
         if (count > maxPerIdentifier) {
             SINFO("Blocking queue rate limit: rejecting '" << command->request.methodLine
                   << "' for identifier '" << identifier << "' (count=" << count
                   << ", threshold=" << maxPerIdentifier << ")");
             // TODO: enable enforcement after monitoring confirms thresholds are correct in production.
+            // count--;
             // STHROW("503 Blocking queue rate limited");
         }
-
-        count++;
     }
 
     // A command is entering the queue, so it is no longer empty. Clear the empty timestamp so


### PR DESCRIPTION
### Details
1. There was a repeated if/log snuck through the review. I combined them and removed the duplicate
2. We were incrementing _after_ the throw check, which means if the limit was 10, there were already 10 commands in the queue, and another one came in (number 11) we would not throw, and allow the 11th to go through. Switching it to increment beforehand and decrement (because it doesn't get added) is the proper solution

### Fixed Issues
Fixes https://github.com/Expensify/Bedrock/pull/2555/changes/BASE..2186fddcffd6e5dd2dda93c4ae76080ca1a4521e#r3302019571

### Tests
n/a
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
