### PR TITLE
Revert "start transaction in prePeek and postProcess too to benefit from cache"

### DIFF
--- a/BedrockCore.cpp
+++ b/BedrockCore.cpp
@@ -100,10 +100,6 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlo
             _db.setTimeout(getRemainingTime(command, false));
             _db.setAbortRef(command->shouldAbort);
 
-            if (!_db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED)) {
-                STHROW("501 Failed to begin shared transaction");
-            }
-
             // Make sure no writes happen while in prePeek command
             _db.setQueryOnly(true);
 
@@ -143,7 +139,6 @@ void BedrockCore::prePeekCommand(unique_ptr<BedrockCommand>& command, bool isBlo
         command->complete = true;
         command->_inDBReadOperation = false;
     }
-    _db.rollback(command->getMethodName());
     _db.clearTimeout();
     _db.clearAbortRef();
 
@@ -381,10 +376,6 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool i
             _db.setTimeout(getRemainingTime(command, false));
             _db.setAbortRef(command->shouldAbort);
 
-            if (!_db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED)) {
-                STHROW("501 Failed to begin shared transaction");
-            }
-
             // Make sure no writes happen while in postProcess command
             _db.setQueryOnly(true);
 
@@ -426,7 +417,6 @@ void BedrockCore::postProcessCommand(unique_ptr<BedrockCommand>& command, bool i
 
     // The command is complete.
     command->complete = true;
-    _db.rollback(command->getMethodName());
     _db.clearTimeout();
     _db.clearAbortRef();
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -441,6 +441,11 @@ void BedrockServer::sync()
             // Record the time spent.
             command->stopTiming(BedrockCommand::COMMIT_SYNC);
 
+            if (command->shouldPostProcess() && command->response.methodLine == "200 OK") {
+                // PostProcess if the command should run postProcess, and there have been no errors thrown thus far.
+                core.postProcessCommand(command, false);
+            }
+
             if (_syncNode->commitSucceeded()) {
                 SINFO("Sync thread finished committing command " << command->request.methodLine);
                 _conflictManager.recordTables(command->request.methodLine, db.getTablesUsed());
@@ -448,6 +453,7 @@ void BedrockServer::sync()
                 // Otherwise, save the commit count, mark this command as complete, and reply.
                 command->response["commitCount"] = to_string(db.getCommitCount());
                 command->complete = true;
+                _reply(command);
             } else {
                 // This should only happen if the cluster becomes largely disconnected while we were in the process of
                 // committing a QUORUM command - if we no longer have enough peers to reach QUORUM, we'll fall out of
@@ -459,16 +465,6 @@ void BedrockServer::sync()
                       << " after failed sync commit. Sync thread has " << _syncNodeQueuedCommands.size()
                       << " queued commands.");
                 _syncNodeQueuedCommands.push(move(command));
-            }
-
-            // If the command was completed above, then we'll go ahead and respond.
-            if (command->complete) {
-                if (command->shouldPostProcess() && command->response.methodLine == "200 OK") {
-                    // PostProcess if the command should run postProcess, and there have been no errors thrown thus far.
-                    core.postProcessCommand(command, false);
-                }
-
-                _reply(command);
             }
         }
 


### PR DESCRIPTION
Reverts Expensify/Bedrock#2642

We're investigating if this change is contributing to recent performance degradation, so we're reverting it for now.