### PR TITLE
Add SRandom::randBool

### DIFF
--- a/libstuff/SRandom.cpp
+++ b/libstuff/SRandom.cpp
@@ -32,7 +32,7 @@ string SRandom::randStr(unsigned length)
     return newstr;
 }
 
-const mt19937_64& SRandom::getGenerator()
+bool SRandom::randBool(const double probability)
 {
-    return _generator;
+    return bernoulli_distribution(probability)(_generator);
 }

--- a/libstuff/SRandom.cpp
+++ b/libstuff/SRandom.cpp
@@ -31,3 +31,8 @@ string SRandom::randStr(unsigned length)
     }
     return newstr;
 }
+
+const mt19937_64& SRandom::getGenerator()
+{
+    return _generator;
+}

--- a/libstuff/SRandom.h
+++ b/libstuff/SRandom.h
@@ -12,6 +12,8 @@ public:
     static uint64_t limitedRand64(uint64_t min, uint64_t max);
     static string randStr(unsigned length);
 
+    static const mt19937_64& getGenerator();
+
 private:
     static mt19937_64 _generator;
     static uniform_int_distribution<uint64_t> _distribution64;

--- a/libstuff/SRandom.h
+++ b/libstuff/SRandom.h
@@ -11,8 +11,7 @@ public:
     static uint64_t rand64();
     static uint64_t limitedRand64(uint64_t min, uint64_t max);
     static string randStr(unsigned length);
-
-    static const mt19937_64& getGenerator();
+    static bool randBool(const double probability);
 
 private:
     static mt19937_64 _generator;


### PR DESCRIPTION
### Details

Added `SRandom::randBool`. Adding this here instead of `Auth` so that we can reuse the existing RNG

### Fixed Issues
Related to https://github.com/Expensify/Expensify/issues/512096

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
