### PR TITLE
chore(clang): upgrade to clang 22

### DIFF
--- a/.github/actions/composite/download-binaries/action.yml
+++ b/.github/actions/composite/download-binaries/action.yml
@@ -5,11 +5,20 @@ runs:
   using: composite
   steps:
     - name: Download binaries
-      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.10.0
       with:
-        name: bedrock-binaries
+        key: bedrock-binaries-${{ github.sha }}
+        # Fail on cache miss to avoid odd chmod errors as the only visible error if this part
+        # of the workflow fails.
+        fail-on-cache-miss: true
+        path: |
+          bedrock
+          test/test
+          test/clustertest/clustertest
+          test/clustertest/testplugin/testplugin.so
+          test/sample_data/lottoNumbers.json
 
     - name: Set permissions of the new binary files
       run: |
-        sudo chmod +x bedrock test/test test/clustertest/clustertest test/sample_data/lottoNumbers.json test/clustertest/testplugin/testplugin.so
+        sudo chmod +x bedrock test/test test/clustertest/clustertest
       shell: bash

--- a/.github/workflows/bedrock.yml
+++ b/.github/workflows/bedrock.yml
@@ -4,13 +4,16 @@ on:
     types: [opened, synchronize]
   release:
     types: [prereleased, published]
+
 concurrency:
   group: "${{ github.ref }}"
   cancel-in-progress: true
+
 env:
   CCACHE_BASEDIR: "/home/runner/.cache/ccache"
   # Use mirror.bastion1.sjc if running locally
   APT_MIRROR_URL: "apt-mirror.expensify.com:843"
+
 jobs:
   Style_Check:
     name: "C++ Styler"
@@ -22,16 +25,16 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
-    - name: Checkout Bedrock
-      # v4.1.0
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
-      with:
-        repository: Expensify/Bedrock
-        path: .
-        # Set fetch-depth to 0 so that we can compare HEAD with all git log history
-        fetch-depth: 0
-    - name: Run style checks
-      run: "./ci_style.sh"
+      - name: Checkout Bedrock
+        # v4.1.0
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        with:
+          repository: Expensify/Bedrock
+          path: .
+          # Set fetch-depth to 0 so that we can compare HEAD with all git log history
+          fetch-depth: 0
+      - name: Run style checks
+        run: "./ci_style.sh"
 
   Build_Bedrock:
     name: "Create Bedrock and Test"
@@ -43,41 +46,40 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
-    - name: Checkout Bedrock
-      # v4.1.0
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
-      with:
-        repository: Expensify/Bedrock
-        path: .
+      - name: Checkout Bedrock
+        # v4.1.0
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        with:
+          repository: Expensify/Bedrock
+          path: .
 
-    - name: Setup tmate session
-      if: runner.debug == '1'
-      # v3
-      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48
-      timeout-minutes: 60
-      with:
-        limit-access-to-actor: true
+      - name: Setup tmate session
+        if: runner.debug == '1'
+        # v3
+        uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48
+        timeout-minutes: 60
+        with:
+          limit-access-to-actor: true
 
-    # If tmate was run, we want to mark this step as failed
-    - name: Mark failure if debugging
-      if: runner.debug == '1'
-      run: exit 1
-    - name: Install zstd
-      run: apt-get update -y && apt-get install -y libzstd-dev
-    - name: Build Bedrock
-      run: "./ci_build.sh"
-    - name: Upload binaries
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-      with:
-        name: bedrock-binaries
-        path: |
-          bedrock
-          test/test
-          test/clustertest/clustertest
-          test/clustertest/testplugin/testplugin.so
-          test/sample_data/lottoNumbers.json
-        retention-days: 1
-        compression-level: 1
+      # If tmate was run, we want to mark this step as failed
+      - name: Mark failure if debugging
+        if: runner.debug == '1'
+        run: exit 1
+
+      - name: Build Bedrock
+        run: "./ci_build.sh"
+
+      - name: Upload binaries
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.10.0
+        with:
+          key: bedrock-binaries-${{ github.sha }}
+          path: |
+            bedrock
+            test/test
+            test/clustertest/clustertest
+            test/clustertest/testplugin/testplugin.so
+            test/sample_data/lottoNumbers.json
+
   BedrockTests:
     name: "Bedrock Tests"
     runs-on: blacksmith-32vcpu-ubuntu-2404
@@ -90,31 +92,34 @@ jobs:
     timeout-minutes: 30
     needs: Build_Bedrock
     steps:
-    - name: Checkout Bedrock
-      # v4.1.0
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
-      with:
-        repository: Expensify/Bedrock
-        path: .
-    - name: Install zstd
-      run: apt-get update -y && apt-get install -y libzstd-dev
-    - name: Download binaries
-      uses: ./.github/actions/composite/download-binaries
-    - name: Setup tmate session
-      if: runner.debug == '1'
-      # v3
-      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48
-      timeout-minutes: 60
-      with:
-        limit-access-to-actor: true
-    # If tmate was run, we want to mark this step as failed so bedrock tests don't look like they're passing
-    - name: Mark failure if debugging
-      if: runner.debug == '1'
-      run: exit 1
-    - name: Run tests
-      env:
-        ENABLE_HCTREE: "false"
-      run: "./ci_tests.sh"
+      - name: Checkout Bedrock
+        # v4.1.0
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        with:
+          repository: Expensify/Bedrock
+          path: .
+
+      - name: Download binaries
+        uses: ./.github/actions/composite/download-binaries
+
+      - name: Setup tmate session
+        if: runner.debug == '1'
+        # v3
+        uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48
+        timeout-minutes: 60
+        with:
+          limit-access-to-actor: true
+
+          # If tmate was run, we want to mark this step as failed so bedrock tests don't look like they're passing
+      - name: Mark failure if debugging
+        if: runner.debug == '1'
+        run: exit 1
+
+      - name: Run tests
+        env:
+          ENABLE_HCTREE: "false"
+        run: "./ci_tests.sh"
+
   BedrockTestsWithHCTree:
     name: "Bedrock Tests with HCTree"
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -127,47 +132,50 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     needs: Build_Bedrock
     steps:
-    - name: Checkout Bedrock
-      # v4.1.0
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
-      with:
-        repository: Expensify/Bedrock
-        path: .
-    - name: Install zstd
-      run: apt-get update -y && apt-get install -y libzstd-dev
-    - name: Download binaries
-      uses: ./.github/actions/composite/download-binaries
-    - name: Setup tmate session
-      if: runner.debug == '1'
-      # v3
-      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48
-      timeout-minutes: 60
-      with:
-        limit-access-to-actor: true
-    # If tmate was run, we want to mark this step as failed so bedrock tests don't look like they're passing
-    - name: Mark failure if debugging
-      if: runner.debug == '1'
-      run: exit 1
-    - name: Run tests
-      run: "ENABLE_HCTREE=true ./ci_tests.sh"
+      - name: Checkout Bedrock
+        # v4.1.0
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        with:
+          repository: Expensify/Bedrock
+          path: .
+
+      - name: Download binaries
+        uses: ./.github/actions/composite/download-binaries
+
+      - name: Setup tmate session
+        if: runner.debug == '1'
+        # v3
+        uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48
+        timeout-minutes: 60
+        with:
+          limit-access-to-actor: true
+
+      # If tmate was run, we want to mark this step as failed so bedrock tests don't look like they're passing
+      - name: Mark failure if debugging
+        if: runner.debug == '1'
+        run: exit 1
+      
+      - name: Run tests
+        run: "ENABLE_HCTREE=true ./ci_tests.sh"
+
   Upload_Bedrock_Binaries:
     name: "Upload Bedrock Binaries"
     if: "${{ startsWith(github.ref, 'refs/tags/') }}"
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
-    needs: [BedrockTests,BedrockTestsWithHCTree]
+    needs: [BedrockTests, BedrockTestsWithHCTree]
     steps:
-    - name: Checkout Bedrock
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
-    - name: Download binaries
-      uses: ./.github/actions/composite/download-binaries
-    - name: Strip bedrock binary
-      run: "strip bedrock"
-    - name: Upload bedrock binary to release
-      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        GITHUB_REPOSITORY: "${{ github.repository }}"
-      with:
-        files: |-
-          ./bedrock
+      - name: Download binaries
+        uses: ./.github/actions/composite/download-binaries
+        
+      - name: Strip bedrock binary
+        run: "strip bedrock"
+
+      - name: Upload bedrock binary to release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_REPOSITORY: "${{ github.repository }}"
+        with:
+          files: |-
+            ./bedrock

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -123,11 +123,12 @@ void BedrockServer::sync()
     uint64_t firstTimeout = STIME_US_PER_M * 2 + SRandom::rand64() % STIME_US_PER_S * 30;
 
     // Initialize the shared pointer to our sync node object.
-    atomic_store(&_syncNode, make_shared<SQLiteNode>(*this, _dbPool, args["-nodeName"], args["-nodeHost"],
-                                                            args["-peerList"], args.calc("-priority"), firstTimeout,
-                                                            _version, args["-commandPortPrivate"]));
+    auto syncNode = make_shared<SQLiteNode>(*this, _dbPool, args["-nodeName"], args["-nodeHost"],
+                                                    args["-peerList"], args.calc("-priority"), firstTimeout,
+                                                    _version, args["-commandPortPrivate"]);
+    _syncNode.store(syncNode);
 
-    _clusterMessenger = make_shared<SQLiteClusterMessenger>(_syncNode);
+    _clusterMessenger = make_shared<SQLiteClusterMessenger>(syncNode);
 
     // The node is now coming up, and should eventually end up in a `LEADING` or `FOLLOWING` state. We can start adding
     // our worker threads now. We don't wait until the node is `LEADING` or `FOLLOWING`, as it's state can change while
@@ -231,7 +232,7 @@ void BedrockServer::sync()
         // commands, and we'll shortly run through the existing queue.
         if (_shutdownState.load() == COMMANDS_FINISHED) {
             SINFO("All clients responded to, " << BedrockCommand::getCommandCount() << " commands remaining.");
-            if (_syncNode->beginShutdown()) {
+            if (syncNode->beginShutdown()) {
                 SINFO("Beginning shuttdown of sync node.");
                 // This will cause us to skip the next `poll` iteration which avoids a 1 second wait.
                 _notifyDoneSync.push(true);
@@ -244,7 +245,7 @@ void BedrockServer::sync()
 
         // Pre-process any sockets the sync node is managing (i.e., communication with peer nodes).
         _notifyDoneSync.prePoll(fdm);
-        _syncNode->prePoll(fdm);
+        syncNode->prePoll(fdm);
 
         // Add our command queues to our fd_map.
         _syncNodeQueuedCommands.prePoll(fdm);
@@ -269,7 +270,7 @@ void BedrockServer::sync()
         // set it just before that call, because it is now also possible for the state to change in postPoll -- for example,
         // if we lose connection to a peer, and that peer was the last one that gave us quorum, then we can drop from
         // LEADING to SEARCHING. This transition triggers our "fall out of leading" logic.
-        SQLiteNodeState preUpdateState = _syncNode->getState();
+        SQLiteNodeState preUpdateState = syncNode->getState();
 
         // Process any network traffic that happened. Scope this so that we can change the log prefix and have it
         // auto-revert when we're finished.
@@ -279,7 +280,7 @@ void BedrockServer::sync()
 
             // Process any activity in our plugins.
             AutoTimerTime postPollTime(postPollTimer);
-            _syncNode->postPoll(fdm, nextActivity);
+            syncNode->postPoll(fdm, nextActivity);
             _syncNodeQueuedCommands.postPoll(fdm);
             _notifyDoneSync.postPoll(fdm);
         }
@@ -288,19 +289,19 @@ void BedrockServer::sync()
             void (*onPrepareHandler)(SQLite& db, int64_t tableID) = nullptr;
             bool enabled = command->shouldEnableOnPrepareNotification(db, &onPrepareHandler);
             if (enabled) {
-                _syncNode->onPrepareHandlerEnabled = enabled;
-                _syncNode->onPrepareHandler = onPrepareHandler;
+                syncNode->onPrepareHandlerEnabled = enabled;
+                syncNode->onPrepareHandler = onPrepareHandler;
             }
         } else {
-            _syncNode->onPrepareHandlerEnabled = false;
-            _syncNode->onPrepareHandler = nullptr;
+            syncNode->onPrepareHandlerEnabled = false;
+            syncNode->onPrepareHandler = nullptr;
         }
 
         // Ok, let the sync node update for as many iterations as it requires. We'll update the replication
         // state when it's finished.
-        while (_syncNode->update()) {
+        while (syncNode->update()) {
         }
-        _leaderVersion.store(_syncNode->getLeaderVersion());
+        _leaderVersion.store(syncNode->getLeaderVersion());
 
         // If we're not leading, move any commands from the blocking queue back to the main queue.
         if (getState() != SQLiteNodeState::LEADING && getState() != preUpdateState) {
@@ -364,7 +365,7 @@ void BedrockServer::sync()
         // Otherwise, if we're leading, let's start the commit.
         // Also, if a commit is in progress, skip it (it's the commit we started on the last loop iteration).
         if (!_upgradeCompleted && getState() == SQLiteNodeState::LEADING && !commitInProgress) {
-            if (!_syncNode->hasQuorum()) {
+            if (!syncNode->hasQuorum()) {
                 // Because we are going to commit the upgrade as a QUORUM commit (i.e., wait until over half of nodes
                 // approve it), we wait until `hasQuorum()` is true before we even attempt to start it.
                 // You might ask "if we are LEADING, how do we not have QUORUM?" and the answer to that is that as soon as
@@ -392,7 +393,7 @@ void BedrockServer::sync()
             }
             if (dbHasChanges) {
                 commitInProgress = true;
-                _syncNode->startCommit(SQLiteNode::QUORUM);
+                syncNode->startCommit(SQLiteNode::QUORUM);
                 _lastQuorumCommandTime = STimeNow();
 
                 // This interrupts the next poll loop immediately. This prevents a 1-second wait when running as a single server.
@@ -413,7 +414,7 @@ void BedrockServer::sync()
         // stick it back in the appropriate queue.
         if (commitInProgress) {
             // If the sync node's still working on the existing commit, just continue.
-            if (_syncNode->commitInProgress()) {
+            if (syncNode->commitInProgress()) {
                 continue;
             }
             commitInProgress = false;
@@ -422,7 +423,7 @@ void BedrockServer::sync()
             // But if we failed, we just try again. We have no real other options as this is required for
             // the database to be in a usable state.
             if (!_upgradeCompleted) {
-                if (_syncNode->commitSucceeded()) {
+                if (syncNode->commitSucceeded()) {
                     _upgradeCompleted = true;
                     SINFO("UpgradeDB succeeded, done.");
                     _notifyDone.push(true);
@@ -446,7 +447,7 @@ void BedrockServer::sync()
                 core.postProcessCommand(command, false);
             }
 
-            if (_syncNode->commitSucceeded()) {
+            if (syncNode->commitSucceeded()) {
                 SINFO("Sync thread finished committing command " << command->request.methodLine);
                 _conflictManager.recordTables(command->request.methodLine, db.getTablesUsed());
 
@@ -476,7 +477,7 @@ void BedrockServer::sync()
             // until one of these states changes. This prevents an endless loop of escalating commands, having
             // SQLiteNode re-queue them because leader is standing down, and then escalating them again until leader
             // sorts itself out.
-            if (getState() == SQLiteNodeState::FOLLOWING && _syncNode->leaderState() == SQLiteNodeState::STANDINGDOWN) {
+            if (getState() == SQLiteNodeState::FOLLOWING && syncNode->leaderState() == SQLiteNodeState::STANDINGDOWN) {
                 continue;
             }
 
@@ -574,7 +575,7 @@ void BedrockServer::sync()
                         SINFO("[performance] Sync thread beginning committing command " << command->request.methodLine);
                         // START TIMING.
                         command->startTiming(BedrockCommand::COMMIT_SYNC);
-                        _syncNode->startCommit(command->writeConsistency);
+                        syncNode->startCommit(command->writeConsistency);
 
                         // And we'll start the next main loop.
                         // NOTE: This will cause us to read from the network again. This, in theory, is fine, but we saw
@@ -610,7 +611,7 @@ void BedrockServer::sync()
             // _syncNodeQueuedCommands had no commands to work on, we'll need to re-poll for some.
             continue;
         }
-    } while (!_syncNode->shutdownComplete() || BedrockCommand::getCommandCount());
+    } while (!syncNode->shutdownComplete() || BedrockCommand::getCommandCount());
 
     SSetSignalHandlerDieFunc([]() {
         return "Dying in shutdown";
@@ -619,7 +620,7 @@ void BedrockServer::sync()
     // If we forced a shutdown mid-transaction (this can happen, if, for instance, we hit our graceful timeout between
     // getting a `BEGIN_TRANSACTION` and `COMMIT_TRANSACTION`) then we need to roll back the existing transaction and
     // release the lock.
-    if (_syncNode->commitInProgress()) {
+    if (syncNode->commitInProgress()) {
         SWARN("Shutting down mid-commit. Rolling back.");
         db.rollback();
     }
@@ -666,7 +667,8 @@ void BedrockServer::sync()
 
     // Release our handle to this pointer. Any other functions that are still using it will keep the object alive
     // until they return.
-    atomic_store(&_syncNode, shared_ptr<SQLiteNode>(nullptr));
+    _syncNode.store(nullptr);
+    syncNode.reset();
 
     // If we're not detaching, save that we're shutting down.
     if (!_detach) {
@@ -736,7 +738,7 @@ void BedrockServer::worker(int threadId)
 bool BedrockServer::isShuttingDown()
 {
     bool shuttingDown = false;
-    auto _syncNodeCopy = atomic_load(&_syncNode);
+    auto _syncNodeCopy = _syncNode.load();
     if (_shutdownState.load() != RUNNING || (_syncNodeCopy && _syncNodeCopy->getState() == SQLiteNodeState::STANDINGDOWN)) {
         shuttingDown = true;
     }
@@ -784,7 +786,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
     // Also, if this command is scheduled in the future, we can't run it either, we need to enqueue it to run at that point.
     // This functionality will go away as we remove the queues from bedrock, and so this can be removed at that time.
     {
-        auto _syncNodeCopy = atomic_load(&_syncNode);
+        auto _syncNodeCopy = _syncNode.load();
         if (!_syncNodeCopy || command->request.calcU64("commandExecuteTime") > STimeNow()) {
             _commandQueue.push(move(command));
             return;
@@ -1030,6 +1032,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                         bool commitSuccess = false;
                         uint64_t transactionID = 0;
                         string transactionHash;
+                        auto syncNode = _syncNode.load();
 
                         // Let's use a default value of 0 for the time to acquire the lock, which would work as a try_lock.
                         chrono::microseconds timeToCommit = chrono::microseconds(0);
@@ -1047,7 +1050,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                             } catch (const SException& e) {
                                 SINFO("Command '" << command->getMethodName() << "' timed out before commit.");
                             }
-                            commitSuccess = core.commit(*_syncNode, transactionID, transactionHash, command->getMethodName(), enableOnPrepareNotifications, onPrepareHandler, timeToCommit, &command->shouldAbort);
+                            commitSuccess = core.commit(*syncNode, transactionID, transactionHash, command->getMethodName(), enableOnPrepareNotifications, onPrepareHandler, timeToCommit, &command->shouldAbort);
 
                             if (getState() != SQLiteNodeState::LEADING) {
                                 SINFO("Stopped leading while trying to commit, will retry.");
@@ -1063,7 +1066,7 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
                             // Tell the sync node that there's been a commit so that it can jump out of it's "poll"
                             // loop and send it to followers. NOTE: we don't check for null here, that should be
                             // impossible inside a worker thread.
-                            _syncNode->notifyCommit();
+                            syncNode->notifyCommit();
                             _conflictManager.recordTables(command->request.methodLine, db.getTablesUsed());
                             // So we must still be leading, and at this point our commit has succeeded, let's
                             // mark it as complete. We add the currentCommit count here as well.
@@ -1269,7 +1272,7 @@ void BedrockServer::_resetServer()
         _commandPortBlockReasons.clear();
     }
     _syncLoopShouldBeRunning = true;
-    atomic_store(&_syncNode, shared_ptr<SQLiteNode>(nullptr));
+    _syncNode.store(nullptr);
     _shutdownState = RUNNING;
     _shouldBackup = false;
     _commandPortPublic = nullptr;
@@ -1555,8 +1558,8 @@ void BedrockServer::postPoll(fd_map& fdm, uint64_t& nextActivity)
 
             // This interrupts the sync thread's poll() loop so it doesn't wait for up to an extra second to finish.
             // When it wakes up, it will begin its own shutdown.
-            if (_syncNode) {
-                _syncNode->notifyCommit();
+            if (auto syncNode = _syncNode.load()) {
+                syncNode->notifyCommit();
             }
         }
     }
@@ -1736,7 +1739,7 @@ bool BedrockServer::_isStatusCommand(const unique_ptr<BedrockCommand>& command)
 list<STable> BedrockServer::getPeerInfo()
 {
     list<STable> peerData;
-    auto _syncNodeCopy = atomic_load(&_syncNode);
+    auto _syncNodeCopy = _syncNode.load();
     if (_syncNodeCopy) {
         peerData = _syncNodeCopy->getPeerInfo();
     }
@@ -1898,7 +1901,7 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command)
         content["queuedCommandList"] = SComposeJSONArray(_commandQueue.getRequestMethodLines());
         content["syncThreadQueuedCommandList"] = SComposeJSONArray(syncNodeQueuedMethods);
 
-        auto _syncNodeCopy = atomic_load(&_syncNode);
+        auto _syncNodeCopy = _syncNode.load();
         if (_syncNodeCopy) {
             content["syncNodeAvailable"] = "true";
             // Set some information about this node.
@@ -2183,7 +2186,7 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
             response.methodLine = "400 Missing priority";
         } else {
             int64_t newPriority = command->request.calc64("priority");
-            auto _syncNodeCopy = atomic_load(&_syncNode);
+            auto _syncNodeCopy = _syncNode.load();
             // Priority 1 is reserved for shutdown.
             if (newPriority < 0 || newPriority == 1) {
                 response.methodLine = "400 Invalid priority";
@@ -2256,7 +2259,7 @@ void BedrockServer::_beginShutdown(const string& reason, bool detach)
             _shutdownState.store(START_SHUTDOWN);
         }
         SQLiteNodeState currentState = SQLiteNodeState::UNKNOWN;
-        auto syncNodeCopy = atomic_load(&_syncNode);
+        auto syncNodeCopy = _syncNode.load();
         if (syncNodeCopy) {
             currentState = syncNodeCopy->getState();
             syncNodeCopy->setShutdownPriority();
@@ -2732,7 +2735,7 @@ void BedrockServer::notifyStateChangeToPlugins(SQLite& db, SQLiteNodeState newSt
 
 SQLiteNodeState BedrockServer::getState() const
 {
-    auto _syncNodeCopy = atomic_load(&_syncNode);
+    auto _syncNodeCopy = _syncNode.load();
     if (_syncNodeCopy) {
         return _syncNodeCopy->getState();
     }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -343,7 +343,7 @@ private:
     // until all references to it go out of scope. Since an STCPNode never deletes `Peer` objects until it's being
     // destroyed, we are also guaranteed that all peers are accessible as long as we hold a shared pointer to this
     // object.
-    shared_ptr<SQLiteNode> _syncNode;
+    atomic<shared_ptr<SQLiteNode>> _syncNode;
 
     // SStandaloneHTTPSManager for communication between SQLiteNodes for anything other than cluster state and
     // synchronization.

--- a/libstuff/SHTTPSProxySocket.cpp
+++ b/libstuff/SHTTPSProxySocket.cpp
@@ -3,6 +3,7 @@
 #include "libstuff/STCPManager.h"
 #include "libstuff/libstuff.h"
 #include <libstuff/SSSLState.h>
+#include <unistd.h>
 #include <mutex>
 
 SHTTPSProxySocket::SHTTPSProxySocket(const string& proxyAddress, const string& host, const string& requestID)
@@ -117,7 +118,7 @@ bool SHTTPSProxySocket::recv()
                         ssl = new SSSLState(hostname, s);
                     } else {
                         SWARN("Proxy server " << proxyAddress << " returned methodLine: " << connectionEstablished.methodLine);
-                        close(s);
+                        ::close(s);
                         s = -1;
                         state = STCPManager::Socket::CLOSED;
                     }


### PR DESCRIPTION
### Details

As with the other PRs, this upgrades this repo to clang 22. The only functional change in this repo is the switch from `atomic_store` and `atomic_load` to `atomic` with `.load()`, the previous pattern was deprecated in c++-20, but not marked deprecated until we upgraded from `libstdc++-13-dev` to `libstdc++-16-dev`

### Fixed Issues
Related https://github.com/Expensify/Expensify/issues/659917

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
