### PR TITLE
Make SQLite::prepare lock acquisition interruptible on command abort

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1072,7 +1072,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                         } else if (!core.isTimedOut(command, &db, this)) {
                             // One of the reasons the commit failed might be because of a timeout. If that's the case,
                             // then we skip this part since everything will be done in the method call above.
-                            SINFO("Conflict or state change committing " << command->request.methodLine);
+                            SINFO("Conflict, abort, or state change committing " << command->request.methodLine);
                             if (_enableConflictPageLocks) {
                                 lastConflictLocation = db.getLastConflictLocation();
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1042,7 +1042,12 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                             } catch (const SException& e) {
                                 SINFO("Command '" << command->getMethodName() << "' timed out before commit.");
                             }
+
+                            // We set the abortRef here, rather than inside `commit`, because commit is only aware of the transaction, not the command,
+                            // and thus does not have access to the command's properties.
+                            db.setAbortRef(command->shouldAbort);
                             commitSuccess = core.commit(*_syncNode, transactionID, transactionHash, command->getMethodName(), enableOnPrepareNotifications, onPrepareHandler, timeToCommit);
+                            db.clearAbortRef();
 
                             if (getState() != SQLiteNodeState::LEADING) {
                                 SINFO("Stopped leading while trying to commit, will retry.");

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1042,7 +1042,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                             } catch (const SException& e) {
                                 SINFO("Command '" << command->getMethodName() << "' timed out before commit.");
                             }
-                            commitSuccess = core.commit(*_syncNode, transactionID, transactionHash, command->getMethodName(), enableOnPrepareNotifications, onPrepareHandler, timeToCommit);
+                            commitSuccess = core.commit(*_syncNode, transactionID, transactionHash, command->getMethodName(), enableOnPrepareNotifications, onPrepareHandler, timeToCommit, &command->shouldAbort);
 
                             if (getState() != SQLiteNodeState::LEADING) {
                                 SINFO("Stopped leading while trying to commit, will retry.");

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1042,12 +1042,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                             } catch (const SException& e) {
                                 SINFO("Command '" << command->getMethodName() << "' timed out before commit.");
                             }
-
-                            // We set the abortRef here, rather than inside `commit`, because commit is only aware of the transaction, not the command,
-                            // and thus does not have access to the command's properties.
-                            db.setAbortRef(command->shouldAbort);
                             commitSuccess = core.commit(*_syncNode, transactionID, transactionHash, command->getMethodName(), enableOnPrepareNotifications, onPrepareHandler, timeToCommit);
-                            db.clearAbortRef();
 
                             if (getState() != SQLiteNodeState::LEADING) {
                                 SINFO("Stopped leading while trying to commit, will retry.");

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1,5 +1,6 @@
 #include "SQLite.h"
 
+#include <chrono>
 #include <linux/limits.h>
 #include <string.h>
 
@@ -864,16 +865,33 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
 
     // We lock this here, so that we can guarantee the order in which commits show up in the database.
     if (!_mutexLocked) {
-        auto start = STimeNow();
-        if (!_sharedData.commitLock.try_lock_for(commitLockTimeout)) {
+        auto start = chrono::steady_clock::now();
+        auto finalLockTimeout = start + commitLockTimeout;
+        auto nextLockTimeout = start + min(commitLockTimeout, 1'000'000us);
+
+        bool lockAcquired = false;
+        while (true) {
+            lockAcquired = _sharedData.commitLock.try_lock_until(nextLockTimeout);
+            if (lockAcquired || chrono::steady_clock::now() >= finalLockTimeout) {
+                break;
+            }
+
+            nextLockTimeout += 1s;
+            if (nextLockTimeout > finalLockTimeout) {
+                nextLockTimeout = finalLockTimeout;
+            }
+        }
+
+        if (!lockAcquired) {
             // Couldn't get the lock in time. Roll back the open transaction.
             SINFO("Timed out after " << chrono::duration_cast<chrono::microseconds>(commitLockTimeout).count()
                   << "us waiting for commit lock.");
             return false;
         }
-        auto end = STimeNow();
-        if (end - start > 5'000) {
-            SINFO("Waited " << (end - start) << "us for commit lock.");
+
+        auto elapsed = chrono::steady_clock::now() - start;
+        if (elapsed > 5ms) {
+            SINFO("Waited " << chrono::duration_cast<chrono::microseconds>(elapsed) << "us for commit lock.");
         }
         _sharedData._commitLockTimer.start("SHARED");
         _mutexLocked = true;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -965,7 +965,7 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
     return true;
 }
 
-int SQLite::commit(const string& description, const string& commandName, function<void()>* preCheckpointCallback) noexcept
+int SQLite::commit(const string& description, const string& commandName, function<void()>* preCheckpointCallback)
 {
     // If commits have been disabled, return an error without attempting the commit.
     if (!_sharedData._commitEnabled) {
@@ -1026,8 +1026,7 @@ int SQLite::commit(const string& description, const string& commandName, functio
     _lastConflictLocation = _conflictLocation;
 
     // If there were conflicting commits, will return SQLITE_BUSY_SNAPSHOT
-    // If there was a timeout, will return SQLITE_INTERRUPT.
-    SASSERT(result == SQLITE_OK || result == SQLITE_BUSY_SNAPSHOT || result == SQLITE_INTERRUPT);
+    SASSERT(result == SQLITE_OK || result == SQLITE_BUSY_SNAPSHOT);
     if (result == SQLITE_OK) {
         char time[16];
         snprintf(time, 16, "%.2fms", (double) (STimeNow() - beforeCommit) / 1000.0);
@@ -1057,15 +1056,10 @@ int SQLite::commit(const string& description, const string& commandName, functio
         // Only check for commits over 100ms.
         if (_commitElapsed > 100'000 && _hctree) {
             SQResult stats;
-            try {
-                if (read("SELECT * FROM hctstats", stats)) {
-                    for (const auto& row : stats) {
-                        SINFO("slow HC-Tree commit", {{"hctstats", SComposeList(row)}});
-                    }
+            if (read("SELECT * FROM hctstats", stats)) {
+                for (const auto& row : stats) {
+                    SINFO("slow HC-Tree commit", {{"hctstats", SComposeList(row)}});
                 }
-            } catch (const SException& e) {
-                // It's possible for the read to hit the timeout or abort flag, in which case, we need to handle that as this function is `noexcept`.
-                SINFO("Timeout or about gettings HC-Tree stats after commit. Ignoring.");
             }
         }
 
@@ -1115,7 +1109,7 @@ int SQLite::commit(const string& description, const string& commandName, functio
         // The commit failed, we will rollback.
     }
 
-    // if we did not get SQLITE_OK, then we're *still* holding commitLock, and it will need to be unlocked by
+    // if we got SQLITE_BUSY_SNAPSHOT, then we're *still* holding commitLock, and it will need to be unlocked by
     // calling rollback().
     return result;
 }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -832,7 +832,7 @@ bool SQLite::_writeIdempotent(const string& query, const map<string, Parameter>&
     return true;
 }
 
-bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::microseconds commitLockTimeout)
+bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::microseconds commitLockTimeout, atomic<bool>* abortPtr)
 {
     SASSERT(_insideTransaction);
 
@@ -869,6 +869,10 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
         auto finalLockTimeout = start + commitLockTimeout;
         auto nextLockTimeout = start + min(commitLockTimeout, 1'000'000us);
 
+        if (abortPtr) {
+            setAbortRef(*abortPtr);
+        }
+
         bool lockAcquired = false;
         while (true) {
             lockAcquired = _sharedData.commitLock.try_lock_until(nextLockTimeout);
@@ -885,6 +889,10 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
             if (nextLockTimeout > finalLockTimeout) {
                 nextLockTimeout = finalLockTimeout;
             }
+        }
+
+        if (abortPtr) {
+            clearAbortRef();
         }
 
         if (!lockAcquired) {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -881,7 +881,6 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
             }
 
             if (_shouldAbortPtr && *_shouldAbortPtr) {
-                SINFO("Transaction was aborted while waiting for commitLock acquisition");
                 break;
             }
 
@@ -895,9 +894,18 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
             clearAbortRef();
         }
 
-        if (!lockAcquired) {
-            // Couldn't get the lock in time. Roll back the open transaction.
-            SINFO("Timed out or aborted after " << chrono::duration_cast<chrono::microseconds>(commitLockTimeout).count()
+        if (_shouldAbortPtr && *_shouldAbortPtr) {
+            SINFO("Transaction was aborted while waiting for commitLock acquisition.");
+
+            // It's possible for us to get the lock, and also the caller sets the abort flag at the same time.
+            // In this case, we still abort, but we need to make sure that the lock isn't held, as _mutexLocked is
+            // not yet set and so won't get reset in a call to rollback().
+            if (lockAcquired) {
+                _sharedData.commitLock.unlock();
+            }
+            return false;
+        } else if (!lockAcquired) {
+            SINFO("Timed out after " << chrono::duration_cast<chrono::microseconds>(commitLockTimeout).count()
                   << "us waiting for commit lock.");
             return false;
         }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -890,11 +890,12 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
             }
         }
 
+        bool abortPtrWasSet = _shouldAbortPtr && *_shouldAbortPtr;
         if (abortPtr) {
             clearAbortRef();
         }
 
-        if (_shouldAbortPtr && *_shouldAbortPtr) {
+        if (abortPtrWasSet) {
             SINFO("Transaction was aborted while waiting for commitLock acquisition.");
 
             // It's possible for us to get the lock, and also the caller sets the abort flag at the same time.

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -876,6 +876,11 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
                 break;
             }
 
+            if (_shouldAbortPtr && *_shouldAbortPtr) {
+                SINFO("Transaction was aborted while waiting for commitLock acquisition");
+                break;
+            }
+
             nextLockTimeout += 1s;
             if (nextLockTimeout > finalLockTimeout) {
                 nextLockTimeout = finalLockTimeout;
@@ -884,7 +889,7 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
 
         if (!lockAcquired) {
             // Couldn't get the lock in time. Roll back the open transaction.
-            SINFO("Timed out after " << chrono::duration_cast<chrono::microseconds>(commitLockTimeout).count()
+            SINFO("Timed out or aborted after " << chrono::duration_cast<chrono::microseconds>(commitLockTimeout).count()
                   << "us waiting for commit lock.");
             return false;
         }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1018,7 +1018,8 @@ int SQLite::commit(const string& description, const string& commandName, functio
     _lastConflictLocation = _conflictLocation;
 
     // If there were conflicting commits, will return SQLITE_BUSY_SNAPSHOT
-    SASSERT(result == SQLITE_OK || result == SQLITE_BUSY_SNAPSHOT);
+    // If there was a timeout, will return SQLITE_INTERRUPT.
+    SASSERT(result == SQLITE_OK || result == SQLITE_BUSY_SNAPSHOT || result == SQLITE_INTERRUPT);
     if (result == SQLITE_OK) {
         char time[16];
         snprintf(time, 16, "%.2fms", (double) (STimeNow() - beforeCommit) / 1000.0);
@@ -1101,7 +1102,7 @@ int SQLite::commit(const string& description, const string& commandName, functio
         // The commit failed, we will rollback.
     }
 
-    // if we got SQLITE_BUSY_SNAPSHOT, then we're *still* holding commitLock, and it will need to be unlocked by
+    // if we did not get SQLITE_OK, then we're *still* holding commitLock, and it will need to be unlocked by
     // calling rollback().
     return result;
 }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -957,7 +957,7 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
     return true;
 }
 
-int SQLite::commit(const string& description, const string& commandName, function<void()>* preCheckpointCallback)
+int SQLite::commit(const string& description, const string& commandName, function<void()>* preCheckpointCallback) noexcept
 {
     // If commits have been disabled, return an error without attempting the commit.
     if (!_sharedData._commitEnabled) {
@@ -1049,10 +1049,15 @@ int SQLite::commit(const string& description, const string& commandName, functio
         // Only check for commits over 100ms.
         if (_commitElapsed > 100'000 && _hctree) {
             SQResult stats;
-            if (read("SELECT * FROM hctstats", stats)) {
-                for (const auto& row : stats) {
-                    SINFO("slow HC-Tree commit", {{"hctstats", SComposeList(row)}});
+            try {
+                if (read("SELECT * FROM hctstats", stats)) {
+                    for (const auto& row : stats) {
+                        SINFO("slow HC-Tree commit", {{"hctstats", SComposeList(row)}});
+                    }
                 }
+            } catch (const SException& e) {
+                // It's possible for the read to hit the timeout or abort flag, in which case, we need to handle that as this function is `noexcept`.
+                SINFO("Timeout or about gettings HC-Tree stats after commit. Ignoring.");
             }
         }
 

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -218,7 +218,7 @@ public:
     // Commits the current transaction to disk. Returns an sqlite3 result code.
     // preCheckpointCallback is an optional callback that will be called before the checkpoint code runs, after the commit has completed. Note that if the commit fails, this is not called.
     // The main purpose of this is to allow replications in SQLiteNode to notify other waiting threads that the commit has finished even before the checkpoint is done.
-    int commit(const string& description = "UNSPECIFIED", const string& commandName = "", function<void()>* preCheckpointCallback = nullptr);
+    int commit(const string& description = "UNSPECIFIED", const string& commandName = "", function<void()>* preCheckpointCallback = nullptr) noexcept;
 
     // Cancels the current transaction and rolls it back.
     void rollback(const string& commandName = "");

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -174,7 +174,7 @@ public:
     // The commitLockTimeout, if passed, will limit the time we wait for the lock. If not, we'll use 24 hours, which
     // is effectively no timeout.
     // Note that if this transaction fails to commit, these will not ultimately be accurate.
-    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr, chrono::microseconds commitLockTimeout = chrono::hours(24));
+    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr, chrono::microseconds commitLockTimeout = chrono::hours(24), atomic<bool>* abortPtr = nullptr);
 
     // This enables or disables automatic re-writing. This feature is to support mocked requests and load testing. This
     // overloads set_authorizer to allow a plugin to deny certain queries from running (currently based only on the

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -218,7 +218,7 @@ public:
     // Commits the current transaction to disk. Returns an sqlite3 result code.
     // preCheckpointCallback is an optional callback that will be called before the checkpoint code runs, after the commit has completed. Note that if the commit fails, this is not called.
     // The main purpose of this is to allow replications in SQLiteNode to notify other waiting threads that the commit has finished even before the checkpoint is done.
-    int commit(const string& description = "UNSPECIFIED", const string& commandName = "", function<void()>* preCheckpointCallback = nullptr) noexcept;
+    int commit(const string& description = "UNSPECIFIED", const string& commandName = "", function<void()>* preCheckpointCallback = nullptr);
 
     // Cancels the current transaction and rolls it back.
     void rollback(const string& commandName = "");

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -9,7 +9,7 @@ SQLiteCore::SQLiteCore(SQLite& db) : _db(db)
 {
 }
 
-bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, const string& commandName, bool needsPluginNotification, void (*notificationHandler)(SQLite& _db, int64_t tableID), chrono::microseconds commitLockTimeout) noexcept
+bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, const string& commandName, bool needsPluginNotification, void (*notificationHandler)(SQLite& _db, int64_t tableID), chrono::microseconds commitLockTimeout, atomic<bool>* abortPtr) noexcept
 {
     // This handler only needs to exist in prepare so we scope it here to automatically unset
     // the handler function once we are done with prepare.
@@ -19,10 +19,15 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
         // This will fail only if we can't acquire the commit lock respecting the command timeout, which
         // likely means our cluster health is not optimal. In this case, we want to roll back and
         // return false, which will make the caller return the appropriate exception.
+        if(abortPtr) {
+            _db.setAbortRef(*abortPtr);
+        }
         if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout)) {
+            _db.clearAbortRef();
             _db.rollback(commandName);
             return false;
         }
+        _db.clearAbortRef();
     }
 
     // Check for any state other than leading and refuse.

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -16,10 +16,9 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
     {
         AutoScopeOnPrepare onPrepare(needsPluginNotification, _db, notificationHandler);
 
-        // This will fail only if we can't acquire the commit lock respecting the command timeout, which
-        // likely means our cluster health is not optimal. In this case, we want to roll back and
-        // return false, which will make the caller return the appropriate exception.
-        if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout)) {
+        // This will fail only if we can't acquire the commit lock respecting the command timeout, or the command is aborted while waiting for it.
+        // In this case, we want to roll back and return false, which will make the caller return the appropriate exception.
+        if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout, abortPtr)) {
             _db.rollback(commandName);
             return false;
         }

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -19,7 +19,7 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
         // This will fail only if we can't acquire the commit lock respecting the command timeout, which
         // likely means our cluster health is not optimal. In this case, we want to roll back and
         // return false, which will make the caller return the appropriate exception.
-        if(abortPtr) {
+        if (abortPtr) {
             _db.setAbortRef(*abortPtr);
         }
         if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout)) {

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -3,6 +3,7 @@
 #include "SQLiteCore.h"
 #include "SQLite.h"
 #include "SQLiteNode.h"
+#include "libstuff/sqlite3.h"
 
 SQLiteCore::SQLiteCore(SQLite& db) : _db(db)
 {
@@ -39,11 +40,14 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
 
     // Perform the actual commit, rollback if it fails.
     int errorCode = _db.commit(SQLiteNode::stateName(node.getState()), commandName);
-    if (errorCode == SQLITE_BUSY_SNAPSHOT) {
-        _db.rollback(commandName);
-        return false;
-    } else if (errorCode == SQLite::COMMIT_DISABLED) {
-        SINFO("Commits currently disabled, rolling back.");
+    if (errorCode) {
+        if (errorCode == SQLITE_BUSY_SNAPSHOT || errorCode == SQLITE_INTERRUPT) {
+            // No extra logging needed for expected cases.
+        } else if (errorCode == SQLite::COMMIT_DISABLED) {
+            SINFO("Commits currently disabled, rolling back.");
+        } else {
+            SWARN("Unexpected commit error: " << errorCode << ", rolling back.");
+        }
         _db.rollback(commandName);
         return false;
     }

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -16,18 +16,26 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
     {
         AutoScopeOnPrepare onPrepare(needsPluginNotification, _db, notificationHandler);
 
-        // This will fail only if we can't acquire the commit lock respecting the command timeout, which
-        // likely means our cluster health is not optimal. In this case, we want to roll back and
-        // return false, which will make the caller return the appropriate exception.
+        // Allow commands to aport in prepare(), particularly, while waiting for the mutex.
         if (abortPtr) {
             _db.setAbortRef(*abortPtr);
         }
-        if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout)) {
-            _db.clearAbortRef();
+
+        bool prepareSuccess = false;
+        try {
+            // This will fail if we can't acquire the commit lock or the command has been aborted.
+            prepareSuccess = _db.prepare(&commitID, &transactionHash, commitLockTimeout);
+        } catch (const exception& e) {
+            // _onPrepareHandler can potentially throw, depending on what it does. Particularly if the abortPtr's value has become true.
+            // Since this function is noexcept, we convert this to a warning. The command will stil fail.
+            SWARN("Exception " << e.what() << " caught in prepare()");
+        }
+        _db.clearAbortRef();
+
+        if (!prepareSuccess) {
             _db.rollback(commandName);
             return false;
         }
-        _db.clearAbortRef();
     }
 
     // Check for any state other than leading and refuse.

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -16,23 +16,10 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
     {
         AutoScopeOnPrepare onPrepare(needsPluginNotification, _db, notificationHandler);
 
-        // Allow commands to aport in prepare(), particularly, while waiting for the mutex.
-        if (abortPtr) {
-            _db.setAbortRef(*abortPtr);
-        }
-
-        bool prepareSuccess = false;
-        try {
-            // This will fail if we can't acquire the commit lock or the command has been aborted.
-            prepareSuccess = _db.prepare(&commitID, &transactionHash, commitLockTimeout);
-        } catch (const exception& e) {
-            // _onPrepareHandler can potentially throw, depending on what it does. Particularly if the abortPtr's value has become true.
-            // Since this function is noexcept, we convert this to a warning. The command will stil fail.
-            SWARN("Exception " << e.what() << " caught in prepare()");
-        }
-        _db.clearAbortRef();
-
-        if (!prepareSuccess) {
+        // This will fail only if we can't acquire the commit lock respecting the command timeout, which
+        // likely means our cluster health is not optimal. In this case, we want to roll back and
+        // return false, which will make the caller return the appropriate exception.
+        if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout)) {
             _db.rollback(commandName);
             return false;
         }
@@ -54,8 +41,8 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
     // Perform the actual commit, rollback if it fails.
     int errorCode = _db.commit(SQLiteNode::stateName(node.getState()), commandName);
     if (errorCode) {
-        if (errorCode == SQLITE_BUSY_SNAPSHOT || errorCode == SQLITE_INTERRUPT) {
-            // No extra logging needed for expected cases.
+        if (errorCode == SQLITE_BUSY_SNAPSHOT) {
+            // No extra logging needed for expected case.
         } else if (errorCode == SQLite::COMMIT_DISABLED) {
             SINFO("Commits currently disabled, rolling back.");
         } else {

--- a/sqlitecluster/SQLiteCore.h
+++ b/sqlitecluster/SQLiteCore.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <atomic>
+#include <chrono>
 class SQLite;
 class SQLiteNode;
 
@@ -14,7 +16,7 @@ public:
 
     // Commit the outstanding transaction on the DB.
     // Returns true on successful commit, false on conflict.
-    bool commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, const string& commandName, bool needsPluginNotifiation, void (*notificationHandler)(SQLite& _db, int64_t tableID) = nullptr, chrono::microseconds commitLockTimeout = chrono::hours(24)) noexcept;
+    bool commit(const SQLiteNode& node, uint64_t& commitID, string& transactionHash, const string& commandName, bool needsPluginNotifiation, void (*notificationHandler)(SQLite& _db, int64_t tableID) = nullptr, chrono::microseconds commitLockTimeout = chrono::hours(24), atomic<bool>* abortPtr = nullptr) noexcept;
 
     // Roll back a transaction if we've decided not to commit it.
     void rollback(const string& commandName = "NONE");


### PR DESCRIPTION
### Details
Took a few iterations to get all the nuances for this correct.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/648226

### Tests
No new tests. This is very difficult to test.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
