### PR TITLE
Free listening port earlier in shutdown process

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -164,6 +164,12 @@ SQLiteNode::~SQLiteNode()
         delete peer;
     }
 
+    // Close the listening peer port before deleting pluginDB. pluginDB is a separate handle on the database, so closing
+    // it unmaps that handle's memory-mapped pages, which can take a long time when the database is large. _port is a
+    // member and would otherwise only be destroyed after this destructor body returns, leaving the kernel holding the
+    // listening port bound for the duration of that unmap.
+    _port = nullptr;
+
     if (pluginDB != nullptr) {
         delete pluginDB;
     }
@@ -259,6 +265,14 @@ bool SQLiteNode::beginShutdown()
         // Start graceful shutdown
         SINFO("Beginning graceful shutdown.");
         _isShuttingDown = true;
+
+        // Free the listening peer port now rather than waiting for the node to be destroyed during DB teardown. A
+        // shutting-down node won't accept new peer connections (established peer connections are independent of this
+        // listening socket), and the database teardown that follows can take a long time when the memory-mapped
+        // database is large. Until the FD is closed, the kernel keeps the listening port bound while it unmaps that
+        // memory, which prevents a restarted node from rebinding the port.
+        _port = nullptr;
+
         return true;
     }
 
@@ -516,8 +530,9 @@ bool SQLiteNode::update()
     }
     unique_lock<decltype(_stateMutex)> uniqueLock(_stateMutex);
 
-    // If we failed to open the port at creation time, try again on each upate.
-    if (_port == nullptr) {
+    // If we failed to open the port at creation time, try again on each update. We skip this while shutting down,
+    // because we intentionally close the listening port at that point and don't want to reopen it.
+    if (_port == nullptr && !_isShuttingDown) {
         _port = openPort(_host);
     }
 


### PR DESCRIPTION
Close the SQLiteNode peer listening port (`-nodeHost`) early during shutdown so the kernel releases it before the database memory is unmapped, instead of holding it bound for the duration of the `unmap()`.

When a node shuts down with a large memory-mapped database, the kernel keeps the peer listening port bound while it unmaps that memory, which can take a long time and prevents a new process starting.

The port was held because `~SQLiteNode` deletes `pluginDB` (a separate handle whose `sqlite3_close()` unmaps its pages) in the destructor body, while `_port` is a member only destroyed after the body returns. This closes `_port` before `delete pluginDB` in the destructor, and also frees it in `beginShutdown()` so it's released early and deterministically on the graceful path, with `update()` guarded so it won't reopen the port while shutting down.

### Fixed Issues
Fixes https://expensify.slack.com/archives/C094TGUTZ/p1780360333816159?thread_ts=1780356276.321669&cid=C094TGUTZ

### Tests

<img width="1156" height="362" alt="image" src="https://github.com/user-attachments/assets/1bc56b6c-8b50-406d-8636-e814d6d4defe" />

<img width="1082" height="279" alt="image" src="https://github.com/user-attachments/assets/a84f0ab3-6a71-4f34-a01f-47fce1d32532" />
