### PR TITLE
feat(sqlite3): update to 45f6fccc2ed3e0b6

### DIFF
--- a/libstuff/sqlite3.h
+++ b/libstuff/sqlite3.h
@@ -148,10 +148,10 @@ extern "C" {
 */
 #define SQLITE_VERSION        "3.54.0"
 #define SQLITE_VERSION_NUMBER 3054000
-#define SQLITE_SOURCE_ID      "2026-06-17 16:05:18 69941fdcdb2e41de2487c30730446f3ea916d48dcc4288d5a9ff1c91d80ea8a1"
-#define SQLITE_SCM_BRANCH     "hctree-bedrock-lcd-ex"
-#define SQLITE_SCM_TAGS       ""
-#define SQLITE_SCM_DATETIME   "2026-06-17T16:05:18.255Z"
+#define SQLITE_SOURCE_ID      "2026-07-09 16:12:25 45f6fccc2ed3e0b6d6f72cf3aeb849a77eace5f8675f40d3fff-experimental"
+#define SQLITE_SCM_BRANCH     "unknown"
+#define SQLITE_SCM_TAGS       "unknown"
+#define SQLITE_SCM_DATETIME   "2026-07-09T16:12:25.329Z"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers

--- a/libstuff/sqlite3ext.h
+++ b/libstuff/sqlite3ext.h
@@ -375,6 +375,9 @@ struct sqlite3_api_routines {
   void (*str_truncate)(sqlite3_str*,int);
   void (*str_free)(sqlite3_str*);
   int (*carray_bind)(sqlite3_stmt*,int,void*,int,int,void(*)(void*));
+  int (*carray_bind_v2)(sqlite3_stmt*,int,void*,int,int,void(*)(void*),void*);
+  /* Version 3.54.0 and later */
+  sqlite3_int64 (*incomplete)(const char*);
 };
 
 /*
@@ -717,6 +720,9 @@ typedef int (*sqlite3_loadext_entry)(
 #define sqlite3_str_truncate           sqlite3_api->str_truncate
 #define sqlite3_str_free               sqlite3_api->str_free
 #define sqlite3_carray_bind            sqlite3_api->carray_bind
+#define sqlite3_carray_bind_v2         sqlite3_api->carray_bind_v2
+/* Version 3.54.0 and later */
+#define sqlite3_incomplete             sqlite3_api->incomplete
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)


### PR DESCRIPTION
### Details
Updates sqlite3 version to 45f6fccc2ed3e0b6. 

### Fixed Issues
https://expensify.slack.com/archives/C0BG48U5VM2/p1783614260732319
$ https://github.com/Expensify/Expensify/issues/656223

### Tests
Auth tests still running, but they seem to pass.


_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
