### PR TITLE
Decrease default sockets and db pool size from 25k to 5k

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1386,7 +1386,7 @@ BedrockServer::BedrockServer(const SData& args_)
     if (args.isSet("-dbPoolSize")) {
         _dbPoolSize = args.calcU64("-dbPoolSize");
     } else {
-        _dbPoolSize = args.isSet("-live") ? 25'000 : 250;
+        _dbPoolSize = args.isSet("-live") ? DEFAULT_POOL_SIZE : 250;
     }
 
     if (args.isSet("-maxSocketThreads")) {

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -485,7 +485,7 @@ private:
     SSynchronizedQueue<bool> _notifyDone;
     SSynchronizedQueue<bool> _notifyDoneSync;
 
-    static const size_t DEFAULT_POOL_SIZE = 25'000;
+    static const size_t DEFAULT_POOL_SIZE = 5'000;
     atomic<size_t> _maxSocketThreads{DEFAULT_POOL_SIZE};
     atomic<size_t> _dbPoolSize{DEFAULT_POOL_SIZE};
 };


### PR DESCRIPTION
### Details

Follow-up to https://github.com/Expensify/Bedrock/pull/2404. In that PR, the intention was to set the max sockets to the same number as the max DB pool size. This PR keeps this intention. 

The proposal here is to decrease the max number of sockets to something much more reasonable. Indeed, we never have 5k sockets outside of fires: 

https://graphs.expensify.com/grafana/d/AheoehQ4k/auth-deploy-dashboard?var-Timeframe=1m&orgId=1&from=2026-06-11T04:24:46.424Z&to=2026-06-22T08:15:10.424Z&timezone=utc&refresh=30s&viewPanel=panel-45

https://graphs.expensify.com/grafana/d/AheoehQ4k/auth-deploy-dashboard?var-Timeframe=1m&orgId=1&from=2026-06-01T00:00:46.000Z&to=2026-06-09T08:15:10.000Z&timezone=utc&refresh=30s&viewPanel=panel-45

<img width="1677" height="876" alt="image" src="https://github.com/user-attachments/assets/5df82110-1a53-4747-ae64-058563a1d32c" />


<img width="1669" height="876" alt="image" src="https://github.com/user-attachments/assets/77b254bb-4eba-44b9-99f0-69275a5219a0" />

However, we believe that having >10k open sockets during fires worsens the situation and prevents us from returning to a stable state faster. This PR aims to address this problem by setting the socket limit to 5k, which is likely already more than a single server can handle. 

### Fixed Issues
Fixes https://expensify.slack.com/archives/C0B96MS9B8X/p1781529360299489?thread_ts=1781283285.508369&cid=C0B96MS9B8X

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
