### PR TITLE
Document nextRun parameter on UpdateJob

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -27,6 +27,7 @@ Bedrock::Jobs is a plugin to the [Bedrock data foundation](../README.md) that ma
    * *data* - New data object to associate with the job
    * *repeat* - A description of how often to repeat this job (optional)
    * *jobPriority* - New priority of the job (optional)
+   * *nextRun* - When to next run the job, as a `YYYY-MM-DD HH:MM:SS` UTC datetime (optional); takes priority over the schedule computed from *repeat*
 
  * **QueryJob( jobID )** - Retrieves the current state and data associated with a job.
    * *jobID* - Identifier of the job to query

--- a/plugins/Jobs.md
+++ b/plugins/Jobs.md
@@ -17,6 +17,7 @@ Bedrock::Jobs is a plugin to the [Bedrock data foundation](../README.md) that ma
    * *data* - New data object to associate with the job
    * *repeat* - A description of how often to repeat this job (optional)
    * *jobPriority* - New priority of the job (optional)
+   * *nextRun* - When to next run the job, as a `YYYY-MM-DD HH:MM:SS` UTC datetime (optional); takes priority over the schedule computed from *repeat*
 
  * **QueryJob( jobID )** - Retrieves the current state and data associated with a job.
    * *jobID* - Identifier of the job to query


### PR DESCRIPTION
### Details
`UpdateJob` has accepted and applied a `nextRun` parameter since 2020 (commit `5987b1e3`, "Allow to update nextRun in UpdateJob"), and an explicit `nextRun` takes priority over the schedule computed from `repeat`. The docs, however, only list `jobID`, `data`, `repeat`, and `jobPriority` — so the capability is invisible to anyone reading them. This adds `nextRun` to the public Jobs docs (`docs/jobs.md`, which renders to bedrockdb.com/jobs) and the plugin README (`plugins/Jobs.md`).

Surfaced during review of [Auth#21635](https://github.com/Expensify/Auth/pull/21635), where the missing doc led a reviewer to believe `UpdateJob` ignores `nextRun`.

### Fixed Issues
N/A — docs-only fix, no tracking issue.

### Tests
Docs-only change; no code or behavior is affected. `UpdateJob`'s `nextRun` handling is already covered by `test/tests/jobs/UpdateJobTest.cpp`.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes

– written by Claude on Ben's behalf
