### PR TITLE
fix code to not segfault when we don't find a conflicting page

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -348,9 +348,14 @@ void SQLite::_sqliteLogCallback(void* pArg, int iErrCode, const char* zMsg)
 
     // This is sort of hacky to parse this from the logging info. If it works we could ask sqlite for a better interface to get this info.
     if (SStartsWith(zMsg, "cannot commit")) {
-        // 17 is the length of "conflict at page" and the following space.
-        const char* pageOffset = strstr(zMsg, "conflict at page") + 17;
-        _conflictPage = atol(pageOffset);
+        // Page conflicts are reported on SQLite versions which handle conflict at the page level.
+        // Other versions of SQLite report conflict at the row level, but we don't handle that yet. These versions are experimental as of May 2026.
+        _conflictPage = 0;
+        const char* conflictAt = strstr(zMsg, "conflict at page");
+        if (conflictAt) {
+            // 17 is the length of "conflict at page" and the following space.
+            _conflictPage = atol(conflictAt + 17);
+        }
 
         // Sample conflict log lines:
         // {SQLITE} Code: 0, Message: cannot commit CONCURRENT transaction - conflict at page 1854553 (read/write page; part of db table reports; content=0D00000009007100...)


### PR DESCRIPTION
### Details

Copies the change to `sqlitecluster/SQLite.cpp` from https://github.com/Expensify/Bedrock/pull/2605/changes which was reverted so we stop reverting this change.

### Fixed Issues
Related with https://github.com/Expensify/Expensify/issues/640874

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
