### PR TITLE
Fix read/write timings in case a query is interrupted

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -624,8 +624,8 @@ int SQLite::read(const string& query, const map<string, Parameter>& params, sqli
     uint64_t before = STimeNow();
     SQResult ignore;
     int queryResult = SQuery(_db, query, ignore, 0, true, spec, params);
-    _checkInterruptErrors("SQLite::read"s);
     _readElapsed += STimeNow() - before;
+    _checkInterruptErrors("SQLite::read"s);
     return queryResult;
 }
 
@@ -653,8 +653,8 @@ bool SQLite::read(const string& query, const map<string, Parameter>& params, SQR
             _queryCache.emplace(make_pair(query, result));
         }
     }
-    _checkInterruptErrors("SQLite::read"s);
     _readElapsed += STimeNow() - before;
+    _checkInterruptErrors("SQLite::read"s);
     return queryResult;
 }
 
@@ -810,8 +810,8 @@ bool SQLite::_writeIdempotent(const string& query, const map<string, Parameter>&
         throw constraint_error();
     }
 
-    _checkInterruptErrors("SQLite::write"s);
     _writeElapsed += STimeNow() - before;
+    _checkInterruptErrors("SQLite::write"s);
     if (resultCode) {
         _currentlyWriting = false;
         return false;


### PR DESCRIPTION
### Details

This PR moves the timing collection one line above `_checkInterruptErrors`. That function could throw, and if it did, we would not collect the timings spent on those queries in the final timing log

### Fixed Issues
https://github.com/Expensify/Expensify/issues/655406

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
