### PR TITLE
[HOLD] Update SQLite to branch hctree-bedrock-lcd-ex

### DIFF
--- a/libstuff/sqlite3.h
+++ b/libstuff/sqlite3.h
@@ -148,10 +148,10 @@ extern "C" {
 */
 #define SQLITE_VERSION        "3.54.0"
 #define SQLITE_VERSION_NUMBER 3054000
-#define SQLITE_SOURCE_ID      "2026-05-12 17:42:11 012a04edd0ab7001f2635eeb766089201cbe372d54e5008e7138a5dbe522bf06"
-#define SQLITE_SCM_BRANCH     "hctree-bedrock"
+#define SQLITE_SOURCE_ID      "2026-05-27 18:37:40 4b66dc55fe9a13d543e85ac7a592165bbb2a15eed717a4604ae6a09c0bac5840"
+#define SQLITE_SCM_BRANCH     "hctree-bedrock-lcd-ex"
 #define SQLITE_SCM_TAGS       ""
-#define SQLITE_SCM_DATETIME   "2026-05-12T17:42:11.503Z"
+#define SQLITE_SCM_DATETIME   "2026-05-27T18:37:40.605Z"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -2210,6 +2210,19 @@ struct sqlite3_mem_methods {
 ** recommended case) then the integer is always filled with zero, regardless
 ** if its initial value.
 ** </dl>
+**
+** [[SQLITE_CONFIG_SHAREDLOG_MAXSIZE]]
+** <dt>SQLITE_CONFIG_SHAREDLOG_MAXSIZE
+** <dd>This option is used to set the maximum size of a BEGIN CONCURRENT
+** shared-log in bytes. The default value is 1GiB (1*1024*1024*1024). The
+** argument to this configuration option must be a 64-bit signed integer
+** (type sqlite3_int64) to use as the new limit. A negative parameter
+** restores the default value, a value of zero disabled shared-logs
+** altogether. There is no way to configure unlimited memory usage, but
+** applications may instead configure a very large value (e.g. 1TiB).
+** Shared-log entries are automatically discarded when their associated
+** transactions are checkpointed, which prevents the shared-log from growing
+** indefinitely in this case.
 */
 #define SQLITE_CONFIG_SINGLETHREAD         1  /* nil */
 #define SQLITE_CONFIG_MULTITHREAD          2  /* nil */
@@ -2241,6 +2254,7 @@ struct sqlite3_mem_methods {
 #define SQLITE_CONFIG_SORTERREF_SIZE      28  /* int nByte */
 #define SQLITE_CONFIG_MEMDB_MAXSIZE       29  /* sqlite3_int64 */
 #define SQLITE_CONFIG_ROWID_IN_VIEW       30  /* int* */
+#define SQLITE_CONFIG_SHAREDLOG_MAXSIZE   31  /* sqlite3_int64 */
 
 /*
 ** CAPI3REF: Database Connection Configuration Options

--- a/libstuff/sqlite3ext.h
+++ b/libstuff/sqlite3ext.h
@@ -375,6 +375,9 @@ struct sqlite3_api_routines {
   void (*str_truncate)(sqlite3_str*,int);
   void (*str_free)(sqlite3_str*);
   int (*carray_bind)(sqlite3_stmt*,int,void*,int,int,void(*)(void*));
+  int (*carray_bind_v2)(sqlite3_stmt*,int,void*,int,int,void(*)(void*),void*);
+  /* Version 3.54.0 and later */
+  sqlite3_int64 (*incomplete)(const char*);
 };
 
 /*
@@ -717,6 +720,9 @@ typedef int (*sqlite3_loadext_entry)(
 #define sqlite3_str_truncate           sqlite3_api->str_truncate
 #define sqlite3_str_free               sqlite3_api->str_free
 #define sqlite3_carray_bind            sqlite3_api->carray_bind
+#define sqlite3_carray_bind_v2         sqlite3_api->carray_bind_v2
+/* Version 3.54.0 and later */
+#define sqlite3_incomplete             sqlite3_api->incomplete
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)


### PR DESCRIPTION
### Details

### Fixed Issues
Redo of https://github.com/Expensify/Bedrock/pull/2605/ with a bug fix:

> contains a fix to a problem that could cause certain kinds of UPDATE (and maybe other) statements to erroneously record full table scans. It also emits a log message each time a BEGIN CONCURRENT transaction records a full-table scan of an IPK table. Hopefully that won't be too many log messages..

Needs https://github.com/Expensify/Bedrock/pull/2619 which was broken out in another PR.

For https://github.com/Expensify/Expensify/issues/640874

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
