### PR TITLE
Append the command to all log lines

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1615,9 +1615,7 @@ unique_ptr<BedrockCommand> BedrockServer::getCommandFromPlugins(unique_ptr<SQLit
 
 void BedrockServer::_reply(unique_ptr<BedrockCommand>& command)
 {
-    // Some callers reply to a command from outside the scope that originally set the log prefix for it (e.g. a
-    // completed-command drain loop), so re-assert it here to make sure the timing/reply logging below is tagged
-    // with the right command.
+    // Some control commands like Status go through a different flow where its SAUTOPREFIX scope has already closed, so we re-set it here so it handles those commands properly.
     SAUTOPREFIX(command->request);
 
     // Finalize timing info even for commands we won't respond to (this makes this data available in logs).

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1615,6 +1615,11 @@ unique_ptr<BedrockCommand> BedrockServer::getCommandFromPlugins(unique_ptr<SQLit
 
 void BedrockServer::_reply(unique_ptr<BedrockCommand>& command)
 {
+    // Some callers reply to a command from outside the scope that originally set the log prefix for it (e.g. a
+    // completed-command drain loop), so re-assert it here to make sure the timing/reply logging below is tagged
+    // with the right command.
+    SAUTOPREFIX(command->request);
+
     // Finalize timing info even for commands we won't respond to (this makes this data available in logs).
     command->finalizeTimingInfo();
 

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -88,7 +88,7 @@ static atomic<shared_ptr<const set<string>>> PARAMS_WHITELIST{
 
 string addLogParams(string&& message, const STable& params)
 {
-    // Every log line emitted while a command is in flight gets tagged with that command's name, unless the call
+    // Every log line emitted while a command is running gets tagged with that command's name, unless the call
     // site already passed its own `command` param (e.g. logging about a *different* command than the one
     // currently executing on this thread).
     const bool addCommand = !SThreadLogCommand.empty() && !params.count("command");

--- a/libstuff/SLog.cpp
+++ b/libstuff/SLog.cpp
@@ -88,7 +88,12 @@ static atomic<shared_ptr<const set<string>>> PARAMS_WHITELIST{
 
 string addLogParams(string&& message, const STable& params)
 {
-    if (params.empty()) {
+    // Every log line emitted while a command is in flight gets tagged with that command's name, unless the call
+    // site already passed its own `command` param (e.g. logging about a *different* command than the one
+    // currently executing on this thread).
+    const bool addCommand = !SThreadLogCommand.empty() && !params.count("command");
+
+    if (params.empty() && !addCommand) {
         return message;
     }
 
@@ -104,6 +109,10 @@ string addLogParams(string&& message, const STable& params)
             valueToLog = "<REDACTED>";
         }
         message += key + ": '" + valueToLog + "'";
+    }
+
+    if (addCommand) {
+        message += " command: '" + SThreadLogCommand + "'";
     }
 
     return message;

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -91,6 +91,7 @@
 thread_local string SThreadLogPrefix{"xxxxxx"};
 thread_local string SThreadLogParam{"we@dont.know"};
 thread_local string SThreadLogName;
+thread_local string SThreadLogCommand;
 thread_local bool isSyncThread;
 
 // We store the process name passed in `SInitialize` to use in logging.
@@ -302,6 +303,7 @@ void SFluentdLog(int priority, const char* typeTag, string&& message, const char
     record["source"] = "bedrock";
     record["request_id"] = SThreadLogPrefix;
     record["log_param"] = SThreadLogParam;
+    record["command"] = SThreadLogCommand;
     record["type_tag"] = typeTag;
     record["thread_name"] = SThreadLogName;
     record["file"] = file;
@@ -3365,15 +3367,20 @@ SAutoThreadPrefix::SAutoThreadPrefix(const SData& request)
     // Retain the old values
     oldPrefix = SThreadLogPrefix;
     oldLogParam = SThreadLogParam;
+    oldCommand = SThreadLogCommand;
     const string requestID = request.isSet("requestID") ? request["requestID"] : "xxxxxx";
     SThreadLogPrefix = requestID;
     SThreadLogParam = request.isSet("logParam") ? request["logParam"] : "we@dont.know";
+    SThreadLogCommand = request.methodLine;
 }
 
 SAutoThreadPrefix::SAutoThreadPrefix(const string& rID)
 {
+    // This overload is used for sub-scopes (e.g. an individual HTTPS transaction) that have their own request ID
+    // but aren't themselves a command, so we leave SThreadLogCommand as whatever the enclosing command set it to.
     oldPrefix = SThreadLogPrefix;
     oldLogParam = SThreadLogParam;
+    oldCommand = SThreadLogCommand;
     SThreadLogPrefix = rID.empty() ? "xxxxxx" : rID;
     SThreadLogParam = "we@dont.know";
 }
@@ -3382,6 +3389,7 @@ SAutoThreadPrefix::~SAutoThreadPrefix()
 {
     SThreadLogPrefix = move(oldPrefix);
     SThreadLogParam = move(oldLogParam);
+    SThreadLogCommand = move(oldCommand);
 }
 
 float SToFloat(const string& val)

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -338,7 +338,7 @@ extern thread_local string SThreadLogParam;
 extern thread_local string SThreadLogName;
 
 // The command currently being processed on this thread (methodLine of the request), if any. Read by
-// `addLogParams` so every log line emitted while a command is in flight automatically gets tagged with it.
+// `addLogParams` so every log line emitted while a command is running automatically gets tagged with it.
 extern thread_local string SThreadLogCommand;
 
 extern thread_local bool isSyncThread;

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -337,6 +337,10 @@ extern thread_local string SThreadLogPrefix;
 extern thread_local string SThreadLogParam;
 extern thread_local string SThreadLogName;
 
+// The command currently being processed on this thread (methodLine of the request), if any. Read by
+// `addLogParams` so every log line emitted while a command is in flight automatically gets tagged with it.
+extern thread_local string SThreadLogCommand;
+
 extern thread_local bool isSyncThread;
 
 // Thread-local log prefix
@@ -354,6 +358,7 @@ private:
     // Attributes
     string oldPrefix;
     string oldLogParam;
+    string oldCommand;
 };
 #define SAUTOPREFIX(_PREFIX_) SAutoThreadPrefix __SAUTOPREFIX ## __LINE__(_PREFIX_)
 


### PR DESCRIPTION
### Details

Needs https://github.com/Expensify/Salt/pull/16927 so command get parsed

### Fixed Issues
$https://github.com/Expensify/Expensify/issues/651951

### Tests
Run some commands, checked log lines had the command in it:
```
2026-07-01T11:12:37.354383+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'GetPersonalDetailsForEmails' clusterName: 'auth' headers: '[emailList: 'submita@submit.com' authToken: '<REDACTED>' shouldCheckIfKnownUser: '' idempotent: '1' logParam: 'submita@submit.com' urlToNewDot: 'https://dev.new.expensify.com:8082/' shouldReadUsingThreads: '1' shouldHandleOnyxUpdates: '1' isNewDotRequest: '1' clientUpdateID: '77329' isFromIntegrationServer: '' maxNumberOfUpdates: '500' commitCount: '41386' requestID: 'xmx4Kx' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '110000']'
2026-07-01T11:12:37.354429+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [dbug] Bedrock\Client - APC fetch host configs ~~ 0: 'auth'
2026-07-01T11:12:37.354467+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'auth']'
2026-07-01T11:12:37.354504+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] Bedrock\Client - Reusing socket ~~ host: 'auth' cluster: 'auth' pid: '1300'
2026-07-01T11:12:37.354653+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (BedrockServer.cpp:1582) getCommandFromPlugins [socket2] [dbug] Plugin Auth handling command GetPersonalDetailsForEmails ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.354685+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (BedrockServer.cpp:2506) buildCommandFromRequest [socket2] [dbug] Deserialized command GetPersonalDetailsForEmails ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.354734+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (SQLitePool.cpp:50) getIndex [socket2_cmd] [dbug] Returning existing DB handle ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.354758+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (BedrockCore.cpp:164) peekCommand [socket2_cmd] [dbug] Peeking at 'GetPersonalDetailsForEmails' ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.354771+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] BEGIN CONCURRENT ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.354783+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] PRAGMA query_only = true; ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.354798+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (AuthCommand.cpp:667) peekCommand [socket2_cmd] [dbug] Peeking at 'GetPersonalDetailsForEmails' ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.354854+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] SELECT a.email, nvps.name, nvps.value, a.validated, a.accountID, 0 AS definitelyKnown, GROUP_CONCAT(IIF(l.partnerUserID GLOB '*@expensify.sms', l.partnerUserID, NULL) ORDER BY l.created) AS phoneNumber FROM accounts a LEFT JOIN nameValuePairs nvps ON nvps.accountID = a.accountID AND SUBSTR(SUBSTR(a.email, INSTR(a.email, '@') + 1), INSTR(SUBSTR(a.email, INSTR(a.email, '@') + 1), '@') + 1) != 'expensify.anon' AND nvps.name IN ('expensify_personalDetails', 'timeZone') LEFT OUTER JOIN logins l ON nvps.accountID = l.accountID WHERE a.email IN ('submita@submit.com') GROUP BY a.email, nvps.name UNION ALL SELECT l.partnerUserID AS email, nvps.name, nvps.value, a.validated, a.accountID, 0 AS definitelyKnown, GROUP_CONCAT(IIF(l.partnerUserID GLOB '*@expensify.sms', l.partnerUserID, NULL) ORDER BY l.created) AS phoneNumber FROM logins l INNER JOIN accounts a ON a.accountID = l.accountID LEFT JOIN nameValuePairs nvps ON nvps.accountID = l.accountID AND SUBSTR(SUBSTR(a.email, INSTR(a.email, '@') + 1), INSTR(SUBSTR(a.email, INSTR(a.email, '@') + 1), '@') + 1) != 'expensify.anon' AND nvps.name IN ('expensify_personalDetails', 'timeZone') WHERE l.partnerUserID IN ('submita@submit.com') AND l.validatedDate IS NOT NULL GROUP BY l.partnerUserID, nvps.name; ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355206+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] SELECT email FROM accounts WHERE accountID = 0; ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355486+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (Bench.cpp:48) stop [socket2_cmd] [dbug] [timing] Account::getPersonalDetails batchCheckKnownUsers for 0 accountIDs took 0 ms. ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355511+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] SELECT accountID FROM nameValuePairs WHERE accountID IN (1851)   AND name = 'private_lockAccountDetails'   AND JSON_EXTRACT(value, '$.isLocked') = 1 ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355525+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] SELECT nvp.accountID FROM nameValuePairs AS nvp INNER JOIN accounts AS a ON a.accountID = nvp.accountID WHERE nvp.name = 'private_agentOwnerID'   AND nvp.accountID IN (1851)   AND a.closed IS NULL; ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355559+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (Account.cpp:782) getPersonalDetails [socket2_cmd] [info] Checking if closed for 1 accountIDs ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355592+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] SELECT accountID, created, closed FROM accounts WHERE accountID IN (1851) AND created != closed; ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355605+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (Bench.cpp:48) stop [socket2_cmd] [dbug] [timing] Account::getPersonalDetails for loop for 4 accounts took 0 ms. ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355614+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (BedrockCore.cpp:191) peekCommand [socket2_cmd] [dbug] Plugin 'Auth' peeked command 'GetPersonalDetailsForEmails' ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355632+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] ROLLBACK ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355646+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (SQLite.cpp:1222) logLastTransactionTiming [socket2_cmd] [info] Transaction rollback with 5 read queries attempted, 0 write queries attempted, 0 served from cache. ~~ beginElapsed: '0' command: 'GetPersonalDetailsForEmails' commitElapsed: '0' commitLockElapsed: '0' prepareElapsed: '0' readElapsed: '0' rollbackElapsed: '0' totalElapsed: '0' totalTransactionElapsed: '0' writeElapsed: '0'
2026-07-01T11:12:37.355654+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] PRAGMA query_only = false; ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355692+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (BedrockCommand.cpp:379) finalizeTimingInfo [socket2_cmd] [info] command 'GetPersonalDetailsForEmails' timing info (ms): prePeek:0 (count: 0), peek:0 (count:1), process:0 (count:0), postProcess:0 (count:0), total:1, unaccounted:0, blockingCommitThreadTime:0, exclusiveTransactionLockTime:0. Commit: worker:0, sync:0. Queue: worker:0, sync:0, blocking:0, pageLock:0, escalation:0. Blocking: prePeek:0, peek:0, process:0, postProcess:0, commit:0. Upstream: peek:0, process:0, total:0, unaccounted:0. ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355726+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (SQLitePool.cpp:90) returnToPool [socket2_cmd] [dbug] DB handle returned to pool. ~~ command: 'GetPersonalDetailsForEmails'
2026-07-01T11:12:37.355855+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] Bedrock\Client - Request finished ~~ host: 'auth' command: 'GetPersonalDetailsForEmails' jsonCode: '200 OK' duration: '2' net: '0.932' wait: '1.068' proc: '0' commitCount: '41386'
2026-07-01T11:12:37.355932+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] Auth - AuthRequest #6 ~~ command: 'GetPersonalDetailsForEmails' jsonCode: '200' size: '373' duration: '2ms' host: 'auth'
2026-07-01T11:12:37.355977+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] [MemoryUsage] Auth - Converting updates to Onyx format ~~ startMemoryUsage: '2,005,136' endMemoryUsage: '2,005,136' diff: '0'
2026-07-01T11:12:37.356019+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] [MemoryUsage] Auth - Queuing Pusher events ~~ startMemoryUsage: '2,005,136' endMemoryUsage: '2,005,136' diff: '0'
2026-07-01T11:12:37.360516+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] Found a deleted comment without any edit history ~~ reportActionID: '1068098334977320073' sequenceNumber: '1'
2026-07-01T11:12:37.362638+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [dbug] Auth - AuthRequest #7 command='GetAccountIDsByEmails'
2026-07-01T11:12:37.362653+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [hmmm] DEBUG is on and not in tests, using referer for Request::isIntegrationServer()
2026-07-01T11:12:37.362907+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] Bedrock\Client - Starting a request ~~ command: 'GetAccountIDsByEmails' clusterName: 'auth' headers: '[authToken: '<REDACTED>' emailList: 'submita@submit.com' idempotent: '' logParam: 'submita@submit.com' urlToNewDot: 'https://dev.new.expensify.com:8082/' shouldReadUsingThreads: '1' shouldHandleOnyxUpdates: '1' isNewDotRequest: '1' clientUpdateID: '77329' isFromIntegrationServer: '' maxNumberOfUpdates: '500' commitCount: '41386' requestID: 'xmx4Kx' lastIP: '10.2.2.1' writeConsistency: 'ASYNC' priority: '500' timeout: '110000']'
2026-07-01T11:12:37.362959+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [dbug] Bedrock\Client - APC fetch host configs ~~ 0: 'auth'
2026-07-01T11:12:37.362997+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] Bedrock\Client - Possible hosts ~~ nonBlacklistedHosts: '[0: 'auth']'
2026-07-01T11:12:37.363032+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] Bedrock\Client - Reusing socket ~~ host: 'auth' cluster: 'auth' pid: '1300'
2026-07-01T11:12:37.363332+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (BedrockServer.cpp:1582) getCommandFromPlugins [socket2] [dbug] Plugin Auth handling command GetAccountIDsByEmails ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363381+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (BedrockServer.cpp:2506) buildCommandFromRequest [socket2] [dbug] Deserialized command GetAccountIDsByEmails ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363446+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (SQLitePool.cpp:50) getIndex [socket2_cmd] [dbug] Returning existing DB handle ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363469+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (BedrockCore.cpp:164) peekCommand [socket2_cmd] [dbug] Peeking at 'GetAccountIDsByEmails' ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363484+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] BEGIN CONCURRENT ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363499+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] PRAGMA query_only = true; ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363510+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (AuthCommand.cpp:667) peekCommand [socket2_cmd] [dbug] Peeking at 'GetAccountIDsByEmails' ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363599+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (AuthToken.cpp:1419) checkRevoked [socket2_cmd] [info] Checking authToken validity for accountID=1851 / partnerID=83 / partnerUserID=expensify.cash-aff61f8d-153b-49af-8cc2-63dd5228a63b85f5a604-0979-61f0-52bb-b5e01de95d10 / isValidated=true / expiresAt=1782909326121349 / isPasswordless=true /  ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363612+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] SELECT value FROM nameValuePairs WHERE accountID=1851 AND name='private_minimumAuthTokenIssueTime'; ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363680+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] SELECT count(*) FROM logins WHERE accountID=1851 AND partnerID='83' AND partnerUserID='expensify.cash-aff61f8d-153b-49af-8cc2-63dd5228a63b85f5a604-0979-61f0-52bb-b5e01de95d10'; ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363712+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] SELECT email FROM accounts WHERE accountID = 1851; ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363743+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] SELECT validated FROM accounts WHERE accountID = 1851; ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363756+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] SELECT closed FROM accounts WHERE accountID = 1851; ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363797+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] SELECT email, accountID FROM accounts WHERE email IN ('submita@submit.com') ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363962+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (Bench.cpp:48) stop [socket2_cmd] [dbug] [timing] AuthCommand::addAuthResponseFields responseFields took 0 ms. ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363979+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (BedrockCore.cpp:191) peekCommand [socket2_cmd] [dbug] Plugin 'Auth' peeked command 'GetAccountIDsByEmails' ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.363992+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] ROLLBACK ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.364021+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (SQLite.cpp:1222) logLastTransactionTiming [socket2_cmd] [info] Transaction rollback with 8 read queries attempted, 0 write queries attempted, 2 served from cache. ~~ beginElapsed: '0' command: 'GetAccountIDsByEmails' commitElapsed: '0' commitLockElapsed: '0' prepareElapsed: '0' readElapsed: '0' rollbackElapsed: '0' totalElapsed: '0' totalTransactionElapsed: '0' writeElapsed: '0'
2026-07-01T11:12:37.364034+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (libstuff.cpp:2827) SQuery [socket2_cmd] [dbug] PRAGMA query_only = false; ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.364047+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (BedrockCommand.cpp:379) finalizeTimingInfo [socket2_cmd] [info] command 'GetAccountIDsByEmails' timing info (ms): prePeek:0 (count: 0), peek:0 (count:1), process:0 (count:0), postProcess:0 (count:0), total:0, unaccounted:0, blockingCommitThreadTime:0, exclusiveTransactionLockTime:0. Commit: worker:0, sync:0. Queue: worker:0, sync:0, blocking:0, pageLock:0, escalation:0. Blocking: prePeek:0, peek:0, process:0, postProcess:0, commit:0. Upstream: peek:0, process:0, total:0, unaccounted:0. ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.364094+00:00 expensidev-2404 bedrock: xmx4Kx submita@submit.com (SQLitePool.cpp:90) returnToPool [socket2_cmd] [dbug] DB handle returned to pool. ~~ command: 'GetAccountIDsByEmails'
2026-07-01T11:12:37.364206+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] Bedrock\Client - Request finished ~~ host: 'auth' command: 'GetAccountIDsByEmails' jsonCode: '200 OK' duration: '1' net: '0.099' wait: '0.901' proc: '0' commitCount: '41386'
2026-07-01T11:12:37.364304+00:00 expensidev-2404 php-fpm: xmx4Kx /api.php submita@submit.com !ecash9.4.25-1! ?api? [info] Auth - AuthRequest #7 ~~ command: 'GetAccountIDsByEmails' jsonCode: '200' size: '1,013' duration: '2ms' host: 'auth'
```

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
