### PR TITLE
Expose server version for plugins

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1716,6 +1716,11 @@ list<STable> BedrockServer::getPeerInfo()
     return peerData;
 }
 
+const string& BedrockServer::getVersion() const
+{
+    return _version;
+}
+
 void BedrockServer::setDetach(bool detach)
 {
     if (detach) {

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -204,6 +204,9 @@ public:
     // peers, or no sync node.
     list<STable> getPeerInfo();
 
+    // Returns our own version string, as advertised to peers when we log in.
+    const string& getVersion() const;
+
     // Send a command to all of our peers. It will be wrapped appropriately.
     // If peerName is specified, command will be sent to only that peer.
     void broadcastCommand(const SData& message, const string& peerName = "");


### PR DESCRIPTION
### Details
Exposes server version to plugins.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/649037

### Tests
None.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
