### PR TITLE
More reliably abort commands if client disconnects.

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -123,15 +123,21 @@ void BedrockCommand::_waitForHTTPSRequests()
         // from the the point of the list of known completed request.
         auto requestIt = (_lastContiguousCompletedTransaction == httpsRequests.end()) ? httpsRequests.begin() : _lastContiguousCompletedTransaction;
 
-        // Wait until the command's timeout, or break early if the command has timed out.
+        // Wait until the command's timeout, or break early if the command has timed out or the connection that
+        // originated this command has dropped (in which case there's nobody left to receive the response).
         uint64_t maxWaitUs = 0;
         uint64_t now = STimeNow();
         if (!startTime) {
             startTime = now;
         }
-        if (now < timeout()) {
+        bool aborted = socket && shouldAbort.load();
+        if (now < timeout() && !aborted) {
             maxWaitUs = timeout() - now;
         } else {
+            if (aborted) {
+                SINFO("Abandoning in-flight HTTPS requests, originating connection dropped.");
+            }
+
             // Look at all our uncompleted requests, mark them failed.
             while (requestIt != httpsRequests.end()) {
                 if (!(*requestIt)->response) {
@@ -140,7 +146,7 @@ void BedrockCommand::_waitForHTTPSRequests()
                 requestIt++;
             }
 
-            // Timed everything out, can return.
+            // Timed everything out (or abandoned them), can return.
             break;
         }
 

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -74,6 +74,19 @@ bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command, SQLite* db, co
     return false;
 }
 
+bool BedrockCore::isAborted(unique_ptr<BedrockCommand>& command, SQLite* db, const BedrockServer* server)
+{
+    if (!command->shouldAbort.load()) {
+        return false;
+    }
+
+    // The connection that started this command has dropped, so there's nobody left to receive the response. Abandon
+    // it the same way a timeout would: route through the standard exception handler and mark it complete.
+    _handleCommandException(command, SException(__FILE__, __LINE__, false, "556 Aborted"), db, server);
+    command->complete = true;
+    return true;
+}
+
 void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlockingCommitThread)
 {
     AutoTimer timer(command, isBlockingCommitThread ? BedrockCommand::BLOCKING_PREPEEK : BedrockCommand::PREPEEK);
@@ -82,6 +95,10 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlo
     const SData& request = command->request;
     SData& response = command->response;
     STable& content = command->jsonContent;
+
+    if (isAborted(command, &_db, &_server)) {
+        return;
+    }
 
     try {
         try {
@@ -98,6 +115,9 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlo
             command->_inDBReadOperation = true;
             command->prePeek(_db);
             command->_inDBReadOperation = false;
+            if (command->shouldAbort.load()) {
+                STHROW("556 Aborted");
+            }
             SDEBUG("Plugin '" << command->getName() << "' prePeeked command '" << request.methodLine << "'");
 
             if (!content.empty()) {
@@ -144,6 +164,9 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
 
     // We catch any exception and handle in `_handleCommandException`.
     RESULT returnValue = RESULT::COMPLETE;
+    if (isAborted(command, &_db, &_server)) {
+        return RESULT::COMPLETE;
+    }
     try {
         SDEBUG("Peeking at '" << request.methodLine << "'");
         command->peekCount++;
@@ -170,6 +193,9 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
             command->_inDBReadOperation = true;
             bool completed = command->peek(_db);
             command->_inDBReadOperation = false;
+            if (command->shouldAbort.load()) {
+                STHROW("556 Aborted");
+            }
             SDEBUG("Plugin '" << command->getName() << "' peeked command '" << request.methodLine << "'");
 
             if (!completed) {
@@ -242,6 +268,9 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
 
     // Keep track of whether we've modified the database and need to perform a `commit`.
     bool needsCommit = false;
+    if (isAborted(command, &_db, &_server)) {
+        return RESULT::NO_COMMIT_REQUIRED;
+    }
     try {
         SDEBUG("Processing '" << request.methodLine << "'");
         command->processCount++;
@@ -276,6 +305,9 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
                 command->_inDBWriteOperation = true;
                 command->process(_db);
                 command->_inDBWriteOperation = false;
+                if (command->shouldAbort.load()) {
+                    STHROW("556 Aborted");
+                }
                 SDEBUG("Plugin '" << command->getName() << "' processed command '" << request.methodLine << "'");
             } catch (const SQLite::timeout_error& e) {
                 if (!command->shouldSuppressTimeoutWarnings()) {
@@ -352,6 +384,10 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool i
     SData& response = command->response;
     STable& content = command->jsonContent;
 
+    if (isAborted(command, &_db, &_server)) {
+        return;
+    }
+
     // We catch any exception and handle in `_handleCommandException`.
     try {
         try {
@@ -367,6 +403,9 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool i
             command->_inDBReadOperation = true;
             command->postProcess(_db);
             command->_inDBReadOperation = false;
+            if (command->shouldAbort.load()) {
+                STHROW("556 Aborted");
+            }
             SDEBUG("Plugin '" << command->getName() << "' postProcess command '" << request.methodLine << "'");
 
             // Success. If a command has set "content", encode it in the response.

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -275,11 +275,15 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
 
     // Keep track of whether we've modified the database and need to perform a `commit`.
     bool needsCommit = false;
-    if (isAborted(command, &_db, &_server)) {
-        return RESULT::NO_COMMIT_REQUIRED;
-    }
     try {
         SDEBUG("Processing '" << request.methodLine << "'");
+
+        // If the originating connection has dropped, abandon the command before doing any work. Unlike the other
+        // phases, `process` is entered with the transaction that `peekCommand` left open on the `SHOULD_PROCESS` path,
+        // so we throw (rather than returning early) to route through the catch below, which rolls that back.
+        if (command->socket && command->shouldAbort.load()) {
+            STHROW("556 Aborted");
+        }
         command->processCount++;
         _db.setTimeout(getRemainingTime(command, true));
         _db.setAbortRef(command->shouldAbort);

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -76,6 +76,13 @@ bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command, SQLite* db, co
 
 bool BedrockCore::isAborted(unique_ptr<BedrockCommand>& command, SQLite* db, const BedrockServer* server)
 {
+    // A command with no socket has nobody awaiting a reply (it's fire-and-forget, escalated, or internally
+    // generated), so there's no connection to drop and it must never be abandoned. The abort flag is only ever set
+    // for commands that have a socket, but we guard explicitly here so the invariant doesn't depend on that.
+    if (!command->socket) {
+        return false;
+    }
+
     if (!command->shouldAbort.load()) {
         return false;
     }
@@ -115,7 +122,7 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlo
             command->_inDBReadOperation = true;
             command->prePeek(_db);
             command->_inDBReadOperation = false;
-            if (command->shouldAbort.load()) {
+            if (command->socket && command->shouldAbort.load()) {
                 STHROW("556 Aborted");
             }
             SDEBUG("Plugin '" << command->getName() << "' prePeeked command '" << request.methodLine << "'");
@@ -193,7 +200,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
             command->_inDBReadOperation = true;
             bool completed = command->peek(_db);
             command->_inDBReadOperation = false;
-            if (command->shouldAbort.load()) {
+            if (command->socket && command->shouldAbort.load()) {
                 STHROW("556 Aborted");
             }
             SDEBUG("Plugin '" << command->getName() << "' peeked command '" << request.methodLine << "'");
@@ -305,7 +312,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
                 command->_inDBWriteOperation = true;
                 command->process(_db);
                 command->_inDBWriteOperation = false;
-                if (command->shouldAbort.load()) {
+                if (command->socket && command->shouldAbort.load()) {
                     STHROW("556 Aborted");
                 }
                 SDEBUG("Plugin '" << command->getName() << "' processed command '" << request.methodLine << "'");
@@ -403,7 +410,7 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool i
             command->_inDBReadOperation = true;
             command->postProcess(_db);
             command->_inDBReadOperation = false;
-            if (command->shouldAbort.load()) {
+            if (command->socket && command->shouldAbort.load()) {
                 STHROW("556 Aborted");
             }
             SDEBUG("Plugin '" << command->getName() << "' postProcess command '" << request.methodLine << "'");

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -77,8 +77,7 @@ bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command, SQLite* db, co
 void BedrockCore::_throwIfAborted(const unique_ptr<BedrockCommand>& command)
 {
     // A command with no socket has nobody awaiting a reply (it's fire-and-forget, escalated, or internally
-    // generated), so there's no connection to drop and it must never be abandoned. The abort flag is only ever set
-    // for commands that have a socket, but we guard explicitly here so the invariant doesn't depend on that.
+    // generated), so there's no connection to drop and it must never be abandoned.
     if (command->socket && command->shouldAbort.load()) {
         STHROW("556 Aborted");
     }

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -74,24 +74,14 @@ bool BedrockCore::isTimedOut(unique_ptr<BedrockCommand>& command, SQLite* db, co
     return false;
 }
 
-bool BedrockCore::isAborted(unique_ptr<BedrockCommand>& command, SQLite* db, const BedrockServer* server)
+void BedrockCore::_throwIfAborted(const unique_ptr<BedrockCommand>& command)
 {
     // A command with no socket has nobody awaiting a reply (it's fire-and-forget, escalated, or internally
     // generated), so there's no connection to drop and it must never be abandoned. The abort flag is only ever set
     // for commands that have a socket, but we guard explicitly here so the invariant doesn't depend on that.
-    if (!command->socket) {
-        return false;
+    if (command->socket && command->shouldAbort.load()) {
+        STHROW("556 Aborted");
     }
-
-    if (!command->shouldAbort.load()) {
-        return false;
-    }
-
-    // The connection that started this command has dropped, so there's nobody left to receive the response. Abandon
-    // it the same way a timeout would: route through the standard exception handler and mark it complete.
-    _handleCommandException(command, SException(__FILE__, __LINE__, false, "556 Aborted"), db, server);
-    command->complete = true;
-    return true;
 }
 
 void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlockingCommitThread)
@@ -103,13 +93,10 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlo
     SData& response = command->response;
     STable& content = command->jsonContent;
 
-    if (isAborted(command, &_db, &_server)) {
-        return;
-    }
-
     try {
         try {
             SDEBUG("prePeeking at '" << request.methodLine << "'");
+            _throwIfAborted(command);
             command->prePeekCount++;
             _db.setTimeout(getRemainingTime(command, false));
             _db.setAbortRef(command->shouldAbort);
@@ -122,9 +109,7 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlo
             command->_inDBReadOperation = true;
             command->prePeek(_db);
             command->_inDBReadOperation = false;
-            if (command->socket && command->shouldAbort.load()) {
-                STHROW("556 Aborted");
-            }
+            _throwIfAborted(command);
             SDEBUG("Plugin '" << command->getName() << "' prePeeked command '" << request.methodLine << "'");
 
             if (!content.empty()) {
@@ -171,11 +156,9 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
 
     // We catch any exception and handle in `_handleCommandException`.
     RESULT returnValue = RESULT::COMPLETE;
-    if (isAborted(command, &_db, &_server)) {
-        return RESULT::COMPLETE;
-    }
     try {
         SDEBUG("Peeking at '" << request.methodLine << "'");
+        _throwIfAborted(command);
         command->peekCount++;
         _db.setTimeout(getRemainingTime(command, false));
         _db.setAbortRef(command->shouldAbort);
@@ -200,9 +183,7 @@ BedrockCore::RESULT BedrockCore::peekCommand(unique_ptr<BedrockCommand>& command
             command->_inDBReadOperation = true;
             bool completed = command->peek(_db);
             command->_inDBReadOperation = false;
-            if (command->socket && command->shouldAbort.load()) {
-                STHROW("556 Aborted");
-            }
+            _throwIfAborted(command);
             SDEBUG("Plugin '" << command->getName() << "' peeked command '" << request.methodLine << "'");
 
             if (!completed) {
@@ -277,13 +258,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
     bool needsCommit = false;
     try {
         SDEBUG("Processing '" << request.methodLine << "'");
-
-        // If the originating connection has dropped, abandon the command before doing any work. Unlike the other
-        // phases, `process` is entered with the transaction that `peekCommand` left open on the `SHOULD_PROCESS` path,
-        // so we throw (rather than returning early) to route through the catch below, which rolls that back.
-        if (command->socket && command->shouldAbort.load()) {
-            STHROW("556 Aborted");
-        }
+        _throwIfAborted(command);
         command->processCount++;
         _db.setTimeout(getRemainingTime(command, true));
         _db.setAbortRef(command->shouldAbort);
@@ -316,9 +291,7 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
                 command->_inDBWriteOperation = true;
                 command->process(_db);
                 command->_inDBWriteOperation = false;
-                if (command->socket && command->shouldAbort.load()) {
-                    STHROW("556 Aborted");
-                }
+                _throwIfAborted(command);
                 SDEBUG("Plugin '" << command->getName() << "' processed command '" << request.methodLine << "'");
             } catch (const SQLite::timeout_error& e) {
                 if (!command->shouldSuppressTimeoutWarnings()) {
@@ -395,14 +368,11 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool i
     SData& response = command->response;
     STable& content = command->jsonContent;
 
-    if (isAborted(command, &_db, &_server)) {
-        return;
-    }
-
     // We catch any exception and handle in `_handleCommandException`.
     try {
         try {
             SDEBUG("postProcessing at '" << request.methodLine << "'");
+            _throwIfAborted(command);
             command->postProcessCount++;
             _db.setTimeout(getRemainingTime(command, false));
             _db.setAbortRef(command->shouldAbort);
@@ -414,9 +384,7 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool i
             command->_inDBReadOperation = true;
             command->postProcess(_db);
             command->_inDBReadOperation = false;
-            if (command->socket && command->shouldAbort.load()) {
-                STHROW("556 Aborted");
-            }
+            _throwIfAborted(command);
             SDEBUG("Plugin '" << command->getName() << "' postProcess command '" << request.methodLine << "'");
 
             // Success. If a command has set "content", encode it in the response.

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -41,6 +41,13 @@ private:
     // the command hasn't timed out.
     static bool isTimedOut(unique_ptr<BedrockCommand>& command, SQLite* db = nullptr, const BedrockServer* server = nullptr);
 
+    // Checks if a command's originating connection has dropped, signalled via `command->shouldAbort`. Like
+    // `isTimedOut`, returns `true` and sets the command's response/complete state (to "556 Aborted") if it should be
+    // abandoned, and returns `false` and does nothing otherwise. Intended to be called at the start and end of each
+    // command phase so a command can be abandoned between phases (or before one begins), in addition to the
+    // mid-query aborts handled by SQLite's progress handler.
+    static bool isAborted(unique_ptr<BedrockCommand>& command, SQLite* db = nullptr, const BedrockServer* server = nullptr);
+
     void prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlockingCommitThread);
 
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -41,13 +41,6 @@ private:
     // the command hasn't timed out.
     static bool isTimedOut(unique_ptr<BedrockCommand>& command, SQLite* db = nullptr, const BedrockServer* server = nullptr);
 
-    // Checks if a command's originating connection has dropped, signalled via `command->shouldAbort`. Like
-    // `isTimedOut`, returns `true` and sets the command's response/complete state (to "556 Aborted") if it should be
-    // abandoned, and returns `false` and does nothing otherwise. Intended to be called at the start and end of each
-    // command phase so a command can be abandoned between phases (or before one begins), in addition to the
-    // mid-query aborts handled by SQLite's progress handler.
-    static bool isAborted(unique_ptr<BedrockCommand>& command, SQLite* db = nullptr, const BedrockServer* server = nullptr);
-
     void prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlockingCommitThread);
 
     // Peek lets you pre-process a command. It will be called on each command before `process` is called on the same
@@ -87,6 +80,14 @@ private:
     string _getExceptionName();
 
     static void _handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e, SQLite* db = nullptr, const BedrockServer* server = nullptr);
+
+    // Throws "556 Aborted" if the command's originating connection has dropped (signalled via `command->shouldAbort`).
+    // Called at the start and end of each command phase so a command can be abandoned between phases (or before one
+    // begins), in addition to the mid-query aborts handled by SQLite's progress handler. Must be called from inside a
+    // phase's `try` block: the phase's existing `catch` handler performs the appropriate rollback/cleanup. It's a
+    // no-op for commands with no socket (fire-and-forget, escalated, or internally generated), which have nobody
+    // awaiting a reply and so must never be abandoned on connection loss.
+    static void _throwIfAborted(const unique_ptr<BedrockCommand>& command);
 
     const BedrockServer& _server;
 };

--- a/BedrockCore.h
+++ b/BedrockCore.h
@@ -82,11 +82,6 @@ private:
     static void _handleCommandException(unique_ptr<BedrockCommand>& command, const SException& e, SQLite* db = nullptr, const BedrockServer* server = nullptr);
 
     // Throws "556 Aborted" if the command's originating connection has dropped (signalled via `command->shouldAbort`).
-    // Called at the start and end of each command phase so a command can be abandoned between phases (or before one
-    // begins), in addition to the mid-query aborts handled by SQLite's progress handler. Must be called from inside a
-    // phase's `try` block: the phase's existing `catch` handler performs the appropriate rollback/cleanup. It's a
-    // no-op for commands with no socket (fire-and-forget, escalated, or internally generated), which have nobody
-    // awaiting a reply and so must never be abandoned on connection loss.
     static void _throwIfAborted(const unique_ptr<BedrockCommand>& command);
 
     const BedrockServer& _server;

--- a/sqlitecluster/SQLiteClusterMessenger.cpp
+++ b/sqlitecluster/SQLiteClusterMessenger.cpp
@@ -21,7 +21,7 @@ void SQLiteClusterMessenger::setErrorResponse(BedrockCommand& command)
 }
 
 // Returns true on ready or false on error or timeout.
-SQLiteClusterMessenger::WaitForReadyResult SQLiteClusterMessenger::waitForReady(pollfd& fdspec, uint64_t timeoutTimestamp) const
+SQLiteClusterMessenger::WaitForReadyResult SQLiteClusterMessenger::waitForReady(pollfd& fdspec, const BedrockCommand& command) const
 {
     static const map<int, string> labels = {
         {POLLOUT, "send"},
@@ -40,7 +40,14 @@ SQLiteClusterMessenger::WaitForReadyResult SQLiteClusterMessenger::waitForReady(
         fdspec.events |= POLLRDHUP;
     }
 
+    const uint64_t timeoutTimestamp = command.timeout();
     while (true) {
+        // If the client that originated this command has disconnected, abandon the escalation.
+        if (command.socket && command.shouldAbort.load()) {
+            SINFO("[HTTPESC] Command aborted (originating connection dropped) while waiting (" << type << ").");
+            return WaitForReadyResult::ABORTED;
+        }
+
         int result = poll(&fdspec, 1, 100); // 100 is timeout in ms.
         if (!result) {
             if (timeoutTimestamp && timeoutTimestamp < STimeNow()) {
@@ -153,7 +160,7 @@ bool SQLiteClusterMessenger::_sendCommandOnSocket(SHTTPSManager::Socket& socket,
     // We only have one FD to poll.
     pollfd fdspec = {socket.s, POLLOUT, 0};
     while (true) {
-        WaitForReadyResult result = waitForReady(fdspec, command.timeout());
+        WaitForReadyResult result = waitForReady(fdspec, command);
         if (result != WaitForReadyResult::OK) {
             return false;
         }
@@ -193,7 +200,7 @@ bool SQLiteClusterMessenger::_sendCommandOnSocket(SHTTPSManager::Socket& socket,
     string responseStr;
     char response[4096] = {0};
     while (true) {
-        if (waitForReady(fdspec, command.timeout()) != WaitForReadyResult::OK) {
+        if (waitForReady(fdspec, command) != WaitForReadyResult::OK) {
             setErrorResponse(command);
             return false;
         }
@@ -292,6 +299,16 @@ bool SQLiteClusterMessenger::runOnPeer(BedrockCommand& command, bool runOnLeader
         sent = _sendCommandOnSocket(*s, command);
         if (!sent) {
             command.escalationTimeUS = STimeNow() - command.escalationTimeUS;
+
+            // If the originating client disconnected, the command was aborted. We deliberately do not return the
+            // socket to the pool below, so `s` is destroyed here and our connection to the peer is closed, which
+            // signals the peer to abort the escalated command too.
+            if (command.socket && command.shouldAbort.load()) {
+                SINFO("[HTTPESC] Abandoning escalation of '" << command.request.methodLine << "', originating connection dropped.");
+                command.response.methodLine = "556 Aborted";
+                command.complete = true;
+                return true;
+            }
             return false;
         }
     }

--- a/sqlitecluster/SQLiteClusterMessenger.h
+++ b/sqlitecluster/SQLiteClusterMessenger.h
@@ -17,6 +17,7 @@ public:
         DISCONNECTED_OUT,
         UNSPECIFIED,
         POLL_ERROR,
+        ABORTED,
     };
 
     SQLiteClusterMessenger(const shared_ptr<const SQLiteNode>& node);
@@ -47,9 +48,9 @@ public:
 
 private:
     // This takes a pollfd with either POLLIN or POLLOUT set, and waits for the socket to be ready to read or write,
-    // respectively. It returns true if ready, or false if error or timeout. The timeout is specified as a timestamp in
-    // microseconds.
-    WaitForReadyResult waitForReady(pollfd& fdspec, uint64_t timeoutTimestamp) const;
+    // respectively. It returns OK if ready, or another result on error, timeout, peer disconnect, or if the command
+    // was aborted because its originating client disconnected (ABORTED). The command's timeout is used as the deadline.
+    WaitForReadyResult waitForReady(pollfd& fdspec, const BedrockCommand& command) const;
 
     // This sets a command as a 500 and marks it as complete.
     static void setErrorResponse(BedrockCommand& command);

--- a/test/clustertest/tests/TimeoutTest.cpp
+++ b/test/clustertest/tests/TimeoutTest.cpp
@@ -1,7 +1,33 @@
 #include "test/lib/tpunit++.hpp"
 #include <BedrockCommand.h>
+#include <libstuff/libstuff.h>
 #include <libstuff/SData.h>
+#include <libstuff/SFastBuffer.h>
+#include <libstuff/SQResult.h>
 #include <test/clustertest/BedrockClusterTester.h>
+
+// Opens a connection to a tester's command port, sends a single request, waits `holdForUS` for the server to begin
+// handling it, then closes the socket without reading a response -- simulating a client that disconnects while its
+// command is still in flight.
+static void sendRequestAndDisconnect(BedrockTester& tester, const SData& request, uint64_t holdForUS = 250'000)
+{
+    int socket = S_socket(tester.getArg("-serverHost"), true, false, true);
+    if (socket == -1) {
+        STHROW("sendRequestAndDisconnect: failed to open socket.");
+    }
+
+    SFastBuffer sendBuffer(request.serialize());
+    while (sendBuffer.size()) {
+        if (!S_sendconsume(socket, sendBuffer)) {
+            S_close(&socket);
+            STHROW("sendRequestAndDisconnect: failed to send request.");
+        }
+    }
+
+    // Give the server time to read the request and start handling the command, then disconnect.
+    usleep(holdForUS);
+    S_close(&socket);
+}
 
 struct TimeoutTest : tpunit::TestFixture
 {
@@ -15,7 +41,10 @@ struct TimeoutTest : tpunit::TestFixture
                               TEST(TimeoutTest::testPostProcess),
                               TEST(TimeoutTest::totalTimeout),
                               TEST(TimeoutTest::quorumHTTPS),
-                              TEST(TimeoutTest::futureCommitTimeout))
+                              TEST(TimeoutTest::futureCommitTimeout),
+                              TEST(TimeoutTest::abortDuringProcessRollsBack),
+                              TEST(TimeoutTest::abortDuringEscalationRollsBack),
+                              TEST(TimeoutTest::forgetCommandNotAborted))
     {
     }
 
@@ -116,5 +145,106 @@ struct TimeoutTest : tpunit::TestFixture
         https["timeout"] = "5000"; // 5s.
         https["commitCount"] = "10000000000";
         brtester.executeWaitVerifyContent(https, "555 Timeout");
+    }
+
+    void abortDuringProcessRollsBack()
+    {
+        // When the client that sent a command disconnects while the command is still being processed, the command
+        // should be aborted and its (uncommitted) write rolled back rather than committed.
+        BedrockTester& brtester = tester->getTester(0);
+
+        SQResult before;
+        brtester.readDB("SELECT COUNT(*) FROM test;", before);
+        ASSERT_TRUE(before.size());
+        int64_t rowsBefore = SToInt64(before[0][0]);
+
+        // A slow write, sized so it's still running a couple of seconds after we disconnect. The timeouts are set
+        // high (well past how long it takes to finish) on purpose: if abort-on-disconnect were broken, the command
+        // would run to completion and *write its rows* -- caught by the row-count assertion below -- rather than
+        // quietly rolling back via a 555 timeout, which would let a regression pass unnoticed.
+        SData slow("slowprocessquery");
+        slow["size"] = "10000";
+        slow["count"] = "2000";
+        slow["timeout"] = "120000";        // 120s
+        slow["processTimeout"] = "120000"; // 120s
+        sendRequestAndDisconnect(brtester, slow);
+
+        // Once the disconnect is noticed, the command is abandoned and destroyed, leaving only the Status command we
+        // poll with alive. A `commandCount` of 1 means nothing else is running. We bound the wait well under the
+        // command's timeout: if the abort didn't happen, the command would still be running when this gives up.
+        ASSERT_TRUE(brtester.waitForStatusTerm("commandCount", "1", 30'000'000));
+
+        // The aborted write must have been rolled back: the row count is unchanged.
+        SQResult afterAbort;
+        brtester.readDB("SELECT COUNT(*) FROM test;", afterAbort);
+        ASSERT_EQUAL(SToInt64(afterAbort[0][0]), rowsBefore);
+    }
+
+    void forgetCommandNotAborted()
+    {
+        // A fire-and-forget command (`Connection: forget`) gets a 202 and the server closes its socket immediately.
+        // That close must NOT abort the command -- with no client awaiting a reply, it should still run to completion
+        // in the background.
+        BedrockTester& brtester = tester->getTester(0);
+
+        SQResult before;
+        brtester.readDB("SELECT COUNT(*) FROM test;", before);
+        ASSERT_TRUE(before.size());
+        int64_t rowsBefore = SToInt64(before[0][0]);
+
+        SData forget("slowprocessquery");
+        forget["size"] = "100";
+        forget["count"] = "1";
+        forget["Connection"] = "forget";
+        brtester.executeWaitVerifyContent(forget, "202");
+
+        // The command runs after its socket closed, so poll until its rows appear.
+        int64_t rowsAfter = rowsBefore;
+        uint64_t start = STimeNow();
+        while (STimeNow() < start + 10'000'000) {
+            SQResult after;
+            brtester.readDB("SELECT COUNT(*) FROM test;", after);
+            rowsAfter = SToInt64(after[0][0]);
+            if (rowsAfter > rowsBefore) {
+                break;
+            }
+            usleep(100'000);
+        }
+        ASSERT_GREATER_THAN(rowsAfter, rowsBefore);
+    }
+
+    void abortDuringEscalationRollsBack()
+    {
+        // Like abortDuringProcessRollsBack, but the command is sent to a *follower*, which escalates it to the leader
+        // (via SQLiteClusterMessenger::runOnPeer). Disconnecting the client should cancel the command all the way
+        // through the escalation chain: the follower drops its connection to the leader, and the leader then aborts
+        // the escalated command and rolls back its write.
+        BedrockTester& leader = tester->getTester(0);
+        BedrockTester& follower = tester->getTester(1);
+        ASSERT_TRUE(leader.waitForState("LEADING"));
+        ASSERT_TRUE(follower.waitForState("FOLLOWING"));
+
+        // Row counts are observed on the leader, where the escalated write actually executes.
+        SQResult before;
+        leader.readDB("SELECT COUNT(*) FROM test;", before);
+        ASSERT_TRUE(before.size());
+        int64_t rowsBefore = SToInt64(before[0][0]);
+
+        SData slow("slowprocessquery");
+        slow["size"] = "10000";
+        slow["count"] = "2000";
+        slow["timeout"] = "120000";        // 120s
+        slow["processTimeout"] = "120000"; // 120s
+        sendRequestAndDisconnect(follower, slow);
+
+        // The escalated command should be abandoned on the *leader*, not just the follower. Wait for the leader's
+        // commandCount to fall back to 1 (only the Status command we poll with is left), bounded well under the
+        // command's timeout so a failure to propagate the abort to the leader is caught here.
+        ASSERT_TRUE(leader.waitForStatusTerm("commandCount", "1", 30'000'000));
+
+        // The aborted write must have been rolled back on the leader.
+        SQResult afterAbort;
+        leader.readDB("SELECT COUNT(*) FROM test;", afterAbort);
+        ASSERT_EQUAL(SToInt64(afterAbort[0][0]), rowsBefore);
     }
 } __TimeoutTest;


### PR DESCRIPTION
### Details
This extends our Abort for commands where the client has disconnected from just inside sql queries to before and after each command phase, and during HTTPS requests.

### Fixed Issues
Fixes https://expensify.slack.com/archives/C0B96MS9B8X/p1781194408074179

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
