### PR TITLE
Change the default prepare timeout to 24 hours

### DIFF
--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -171,10 +171,10 @@ public:
     // Prepare to commit or rollback the transaction. This also inserts the current uncommitted query into the
     // journal; no additional writes are allowed until the next transaction has begun.
     // The transactionID and transactionHash, if passed, will be updated with the values prepared for this transaction.
-    // The commitLockTimeout, if passed, will limit the time we wait for the lock. If not, we'll use the max value, which
+    // The commitLockTimeout, if passed, will limit the time we wait for the lock. If not, we'll use 24 hours, which
     // is effectively no timeout.
     // Note that if this transaction fails to commit, these will not ultimately be accurate.
-    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr, chrono::microseconds commitLockTimeout = chrono::microseconds::max());
+    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr, chrono::microseconds commitLockTimeout = chrono::hours(24));
 
     // This enables or disables automatic re-writing. This feature is to support mocked requests and load testing. This
     // overloads set_authorizer to allow a plugin to deny certain queries from running (currently based only on the

--- a/sqlitecluster/SQLiteCore.h
+++ b/sqlitecluster/SQLiteCore.h
@@ -14,7 +14,7 @@ public:
 
     // Commit the outstanding transaction on the DB.
     // Returns true on successful commit, false on conflict.
-    bool commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, const string& commandName, bool needsPluginNotifiation, void (*notificationHandler)(SQLite& _db, int64_t tableID) = nullptr, chrono::microseconds commitLockTimeout = chrono::microseconds::max()) noexcept;
+    bool commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, const string& commandName, bool needsPluginNotifiation, void (*notificationHandler)(SQLite& _db, int64_t tableID) = nullptr, chrono::microseconds commitLockTimeout = chrono::hours(24)) noexcept;
 
     // Roll back a transaction if we've decided not to commit it.
     void rollback(const string& commandName = "NONE");


### PR DESCRIPTION
### Details

Follow up to https://github.com/Expensify/Bedrock/pull/2610

The `try_lock_for` we've implemented to timeout commands waiting on the commit lock implementation sums the current time to the value we're passing as a parameter.

```cpp
  _LIBCPP_HIDE_FROM_ABI bool try_lock_for(const chrono::duration<_Rep, _Period>& __d) {
    return try_lock_until(chrono::steady_clock::now() + __d);
  }
```

The way we implemented `try_lock_for` had a default value of `chrono::microseconds::max()`, which returns INT64_MAX:

```cpp
int main() {
    std::int64_t max_micros = std::chrono::microseconds::max().count();
    std::cout << "The max microsecond count is: " << max_micros << "\n";
}
```

`The max microsecond count is: 9223372036854775807`

So when we called `prepare`, the default implementation for parsing the `microseconds::max` to nanoseconds (x1000) created an overflow, and we had a negative 1000ns

```cpp
int main() {
    auto duration = std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::microseconds::max());
    std::string message = std::format("The duration is: {} \n", duration);  
    std::cout << message;
    return 0;
}
```

`The duration is: -1000ns`

Since `try_lock_for` calls `try_lock_until` with the current datetime + our duration, it was sending a past time, making it behave effectively as a try_lock, returning immediately.

Changing the max time to 24h will solve this.


### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/642657

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
