### PR TITLE
Re-anchor missed SCHEDULED job repeats to preserve stagger

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1403,32 +1403,32 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
     // Apply the repeat's date modifiers to a base timestamp, returning the result as a quoted SQL
     // literal (or "" on a syntax error).
     auto applyModifiers = [&](const string& startExpr) -> string {
-        string nextRun = startExpr;
+        string current = startExpr;
         for (const string& part : parts) {
             // This isn't supported natively by SQLite, so do it manually here instead.
             if (SToUpper(part) == "START OF HOUR") {
                 SQResult result;
-                if (!db.read("SELECT STRFTIME('%Y-%m-%d %H:00:00', " + nextRun + ");", result) || result.empty()) {
+                if (!db.read("SELECT STRFTIME('%Y-%m-%d %H:00:00', " + current + ");", result) || result.empty()) {
                     SWARN("Syntax error, failed parsing repeat " + part);
                     return "";
                 }
 
-                nextRun = SQ(result[0][0]);
+                current = SQ(result[0][0]);
             } else if (!SIsValidSQLiteDateModifier(part)) {
                 // Validate the sqlite date modifiers
                 SWARN("Syntax error, failed parsing repeat " + part);
                 return "";
             } else {
                 SQResult result;
-                if (!db.read("SELECT DATETIME(" + nextRun + ", " + SQ(part) + ");", result) || result.empty()) {
+                if (!db.read("SELECT DATETIME(" + current + ", " + SQ(part) + ");", result) || result.empty()) {
                     SWARN("Syntax error, failed parsing repeat " + part);
                     return "";
                 }
 
-                nextRun = SQ(result[0][0]);
+                current = SQ(result[0][0]);
             }
         }
-        return nextRun;
+        return current;
     };
 
     string nextRun = applyModifiers(baseExpr);

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -7,6 +7,10 @@
 #undef SLOGPREFIX
 #define SLOGPREFIX "{" << getName() << "} "
 
+// Only SCHEDULED repeats shorter than this re-anchor to now after a missed window; longer intervals
+// keep their scheduled time since they may need to run on a specific calendar date.
+static constexpr int64_t REPEAT_REANCHOR_THRESHOLD_SECONDS = 4 * 60 * 60;
+
 const int64_t BedrockPlugin_Jobs::JOBS_DEFAULT_PRIORITY = 500;
 const string BedrockPlugin_Jobs::name("Jobs");
 const string& BedrockPlugin_Jobs::getName() const
@@ -1382,41 +1386,75 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
     }
 
     // Make sure the first part indicates the base (eg, what we are modifying)
-    string nextRun = parts.front();
+    const string base = parts.front();
     parts.pop_front();
-    if (nextRun == "SCHEDULED") {
-        nextRun = SQ(lastScheduled);
-    } else if (nextRun == "STARTED") {
-        nextRun = SQ(lastRun);
-    } else if (nextRun == "FINISHED") {
-        nextRun = SCURRENT_TIMESTAMP();
+    string baseExpr;
+    if (base == "SCHEDULED") {
+        baseExpr = SQ(lastScheduled);
+    } else if (base == "STARTED") {
+        baseExpr = SQ(lastRun);
+    } else if (base == "FINISHED") {
+        baseExpr = SCURRENT_TIMESTAMP();
     } else {
-        SWARN("Syntax error, failed parsing repeat '" << repeat << "': missing base (" << nextRun << ")");
+        SWARN("Syntax error, failed parsing repeat '" << repeat << "': missing base (" << base << ")");
         return "";
     }
 
-    for (const string& part : parts) {
-        // This isn't supported natively by SQLite, so do it manually here instead.
-        if (SToUpper(part) == "START OF HOUR") {
-            SQResult result;
-            if (!db.read("SELECT STRFTIME('%Y-%m-%d %H:00:00', " + nextRun + ");", result) || result.empty()) {
+    // Apply the repeat's date modifiers to a base timestamp, returning the result as a quoted SQL
+    // literal (or "" on a syntax error).
+    auto applyModifiers = [&](const string& startExpr) -> string {
+        string nextRun = startExpr;
+        for (const string& part : parts) {
+            // This isn't supported natively by SQLite, so do it manually here instead.
+            if (SToUpper(part) == "START OF HOUR") {
+                SQResult result;
+                if (!db.read("SELECT STRFTIME('%Y-%m-%d %H:00:00', " + nextRun + ");", result) || result.empty()) {
+                    SWARN("Syntax error, failed parsing repeat " + part);
+                    return "";
+                }
+
+                nextRun = SQ(result[0][0]);
+            } else if (!SIsValidSQLiteDateModifier(part)) {
+                // Validate the sqlite date modifiers
                 SWARN("Syntax error, failed parsing repeat " + part);
                 return "";
-            }
+            } else {
+                SQResult result;
+                if (!db.read("SELECT DATETIME(" + nextRun + ", " + SQ(part) + ");", result) || result.empty()) {
+                    SWARN("Syntax error, failed parsing repeat " + part);
+                    return "";
+                }
 
-            nextRun = SQ(result[0][0]);
-        } else if (!SIsValidSQLiteDateModifier(part)) {
-            // Validate the sqlite date modifiers
-            SWARN("Syntax error, failed parsing repeat " + part);
+                nextRun = SQ(result[0][0]);
+            }
+        }
+        return nextRun;
+    };
+
+    string nextRun = applyModifiers(baseExpr);
+    if (nextRun.empty()) {
+        return "";
+    }
+
+    // A SCHEDULED repeat anchors the next run to the job's previously scheduled time. After an outage that
+    // anchor can be far enough in the past that scheduled+interval is also in the past, making every job
+    // immediately runnable at once (thundering herd). For short-interval jobs, skip the missed window and
+    // re-anchor to now so inter-job stagger survives a restart; long intervals are left untouched since they
+    // may need to run on a specific calendar date.
+    if (base == "SCHEDULED") {
+        const string nowExpr = SCURRENT_TIMESTAMP();
+        SQResult result;
+        if (!db.read("SELECT " + nextRun + " <= " + nowExpr + ", STRFTIME('%s', " + nextRun + ") - STRFTIME('%s', " + SQ(lastScheduled) + ");", result) || result.empty()) {
+            SWARN("Failed evaluating SCHEDULED repeat staleness for '" << repeat << "'");
             return "";
-        } else {
-            SQResult result;
-            if (!db.read("SELECT DATETIME(" + nextRun + ", " + SQ(part) + ");", result) || result.empty()) {
-                SWARN("Syntax error, failed parsing repeat " + part);
+        }
+        const bool missedWindow = result[0][0] == "1";
+        const int64_t intervalSeconds = SToInt64(result[0][1]);
+        if (missedWindow && intervalSeconds > 0 && intervalSeconds < REPEAT_REANCHOR_THRESHOLD_SECONDS) {
+            nextRun = applyModifiers(nowExpr);
+            if (nextRun.empty()) {
                 return "";
             }
-
-            nextRun = SQ(result[0][0]);
         }
     }
 

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1436,11 +1436,8 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
         return "";
     }
 
-    // A SCHEDULED repeat anchors the next run to the job's previously scheduled time. After an outage that
-    // anchor can be far enough in the past that scheduled+interval is also in the past, making every job
-    // immediately runnable at once (thundering herd). For short-interval jobs, skip the missed window and
-    // re-anchor to now so inter-job stagger survives a restart; long intervals are left untouched since they
-    // may need to run on a specific calendar date.
+    // After an outage, every missed SCHEDULED job becomes runnable at once (thundering herd). Re-anchor
+    // short-interval ones to now to preserve stagger; leave long intervals for jobs tied to a calendar date.
     if (base == "SCHEDULED") {
         const string nowExpr = SCURRENT_TIMESTAMP();
         SQResult result;

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1449,6 +1449,7 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
             return "";
         }
         const bool missedWindow = result[0][0] == "1";
+        // Realized delta as a proxy for the repeat interval; calendar modifiers make the exact period vary.
         const int64_t intervalSeconds = SToInt64(result[0][1]);
         if (missedWindow && intervalSeconds > 0 && intervalSeconds < REPEAT_REANCHOR_THRESHOLD_SECONDS) {
             nextRun = applyModifiers(nowExpr);

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1451,25 +1451,28 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
         const int64_t intervalSeconds = SToInt64(result[0][1]);
         const int64_t secondsBehind = SToInt64(result[0][2]);
 
-        // Only fixed-offset modifiers (eg "+30 SECONDS") have a constant period we can skip by arithmetic.
-        // Snapping modifiers like "START OF HOUR" round the result, so their realized delta isn't the period;
-        // leave those to their own (coarse, low-volume) catch-up rather than re-anchor them off-schedule.
-        bool fixedInterval = true;
-        for (const string& part : parts) {
-            if (part.empty() || (part.front() != '+' && part.front() != '-')) {
-                fixedInterval = false;
-                break;
+        // Only worth re-anchoring if the window was missed and the interval is short enough.
+        if (missedWindow && intervalSeconds > 0 && intervalSeconds < REPEAT_REANCHOR_THRESHOLD_SECONDS) {
+            // Only fixed-offset modifiers (eg "+30 SECONDS") have a constant period we can skip by arithmetic.
+            // Snapping modifiers like "START OF HOUR" round the result, so their realized delta isn't the period;
+            // leave those to their own (coarse, low-volume) catch-up rather than re-anchor them off-schedule.
+            bool fixedInterval = true;
+            for (const string& part : parts) {
+                if (part.empty() || (part.front() != '+' && part.front() != '-')) {
+                    fixedInterval = false;
+                    break;
+                }
             }
-        }
 
-        if (fixedInterval && missedWindow && intervalSeconds > 0 && intervalSeconds < REPEAT_REANCHOR_THRESHOLD_SECONDS) {
-            // Jump whole intervals past lastScheduled to the first slot after now, keeping each job's phase.
-            const int64_t skipSeconds = (secondsBehind / intervalSeconds + 1) * intervalSeconds;
-            if (!db.read("SELECT DATETIME(" + SQ(lastScheduled) + ", '+" + SToStr(skipSeconds) + " SECONDS');", result) || result.empty()) {
-                SWARN("Failed re-anchoring SCHEDULED repeat for '" << repeat << "'");
-                return "";
+            if (fixedInterval) {
+                // Jump whole intervals past lastScheduled to the first slot after now, keeping each job's phase.
+                const int64_t skipSeconds = (secondsBehind / intervalSeconds + 1) * intervalSeconds;
+                if (!db.read("SELECT DATETIME(" + SQ(lastScheduled) + ", '+" + SToStr(skipSeconds) + " SECONDS');", result) || result.empty()) {
+                    SWARN("Failed re-anchoring SCHEDULED repeat for '" << repeat << "'");
+                    return "";
+                }
+                nextRun = SQ(result[0][0]);
             }
-            nextRun = SQ(result[0][0]);
         }
     }
 

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1450,9 +1450,20 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
         const bool missedWindow = result[0][0] == "1";
         const int64_t intervalSeconds = SToInt64(result[0][1]);
         const int64_t secondsBehind = SToInt64(result[0][2]);
-        if (missedWindow && intervalSeconds > 0 && intervalSeconds < REPEAT_REANCHOR_THRESHOLD_SECONDS) {
+
+        // Only fixed-offset modifiers (eg "+30 SECONDS") have a constant period we can skip by arithmetic.
+        // Snapping modifiers like "START OF HOUR" round the result, so their realized delta isn't the period;
+        // leave those to their own (coarse, low-volume) catch-up rather than re-anchor them off-schedule.
+        bool fixedInterval = true;
+        for (const string& part : parts) {
+            if (part.empty() || (part.front() != '+' && part.front() != '-')) {
+                fixedInterval = false;
+                break;
+            }
+        }
+
+        if (fixedInterval && missedWindow && intervalSeconds > 0 && intervalSeconds < REPEAT_REANCHOR_THRESHOLD_SECONDS) {
             // Jump whole intervals past lastScheduled to the first slot after now, keeping each job's phase.
-            // intervalSeconds is the realized delta, so calendar modifiers would vary the exact period.
             const int64_t skipSeconds = (secondsBehind / intervalSeconds + 1) * intervalSeconds;
             if (!db.read("SELECT DATETIME(" + SQ(lastScheduled) + ", '+" + SToStr(skipSeconds) + " SECONDS');", result) || result.empty()) {
                 SWARN("Failed re-anchoring SCHEDULED repeat for '" << repeat << "'");

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1452,10 +1452,8 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
         // Realized delta as a proxy for the repeat interval; calendar modifiers make the exact period vary.
         const int64_t intervalSeconds = SToInt64(result[0][1]);
         if (missedWindow && intervalSeconds > 0 && intervalSeconds < REPEAT_REANCHOR_THRESHOLD_SECONDS) {
+            // Re-applies the already-validated modifiers from now, so this cannot fail.
             nextRun = applyModifiers(nowExpr);
-            if (nextRun.empty()) {
-                return "";
-            }
         }
     }
 

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1436,21 +1436,29 @@ string BedrockJobsCommand::_constructNextRunDATETIME(SQLite& db, const string& l
         return "";
     }
 
-    // After an outage, every missed SCHEDULED job becomes runnable at once (thundering herd). Re-anchor
-    // short-interval ones to now to preserve stagger; leave long intervals for jobs tied to a calendar date.
+    // After an outage, every missed SCHEDULED job becomes runnable at once (thundering herd). Skip the missed
+    // cycles to each job's next phase slot to preserve stagger; leave long intervals for calendar-bound jobs.
     if (base == "SCHEDULED") {
         const string nowExpr = SCURRENT_TIMESTAMP();
         SQResult result;
-        if (!db.read("SELECT " + nextRun + " <= " + nowExpr + ", STRFTIME('%s', " + nextRun + ") - STRFTIME('%s', " + SQ(lastScheduled) + ");", result) || result.empty()) {
+        if (!db.read("SELECT " + nextRun + " <= " + nowExpr + ", "
+                     "STRFTIME('%s', " + nextRun + ") - STRFTIME('%s', " + SQ(lastScheduled) + "), "
+                     "STRFTIME('%s', " + nowExpr + ") - STRFTIME('%s', " + SQ(lastScheduled) + ");", result) || result.empty()) {
             SWARN("Failed evaluating SCHEDULED repeat staleness for '" << repeat << "'");
             return "";
         }
         const bool missedWindow = result[0][0] == "1";
-        // Realized delta as a proxy for the repeat interval; calendar modifiers make the exact period vary.
         const int64_t intervalSeconds = SToInt64(result[0][1]);
+        const int64_t secondsBehind = SToInt64(result[0][2]);
         if (missedWindow && intervalSeconds > 0 && intervalSeconds < REPEAT_REANCHOR_THRESHOLD_SECONDS) {
-            // Re-applies the already-validated modifiers from now, so this cannot fail.
-            nextRun = applyModifiers(nowExpr);
+            // Jump whole intervals past lastScheduled to the first slot after now, keeping each job's phase.
+            // intervalSeconds is the realized delta, so calendar modifiers would vary the exact period.
+            const int64_t skipSeconds = (secondsBehind / intervalSeconds + 1) * intervalSeconds;
+            if (!db.read("SELECT DATETIME(" + SQ(lastScheduled) + ", '+" + SToStr(skipSeconds) + " SECONDS');", result) || result.empty()) {
+                SWARN("Failed re-anchoring SCHEDULED repeat for '" << repeat << "'");
+                return "";
+            }
+            nextRun = SQ(result[0][0]);
         }
     }
 

--- a/test/tests/jobs/RetryJobTest.cpp
+++ b/test/tests/jobs/RetryJobTest.cpp
@@ -21,6 +21,7 @@ struct RetryJobTest : tpunit::TestFixture
                               TEST(RetryJobTest::hasRepeatStartOfHourNotLast),
                               TEST(RetryJobTest::hasRepeatScheduledMissedWindowReanchors),
                               TEST(RetryJobTest::hasRepeatScheduledLongIntervalNotReanchored),
+                              TEST(RetryJobTest::hasRetryAfterScheduledMissedWindowReanchors),
                               TEST(RetryJobTest::inRunqueuedState),
                               TEST(RetryJobTest::simplyRetryWithNextRun),
                               TEST(RetryJobTest::changeNameAndPriority),
@@ -496,6 +497,50 @@ struct RetryJobTest : tpunit::TestFixture
         time_t firstRunTime = JobTestHelper::getTimestampForDateTimeString(firstRun);
         time_t actualNextRun = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
         ASSERT_EQUAL(difftime(actualNextRun, firstRunTime), 5 * 3600);
+    }
+
+    // A ReceiptScan-shaped job (retryAfter + a short SCHEDULED repeat) re-anchors off its original scheduled
+    // time. GetJob stashes the original (past) nextRun in data, so the missed window must be detected against
+    // that rather than the failure-check time GetJob wrote to nextRun.
+    void hasRetryAfterScheduledMissedWindowReanchors()
+    {
+        uint64_t now = STimeNow();
+
+        // Create the job scheduled an hour in the past.
+        SData command("CreateJob");
+        command["name"] = "job";
+        command["repeat"] = "SCHEDULED, +30 SECONDS";
+        command["retryAfter"] = "+10 MINUTES";
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", now - 3600 * STIME_US_PER_S);
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job; for retryAfter + SCHEDULED this stores the original (past) nextRun in data.
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Get a timestamp from before we reschedule.
+        SQResult result;
+        tester->readDB("SELECT DATETIME();", result);
+        time_t minimumTime = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
+
+        // Retry it
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // Get a timestamp from after we reschedule.
+        tester->readDB("SELECT DATETIME();", result);
+        time_t maximumTime = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
+
+        // nextRun is now + 30 seconds, not the missed original nextRun + 30 seconds (~an hour in the past).
+        tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
+        time_t actualNextRun = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
+        ASSERT_TRUE(difftime(actualNextRun, minimumTime) >= 30);
+        ASSERT_TRUE(difftime(actualNextRun, maximumTime) <= 30);
     }
 
     // Retry job in RUNQUEUED state

--- a/test/tests/jobs/RetryJobTest.cpp
+++ b/test/tests/jobs/RetryJobTest.cpp
@@ -422,17 +422,18 @@ struct RetryJobTest : tpunit::TestFixture
         ASSERT_EQUAL(result[0][0], SComposeTime("%Y-%m-%d 00:05:00", now));
     }
 
-    // A short-interval SCHEDULED repeat whose window was missed (eg, after an outage) skips the missed run
-    // and re-anchors to now instead of running again in the past.
+    // A short-interval SCHEDULED repeat whose window was missed (eg, after an outage) skips the missed cycles
+    // and re-anchors to the next slot on its own phase, not to a single bunched-up "now".
     void hasRepeatScheduledMissedWindowReanchors()
     {
         uint64_t now = STimeNow();
+        const string firstRun = SComposeTime("%Y-%m-%d %H:%M:%S", now - 3600 * STIME_US_PER_S);
 
         // Create the job scheduled an hour in the past.
         SData command("CreateJob");
         command["name"] = "job";
         command["repeat"] = "SCHEDULED, +30 SECONDS";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", now - 3600 * STIME_US_PER_S);
+        command["firstRun"] = firstRun;
         STable response = tester->executeWaitVerifyContentTable(command);
         string jobID = response["jobID"];
 
@@ -457,11 +458,14 @@ struct RetryJobTest : tpunit::TestFixture
         tester->readDB("SELECT DATETIME();", result);
         time_t maximumTime = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
 
-        // nextRun is now + 30 seconds, not the missed firstRun + 30 seconds (which is ~an hour in the past).
+        // nextRun is the first future slot (in (now, now + 30]) and stays on firstRun's 30-second phase,
+        // rather than being left in the past or bunched onto a single second.
         tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
         time_t actualNextRun = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
-        ASSERT_TRUE(difftime(actualNextRun, minimumTime) >= 30);
+        time_t firstRunTime = JobTestHelper::getTimestampForDateTimeString(firstRun);
+        ASSERT_TRUE(difftime(actualNextRun, minimumTime) > 0);
         ASSERT_TRUE(difftime(actualNextRun, maximumTime) <= 30);
+        ASSERT_EQUAL(static_cast<int64_t>(difftime(actualNextRun, firstRunTime)) % 30, 0);
     }
 
     // A SCHEDULED repeat longer than the re-anchor threshold keeps its scheduled time even when missed,
@@ -505,13 +509,14 @@ struct RetryJobTest : tpunit::TestFixture
     void hasRetryAfterScheduledMissedWindowReanchors()
     {
         uint64_t now = STimeNow();
+        const string firstRun = SComposeTime("%Y-%m-%d %H:%M:%S", now - 3600 * STIME_US_PER_S);
 
         // Create the job scheduled an hour in the past.
         SData command("CreateJob");
         command["name"] = "job";
         command["repeat"] = "SCHEDULED, +30 SECONDS";
         command["retryAfter"] = "+10 MINUTES";
-        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", now - 3600 * STIME_US_PER_S);
+        command["firstRun"] = firstRun;
         STable response = tester->executeWaitVerifyContentTable(command);
         string jobID = response["jobID"];
 
@@ -536,11 +541,13 @@ struct RetryJobTest : tpunit::TestFixture
         tester->readDB("SELECT DATETIME();", result);
         time_t maximumTime = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
 
-        // nextRun is now + 30 seconds, not the missed original nextRun + 30 seconds (~an hour in the past).
+        // nextRun is the first future slot on the original nextRun's phase, not left in the past or bunched on now.
         tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
         time_t actualNextRun = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
-        ASSERT_TRUE(difftime(actualNextRun, minimumTime) >= 30);
+        time_t firstRunTime = JobTestHelper::getTimestampForDateTimeString(firstRun);
+        ASSERT_TRUE(difftime(actualNextRun, minimumTime) > 0);
         ASSERT_TRUE(difftime(actualNextRun, maximumTime) <= 30);
+        ASSERT_EQUAL(static_cast<int64_t>(difftime(actualNextRun, firstRunTime)) % 30, 0);
     }
 
     // Retry job in RUNQUEUED state

--- a/test/tests/jobs/RetryJobTest.cpp
+++ b/test/tests/jobs/RetryJobTest.cpp
@@ -19,6 +19,8 @@ struct RetryJobTest : tpunit::TestFixture
                               TEST(RetryJobTest::hasRepeat),
                               TEST(RetryJobTest::hasRepeatStartOfHour),
                               TEST(RetryJobTest::hasRepeatStartOfHourNotLast),
+                              TEST(RetryJobTest::hasRepeatScheduledMissedWindowReanchors),
+                              TEST(RetryJobTest::hasRepeatScheduledLongIntervalNotReanchored),
                               TEST(RetryJobTest::inRunqueuedState),
                               TEST(RetryJobTest::simplyRetryWithNextRun),
                               TEST(RetryJobTest::changeNameAndPriority),
@@ -417,6 +419,83 @@ struct RetryJobTest : tpunit::TestFixture
         tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
         ASSERT_EQUAL(result.size(), 1);
         ASSERT_EQUAL(result[0][0], SComposeTime("%Y-%m-%d 00:05:00", now));
+    }
+
+    // A short-interval SCHEDULED repeat whose window was missed (eg, after an outage) skips the missed run
+    // and re-anchors to now instead of running again in the past.
+    void hasRepeatScheduledMissedWindowReanchors()
+    {
+        uint64_t now = STimeNow();
+
+        // Create the job scheduled an hour in the past.
+        SData command("CreateJob");
+        command["name"] = "job";
+        command["repeat"] = "SCHEDULED, +30 SECONDS";
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", now - 3600 * STIME_US_PER_S);
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get a timestamp from before we reschedule.
+        SQResult result;
+        tester->readDB("SELECT DATETIME();", result);
+        time_t minimumTime = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Retry it
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // Get a timestamp from after we reschedule.
+        tester->readDB("SELECT DATETIME();", result);
+        time_t maximumTime = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
+
+        // nextRun is now + 30 seconds, not the missed firstRun + 30 seconds (which is ~an hour in the past).
+        tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
+        time_t actualNextRun = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
+        ASSERT_TRUE(difftime(actualNextRun, minimumTime) >= 30);
+        ASSERT_TRUE(difftime(actualNextRun, maximumTime) <= 30);
+    }
+
+    // A SCHEDULED repeat longer than the re-anchor threshold keeps its scheduled time even when missed,
+    // since long-interval jobs may need to run on a specific calendar date.
+    void hasRepeatScheduledLongIntervalNotReanchored()
+    {
+        uint64_t now = STimeNow();
+        const string firstRun = SComposeTime("%Y-%m-%d %H:%M:%S", now - 10 * 3600 * STIME_US_PER_S);
+
+        // Create the job scheduled ten hours in the past.
+        SData command("CreateJob");
+        command["name"] = "job";
+        command["repeat"] = "SCHEDULED, +5 HOURS";
+        command["firstRun"] = firstRun;
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Retry it
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // nextRun stays at firstRun + 5 hours (still in the past), not re-anchored to now.
+        SQResult result;
+        tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
+        time_t firstRunTime = JobTestHelper::getTimestampForDateTimeString(firstRun);
+        time_t actualNextRun = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
+        ASSERT_EQUAL(difftime(actualNextRun, firstRunTime), 5 * 3600);
     }
 
     // Retry job in RUNQUEUED state

--- a/test/tests/jobs/RetryJobTest.cpp
+++ b/test/tests/jobs/RetryJobTest.cpp
@@ -21,6 +21,7 @@ struct RetryJobTest : tpunit::TestFixture
                               TEST(RetryJobTest::hasRepeatStartOfHourNotLast),
                               TEST(RetryJobTest::hasRepeatScheduledMissedWindowReanchors),
                               TEST(RetryJobTest::hasRepeatScheduledLongIntervalNotReanchored),
+                              TEST(RetryJobTest::hasRepeatScheduledSnappingModifierNotReanchored),
                               TEST(RetryJobTest::hasRetryAfterScheduledMissedWindowReanchors),
                               TEST(RetryJobTest::inRunqueuedState),
                               TEST(RetryJobTest::simplyRetryWithNextRun),
@@ -501,6 +502,42 @@ struct RetryJobTest : tpunit::TestFixture
         time_t firstRunTime = JobTestHelper::getTimestampForDateTimeString(firstRun);
         time_t actualNextRun = JobTestHelper::getTimestampForDateTimeString(result[0][0]);
         ASSERT_EQUAL(difftime(actualNextRun, firstRunTime), 5 * 3600);
+    }
+
+    // A SCHEDULED repeat with a snapping modifier (eg START OF HOUR) keeps its rounded cadence; arithmetic
+    // re-anchoring would shift it off the hour, so it is left to catch up on its own.
+    void hasRepeatScheduledSnappingModifierNotReanchored()
+    {
+        uint64_t now = STimeNow();
+        // Pin the minutes to :30 so the snapped scheduled run differs from any arithmetic re-anchor.
+        const string firstRun = SComposeTime("%Y-%m-%d %H", now - 2 * 3600 * STIME_US_PER_S) + ":30:00";
+
+        // Create the job scheduled in the past.
+        SData command("CreateJob");
+        command["name"] = "job";
+        command["repeat"] = "SCHEDULED, +1 HOUR, START OF HOUR";
+        command["firstRun"] = firstRun;
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+
+        // Get the job
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "job";
+        tester->executeWaitVerifyContent(command);
+
+        // Retry it
+        command.clear();
+        command.methodLine = "RetryJob";
+        command["jobID"] = jobID;
+        tester->executeWaitVerifyContent(command);
+
+        // nextRun is the snapped scheduled time (top of the hour after firstRun), not an off-hour arithmetic slot.
+        SQResult result;
+        tester->readDB("SELECT STRFTIME('%Y-%m-%d %H:00:00', DATETIME('" + firstRun + "', '+1 HOUR'));", result);
+        const string expectedNextRun = result[0][0];
+        tester->readDB("SELECT nextRun FROM jobs WHERE jobID = " + jobID + ";", result);
+        ASSERT_EQUAL(result[0][0], expectedNextRun);
     }
 
     // A ReceiptScan-shaped job (retryAfter + a short SCHEDULED repeat) re-anchors off its original scheduled


### PR DESCRIPTION
### Details
When a scheduled job misses it run due to bwm being offline for any reason, the job will run immediately when bwm is back up again. This results in us losing a stagger between jobs that was previously set for jobs that were run in the past.

For any jobs that have an interval of less than 4h and their last run was missed, find the next scheduled slot when bwm is back to preserve the stagger time.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/649216

### Tests
I added automated tests

I did a manual test as well.

1. create a job scheduled to run in the past with a repeat of scheduled +5m
2. run it
3. confirm the next run after it finishes is still staggered for the future run instead of also being scheduled in the past

note that this does not prevent the initial flood of jobs that will just run immediately when BWM is restarted if the scheduled next run is in the past because that is a much larger change that has a larger blast radius

AI helped me run the manual test case. `bcmd` is just a wrapper to send a command to bedrock

```
expensidev-2404->/vagrant (main) > date
Mon Jun 22 06:11:48 PM UTC 2026
expensidev-2404->/vagrant (main) > which bcmd
expensidev-2404->/vagrant (main) > PAST=$(date -u -d '1 hour ago' '+%Y-%m-%d %H:%M:00')
expensidev-2404->/vagrant (main) > echo "firstRun (missed) = $PAST"
bcmd "CreateJob\r\nname: test/StaggerProof\r\nrepeat: SCHEDULED, +5 MINUTES\r\nfirstRun: $PAST"
firstRun (missed) = 2026-06-23 17:52:00
200 OK
commitCount: 364332
Connection: close
nodeName: bedrock
peekTime: 179
processTime: 979
totalTime: 2873
unaccountedTime: 838
Content-Length: 28

{"jobID":458899167125282596}
expensidev-2404->/vagrant (main) > bcmd "Query\r\nformat: json\r\nquery: SELECT state, nextRun, CAST(STRFTIME('%s',nextRun)-STRFTIME('%s','now') AS INT) AS secs_from_now FROM jobs WHERE name='test/StaggerProof';"
200 OK
commitCount: 364332
Connection: close
nodeName: bedrock
peekTime: 682
totalTime: 1162
unaccountedTime: 479
Content-Length: 95

{"headers":["state","nextRun","secs_from_now"],"rows":[["QUEUED","2026-06-23 17:52:00",-3669]]}
expensidev-2404->/vagrant (main) > bcmd "GetJob\r\nname: test/StaggerProof"
200 OK
commitCount: 364333
Connection: close
nodeName: bedrock
peekTime: 78
processTime: 2681
totalTime: 3651
unaccountedTime: 360
Content-Length: 207

{"created":"2026-06-23 18:53:00","data":{},"jobID":458899167125282596,"lastRun":"","name":"test\/StaggerProof","nextRun":"2026-06-23 17:52:00","priority":500,"repeat":"SCHEDULED, +5 MINUTES","retryAfter":""}
expensidev-2404->/vagrant (main) > date
Tue Jun 23 06:53:38 PM UTC 2026
expensidev-2404->/vagrant (main) > bcmd "FinishJob\r\njobID: 458899167125282596"
200 OK
commitCount: 364334
Connection: close
nodeName: bedrock
peekTime: 179
processTime: 1214
totalTime: 3012
unaccountedTime: 795
Content-Length: 0


expensidev-2404->/vagrant (main) > bcmd "Query\r\nformat: json\r\nquery: SELECT nextRun, CAST(STRFTIME('%s',nextRun)-STRFTIME('%s','now') AS INT) AS secs_from_now, (STRFTIME('%s',nextRun)-STRFTIME('%s','$PAST')) % 300 AS phase_offset FROM jobs WHERE name='test/StaggerProof';"
200 OK
commitCount: 364334
Connection: close
nodeName: bedrock
peekTime: 500
totalTime: 774
unaccountedTime: 273
Content-Length: 93

{"headers":["nextRun","secs_from_now","phase_offset"],"rows":[["2026-06-23 18:57:00",172,0]]}
expensidev-2404->/vagrant (main) > date
Tue Jun 23 06:54:11 PM UTC 2026
```
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes