### PR TITLE
Log transaction timings for standalone queries.

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -596,12 +596,12 @@ bool SQLite::addColumn(const string& tableName, const string& column, const stri
     return false;
 }
 
-string SQLite::read(const string& query) const
+string SQLite::read(const string& query)
 {
     return read(query, map<string, Parameter>{});
 }
 
-string SQLite::read(const string& query, const map<string, Parameter>& params) const
+string SQLite::read(const string& query, const map<string, Parameter>& params)
 {
     SQResult result;
     if (!read(query, params, result)) {
@@ -613,12 +613,12 @@ string SQLite::read(const string& query, const map<string, Parameter>& params) c
     return result[0][0];
 }
 
-int SQLite::read(const string& query, sqlite3_qrf_spec* spec) const
+int SQLite::read(const string& query, sqlite3_qrf_spec* spec)
 {
     return read(query, {}, spec);
 }
 
-int SQLite::read(const string& query, const map<string, Parameter>& params, sqlite3_qrf_spec* spec) const
+int SQLite::read(const string& query, const map<string, Parameter>& params, sqlite3_qrf_spec* spec) 
 {
     // Execute the read-only query. Skips caching.
     uint64_t before = STimeNow();
@@ -629,12 +629,12 @@ int SQLite::read(const string& query, const map<string, Parameter>& params, sqli
     return queryResult;
 }
 
-bool SQLite::read(const string& query, SQResult& result, bool skipInfoWarn) const
+bool SQLite::read(const string& query, SQResult& result, bool skipInfoWarn)
 {
     return read(query, {}, result, skipInfoWarn);
 }
 
-bool SQLite::read(const string& query, const map<string, Parameter>& params, SQResult& result, bool skipInfoWarn) const
+bool SQLite::read(const string& query, const map<string, Parameter>& params, SQResult& result, bool skipInfoWarn)
 {
     uint64_t before = STimeNow();
     bool queryResult = false;
@@ -648,7 +648,18 @@ bool SQLite::read(const string& query, const map<string, Parameter>& params, SQR
         queryResult = true;
     } else {
         _isDeterministicQuery = true;
+        // If we're not inside a transaction, let's start one so we know exaclty how long we're holding transactions for.
+        // SQLite will automatically start a transaction if we don't do so, and by doing so, it will also continue to hold
+        // WAL files. So let's keep control of our transactions, and log when we roll it back so we can actually see the
+        // impact those queries are doing.
+        bool shouldBeginTransaction = !_insideTransaction;
+        if(shouldBeginTransaction) {
+            beginTransaction();
+        }
         queryResult = !SQuery(_db, query, result, 2000 * STIME_US_PER_MS, skipInfoWarn, nullptr, params);
+        if(shouldBeginTransaction) {
+            rollback();
+        }
         if (params.empty() && _isDeterministicQuery && queryResult && insideTransaction()) {
             _queryCache.emplace(make_pair(query, result));
         }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -596,12 +596,12 @@ bool SQLite::addColumn(const string& tableName, const string& column, const stri
     return false;
 }
 
-string SQLite::read(const string& query)
+string SQLite::read(const string& query) const
 {
     return read(query, map<string, Parameter>{});
 }
 
-string SQLite::read(const string& query, const map<string, Parameter>& params)
+string SQLite::read(const string& query, const map<string, Parameter>& params) const
 {
     SQResult result;
     if (!read(query, params, result)) {
@@ -613,12 +613,12 @@ string SQLite::read(const string& query, const map<string, Parameter>& params)
     return result[0][0];
 }
 
-int SQLite::read(const string& query, sqlite3_qrf_spec* spec)
+int SQLite::read(const string& query, sqlite3_qrf_spec* spec) const
 {
     return read(query, {}, spec);
 }
 
-int SQLite::read(const string& query, const map<string, Parameter>& params, sqlite3_qrf_spec* spec) 
+int SQLite::read(const string& query, const map<string, Parameter>& params, sqlite3_qrf_spec* spec) const
 {
     // Execute the read-only query. Skips caching.
     uint64_t before = STimeNow();
@@ -629,12 +629,12 @@ int SQLite::read(const string& query, const map<string, Parameter>& params, sqli
     return queryResult;
 }
 
-bool SQLite::read(const string& query, SQResult& result, bool skipInfoWarn)
+bool SQLite::read(const string& query, SQResult& result, bool skipInfoWarn) const
 {
     return read(query, {}, result, skipInfoWarn);
 }
 
-bool SQLite::read(const string& query, const map<string, Parameter>& params, SQResult& result, bool skipInfoWarn)
+bool SQLite::read(const string& query, const map<string, Parameter>& params, SQResult& result, bool skipInfoWarn) const
 {
     uint64_t before = STimeNow();
     bool queryResult = false;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -640,15 +640,6 @@ bool SQLite::read(const string& query, const map<string, Parameter>& params, SQR
     bool queryResult = false;
     _readQueryCount++;
 
-    // If we're not inside a transaction, let's start one so we know exaclty how long we're holding transactions for.
-    // SQLite will automatically start a transaction if we don't do so, and by doing so, it will also continue to hold
-    // WAL files. So let's keep control of our transactions, and log when we roll it back so we can actually see the
-    // impact those queries are doing.
-    bool shouldBeginTransaction = !_insideTransaction;
-    if(shouldBeginTransaction) {
-        beginTransaction();
-    }
-
     // The query cache is keyed on SQL text only — different bound-parameter values for the same SQL would
     // share a cache entry. Skip the cache entirely when params are present.
     auto foundQuery = params.empty() ? _queryCache.find(query) : _queryCache.end();
@@ -663,9 +654,15 @@ bool SQLite::read(const string& query, const map<string, Parameter>& params, SQR
             _queryCache.emplace(make_pair(query, result));
         }
     }
-    _readElapsed += STimeNow() - before;
-    if(shouldBeginTransaction) {
-        rollback();
+    uint64_t timeSpent = STimeNow() - before;
+    _readElapsed += timeSpent;
+
+    // If we're not inside a transaction, SQLite will automatically start a transaction when we execute the read,
+    // and it will also hold the WAL files with those. Let's add a specific log line for this case.
+    if(!_insideTransaction) {
+        SINFO("Read with auto-transaction timing info", {
+            {"totalTransactionElapsed", to_string(timeSpent / 1000)},
+        });
     }
     _checkInterruptErrors("SQLite::read"s);
     return queryResult;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -657,8 +657,7 @@ bool SQLite::read(const string& query, const map<string, Parameter>& params, SQR
     uint64_t timeSpent = STimeNow() - before;
     _readElapsed += timeSpent;
 
-    // If we're not inside a transaction, SQLite will automatically start a transaction when we execute the read,
-    // and it will also hold the WAL files with those. Let's add a specific log line for this case.
+    // If we're not inside a transaction, this doesn't get added to our normal transaction timing.
     if (!_insideTransaction) {
         SINFO("Read with auto-transaction timing info", {
             {"totalTransactionElapsed", to_string(timeSpent / 1000)},

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -659,7 +659,7 @@ bool SQLite::read(const string& query, const map<string, Parameter>& params, SQR
 
     // If we're not inside a transaction, SQLite will automatically start a transaction when we execute the read,
     // and it will also hold the WAL files with those. Let's add a specific log line for this case.
-    if(!_insideTransaction) {
+    if (!_insideTransaction) {
         SINFO("Read with auto-transaction timing info", {
             {"totalTransactionElapsed", to_string(timeSpent / 1000)},
         });

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -639,6 +639,16 @@ bool SQLite::read(const string& query, const map<string, Parameter>& params, SQR
     uint64_t before = STimeNow();
     bool queryResult = false;
     _readQueryCount++;
+
+    // If we're not inside a transaction, let's start one so we know exaclty how long we're holding transactions for.
+    // SQLite will automatically start a transaction if we don't do so, and by doing so, it will also continue to hold
+    // WAL files. So let's keep control of our transactions, and log when we roll it back so we can actually see the
+    // impact those queries are doing.
+    bool shouldBeginTransaction = !_insideTransaction;
+    if(shouldBeginTransaction) {
+        beginTransaction();
+    }
+
     // The query cache is keyed on SQL text only — different bound-parameter values for the same SQL would
     // share a cache entry. Skip the cache entirely when params are present.
     auto foundQuery = params.empty() ? _queryCache.find(query) : _queryCache.end();
@@ -648,23 +658,15 @@ bool SQLite::read(const string& query, const map<string, Parameter>& params, SQR
         queryResult = true;
     } else {
         _isDeterministicQuery = true;
-        // If we're not inside a transaction, let's start one so we know exaclty how long we're holding transactions for.
-        // SQLite will automatically start a transaction if we don't do so, and by doing so, it will also continue to hold
-        // WAL files. So let's keep control of our transactions, and log when we roll it back so we can actually see the
-        // impact those queries are doing.
-        bool shouldBeginTransaction = !_insideTransaction;
-        if(shouldBeginTransaction) {
-            beginTransaction();
-        }
         queryResult = !SQuery(_db, query, result, 2000 * STIME_US_PER_MS, skipInfoWarn, nullptr, params);
-        if(shouldBeginTransaction) {
-            rollback();
-        }
         if (params.empty() && _isDeterministicQuery && queryResult && insideTransaction()) {
             _queryCache.emplace(make_pair(query, result));
         }
     }
     _readElapsed += STimeNow() - before;
+    if(shouldBeginTransaction) {
+        rollback();
+    }
     _checkInterruptErrors("SQLite::read"s);
     return queryResult;
 }

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -99,16 +99,16 @@ public:
 
     // Performs a read-only query (eg, SELECT). This can be done inside or outside a transaction. Returns true on
     // success, and fills the 'result' with the result of the query.
-    virtual bool read(const string& query, SQResult& result, bool skipInfoWarn = false) const;
-    virtual bool read(const string& query, const map<string, Parameter>& params, SQResult& result, bool skipInfoWarn = false) const;
+    virtual bool read(const string& query, SQResult& result, bool skipInfoWarn = false);
+    virtual bool read(const string& query, const map<string, Parameter>& params, SQResult& result, bool skipInfoWarn = false);
 
     // Performs a read-only query (eg, SELECT) that returns a single value.
-    virtual string read(const string& query) const;
-    virtual string read(const string& query, const map<string, Parameter>& params) const;
+    virtual string read(const string& query);
+    virtual string read(const string& query, const map<string, Parameter>& params);
 
     // Performs a read-only query (eg, SELECT) that uses a query result formatter to format the response.
-    virtual int read(const string& query, sqlite3_qrf_spec* spec) const;
-    virtual int read(const string& query, const map<string, Parameter>& params, sqlite3_qrf_spec* spec) const;
+    virtual int read(const string& query, sqlite3_qrf_spec* spec);
+    virtual int read(const string& query, const map<string, Parameter>& params, sqlite3_qrf_spec* spec);
 
     // Types of transactions that we can begin.
     enum class TRANSACTION_TYPE

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -99,16 +99,16 @@ public:
 
     // Performs a read-only query (eg, SELECT). This can be done inside or outside a transaction. Returns true on
     // success, and fills the 'result' with the result of the query.
-    virtual bool read(const string& query, SQResult& result, bool skipInfoWarn = false);
-    virtual bool read(const string& query, const map<string, Parameter>& params, SQResult& result, bool skipInfoWarn = false);
+    virtual bool read(const string& query, SQResult& result, bool skipInfoWarn = false) const; 
+    virtual bool read(const string& query, const map<string, Parameter>& params, SQResult& result, bool skipInfoWarn = false) const;
 
     // Performs a read-only query (eg, SELECT) that returns a single value.
-    virtual string read(const string& query);
-    virtual string read(const string& query, const map<string, Parameter>& params);
+    virtual string read(const string& query) const;
+    virtual string read(const string& query, const map<string, Parameter>& params) const;
 
     // Performs a read-only query (eg, SELECT) that uses a query result formatter to format the response.
-    virtual int read(const string& query, sqlite3_qrf_spec* spec);
-    virtual int read(const string& query, const map<string, Parameter>& params, sqlite3_qrf_spec* spec);
+    virtual int read(const string& query, sqlite3_qrf_spec* spec) const;
+    virtual int read(const string& query, const map<string, Parameter>& params, sqlite3_qrf_spec* spec) const;
 
     // Types of transactions that we can begin.
     enum class TRANSACTION_TYPE

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -99,7 +99,7 @@ public:
 
     // Performs a read-only query (eg, SELECT). This can be done inside or outside a transaction. Returns true on
     // success, and fills the 'result' with the result of the query.
-    virtual bool read(const string& query, SQResult& result, bool skipInfoWarn = false) const; 
+    virtual bool read(const string& query, SQResult& result, bool skipInfoWarn = false) const;
     virtual bool read(const string& query, const map<string, Parameter>& params, SQResult& result, bool skipInfoWarn = false) const;
 
     // Performs a read-only query (eg, SELECT) that returns a single value.


### PR DESCRIPTION
### Details

When we have a rolled back command, all read queries for it still hold a transaction for the duration of the read, but we don't really log those. 

This PR will log the transaction held time when we don't have a transaction.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/655406

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
