### PR TITLE
Fix false '500 Mismatched version' from /status/handlingCommands while synchronizing

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1771,7 +1771,9 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command)
             response.methodLine = "HTTP/1.1 503 Backup In Progress";
         } else if (_detach) {
             response.methodLine = "HTTP/1.1 503 Detached";
-        } else if (_version != _leaderVersion.load()) {
+        } else if (!_leaderVersion.load().empty() && _version != _leaderVersion.load()) {
+            // Only a genuine mismatch when the leader's version is known. While SYNCHRONIZING/SEARCHING the leader
+            // version is empty, so fall through to the state-based check below to report the accurate state.
             response.methodLine = "HTTP/1.1 500 Mismatched version. Version=" + _version;
         } else {
             string method = "HTTP/1.1 ";

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1767,11 +1767,12 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command)
     } else if (SIEquals(request.methodLine, STATUS_HANDLING_COMMANDS)) {
         // This is similar to the above check, and is used for letting HAProxy load-balance commands.
 
+        const string leaderVersion = _leaderVersion.load();
         if (_shouldBackup) {
             response.methodLine = "HTTP/1.1 503 Backup In Progress";
         } else if (_detach) {
             response.methodLine = "HTTP/1.1 503 Detached";
-        } else if (!_leaderVersion.load().empty() && _version != _leaderVersion.load()) {
+        } else if (!leaderVersion.empty() && _version != leaderVersion) {
             // Only a genuine mismatch when the leader's version is known. While SYNCHRONIZING/SEARCHING the leader
             // version is empty, so fall through to the state-based check below to report the accurate state.
             response.methodLine = "HTTP/1.1 500 Mismatched version. Version=" + _version;

--- a/test/clustertest/tests/StatusHandlingCommandsTest.cpp
+++ b/test/clustertest/tests/StatusHandlingCommandsTest.cpp
@@ -15,9 +15,14 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture
         BedrockTester& follower = tester.getTester(1);
         vector<string> results(2);
 
+        // While the leader is down the follower loses its lead peer, so its known leader version is empty. All nodes in
+        // this cluster share the same version, so a "Mismatched version" response is always wrong here: an empty leader
+        // version must be reported as the node's actual state, not as a mismatch.
+        atomic<bool> foundMismatch(false);
+
         leader.stopServer();
 
-        thread healthCheckThread([&results, &follower](){
+        thread healthCheckThread([&results, &follower, &foundMismatch](){
             SData cmd("GET /status/handlingCommands HTTP/1.1");
             string result;
             bool foundLeader = false;
@@ -27,6 +32,9 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture
 
             while (chrono::steady_clock::now() < start + 60s && (!foundLeader || !foundFollower || !foundStandingdown)) {
                 result = follower.executeWaitMultipleData({cmd}, 1, false)[0].methodLine;
+                if (SContains(result, "Mismatched version")) {
+                    foundMismatch = true;
+                }
                 if (result == "HTTP/1.1 200 LEADING") {
                     results[0] = result;
                     foundLeader = true;
@@ -46,6 +54,7 @@ struct StatusHandlingCommandsTest : tpunit::TestFixture
 
         ASSERT_EQUAL(results[0], "HTTP/1.1 200 LEADING")
         ASSERT_EQUAL(results[1], "HTTP/1.1 200 FOLLOWING")
+        ASSERT_FALSE(foundMismatch)
         // We don't test STANDINGDOWN because it's unreliable to get it to show up in the status, we can move straight through it too quickly.
     }
 } __StatusHandlingCommandsTest;


### PR DESCRIPTION
### Details

The HAProxy bedrock agent on `db2.sjc` was reporting the node as `down` with `Auth not handling commands: 500 Mismatched version`. Investigation showed the node's version string matched every peer in the cluster — the node was simply `SYNCHRONIZING` after a restart and had no known leader version yet.

`BedrockServer::_status` handles `GET /status/handlingCommands` by checking `_version != _leaderVersion` **before** checking the node's actual state. `SQLiteNode::getLeaderVersion()` returns an empty string while a node is `SYNCHRONIZING`/`SEARCHING` (no lead peer yet), so the comparison against the node's own non-empty version always fails and returns the misleading `500 Mismatched version` instead of the node's true state. This is harmless to HAProxy routing (both responses are 5xx → out of pool) but sends operators down the wrong diagnostic path during routine restarts.

This change only treats a non-empty, differing leader version as a genuine mismatch. Otherwise it falls through to the existing state-based branch, which reports the accurate state (e.g. `500 SYNCHRONIZING`). A genuine version mismatch (leader version known and different, as during a rolling deploy) is unchanged.

### Fixed Issues

https://github.com/Expensify/Expensify/issues/649449

### Tests

1. Build the `bedrock` binary and the cluster tests: `make bedrock clustertest -j$(nproc)`
2. Run the status test with the freshly-built binary on `PATH` so the spawned cluster nodes match the test build: `PATH=$PWD:$PATH ./test/clustertest/clustertest -only StatusHandlingCommands`
3. Confirm the suite reports `Passed: 1, Failed: 0`. The test stops the leader (which clears the follower's lead peer, emptying its known leader version) and asserts `/status/handlingCommands` never returns `Mismatched version` during the transition, while still reaching `200 FOLLOWING`.

```
--------------
✓
[ TEST RESULTS ] Passed: 1, Failed: 0

Slowest Test Classes:
3908ms: StatusHandlingCommands : 100% of total test time
Total test time across threads: 3908ms
```

This change is confined to the internal logic of `BedrockServer::_status` — no header, signature, or public API changed — so Auth requires no source changes to build against it.
