### PR TITLE
Add a Bedrock job blacklist (CrashBedrockJob) to disable individual jobs without stopping BWM

### DIFF
--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "BedrockCommand.h"
 class BedrockServer;
+class SQLitePeer;
 
 // Simple plugin system to add functionality to a node at runtime.
 class BedrockPlugin {
@@ -91,6 +92,12 @@ public:
 
     // Called when a node changes state
     virtual void stateChanged(SQLite& db, SQLiteNodeState newState)
+    {
+    }
+
+    // Called when a peer node logs in, so a plugin can send it any state it needs to replicate (e.g. in-memory data
+    // that isn't stored in the database).
+    virtual void onNodeLogin(SQLitePeer* peer)
     {
     }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1846,6 +1846,13 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command)
             content["crashCommandList"] = SComposeJSONArray(crashCommandListArray);
         }
 
+        {
+            // Make it known which bedrock jobs are blacklisted from running.
+            shared_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
+            content["crashedBedrockJobs"] = _crashedBedrockJobPatterns.size();
+            content["crashedBedrockJobList"] = SComposeJSONArray(vector<string>(_crashedBedrockJobPatterns.begin(), _crashedBedrockJobPatterns.end()));
+        }
+
         for (auto& p : _blockingCommandQueue.getState()) {
             content[p.first] = p.second;
         }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1959,6 +1959,8 @@ bool BedrockServer::_isControlCommand(const unique_ptr<BedrockCommand>& command)
         SIEquals(command->request.methodLine, "SetBlockingQueueTimeRateLimit") ||
         SIEquals(command->request.methodLine, "ClearBlockingQueue") ||
         SIEquals(command->request.methodLine, "SetPriority") ||
+        SIEquals(command->request.methodLine, "CrashBedrockJob") ||
+        SIEquals(command->request.methodLine, "ClearCrashedBedrockJobs") ||
         SIEquals(command->request.methodLine, "CRASH_COMMAND")
     ) {
         return true;
@@ -2054,6 +2056,20 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
             totalCount += s.second.size();
         }
         SALERT("Blacklisting command (now have " << totalCount << " blacklisted commands): " << request.serialize());
+    } else if (SIEquals(command->request.methodLine, "CrashBedrockJob")) {
+        const list<string> names = SParseList(command->request["names"]);
+        if (names.empty()) {
+            SINFO("Got CrashBedrockJob with no 'names'. Nothing to blacklist.");
+            return;
+        }
+        unique_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
+        for (const auto& name : names) {
+            _crashedBedrockJobPatterns.insert(name);
+        }
+        SALERT("Blacklisting bedrock jobs (now have " << _crashedBedrockJobPatterns.size() << " patterns): " << SComposeList(names));
+    } else if (SIEquals(command->request.methodLine, "ClearCrashedBedrockJobs")) {
+        unique_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
+        _crashedBedrockJobPatterns.clear();
     } else if (SIEquals(command->request.methodLine, "ClearBlockingQueue")) {
         auto commands = _blockingCommandQueue.getAll();
         list<string> methodLines;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1975,6 +1975,8 @@ bool BedrockServer::_isNonSecureControlCommand(const unique_ptr<BedrockCommand>&
     // sent from other nodes on the private command port.
     return SIEquals(command->request.methodLine, "SuppressCommandPort") ||
            SIEquals(command->request.methodLine, "ClearCommandPort") ||
+           SIEquals(command->request.methodLine, "CrashBedrockJob") ||
+           SIEquals(command->request.methodLine, "ClearCrashedBedrockJobs") ||
            SIEquals(command->request.methodLine, "CRASH_COMMAND");
 }
 
@@ -2062,14 +2064,28 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
             SINFO("Got CrashBedrockJob with no 'names'. Nothing to blacklist.");
             return;
         }
-        unique_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
-        for (const auto& name : names) {
-            _crashedBedrockJobPatterns.insert(name);
+        {
+            unique_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
+            for (const auto& name : names) {
+                _crashedBedrockJobPatterns.insert(name);
+            }
+            SALERT("Blacklisting bedrock jobs (now have " << _crashedBedrockJobPatterns.size() << " patterns): " << SComposeList(names));
         }
-        SALERT("Blacklisting bedrock jobs (now have " << _crashedBedrockJobPatterns.size() << " patterns): " << SComposeList(names));
+
+        // If this originated locally (from an operator on this node), propagate it to the rest of the cluster so a new
+        // leader still enforces the blacklist after a failover. Commands arriving from a peer have a non-empty _source,
+        // so they update this node only and don't re-broadcast, which prevents an infinite broadcast loop.
+        if (command->request["_source"].empty()) {
+            broadcastCommand(command->request);
+        }
     } else if (SIEquals(command->request.methodLine, "ClearCrashedBedrockJobs")) {
-        unique_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
-        _crashedBedrockJobPatterns.clear();
+        {
+            unique_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
+            _crashedBedrockJobPatterns.clear();
+        }
+        if (command->request["_source"].empty()) {
+            broadcastCommand(command->request);
+        }
     } else if (SIEquals(command->request.methodLine, "ClearBlockingQueue")) {
         auto commands = _blockingCommandQueue.getAll();
         list<string> methodLines;
@@ -2335,6 +2351,27 @@ void BedrockServer::onNodeLogin(SQLitePeer* peer)
         if (_clusterMessengerCopy) {
             thread([command = move(peerCommand), _clusterMessengerCopy, peerName]() {
                 _clusterMessengerCopy->runOnPeer(*command, peerName);
+            }).detach();
+        }
+    }
+
+    // Send the bedrock job blacklist to the newly logged-in peer so it enforces the same patterns if it becomes leader.
+    list<string> jobPatterns;
+    {
+        shared_lock<decltype(_crashedBedrockJobPatternMutex)> jobLock(_crashedBedrockJobPatternMutex);
+        jobPatterns.assign(_crashedBedrockJobPatterns.begin(), _crashedBedrockJobPatterns.end());
+    }
+    if (!jobPatterns.empty()) {
+        SALERT("Sending " << jobPatterns.size() << " blacklisted bedrock job patterns to node " << peer->name << " on login");
+        SData crashJobCommand("CrashBedrockJob");
+        crashJobCommand["names"] = SComposeList(jobPatterns);
+        crashJobCommand["timeout"] = "5000";
+        auto _clusterMessengerCopy = _clusterMessenger;
+        auto peerName = peer->name;
+        if (_clusterMessengerCopy) {
+            thread([command = move(crashJobCommand), _clusterMessengerCopy, peerName]() {
+                BedrockCommand cmd(SQLiteCommand(SData(command)), nullptr);
+                _clusterMessengerCopy->runOnPeer(cmd, peerName);
             }).detach();
         }
     }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2389,6 +2389,11 @@ void BedrockServer::onNodeLogin(SQLitePeer* peer)
             }).detach();
         }
     }
+
+    // Let each plugin send the joining peer any of its own state that needs to replicate.
+    for (auto& p : plugins) {
+        p.second->onNodeLogin(peer);
+    }
 }
 
 void BedrockServer::_acceptSockets()

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1982,8 +1982,6 @@ bool BedrockServer::_isNonSecureControlCommand(const unique_ptr<BedrockCommand>&
     // sent from other nodes on the private command port.
     return SIEquals(command->request.methodLine, "SuppressCommandPort") ||
            SIEquals(command->request.methodLine, "ClearCommandPort") ||
-           SIEquals(command->request.methodLine, "CrashBedrockJob") ||
-           SIEquals(command->request.methodLine, "ClearCrashedBedrockJobs") ||
            SIEquals(command->request.methodLine, "CRASH_COMMAND");
 }
 
@@ -2078,21 +2076,13 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
             }
             SALERT("Blacklisting bedrock jobs (now have " << _crashedBedrockJobPatterns.size() << " patterns): " << SComposeList(names));
         }
-
-        // If this originated locally (from an operator on this node), propagate it to the rest of the cluster so a new
-        // leader still enforces the blacklist after a failover. Commands arriving from a peer have a non-empty _source,
-        // so they update this node only and don't re-broadcast, which prevents an infinite broadcast loop.
-        if (command->request["_source"].empty()) {
-            broadcastCommand(command->request);
-        }
+        _propagateBedrockJobBlacklistCommand(command->request);
     } else if (SIEquals(command->request.methodLine, "ClearCrashedBedrockJobs")) {
         {
             unique_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
             _crashedBedrockJobPatterns.clear();
         }
-        if (command->request["_source"].empty()) {
-            broadcastCommand(command->request);
-        }
+        _propagateBedrockJobBlacklistCommand(command->request);
     } else if (SIEquals(command->request.methodLine, "ClearBlockingQueue")) {
         auto commands = _blockingCommandQueue.getAll();
         list<string> methodLines;
@@ -2302,6 +2292,20 @@ set<string> BedrockServer::getCrashedBedrockJobPatterns()
     return _crashedBedrockJobPatterns;
 }
 
+void BedrockServer::_propagateBedrockJobBlacklistCommand(const SData& request)
+{
+    // Propagate a locally-originated blacklist change to the rest of the cluster so a new leader still enforces it
+    // after a failover. Every intra-cluster command arrives via the private command port with an empty _source, so
+    // _source can't distinguish a local command from a propagated one; instead we tag propagated commands with
+    // "isPropagated" and skip re-broadcasting those, which prevents an infinite broadcast loop between peers.
+    if (request.isSet("isPropagated")) {
+        return;
+    }
+    SData propagated = request;
+    propagated["isPropagated"] = "true";
+    broadcastCommand(propagated);
+}
+
 SData BedrockServer::_generateCrashMessage(const unique_ptr<BedrockCommand>& command)
 {
     SHMMM("Generating CRASH_COMMAND command for " << command->request.methodLine);
@@ -2373,6 +2377,9 @@ void BedrockServer::onNodeLogin(SQLitePeer* peer)
         SData crashJobCommand("CrashBedrockJob");
         crashJobCommand["names"] = SComposeList(jobPatterns);
         crashJobCommand["timeout"] = "5000";
+
+        // Tag as propagated so the joining peer stores it locally without re-broadcasting to the whole cluster.
+        crashJobCommand["isPropagated"] = "true";
         auto _clusterMessengerCopy = _clusterMessenger;
         auto peerName = peer->name;
         if (_clusterMessengerCopy) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2257,6 +2257,12 @@ bool BedrockServer::shouldBackup()
     return _shouldBackup;
 }
 
+set<string> BedrockServer::getCrashedBedrockJobPatterns()
+{
+    shared_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
+    return _crashedBedrockJobPatterns;
+}
+
 SData BedrockServer::_generateCrashMessage(const unique_ptr<BedrockCommand>& command)
 {
     SHMMM("Generating CRASH_COMMAND command for " << command->request.methodLine);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1846,13 +1846,6 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command)
             content["crashCommandList"] = SComposeJSONArray(crashCommandListArray);
         }
 
-        {
-            // Make it known which bedrock jobs are blacklisted from running.
-            shared_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
-            content["crashedBedrockJobs"] = _crashedBedrockJobPatterns.size();
-            content["crashedBedrockJobList"] = SComposeJSONArray(vector<string>(_crashedBedrockJobPatterns.begin(), _crashedBedrockJobPatterns.end()));
-        }
-
         for (auto& p : _blockingCommandQueue.getState()) {
             content[p.first] = p.second;
         }
@@ -1966,8 +1959,6 @@ bool BedrockServer::_isControlCommand(const unique_ptr<BedrockCommand>& command)
         SIEquals(command->request.methodLine, "SetBlockingQueueTimeRateLimit") ||
         SIEquals(command->request.methodLine, "ClearBlockingQueue") ||
         SIEquals(command->request.methodLine, "SetPriority") ||
-        SIEquals(command->request.methodLine, "CrashBedrockJob") ||
-        SIEquals(command->request.methodLine, "ClearCrashedBedrockJobs") ||
         SIEquals(command->request.methodLine, "CRASH_COMMAND")
     ) {
         return true;
@@ -2063,26 +2054,6 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
             totalCount += s.second.size();
         }
         SALERT("Blacklisting command (now have " << totalCount << " blacklisted commands): " << request.serialize());
-    } else if (SIEquals(command->request.methodLine, "CrashBedrockJob")) {
-        const list<string> names = SParseList(command->request["names"]);
-        if (names.empty()) {
-            SINFO("Got CrashBedrockJob with no 'names'. Nothing to blacklist.");
-            return;
-        }
-        {
-            unique_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
-            for (const auto& name : names) {
-                _crashedBedrockJobPatterns.insert(name);
-            }
-            SALERT("Blacklisting bedrock jobs (now have " << _crashedBedrockJobPatterns.size() << " patterns): " << SComposeList(names));
-        }
-        _propagateBedrockJobBlacklistCommand(command->request);
-    } else if (SIEquals(command->request.methodLine, "ClearCrashedBedrockJobs")) {
-        {
-            unique_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
-            _crashedBedrockJobPatterns.clear();
-        }
-        _propagateBedrockJobBlacklistCommand(command->request);
     } else if (SIEquals(command->request.methodLine, "ClearBlockingQueue")) {
         auto commands = _blockingCommandQueue.getAll();
         list<string> methodLines;
@@ -2286,26 +2257,6 @@ bool BedrockServer::shouldBackup()
     return _shouldBackup;
 }
 
-set<string> BedrockServer::getCrashedBedrockJobPatterns()
-{
-    shared_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
-    return _crashedBedrockJobPatterns;
-}
-
-void BedrockServer::_propagateBedrockJobBlacklistCommand(const SData& request)
-{
-    // Propagate a locally-originated blacklist change to the rest of the cluster so a new leader still enforces it
-    // after a failover. Every intra-cluster command arrives via the private command port with an empty _source, so
-    // _source can't distinguish a local command from a propagated one; instead we tag propagated commands with
-    // "isPropagated" and skip re-broadcasting those, which prevents an infinite broadcast loop between peers.
-    if (request.isSet("isPropagated")) {
-        return;
-    }
-    SData propagated = request;
-    propagated["isPropagated"] = "true";
-    broadcastCommand(propagated);
-}
-
 SData BedrockServer::_generateCrashMessage(const unique_ptr<BedrockCommand>& command)
 {
     SHMMM("Generating CRASH_COMMAND command for " << command->request.methodLine);
@@ -2362,30 +2313,6 @@ void BedrockServer::onNodeLogin(SQLitePeer* peer)
         if (_clusterMessengerCopy) {
             thread([command = move(peerCommand), _clusterMessengerCopy, peerName]() {
                 _clusterMessengerCopy->runOnPeer(*command, peerName);
-            }).detach();
-        }
-    }
-
-    // Send the bedrock job blacklist to the newly logged-in peer so it enforces the same patterns if it becomes leader.
-    list<string> jobPatterns;
-    {
-        shared_lock<decltype(_crashedBedrockJobPatternMutex)> jobLock(_crashedBedrockJobPatternMutex);
-        jobPatterns.assign(_crashedBedrockJobPatterns.begin(), _crashedBedrockJobPatterns.end());
-    }
-    if (!jobPatterns.empty()) {
-        SALERT("Sending " << jobPatterns.size() << " blacklisted bedrock job patterns to node " << peer->name << " on login");
-        SData crashJobCommand("CrashBedrockJob");
-        crashJobCommand["names"] = SComposeList(jobPatterns);
-        crashJobCommand["timeout"] = "5000";
-
-        // Tag as propagated so the joining peer stores it locally without re-broadcasting to the whole cluster.
-        crashJobCommand["isPropagated"] = "true";
-        auto _clusterMessengerCopy = _clusterMessenger;
-        auto peerName = peer->name;
-        if (_clusterMessengerCopy) {
-            thread([command = move(crashJobCommand), _clusterMessengerCopy, peerName]() {
-                BedrockCommand cmd(SQLiteCommand(SData(command)), nullptr);
-                _clusterMessengerCopy->runOnPeer(cmd, peerName);
             }).detach();
         }
     }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -211,6 +211,10 @@ public:
     // If peerName is specified, command will be sent to only that peer.
     void broadcastCommand(const SData& message, const string& peerName = "");
 
+    // Returns a copy of the set of GLOB patterns for jobs that have been blacklisted via CrashBedrockJob. The Jobs
+    // plugin uses these to fail matching jobs at GetJob time instead of running them.
+    set<string> getCrashedBedrockJobPatterns();
+
     // Set the detach state of the server. Setting to true will cause the server to detach from the database and go
     // into a sleep loop until this is called again with false
     void setDetach(bool detach);
@@ -424,6 +428,14 @@ private:
     // Definitions of crash-causing commands. This is a map of methodLine to name/value pairs required to match a
     // particular command for it count as a match likely to cause a crash.
     map<string, set<STable>> _crashCommands;
+
+    // A shared mutex to control access to the list of blacklisted bedrock jobs.
+    shared_timed_mutex _crashedBedrockJobPatternMutex;
+
+    // GLOB patterns for bedrock jobs that have been blacklisted via CrashBedrockJob. A job whose name matches any of
+    // these patterns is failed at GetJob time instead of being run. This lets us surgically disable a misbehaving job
+    // without stopping BWM for everyone.
+    set<string> _crashedBedrockJobPatterns;
 
     // Returns whether or not the command was a status or control command. If it was, it will have already been handled
     // and responded to upon return

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -180,7 +180,7 @@ public:
     // Exposes the replication state to plugins.
     SQLiteNodeState getState() const;
 
-    // When a peer node logs in, we'll send it our crash command list and our blacklisted bedrock job patterns.
+    // When a peer node logs in, we'll send it our crash command list, then let each plugin replicate any of its own state.
     void onNodeLogin(SQLitePeer* peer) override;
 
     // You must block and unblock the command port with *identical strings*.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -180,7 +180,7 @@ public:
     // Exposes the replication state to plugins.
     SQLiteNodeState getState() const;
 
-    // When a peer node logs in, we'll send it our crash command list.
+    // When a peer node logs in, we'll send it our crash command list and our blacklisted bedrock job patterns.
     void onNodeLogin(SQLitePeer* peer) override;
 
     // You must block and unblock the command port with *identical strings*.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -211,10 +211,6 @@ public:
     // If peerName is specified, command will be sent to only that peer.
     void broadcastCommand(const SData& message, const string& peerName = "");
 
-    // Returns a copy of the set of GLOB patterns for jobs that have been blacklisted via CrashBedrockJob. The Jobs
-    // plugin uses these to fail matching jobs at GetJob time instead of running them.
-    set<string> getCrashedBedrockJobPatterns();
-
     // Set the detach state of the server. Setting to true will cause the server to detach from the database and go
     // into a sleep loop until this is called again with false
     void setDetach(bool detach);
@@ -429,14 +425,6 @@ private:
     // particular command for it count as a match likely to cause a crash.
     map<string, set<STable>> _crashCommands;
 
-    // A shared mutex to control access to the list of blacklisted bedrock jobs.
-    shared_timed_mutex _crashedBedrockJobPatternMutex;
-
-    // GLOB patterns for bedrock jobs that have been blacklisted via CrashBedrockJob. A job whose name matches any of
-    // these patterns is failed at GetJob time instead of being run. This lets us surgically disable a misbehaving job
-    // without stopping BWM for everyone.
-    set<string> _crashedBedrockJobPatterns;
-
     // Returns whether or not the command was a status or control command. If it was, it will have already been handled
     // and responded to upon return
     bool _handleIfStatusOrControlCommand(unique_ptr<BedrockCommand>& command);
@@ -446,9 +434,6 @@ private:
 
     // Generate a CRASH_COMMAND command for a given bad command.
     static SData _generateCrashMessage(const unique_ptr<BedrockCommand>& command);
-
-    // Broadcast a locally-originated bedrock job blacklist change to peers, tagging it so recipients don't re-broadcast.
-    void _propagateBedrockJobBlacklistCommand(const SData& request);
 
     // The number of seconds to wait between forcing a command to QUORUM.
     uint64_t _quorumCheckpointSeconds;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -447,6 +447,9 @@ private:
     // Generate a CRASH_COMMAND command for a given bad command.
     static SData _generateCrashMessage(const unique_ptr<BedrockCommand>& command);
 
+    // Broadcast a locally-originated bedrock job blacklist change to peers, tagging it so recipients don't re-broadcast.
+    void _propagateBedrockJobBlacklistCommand(const SData& request);
+
     // The number of seconds to wait between forcing a command to QUORUM.
     uint64_t _quorumCheckpointSeconds;
 

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -666,9 +666,10 @@ void BedrockJobsCommand::process(SQLite& db)
         // disable a misbehaving job without stopping BWM for everyone. Two things happen:
         //   - blacklistExclusion is appended to the candidate query below so a blacklisted job is never selected or
         //     run, even ones we haven't converted to FAILED yet.
-        //   - a bounded batch of matching QUEUED/RUNQUEUED jobs is failed here. We cap the batch (rather than failing
-        //     every match) so a large backlog drains over successive GetJob(s) calls instead of one huge commit that
-        //     would lock the table on the hot dequeue path.
+        //   - a bounded batch of matching QUEUED/RUNQUEUED jobs that are due to run (nextRun in the past) is failed
+        //     here. We cap the batch (rather than failing every match) so a large backlog drains over successive
+        //     GetJob(s) calls instead of one huge commit that would lock the table on the hot dequeue path. Jobs
+        //     scheduled in the future are left alone until they're due, mirroring the candidate query below.
         bool failedBlacklistedJobs = false;
         string blacklistExclusion;
         const set<string> crashedJobPatterns = _plugin->server.getCrashedBedrockJobPatterns();
@@ -684,6 +685,7 @@ void BedrockJobsCommand::process(SQLite& db)
             string failQuery = "UPDATE jobs "
                 "SET state='FAILED' "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
+                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND " + nameFilter + " "
                 "AND " + blacklistMatch +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL" : "") +

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -762,12 +762,49 @@ void BedrockJobsCommand::process(SQLite& db)
         // There should only be at most one result if GetJob
         SASSERT(!SIEquals(requestVerb, "GetJob") || result.size() <= 1);
 
+        // Fail (rather than run) any candidate job whose name matches a GLOB pattern blacklisted via CrashBedrockJob.
+        // This lets us surgically disable a misbehaving job without stopping BWM for everyone.
+        set<string> crashedJobIDs;
+        const set<string> crashedJobPatterns = _plugin->server.getCrashedBedrockJobPatterns();
+        if (!crashedJobPatterns.empty()) {
+            list<string> candidateJobIDs;
+            for (size_t c = 0; c < result.size(); ++c) {
+                candidateJobIDs.push_back(result[c][0]);
+            }
+
+            list<string> globClauses;
+            for (const auto& pattern : crashedJobPatterns) {
+                globClauses.push_back("name GLOB " + SQ(pattern));
+            }
+
+            SQResult crashed;
+            if (!db.read("SELECT jobID FROM jobs WHERE jobID IN (" + SQList(candidateJobIDs) + ") AND (" + SComposeList(globClauses, " OR ") + ");", crashed)) {
+                STHROW("502 Failed to select blacklisted jobs");
+            }
+            for (const auto& row : crashed) {
+                crashedJobIDs.insert(row[0]);
+            }
+
+            if (!crashedJobIDs.empty()) {
+                const list<string> failIDs(crashedJobIDs.begin(), crashedJobIDs.end());
+                SALERT("Failing blacklisted bedrock jobs: " << SComposeList(failIDs));
+                if (!db.writeIdempotent("UPDATE jobs SET state='FAILED' WHERE jobID IN (" + SQList(failIDs) + ");")) {
+                    STHROW("502 Failed to fail blacklisted jobs");
+                }
+            }
+        }
+
         // Prepare to update the rows, while also creating all the child objects
         list<string> nonRetriableJobs;
         list<STable> retriableJobs;
         list<string> jobList;
         for (size_t c = 0; c < result.size(); ++c) {
             SASSERT(result[c].size() == 10); // jobID, name, data, parentJobID, retryAfter, created, repeat, lastRun, nextRun, priority
+
+            // Skip any job we just failed for matching the blacklist so it's never returned to the worker.
+            if (crashedJobIDs.count(result[c][0])) {
+                continue;
+            }
 
             // Add this object to our output
             STable job;

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -687,7 +687,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND " + nameFilter + " "
                 "AND " + blacklistMatch +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL" : "") +
-                " LIMIT 1000;";
+                " LIMIT 100;";
             if (!db.writeIdempotent(failQuery)) {
                 STHROW("502 Failed to fail blacklisted jobs");
             }

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -2,6 +2,7 @@
 
 #include <BedrockServer.h>
 #include <libstuff/SQResult.h>
+#include <sqlitecluster/SQLitePeer.h>
 #include <sqlitecluster/SQLiteUtils.h>
 
 #undef SLOGPREFIX
@@ -18,6 +19,42 @@ const string& BedrockPlugin_Jobs::getName() const
     return name;
 }
 
+set<string> BedrockPlugin_Jobs::getCrashedBedrockJobPatterns()
+{
+    shared_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
+    return _crashedBedrockJobPatterns;
+}
+
+STable BedrockPlugin_Jobs::getInfo()
+{
+    STable info;
+    shared_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
+    info["crashedBedrockJobs"] = _crashedBedrockJobPatterns.size();
+    info["crashedBedrockJobList"] = SComposeJSONArray(vector<string>(_crashedBedrockJobPatterns.begin(), _crashedBedrockJobPatterns.end()));
+    return info;
+}
+
+void BedrockPlugin_Jobs::onNodeLogin(SQLitePeer* peer)
+{
+    list<string> jobPatterns;
+    {
+        shared_lock<decltype(_crashedBedrockJobPatternMutex)> lock(_crashedBedrockJobPatternMutex);
+        jobPatterns.assign(_crashedBedrockJobPatterns.begin(), _crashedBedrockJobPatterns.end());
+    }
+    if (jobPatterns.empty()) {
+        return;
+    }
+
+    // Send the current blacklist to the joining peer so it enforces the same patterns if it becomes leader. Tag it as
+    // propagated so the peer stores it without re-broadcasting, and set a timeout so this send can't block for long.
+    SALERT("Sending " << jobPatterns.size() << " blacklisted bedrock job patterns to node " << peer->name << " on login");
+    SData crashJobCommand("CrashBedrockJob");
+    crashJobCommand["names"] = SComposeList(jobPatterns);
+    crashJobCommand["isPropagated"] = "true";
+    crashJobCommand["timeout"] = "5000";
+    server.broadcastCommand(crashJobCommand, peer->name);
+}
+
 const set<string, STableComp> BedrockPlugin_Jobs::supportedRequestVerbs = {
     "GetJob",
     "GetJobs",
@@ -31,6 +68,8 @@ const set<string, STableComp> BedrockPlugin_Jobs::supportedRequestVerbs = {
     "FailJob",
     "DeleteJob",
     "RequeueJobs",
+    "CrashBedrockJob",
+    "ClearCrashedBedrockJobs",
 };
 
 bool BedrockJobsCommand::canEscalateImmediately(SQLiteCommand& baseCommand)
@@ -128,6 +167,43 @@ bool BedrockJobsCommand::peek(SQLite& db)
 
     // We can potentially change this, so we set it here.
     mockRequest = request.isSet("mockRequest");
+
+    if (SIEquals(requestVerb, "CrashBedrockJob") || SIEquals(requestVerb, "ClearCrashedBedrockJobs")) {
+        // These change this node's in-memory job blacklist and don't touch the DB, so we complete them here in peek.
+        // They must originate locally (an operator on this node) or from a peer over the private command port -- both
+        // have an empty _source -- so reject anything from the public command port.
+        if (!request["_source"].empty()) {
+            STHROW("401 Unauthorized");
+        }
+
+        BedrockPlugin_Jobs* jobsPlugin = static_cast<BedrockPlugin_Jobs*>(_plugin);
+        if (SIEquals(requestVerb, "CrashBedrockJob")) {
+            const list<string> names = SParseList(request["names"]);
+            if (names.empty()) {
+                SINFO("Got CrashBedrockJob with no 'names'. Nothing to blacklist.");
+            } else {
+                unique_lock<decltype(jobsPlugin->_crashedBedrockJobPatternMutex)> lock(jobsPlugin->_crashedBedrockJobPatternMutex);
+                for (const auto& name : names) {
+                    jobsPlugin->_crashedBedrockJobPatterns.insert(name);
+                }
+                SALERT("Blacklisting bedrock jobs (now have " << jobsPlugin->_crashedBedrockJobPatterns.size() << " patterns): " << SComposeList(names));
+            }
+        } else {
+            unique_lock<decltype(jobsPlugin->_crashedBedrockJobPatternMutex)> lock(jobsPlugin->_crashedBedrockJobPatternMutex);
+            jobsPlugin->_crashedBedrockJobPatterns.clear();
+        }
+
+        // Propagate a locally-originated change to the rest of the cluster so a new leader still enforces it after a
+        // failover. Peer-delivered commands arrive with "isPropagated" set so recipients update locally without
+        // re-broadcasting -- every intra-cluster command has an empty _source, so _source can't distinguish a local
+        // command from a propagated one, which would otherwise loop forever.
+        if (!request.isSet("isPropagated")) {
+            SData propagated = request;
+            propagated["isPropagated"] = "true";
+            _plugin->server.broadcastCommand(propagated);
+        }
+        return true;
+    }
 
     if (SIEquals(requestVerb, "GetJob") || SIEquals(requestVerb, "GetJobs")) {
         // - GetJob( name )
@@ -662,7 +738,7 @@ void BedrockJobsCommand::process(SQLite& db)
         string safeNumResults = SQ(max(request.calc("numResults"), 1));
         mockRequest = mockRequest || request.isSet("getMockedJobs");
 
-        const set<string> crashedJobPatterns = _plugin->server.getCrashedBedrockJobPatterns();
+        const set<string> crashedJobPatterns = static_cast<BedrockPlugin_Jobs*>(_plugin)->getCrashedBedrockJobPatterns();
 
         string selectQuery;
         if (request.isSet("jobPriority")) {

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -661,6 +661,35 @@ void BedrockJobsCommand::process(SQLite& db)
         const list<string> nameList = SParseList(request["name"]);
         string safeNumResults = SQ(max(request.calc("numResults"), 1));
         mockRequest = mockRequest || request.isSet("getMockedJobs");
+
+        // Fail (rather than run) any matching job whose name matches a GLOB pattern blacklisted via CrashBedrockJob.
+        // This lets us surgically disable a misbehaving job without stopping BWM for everyone. We do this before the
+        // candidate query below so those jobs are no longer QUEUED/RUNQUEUED and the query backfills past them, so a
+        // worker still receives up to numResults runnable jobs.
+        bool failedBlacklistedJobs = false;
+        const set<string> crashedJobPatterns = _plugin->server.getCrashedBedrockJobPatterns();
+        if (!crashedJobPatterns.empty()) {
+            const string nameFilter = nameList.size() > 1 ? "name IN (" + SQList(nameList) + ")" : "name GLOB " + SQ(request["name"]);
+            list<string> globClauses;
+            for (const auto& pattern : crashedJobPatterns) {
+                globClauses.push_back("name GLOB " + SQ(pattern));
+            }
+            string failQuery = "UPDATE jobs "
+                "SET state='FAILED' "
+                "WHERE state IN ('QUEUED', 'RUNQUEUED') "
+                "AND " + nameFilter + " "
+                "AND (" + SComposeList(globClauses, " OR ") + ")" +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL" : "") + ";";
+            if (!db.writeIdempotent(failQuery)) {
+                STHROW("502 Failed to fail blacklisted jobs");
+            }
+            const size_t failedCount = db.getLastWriteChangeCount();
+            if (failedCount) {
+                failedBlacklistedJobs = true;
+                SALERT("Failed " << failedCount << " blacklisted bedrock jobs matching '" << request["name"] << "'");
+            }
+        }
+
         string selectQuery;
         if (request.isSet("jobPriority")) {
             selectQuery =
@@ -750,49 +779,21 @@ void BedrockJobsCommand::process(SQLite& db)
 
         // Are there any results?
         if (result.empty()) {
-            // Ah, there were before, but aren't now -- nothing found
-            // **FIXME: If "Connection: wait" should re-apply the hold.  However, this is super edge
-            //          as we could only get here if the job somehow got consumed between the peek
-            //          and process -- which could happen during heavy load.  But it'd just return
-            //          no results (which is correct) faster than it would otherwise time out.  Either
-            //          way the worker will likely just loop, so it doesn't really matter.
-            STHROW("404 No job found");
+            // If we just failed blacklisted jobs above, fall through and return an empty result so those FAILED updates
+            // commit -- throwing here would roll back the whole transaction and leave the jobs QUEUED.
+            if (!failedBlacklistedJobs) {
+                // Ah, there were before, but aren't now -- nothing found
+                // **FIXME: If "Connection: wait" should re-apply the hold.  However, this is super edge
+                //          as we could only get here if the job somehow got consumed between the peek
+                //          and process -- which could happen during heavy load.  But it'd just return
+                //          no results (which is correct) faster than it would otherwise time out.  Either
+                //          way the worker will likely just loop, so it doesn't really matter.
+                STHROW("404 No job found");
+            }
         }
 
         // There should only be at most one result if GetJob
         SASSERT(!SIEquals(requestVerb, "GetJob") || result.size() <= 1);
-
-        // Fail (rather than run) any candidate job whose name matches a GLOB pattern blacklisted via CrashBedrockJob.
-        // This lets us surgically disable a misbehaving job without stopping BWM for everyone.
-        set<string> crashedJobIDs;
-        const set<string> crashedJobPatterns = _plugin->server.getCrashedBedrockJobPatterns();
-        if (!crashedJobPatterns.empty()) {
-            list<string> candidateJobIDs;
-            for (size_t c = 0; c < result.size(); ++c) {
-                candidateJobIDs.push_back(result[c][0]);
-            }
-
-            list<string> globClauses;
-            for (const auto& pattern : crashedJobPatterns) {
-                globClauses.push_back("name GLOB " + SQ(pattern));
-            }
-
-            SQResult crashed;
-            if (!db.read("SELECT jobID FROM jobs WHERE jobID IN (" + SQList(candidateJobIDs) + ") AND (" + SComposeList(globClauses, " OR ") + ");", crashed)) {
-                STHROW("502 Failed to select blacklisted jobs");
-            }
-            for (const auto& row : crashed) {
-                crashedJobIDs.insert(row[0]);
-            }
-
-            if (!crashedJobIDs.empty()) {
-                const list<string> failIDs(crashedJobIDs.begin(), crashedJobIDs.end());
-                SALERT("Failing blacklisted bedrock jobs: " << SComposeList(failIDs));
-                if (!db.writeIdempotent("UPDATE jobs SET state='FAILED' WHERE jobID IN (" + SQList(failIDs) + ");")) {
-                    STHROW("502 Failed to fail blacklisted jobs");
-                }
-            }
-        }
 
         // Prepare to update the rows, while also creating all the child objects
         list<string> nonRetriableJobs;
@@ -800,11 +801,6 @@ void BedrockJobsCommand::process(SQLite& db)
         list<string> jobList;
         for (size_t c = 0; c < result.size(); ++c) {
             SASSERT(result[c].size() == 10); // jobID, name, data, parentJobID, retryAfter, created, repeat, lastRun, nextRun, priority
-
-            // Skip any job we just failed for matching the blacklist so it's never returned to the worker.
-            if (crashedJobIDs.count(result[c][0])) {
-                continue;
-            }
 
             // Add this object to our output
             STable job;

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -662,24 +662,32 @@ void BedrockJobsCommand::process(SQLite& db)
         string safeNumResults = SQ(max(request.calc("numResults"), 1));
         mockRequest = mockRequest || request.isSet("getMockedJobs");
 
-        // Fail (rather than run) any matching job whose name matches a GLOB pattern blacklisted via CrashBedrockJob.
-        // This lets us surgically disable a misbehaving job without stopping BWM for everyone. We do this before the
-        // candidate query below so those jobs are no longer QUEUED/RUNQUEUED and the query backfills past them, so a
-        // worker still receives up to numResults runnable jobs.
+        // Handle jobs whose name matches a GLOB pattern blacklisted via CrashBedrockJob. This lets us surgically
+        // disable a misbehaving job without stopping BWM for everyone. Two things happen:
+        //   - blacklistExclusion is appended to the candidate query below so a blacklisted job is never selected or
+        //     run, even ones we haven't converted to FAILED yet.
+        //   - a bounded batch of matching QUEUED/RUNQUEUED jobs is failed here. We cap the batch (rather than failing
+        //     every match) so a large backlog drains over successive GetJob(s) calls instead of one huge commit that
+        //     would lock the table on the hot dequeue path.
         bool failedBlacklistedJobs = false;
+        string blacklistExclusion;
         const set<string> crashedJobPatterns = _plugin->server.getCrashedBedrockJobPatterns();
         if (!crashedJobPatterns.empty()) {
-            const string nameFilter = nameList.size() > 1 ? "name IN (" + SQList(nameList) + ")" : "name GLOB " + SQ(request["name"]);
             list<string> globClauses;
             for (const auto& pattern : crashedJobPatterns) {
                 globClauses.push_back("name GLOB " + SQ(pattern));
             }
+            const string blacklistMatch = "(" + SComposeList(globClauses, " OR ") + ")";
+            blacklistExclusion = " AND NOT " + blacklistMatch + " ";
+
+            const string nameFilter = nameList.size() > 1 ? "name IN (" + SQList(nameList) + ")" : "name GLOB " + SQ(request["name"]);
             string failQuery = "UPDATE jobs "
                 "SET state='FAILED' "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND " + nameFilter + " "
-                "AND (" + SComposeList(globClauses, " OR ") + ")" +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL" : "") + ";";
+                "AND " + blacklistMatch +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL" : "") +
+                " LIMIT 1000;";
             if (!db.writeIdempotent(failQuery)) {
                 STHROW("502 Failed to fail blacklisted jobs");
             }
@@ -699,7 +707,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=" + SQ(request.calc("jobPriority")) + " "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND +name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults + ";";
         } else {
             selectQuery =
@@ -711,7 +719,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=1000 "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
                 "UNION ALL "
@@ -722,7 +730,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=850 "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
                 "UNION ALL "
@@ -733,7 +741,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=750 "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
                 "UNION ALL "
@@ -744,7 +752,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=500 "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
                 "UNION ALL "
@@ -755,7 +763,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=250 "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
                 "UNION ALL "
@@ -766,7 +774,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=0 "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
                 ") "

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -47,7 +47,7 @@ void BedrockPlugin_Jobs::onNodeLogin(SQLitePeer* peer)
 
     // Send the current blacklist to the joining peer so it enforces the same patterns if it becomes leader. Tag it as
     // propagated so the peer stores it without re-broadcasting, and set a timeout so this send can't block for long.
-    SALERT("Sending " << jobPatterns.size() << " blacklisted bedrock job patterns to node " << peer->name << " on login");
+    SINFO("Sending " << jobPatterns.size() << " blacklisted bedrock job patterns to node " << peer->name << " on login");
     SData crashJobCommand("CrashBedrockJob");
     crashJobCommand["names"] = SComposeList(jobPatterns);
     crashJobCommand["isPropagated"] = "true";
@@ -186,7 +186,7 @@ bool BedrockJobsCommand::peek(SQLite& db)
                 for (const auto& name : names) {
                     jobsPlugin->_crashedBedrockJobPatterns.insert(name);
                 }
-                SALERT("Blacklisting bedrock jobs (now have " << jobsPlugin->_crashedBedrockJobPatterns.size() << " patterns): " << SComposeList(names));
+                SINFO("Blacklisting bedrock jobs (now have " << jobsPlugin->_crashedBedrockJobPatterns.size() << " patterns): " << SComposeList(names));
             }
         } else {
             unique_lock<decltype(jobsPlugin->_crashedBedrockJobPatternMutex)> lock(jobsPlugin->_crashedBedrockJobPatternMutex);
@@ -861,7 +861,7 @@ void BedrockJobsCommand::process(SQLite& db)
             }
             if (!crashedJobIDs.empty()) {
                 const list<string> failIDs(crashedJobIDs.begin(), crashedJobIDs.end());
-                SALERT("Failing blacklisted bedrock jobs: " << SComposeList(failIDs));
+                SINFO("Failing blacklisted bedrock jobs: " << SComposeList(failIDs));
                 if (!db.writeIdempotent("UPDATE jobs SET state='FAILED' WHERE jobID IN (" + SQList(failIDs) + ");")) {
                     STHROW("502 Failed to fail blacklisted jobs");
                 }

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -662,43 +662,7 @@ void BedrockJobsCommand::process(SQLite& db)
         string safeNumResults = SQ(max(request.calc("numResults"), 1));
         mockRequest = mockRequest || request.isSet("getMockedJobs");
 
-        // Handle jobs whose name matches a GLOB pattern blacklisted via CrashBedrockJob. This lets us surgically
-        // disable a misbehaving job without stopping BWM for everyone. Two things happen:
-        //   - blacklistExclusion is appended to the candidate query below so a blacklisted job is never selected or
-        //     run, even ones we haven't converted to FAILED yet.
-        //   - a bounded batch of matching QUEUED/RUNQUEUED jobs that are due to run (nextRun in the past) is failed
-        //     here. We cap the batch (rather than failing every match) so a large backlog drains over successive
-        //     GetJob(s) calls instead of one huge commit that would lock the table on the hot dequeue path. Jobs
-        //     scheduled in the future are left alone until they're due, mirroring the candidate query below.
-        bool failedBlacklistedJobs = false;
-        string blacklistExclusion;
         const set<string> crashedJobPatterns = _plugin->server.getCrashedBedrockJobPatterns();
-        if (!crashedJobPatterns.empty()) {
-            list<string> globClauses;
-            for (const auto& pattern : crashedJobPatterns) {
-                globClauses.push_back("name GLOB " + SQ(pattern));
-            }
-            const string blacklistMatch = "(" + SComposeList(globClauses, " OR ") + ")";
-            blacklistExclusion = " AND NOT " + blacklistMatch + " ";
-
-            const string nameFilter = nameList.size() > 1 ? "name IN (" + SQList(nameList) + ")" : "name GLOB " + SQ(request["name"]);
-            string failQuery = "UPDATE jobs "
-                "SET state='FAILED' "
-                "WHERE state IN ('QUEUED', 'RUNQUEUED') "
-                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
-                "AND " + nameFilter + " "
-                "AND " + blacklistMatch +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL" : "") +
-                " LIMIT 100;";
-            if (!db.writeIdempotent(failQuery)) {
-                STHROW("502 Failed to fail blacklisted jobs");
-            }
-            const size_t failedCount = db.getLastWriteChangeCount();
-            if (failedCount) {
-                failedBlacklistedJobs = true;
-                SALERT("Failed " << failedCount << " blacklisted bedrock jobs matching '" << request["name"] << "'");
-            }
-        }
 
         string selectQuery;
         if (request.isSet("jobPriority")) {
@@ -709,7 +673,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=" + SQ(request.calc("jobPriority")) + " "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND +name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults + ";";
         } else {
             selectQuery =
@@ -721,7 +685,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=1000 "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
                 "UNION ALL "
@@ -732,7 +696,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=850 "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
                 "UNION ALL "
@@ -743,7 +707,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=750 "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
                 "UNION ALL "
@@ -754,7 +718,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=500 "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
                 "UNION ALL "
@@ -765,7 +729,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=250 "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
                 "UNION ALL "
@@ -776,7 +740,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "AND priority=0 "
                 "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
-                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") + blacklistExclusion +
+                string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
                 ") "
                 ") "
@@ -789,16 +753,42 @@ void BedrockJobsCommand::process(SQLite& db)
 
         // Are there any results?
         if (result.empty()) {
-            // If we just failed blacklisted jobs above, fall through and return an empty result so those FAILED updates
-            // commit -- throwing here would roll back the whole transaction and leave the jobs QUEUED.
-            if (!failedBlacklistedJobs) {
-                // Ah, there were before, but aren't now -- nothing found
-                // **FIXME: If "Connection: wait" should re-apply the hold.  However, this is super edge
-                //          as we could only get here if the job somehow got consumed between the peek
-                //          and process -- which could happen during heavy load.  But it'd just return
-                //          no results (which is correct) faster than it would otherwise time out.  Either
-                //          way the worker will likely just loop, so it doesn't really matter.
-                STHROW("404 No job found");
+            // Ah, there were before, but aren't now -- nothing found
+            // **FIXME: If "Connection: wait" should re-apply the hold.  However, this is super edge
+            //          as we could only get here if the job somehow got consumed between the peek
+            //          and process -- which could happen during heavy load.  But it'd just return
+            //          no results (which is correct) faster than it would otherwise time out.  Either
+            //          way the worker will likely just loop, so it doesn't really matter.
+            STHROW("404 No job found");
+        }
+
+        // Fail (rather than run) any candidate whose name matches a GLOB pattern blacklisted via CrashBedrockJob. This
+        // lets us surgically disable a misbehaving job without stopping BWM for everyone. We only touch the candidates
+        // this query already selected (all due to run), so it's a small write by jobID rather than a scan of the whole
+        // table, and future-scheduled jobs are never candidates so they're left alone until they're due.
+        set<string> crashedJobIDs;
+        if (!crashedJobPatterns.empty()) {
+            list<string> candidateJobIDs;
+            for (size_t c = 0; c < result.size(); ++c) {
+                candidateJobIDs.push_back(result[c][0]);
+            }
+            list<string> globClauses;
+            for (const auto& pattern : crashedJobPatterns) {
+                globClauses.push_back("name GLOB " + SQ(pattern));
+            }
+            SQResult crashed;
+            if (!db.read("SELECT jobID FROM jobs WHERE jobID IN (" + SQList(candidateJobIDs) + ") AND (" + SComposeList(globClauses, " OR ") + ");", crashed)) {
+                STHROW("502 Failed to select blacklisted jobs");
+            }
+            for (const auto& row : crashed) {
+                crashedJobIDs.insert(row[0]);
+            }
+            if (!crashedJobIDs.empty()) {
+                const list<string> failIDs(crashedJobIDs.begin(), crashedJobIDs.end());
+                SALERT("Failing blacklisted bedrock jobs: " << SComposeList(failIDs));
+                if (!db.writeIdempotent("UPDATE jobs SET state='FAILED' WHERE jobID IN (" + SQList(failIDs) + ");")) {
+                    STHROW("502 Failed to fail blacklisted jobs");
+                }
             }
         }
 
@@ -811,6 +801,11 @@ void BedrockJobsCommand::process(SQLite& db)
         list<string> jobList;
         for (size_t c = 0; c < result.size(); ++c) {
             SASSERT(result[c].size() == 10); // jobID, name, data, parentJobID, retryAfter, created, repeat, lastRun, nextRun, priority
+
+            // Skip any candidate we just failed for matching the blacklist so it's never returned to the worker.
+            if (crashedJobIDs.count(result[c][0])) {
+                continue;
+            }
 
             // Add this object to our output
             STable job;

--- a/plugins/Jobs.h
+++ b/plugins/Jobs.h
@@ -10,6 +10,16 @@ public:
     virtual const string& getName() const;
     virtual void upgradeDatabase(SQLite& db);
 
+    // Surfaces the job blacklist (crashedBedrockJobs / crashedBedrockJobList) under this plugin's entry in Status.
+    virtual STable getInfo();
+
+    // On peer login, send the current job blacklist to the peer so it enforces the same patterns after a failover.
+    virtual void onNodeLogin(SQLitePeer* peer);
+
+    // Returns a copy of the GLOB patterns for jobs blacklisted via CrashBedrockJob, used to fail matching jobs at
+    // GetJob time instead of running them.
+    set<string> getCrashedBedrockJobPatterns();
+
     // We were using MAX_SIZE_SMALL in GetJob to check the job name, but now GetJobs accepts more than one job name,
     // because of that, we need to increase the size of the param to be able to accept around 50 job names.
     static constexpr int64_t MAX_SIZE_NAME = 255 * 50;
@@ -22,6 +32,11 @@ public:
 private:
     static const string name;
     static const int64_t JOBS_DEFAULT_PRIORITY;
+
+    // GLOB patterns for jobs blacklisted via CrashBedrockJob, guarded by its mutex. A job whose name matches any
+    // pattern is failed at GetJob time instead of run. In-memory only; cleared on a full cluster restart.
+    shared_timed_mutex _crashedBedrockJobPatternMutex;
+    set<string> _crashedBedrockJobPatterns;
 };
 
 class BedrockJobsCommand : public BedrockCommand {

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -45,6 +45,7 @@ struct GetJobTest : tpunit::TestFixture
                               TEST(GetJobTest::testRetryableParentJobs),
                               TEST(GetJobTest::testInvalidNextRun),
                               TEST(GetJobTest::testCrashBedrockJobBlacklist),
+                              TEST(GetJobTest::testCrashBedrockJobBlacklistBatchLimit),
                               AFTER(GetJobTest::tearDown),
                               AFTER_CLASS(GetJobTest::tearDownClass))
     {
@@ -919,5 +920,42 @@ struct GetJobTest : tpunit::TestFixture
         response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(response["jobID"], afterClearJobID);
         ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + afterClearJobID + ";"), "RUNNING");
+    }
+
+    // With a backlog larger than the per-call batch, each GetJobs fails at most the batch (1000), and the still-QUEUED
+    // blacklisted jobs are excluded from the candidate query so none are ever returned/run while draining.
+    void testCrashBedrockJobBlacklistBatchLimit()
+    {
+        // Create 1001 jobs under one blacklisted prefix in a single batch (one more than the 1000 per-call fail limit).
+        vector<string> jobs;
+        for (int i = 0; i < 1001; i++) {
+            STable job;
+            job["name"] = "www-prod/BatchBad?n=" + to_string(i);
+            jobs.push_back(SComposeJSONObject(job));
+        }
+        SData command("CreateJobs");
+        command["jobs"] = SComposeJSONArray(jobs);
+        tester->executeWaitVerifyContent(command);
+
+        command.clear();
+        command.methodLine = "CrashBedrockJob";
+        command["names"] = "www-prod/BatchBad*";
+        tester->executeWaitVerifyContent(command);
+
+        // One GetJobs fails at most 1000 and returns none: the one still-QUEUED job is excluded, not run.
+        command.clear();
+        command.methodLine = "GetJobs";
+        command["name"] = "www-prod/BatchBad*";
+        command["numResults"] = "10";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_EQUAL(SParseJSONArray(response["jobs"]).size(), 0);
+        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='FAILED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "1000");
+        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='QUEUED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "1");
+
+        // A second GetJobs drains the remaining job.
+        response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_EQUAL(SParseJSONArray(response["jobs"]).size(), 0);
+        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='FAILED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "1001");
+        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='QUEUED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "0");
     }
 } __GetJobTest;

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -889,23 +889,18 @@ struct GetJobTest : tpunit::TestFixture
         command["names"] = "www-prod/UserActivityEvaluator*";
         tester->executeWaitVerifyContent(command);
 
-        // GetJobs returns the matching candidates in one call, so both the ?param form and the V2 sibling are failed
-        // together and none are returned to the worker.
+        // A single GetJobs across the whole www-prod/* space fails both matching jobs (the ?param form and the V2
+        // sibling) and still backfills the unrelated job, so workers aren't starved of runnable work.
         command.clear();
         command.methodLine = "GetJobs";
-        command["name"] = "www-prod/UserActivityEvaluator*";
+        command["name"] = "www-prod/*";
         command["numResults"] = "10";
         STable response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_EQUAL(SParseJSONArray(response["jobs"]).size(), 0);
+        list<string> returnedJobs = SParseJSONArray(response["jobs"]);
+        ASSERT_EQUAL(returnedJobs.size(), 1);
+        ASSERT_EQUAL(SParseJSONObject(returnedJobs.front())["jobID"], otherJobID);
         ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + paramJobID + ";"), "FAILED");
         ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + siblingJobID + ";"), "FAILED");
-
-        // The unrelated job doesn't match the pattern and still runs normally.
-        command.clear();
-        command.methodLine = "GetJob";
-        command["name"] = "www-prod/SomeOtherJob";
-        response = tester->executeWaitVerifyContentTable(command);
-        ASSERT_EQUAL(response["jobID"], otherJobID);
         ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + otherJobID + ";"), "RUNNING");
 
         // After clearing the blacklist, a freshly created matching job runs again.

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -884,6 +884,13 @@ struct GetJobTest : tpunit::TestFixture
         command["name"] = "www-prod/SomeOtherJob";
         string otherJobID = tester->executeWaitVerifyContentTable(command)["jobID"];
 
+        // A blacklisted job scheduled in the future must not be failed until it's due.
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "www-prod/UserActivityEvaluatorFuture";
+        command["firstRun"] = SComposeTime("%Y-%m-%d %H:%M:%S", STimeNow() + 3600ull * 1'000'000);
+        string futureJobID = tester->executeWaitVerifyContentTable(command)["jobID"];
+
         // Blacklist the prefix with a GLOB wildcard.
         command.clear();
         command.methodLine = "CrashBedrockJob";
@@ -903,6 +910,9 @@ struct GetJobTest : tpunit::TestFixture
         ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + paramJobID + ";"), "FAILED");
         ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + siblingJobID + ";"), "FAILED");
         ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + otherJobID + ";"), "RUNNING");
+
+        // The future-scheduled blacklisted job is untouched -- neither failed nor run.
+        ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + futureJobID + ";"), "QUEUED");
 
         // After clearing the blacklist, a freshly created matching job runs again.
         command.clear();

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -44,6 +44,7 @@ struct GetJobTest : tpunit::TestFixture
                               TEST(GetJobTest::testInvalidJobPriority),
                               TEST(GetJobTest::testRetryableParentJobs),
                               TEST(GetJobTest::testInvalidNextRun),
+                              TEST(GetJobTest::testCrashBedrockJobBlacklist),
                               AFTER(GetJobTest::tearDown),
                               AFTER_CLASS(GetJobTest::tearDownClass))
     {
@@ -62,6 +63,10 @@ struct GetJobTest : tpunit::TestFixture
         SData command("Query");
         command["query"] = "DELETE FROM jobs WHERE jobID > 0;";
         tester->executeWaitVerifyContent(command);
+
+        // Clear any job blacklist a test may have set so it doesn't leak into later tests.
+        SData clearCommand("ClearCrashedBedrockJobs");
+        tester->executeWaitVerifyContent(clearCommand);
     }
 
     void tearDownClass()
@@ -857,5 +862,67 @@ struct GetJobTest : tpunit::TestFixture
         SQResult jobData;
         tester->readDB("SELECT state FROM jobs WHERE jobID = " + jobID + ";", jobData);
         ASSERT_EQUAL(jobData[0][0], "FAILED");
+    }
+
+    // A job whose name matches a CrashBedrockJob GLOB pattern is failed at GetJob time instead of running.
+    void testCrashBedrockJobBlacklist()
+    {
+        // Create two jobs under the blacklisted prefix (one with a param suffix, one a "V2" sibling) and one
+        // unrelated job that must still run.
+        SData command("CreateJob");
+        command["name"] = "www-prod/UserActivityEvaluator?accountID=856";
+        string paramJobID = tester->executeWaitVerifyContentTable(command)["jobID"];
+
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "www-prod/UserActivityEvaluatorV2";
+        string siblingJobID = tester->executeWaitVerifyContentTable(command)["jobID"];
+
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "www-prod/SomeOtherJob";
+        string otherJobID = tester->executeWaitVerifyContentTable(command)["jobID"];
+
+        // Blacklist the prefix with a GLOB wildcard.
+        command.clear();
+        command.methodLine = "CrashBedrockJob";
+        command["names"] = "www-prod/UserActivityEvaluator*";
+        tester->executeWaitVerifyContent(command);
+
+        // GetJobs returns the matching candidates in one call, so both the ?param form and the V2 sibling are failed
+        // together and none are returned to the worker.
+        command.clear();
+        command.methodLine = "GetJobs";
+        command["name"] = "www-prod/UserActivityEvaluator*";
+        command["numResults"] = "10";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_EQUAL(SParseJSONArray(response["jobs"]).size(), 0);
+        ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + paramJobID + ";"), "FAILED");
+        ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + siblingJobID + ";"), "FAILED");
+
+        // The unrelated job doesn't match the pattern and still runs normally.
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "www-prod/SomeOtherJob";
+        response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_EQUAL(response["jobID"], otherJobID);
+        ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + otherJobID + ";"), "RUNNING");
+
+        // After clearing the blacklist, a freshly created matching job runs again.
+        command.clear();
+        command.methodLine = "ClearCrashedBedrockJobs";
+        tester->executeWaitVerifyContent(command);
+
+        command.clear();
+        command.methodLine = "CreateJob";
+        command["name"] = "www-prod/UserActivityEvaluator?accountID=857";
+        string afterClearJobID = tester->executeWaitVerifyContentTable(command)["jobID"];
+
+        command.clear();
+        command.methodLine = "GetJob";
+        command["name"] = "www-prod/UserActivityEvaluator?accountID=857";
+        response = tester->executeWaitVerifyContentTable(command);
+        ASSERT_EQUAL(response["jobID"], afterClearJobID);
+        ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + afterClearJobID + ";"), "RUNNING");
     }
 } __GetJobTest;

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -45,7 +45,7 @@ struct GetJobTest : tpunit::TestFixture
                               TEST(GetJobTest::testRetryableParentJobs),
                               TEST(GetJobTest::testInvalidNextRun),
                               TEST(GetJobTest::testCrashBedrockJobBlacklist),
-                              TEST(GetJobTest::testCrashBedrockJobBlacklistBatchLimit),
+                              TEST(GetJobTest::testCrashBedrockJobBlacklistDrainsAcrossCalls),
                               AFTER(GetJobTest::tearDown),
                               AFTER_CLASS(GetJobTest::tearDownClass))
     {
@@ -932,13 +932,13 @@ struct GetJobTest : tpunit::TestFixture
         ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + afterClearJobID + ";"), "RUNNING");
     }
 
-    // With a backlog larger than the per-call batch, each GetJobs fails at most the batch (100), and the still-QUEUED
-    // blacklisted jobs are excluded from the candidate query so none are ever returned/run while draining.
-    void testCrashBedrockJobBlacklistBatchLimit()
+    // Each GetJob(s) only fails the candidates it actually selected (bounded by numResults); the still-QUEUED
+    // blacklisted jobs behind them are never returned/run and get failed on later calls as they surface.
+    void testCrashBedrockJobBlacklistDrainsAcrossCalls()
     {
-        // Create 101 jobs under one blacklisted prefix in a single batch (one more than the 100 per-call fail limit).
+        // Create 15 jobs under one blacklisted prefix, more than the numResults=10 we'll request per call.
         vector<string> jobs;
-        for (int i = 0; i < 101; i++) {
+        for (int i = 0; i < 15; i++) {
             STable job;
             job["name"] = "www-prod/BatchBad?n=" + to_string(i);
             jobs.push_back(SComposeJSONObject(job));
@@ -952,20 +952,20 @@ struct GetJobTest : tpunit::TestFixture
         command["names"] = "www-prod/BatchBad*";
         tester->executeWaitVerifyContent(command);
 
-        // One GetJobs fails at most 100 and returns none: the one still-QUEUED job is excluded, not run.
+        // One GetJobs fails only its 10 candidates and returns none; the other 5 stay QUEUED and are not run.
         command.clear();
         command.methodLine = "GetJobs";
         command["name"] = "www-prod/BatchBad*";
         command["numResults"] = "10";
         STable response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(SParseJSONArray(response["jobs"]).size(), 0);
-        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='FAILED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "100");
-        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='QUEUED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "1");
+        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='FAILED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "10");
+        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='QUEUED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "5");
 
-        // A second GetJobs drains the remaining job.
+        // A second GetJobs drains the remaining jobs.
         response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(SParseJSONArray(response["jobs"]).size(), 0);
-        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='FAILED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "101");
+        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='FAILED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "15");
         ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='QUEUED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "0");
     }
 } __GetJobTest;

--- a/test/tests/jobs/GetJobTest.cpp
+++ b/test/tests/jobs/GetJobTest.cpp
@@ -922,13 +922,13 @@ struct GetJobTest : tpunit::TestFixture
         ASSERT_EQUAL(tester->readDB("SELECT state FROM jobs WHERE jobID = " + afterClearJobID + ";"), "RUNNING");
     }
 
-    // With a backlog larger than the per-call batch, each GetJobs fails at most the batch (1000), and the still-QUEUED
+    // With a backlog larger than the per-call batch, each GetJobs fails at most the batch (100), and the still-QUEUED
     // blacklisted jobs are excluded from the candidate query so none are ever returned/run while draining.
     void testCrashBedrockJobBlacklistBatchLimit()
     {
-        // Create 1001 jobs under one blacklisted prefix in a single batch (one more than the 1000 per-call fail limit).
+        // Create 101 jobs under one blacklisted prefix in a single batch (one more than the 100 per-call fail limit).
         vector<string> jobs;
-        for (int i = 0; i < 1001; i++) {
+        for (int i = 0; i < 101; i++) {
             STable job;
             job["name"] = "www-prod/BatchBad?n=" + to_string(i);
             jobs.push_back(SComposeJSONObject(job));
@@ -942,20 +942,20 @@ struct GetJobTest : tpunit::TestFixture
         command["names"] = "www-prod/BatchBad*";
         tester->executeWaitVerifyContent(command);
 
-        // One GetJobs fails at most 1000 and returns none: the one still-QUEUED job is excluded, not run.
+        // One GetJobs fails at most 100 and returns none: the one still-QUEUED job is excluded, not run.
         command.clear();
         command.methodLine = "GetJobs";
         command["name"] = "www-prod/BatchBad*";
         command["numResults"] = "10";
         STable response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(SParseJSONArray(response["jobs"]).size(), 0);
-        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='FAILED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "1000");
+        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='FAILED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "100");
         ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='QUEUED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "1");
 
         // A second GetJobs drains the remaining job.
         response = tester->executeWaitVerifyContentTable(command);
         ASSERT_EQUAL(SParseJSONArray(response["jobs"]).size(), 0);
-        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='FAILED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "1001");
+        ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='FAILED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "101");
         ASSERT_EQUAL(tester->readDB("SELECT COUNT(*) FROM jobs WHERE name GLOB 'www-prod/BatchBad*' AND state='QUEUED' AND JSON_EXTRACT(data, '$.mockRequest') IS NULL;"), "0");
     }
 } __GetJobTest;


### PR DESCRIPTION
### Details

Adds a Bedrock job blacklist so a single misbehaving job can be surgically disabled without stopping BWM for everyone.

- New localhost control commands: `CrashBedrockJob` (accepts a comma-separated `names` list of GLOB patterns) and `ClearCrashedBedrockJobs`.
- At `GetJob`/`GetJobs` time, any candidate job whose name matches a blacklisted GLOB pattern is transitioned to `FAILED` and never returned to the worker. The extra query only runs when the blacklist is non-empty, so the normal path is unaffected.
- Matching uses SQLite `GLOB`, so `www-prod/UserActivityEvaluator*` matches both `www-prod/UserActivityEvaluator?accountID=856` and `www-prod/UserActivityEvaluatorV2`. This also lets you scope to a single account by including it in the pattern.
- Patterns are broadcast across the cluster and resent to peers on login, so a new leader still enforces them after a failover.
- Surfaced in the `Status` command as `crashedBedrockJobs` / `crashedBedrockJobList`, mirroring how crash commands are shown.
- In-memory only (cleared on a full cluster restart), matching the existing crash-command design.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/649219

### Tests
1. I tested this locally by running the new `CrashBedrockJob` command,
```
CrashBedrockJob
names: www-prod/ProcessAgentZeroRequest*

200 OK
nodeName: bedrock
totalTime: 2500
unaccountedTime: 2500
Content-Length: 0

status

200 OK
nodeName: bedrock
totalTime: 1007
unaccountedTime: 1007
Content-Length: 972

{"blockedIdentifiers":0,"blockedTimeIdentifiers":0,"blockingRateLimitThreshold":10,"blockingTimeRateLimitThresholdMs":60000,"commandCount":1,"commandPortBlockReasons":[],"CommitCount":266693,"crashCommandList":[],"crashCommands":0,"crashedBedrockJobList":["www-prod\/ProcessAgentZeroRequest*"],"crashedBedrockJobs":1,"freelistCount":0,"host":"0.0.0.0:8889","isDetached":false,"isLeader":true,"multiWriteEnabled":true,"multiWriteManualBlacklist":[],"outstandingFramesToCheckpoint":0,"pageCount":44576,"peerList":[],"plugins":[{"name":"Cache"},{"name":"Concierge","version":"62907ef765"},{"name":"DB"},{"name":"ExpensifyTableManager","version":"e2de05c782"},{"name":"Jobs"},{"name":"MySQL"},{"name":"expensifyBackupManager","version":"2a9911f0af"}],"priority":200,"queuedCommandList":[],"state":"LEADING","syncNodeAvailable":true,"syncThreadQueuedCommandList":[],"version":"63a96a407b:Concierge_62907ef765:ExpensifyTableManager_e2de05c782:expensifyBackupManager_2a9911f0af"}
```
2. Then i send a newDot message and confirmed the job failed immediately while bwm was running,
```
SQLite main.db> select * from jobs where name glob 'www-prod/ProcessAgentZeroRequest*';
      created              jobID        state                                      name                                           nextRun       lastRun repeat                                                                                                                                                    data                                                                                                                                                    priority parentJobID retryAfter
------------------- ------------------- ------ ---------------------------------------------------------------------------- ------------------- ------- ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- -------- ----------- -----------
2026-07-02 22:40:04 6986622538182774669 FAILED www-prod/ProcessAgentZeroRequest?reportID=3833388386142844&persona=Concierge 2026-07-02 22:40:04                {"reportID":3833388386142844,"persona":"Concierge","email":"chirag@testjuly2.com","didChatJobExistWhenQueued":false,"pageHTML":"","userAccountID":1583,"triggeringRequestElapsedMS":45,"additionalInputMessages":[],"sidePanelContext":[],"triggeringReportActionID":0,"trigger":"chat_message","               750           0 +10 MINUTES
                                                                                                                                                               _commitCoun...
```
3. Then i ran `ClearCrashedBedrockJobs` and it was cleared. 
```
vagrant@expensidev-2404:/vagrant$ nc localhost 8888
ClearCrashedBedrockJobs

200 OK
nodeName: bedrock
totalTime: 322
unaccountedTime: 322
Content-Length: 0

status

200 OK
nodeName: bedrock
totalTime: 1634
unaccountedTime: 1634
Content-Length: 936

{"blockedIdentifiers":0,"blockedTimeIdentifiers":0,"blockingRateLimitThreshold":10,"blockingTimeRateLimitThresholdMs":60000,"commandCount":1,"commandPortBlockReasons":[],"CommitCount":266718,"crashCommandList":[],"crashCommands":0,"crashedBedrockJobList":[],"crashedBedrockJobs":0,"freelistCount":0,"host":"0.0.0.0:8889","isDetached":false,"isLeader":true,"multiWriteEnabled":true,"multiWriteManualBlacklist":[],"outstandingFramesToCheckpoint":0,"pageCount":44577,"peerList":[],"plugins":[{"name":"Cache"},{"name":"Concierge","version":"62907ef765"},{"name":"DB"},{"name":"ExpensifyTableManager","version":"e2de05c782"},{"name":"Jobs"},{"name":"MySQL"},{"name":"expensifyBackupManager","version":"2a9911f0af"}],"priority":200,"queuedCommandList":[],"state":"LEADING","syncNodeAvailable":true,"syncThreadQueuedCommandList":[],"version":"63a96a407b:Concierge_62907ef765:ExpensifyTableManager_e2de05c782:expensifyBackupManager_2a9911f0af"}
```

Automated coverage: `GetJobTest::testCrashBedrockJobBlacklist` (passes locally, full `GetJob` suite green).

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
