### PR TITLE
Include request origin in Unique Constraints Violation log

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -337,7 +337,10 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
         needsCommit = false;
         command->_inDBWriteOperation = false;
     } catch (const SQLite::constraint_error& e) {
-        SWARN("Unique Constraints Violation, command: " << request.methodLine);
+        // Include the client-reported origin (e.g. '/api.php', '/partners/mailgun/api.php') so log alerting can
+        // group these violations into separate issues per entry point.
+        const string& requestOrigin = request["requestOrigin"];
+        SWARN("Unique Constraints Violation, command: " << request.methodLine << ", origin: " << (requestOrigin.empty() ? "unknown" : requestOrigin));
         command->response.methodLine = "400 Unique Constraints Violation";
         _db.rollback(command->getMethodName());
         needsCommit = false;

--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -337,10 +337,16 @@ BedrockCore::RESULT BedrockCore::processCommand(unique_ptr<BedrockCommand>& comm
         needsCommit = false;
         command->_inDBWriteOperation = false;
     } catch (const SQLite::constraint_error& e) {
-        // Include the client-reported origin (e.g. '/api.php', '/partners/mailgun/api.php') so log alerting can
-        // group these violations into separate issues per entry point.
-        const string& requestOrigin = request["requestOrigin"];
-        SWARN("Unique Constraints Violation, command: " << request.methodLine << ", origin: " << (requestOrigin.empty() ? "unknown" : requestOrigin));
+        // For whitelisted commands, include the client-reported origin (e.g. '/api.php',
+        // '/partners/mailgun/api.php') so log alerting can group these violations into separate issues per
+        // entry point.
+        static const set<string> commandsLoggingOrigin = {"TrackExpense"};
+        string originSuffix;
+        if (commandsLoggingOrigin.count(command->getMethodName())) {
+            const string& requestOrigin = request["requestOrigin"];
+            originSuffix = ", origin: " + (requestOrigin.empty() ? "unknown"s : requestOrigin);
+        }
+        SWARN("Unique Constraints Violation, command: " << request.methodLine << originSuffix);
         command->response.methodLine = "400 Unique Constraints Violation";
         _db.rollback(command->getMethodName());
         needsCommit = false;


### PR DESCRIPTION
### Details

The `Unique Constraints Violation, command: <command>` warning in `BedrockCore::processCommand` is emitted for every un-pre-checked SQLite `constraint_error`, regardless of where the request came from. For `TrackExpense` this currently mixes two unrelated failure modes into a single BugBot issue:

- Mailgun forwarded-receipt races (`/partners/mailgun/api.php`, failing on `transactions.transactionHash`)
- App SequentialQueue retries (`/api.php`, failing on `reportActions.reportActionID`)

This PR appends the client-reported `requestOrigin` header to the warning for whitelisted commands (only `TrackExpense` for now, so other commands keep their existing log signature until intentionally opted in), so it becomes e.g.:

```
Unique Constraints Violation, command: TrackExpense, origin: /partners/mailgun/api.php
```

BugBot hashes the full message, so each origin gets its own UUID and Melvin creates separate issues per entry point. When the header is absent (Auth-internal commands, older callers), the origin logs as `unknown`. Non-whitelisted commands log the unchanged message.

The companion Web-Expensify PR (https://github.com/Expensify/Web-Expensify/pull/54189) adds the `requestOrigin` header to every auth request in `Auth::call`. The two PRs are deploy-order independent: Bedrock alone logs `origin: unknown`, PHP alone sends a header nobody reads.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/600441

### Tests

- Syntax-checked the translation unit: `clang++ -std=c++20 -fsyntax-only BedrockCore.cpp` passes.
- No header/interface changes, only the log statement inside the existing `catch (const SQLite::constraint_error&)` block, so Auth compiles against this unchanged.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
