### PR TITLE
suppress timout warnings when needed

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -48,7 +48,12 @@ chrono::microseconds BedrockCore::getRemainingTime(const unique_ptr<BedrockComma
 
     // Already expired.
     if (adjustedTimeout <= 0 || (isProcessing && processTimeout <= 0)) {
-        SALERT("Command " << command->request.methodLine << " timed out.");
+        // Some plugins want to alert timeout errors themselves, and make them silent on bedrock.
+        if (command->shouldSuppressTimeoutWarnings()) {
+            SWARN("Command " << command->request.methodLine << " timed out.");
+        } else {
+            SALERT("Command " << command->request.methodLine << " timed out.");
+        }
         STHROW("555 Timeout");
     }
 


### PR DESCRIPTION
### Details
This fix changes the timeout alert in `BedrockCore::getRemainingTime`  (Bedrock/BedrockCore.cpp:51) from unconditional to suppressible.

That alert fires when a command is picked up from a queue after its absolute timeout has already expired — which is exactly what happens to fire-and-forget `SetNameValuePairs` commands stuck behind a backed-up blocking queue during instability. It was the source of every alert in the issue.

Bedrock already has a mechanism for this: plugins can override shouldSuppressTimeoutWarnings() to say "I'll handle timeout alerting myself," and `Auth` returns true (it raises its own richer alerts in `AuthCommand.cpp`). The other four timeout-alert sites in `BedrockCore.cpp` honor that flag — this one didn't, which looked like an oversight. The fix makes it consistent: when suppressed, it logs `SWARN` instead of `SALERT`, so the events stay searchable in logs but no longer page BugBot. Other plugins' behavior is unchanged.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/542420

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
