### PR TITLE
start transaction in prePeek and postProcess too to benefit from cache

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -100,6 +100,10 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlo
             _db.setTimeout(getRemainingTime(command, false));
             _db.setAbortRef(command->shouldAbort);
 
+            if (!_db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED)) {
+                STHROW("501 Failed to begin shared transaction");
+            }
+
             // Make sure no writes happen while in prePeek command
             _db.setQueryOnly(true);
 
@@ -139,6 +143,7 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlo
         command->complete = true;
         command->_inDBReadOperation = false;
     }
+    _db.rollback(command->getMethodName());
     _db.clearTimeout();
     _db.clearAbortRef();
 
@@ -376,6 +381,10 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool i
             _db.setTimeout(getRemainingTime(command, false));
             _db.setAbortRef(command->shouldAbort);
 
+            if (!_db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED)) {
+                STHROW("501 Failed to begin shared transaction");
+            }
+
             // Make sure no writes happen while in postProcess command
             _db.setQueryOnly(true);
 
@@ -417,6 +426,7 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool i
 
     // The command is complete.
     command->complete = true;
+    _db.rollback(command->getMethodName());
     _db.clearTimeout();
     _db.clearAbortRef();
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -441,11 +441,6 @@ void BedrockServer::sync()
             // Record the time spent.
             command->stopTiming(BedrockCommand::COMMIT_SYNC);
 
-            if (command->shouldPostProcess() && command->response.methodLine == "200 OK") {
-                // PostProcess if the command should run postProcess, and there have been no errors thrown thus far.
-                core.postProcessCommand(command, false);
-            }
-
             if (_syncNode->commitSucceeded()) {
                 SINFO("Sync thread finished committing command " << command->request.methodLine);
                 _conflictManager.recordTables(command->request.methodLine, db.getTablesUsed());
@@ -453,7 +448,6 @@ void BedrockServer::sync()
                 // Otherwise, save the commit count, mark this command as complete, and reply.
                 command->response["commitCount"] = to_string(db.getCommitCount());
                 command->complete = true;
-                _reply(command);
             } else {
                 // This should only happen if the cluster becomes largely disconnected while we were in the process of
                 // committing a QUORUM command - if we no longer have enough peers to reach QUORUM, we'll fall out of
@@ -465,6 +459,16 @@ void BedrockServer::sync()
                       << " after failed sync commit. Sync thread has " << _syncNodeQueuedCommands.size()
                       << " queued commands.");
                 _syncNodeQueuedCommands.push(move(command));
+            }
+
+            // If the command was completed above, then we'll go ahead and respond.
+            if (command->complete) {
+                if (command->shouldPostProcess() && command->response.methodLine == "200 OK") {
+                    // PostProcess if the command should run postProcess, and there have been no errors thrown thus far.
+                    core.postProcessCommand(command, false);
+                }
+
+                _reply(command);
             }
         }
 


### PR DESCRIPTION
### Details

start transaction in prePeek and postProcess too to benefit from cache

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/341743

### Tests

Before: Notice the get employee query getting run multiple time

<img width="1720" height="553" alt="Screenshot 2026-06-17 at 7 09 57 PM" src="https://github.com/user-attachments/assets/35f90c02-344d-4faa-91e0-99429404089c" />


After: Now it's run only once

<img width="1728" height="194" alt="Screenshot 2026-06-17 at 7 12 54 PM" src="https://github.com/user-attachments/assets/92a8209f-b4a9-48d0-815a-a91330424681" />


_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
