### PR TITLE
Log duplicate escalated write requests

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2631,10 +2631,7 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
                             command->response.methodLine = "500 Server Shutting Down";
                             _reply(command);
                         } else {
-                            // Escalated requests arrive on the private command port. Track each one by its cluster-unique
-                            // id so we can spot duplicates: the same request arriving again while a previous copy is still
-                            // being processed on the leader, causing write amplification. For now we only log these, we
-                            // don't drop them.
+                            // Track each request by its cluster-unique id so we can spot if we have a duplicates problem
                             string escalatedID;
                             if (fromPrivateCommandPort) {
                                 escalatedID = command->id;

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2454,6 +2454,56 @@ string BedrockServer::generateCommandID()
     return args["-nodeName"] + "#" + to_string(_requestCount++);
 }
 
+size_t BedrockServer::escalatedRequestFingerprint(const SData& request)
+{
+    // A follower stamps these transport headers onto the request while escalating (see
+    // SQLiteClusterMessenger::_sendCommandOnSocket), and they differ between two escalations of the same write: `ID`
+    // is the follower's own command id, `timeout` is the recomputed remaining time, and the rest carry per-escalation
+    // state. We skip them so retries of one write (identical `requestID` and payload, re-sent by PHP to a different
+    // follower) fingerprint the same. Keep this list in sync with the headers set in _sendCommandOnSocket. Note that
+    // missing an entry here only causes us to under-count duplicates, never to flag distinct requests as duplicates.
+    static const set<string, STableComp> excludedHeaders = {
+        "ID", "timeout", "serializedData", "httpsRequests", "Content-Length",
+    };
+
+    string canonical = request.methodLine;
+    canonical += '\n';
+    for (const auto& [name, value] : request.nameValueMap) {
+        if (excludedHeaders.count(name)) {
+            continue;
+        }
+        canonical += name;
+        canonical += ':';
+        canonical += value;
+        canonical += '\n';
+    }
+    canonical += request.content;
+    return hash<string>{}(canonical);
+}
+
+size_t BedrockServer::trackInFlightWrite(const SData& request)
+{
+    // Compute the fingerprint before taking the lock so hashing never serializes across socket threads.
+    const size_t fingerprint = escalatedRequestFingerprint(request);
+    bool isDuplicate = false;
+    {
+        lock_guard<mutex> lock(_inFlightEscalatedRequestsMutex);
+        isDuplicate = !_inFlightEscalatedRequests.insert(fingerprint).second;
+    }
+    if (isDuplicate) {
+        _duplicateEscalatedRequestCount++;
+        SWARN("Duplicate write in flight on leader. command:" << request.methodLine
+              << ", requestID:" << request["requestID"] << ", fingerprint:" << fingerprint);
+    }
+    return fingerprint;
+}
+
+void BedrockServer::untrackInFlightWrite(size_t fingerprint)
+{
+    lock_guard<mutex> lock(_inFlightEscalatedRequestsMutex);
+    _inFlightEscalatedRequests.erase(fingerprint);
+}
+
 unique_ptr<BedrockCommand> BedrockServer::buildCommandFromRequest(SData&& request, Socket& socket, bool shouldTreatAsLocalhost)
 {
     SAUTOPREFIX(request);
@@ -2631,16 +2681,16 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
                             command->response.methodLine = "500 Server Shutting Down";
                             _reply(command);
                         } else {
-                            // Track each request by its cluster-unique id so we can spot if we have a duplicates problem
-                            string escalatedID;
-                            if (fromPrivateCommandPort) {
-                                escalatedID = command->id;
-                                lock_guard<mutex> lock(_inFlightEscalatedRequestsMutex);
-                                if (!_inFlightEscalatedRequests.insert(escalatedID).second) {
-                                    _duplicateEscalatedRequestCount++;
-                                    SWARN("Duplicate escalated request in flight on leader. command:" << command->request.methodLine
-                                          << ", id:" << escalatedID);
-                                }
+                            // Detect duplicate writes reaching this leader: the same write arriving again while a
+                            // previous copy is still being processed, causing write amplification. A duplicate can
+                            // arrive escalated from a follower (private command port) or sent directly by a client that
+                            // connected to the leader (public command port). PHP re-sends the same write to a different
+                            // host when one times out, and each escalation mints its own command id, so only the
+                            // content identifies the duplicate. For now we only log these, we don't drop them.
+                            size_t inFlightFingerprint = 0;
+                            const bool trackInFlight = fromPrivateCommandPort || (fromPublicCommandPort && getState() == SQLiteNodeState::LEADING);
+                            if (trackInFlight) {
+                                inFlightFingerprint = trackInFlightWrite(command->request);
                             }
 
                             // If it's not handled by `_handleIfStatusOrControlCommand` we fall into the queuing logic.
@@ -2701,10 +2751,9 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
 
                             commandThread.join();
 
-                            // The escalated request is done, stop tracking it.
-                            if (fromPrivateCommandPort) {
-                                lock_guard<mutex> lock(_inFlightEscalatedRequestsMutex);
-                                _inFlightEscalatedRequests.erase(escalatedID);
+                            // The write is done, stop tracking it.
+                            if (trackInFlight) {
+                                untrackInFlightWrite(inFlightFingerprint);
                             }
                         }
                     }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -2456,12 +2456,7 @@ string BedrockServer::generateCommandID()
 
 size_t BedrockServer::escalatedRequestFingerprint(const SData& request)
 {
-    // A follower stamps these transport headers onto the request while escalating (see
-    // SQLiteClusterMessenger::_sendCommandOnSocket), and they differ between two escalations of the same write: `ID`
-    // is the follower's own command id, `timeout` is the recomputed remaining time, and the rest carry per-escalation
-    // state. We skip them so retries of one write (identical `requestID` and payload, re-sent by PHP to a different
-    // follower) fingerprint the same. Keep this list in sync with the headers set in _sendCommandOnSocket. Note that
-    // missing an entry here only causes us to under-count duplicates, never to flag distinct requests as duplicates.
+    // Headers that can be different between duplicate requests from a client
     static const set<string, STableComp> excludedHeaders = {
         "ID", "timeout", "serializedData", "httpsRequests", "Content-Length",
     };
@@ -2483,7 +2478,6 @@ size_t BedrockServer::escalatedRequestFingerprint(const SData& request)
 
 size_t BedrockServer::trackInFlightWrite(const SData& request)
 {
-    // Compute the fingerprint before taking the lock so hashing never serializes across socket threads.
     const size_t fingerprint = escalatedRequestFingerprint(request);
     bool isDuplicate = false;
     {
@@ -2684,9 +2678,7 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
                             // Detect duplicate writes reaching this leader: the same write arriving again while a
                             // previous copy is still being processed, causing write amplification. A duplicate can
                             // arrive escalated from a follower (private command port) or sent directly by a client that
-                            // connected to the leader (public command port). PHP re-sends the same write to a different
-                            // host when one times out, and each escalation mints its own command id, so only the
-                            // content identifies the duplicate. For now we only log these, we don't drop them.
+                            // connected to the leader (public command port).
                             size_t inFlightFingerprint = 0;
                             const bool trackInFlight = fromPrivateCommandPort || (fromPublicCommandPort && getState() == SQLiteNodeState::LEADING);
                             if (trackInFlight) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1839,6 +1839,7 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command)
         content["host"] = args["-nodeHost"];
         content["commandCount"] = BedrockCommand::getCommandCount();
         content["isDetached"] = isDetached() ? "true" : "false";
+        content["duplicateEscalatedRequestCount"] = _duplicateEscalatedRequestCount.load();
 
         {
             // Make it known if anything is known to cause crashes.
@@ -2630,6 +2631,21 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
                             command->response.methodLine = "500 Server Shutting Down";
                             _reply(command);
                         } else {
+                            // Escalated requests arrive on the private command port. Track each one by its cluster-unique
+                            // id so we can spot duplicates: the same request arriving again while a previous copy is still
+                            // being processed on the leader, causing write amplification. For now we only log these, we
+                            // don't drop them.
+                            string escalatedID;
+                            if (fromPrivateCommandPort) {
+                                escalatedID = command->id;
+                                lock_guard<mutex> lock(_inFlightEscalatedRequestsMutex);
+                                if (!_inFlightEscalatedRequests.insert(escalatedID).second) {
+                                    _duplicateEscalatedRequestCount++;
+                                    SWARN("Duplicate escalated request in flight on leader. command:" << command->request.methodLine
+                                          << ", id:" << escalatedID);
+                                }
+                            }
+
                             // If it's not handled by `_handleIfStatusOrControlCommand` we fall into the queuing logic.
                             // If the command has a socket (it's this socket) then we need to wait for it to finish before
                             // we can dequeue the next command, so that the responses all end up delivered in order.
@@ -2687,6 +2703,12 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
                             }
 
                             commandThread.join();
+
+                            // The escalated request is done, stop tracking it.
+                            if (fromPrivateCommandPort) {
+                                lock_guard<mutex> lock(_inFlightEscalatedRequestsMutex);
+                                _inFlightEscalatedRequests.erase(escalatedID);
+                            }
                         }
                     }
                 }

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -373,6 +373,15 @@ private:
     multimap<uint64_t, uint64_t> _futureCommitCommandTimeouts;
     recursive_mutex _futureCommitCommandMutex;
 
+    // Tracks the ids of escalated requests currently in flight on the leader. It's used to detect (and, for now, only
+    // log) a duplicate escalated request that arrives at the leader while the same request is still being processed,
+    // which causes write amplification.
+    set<string> _inFlightEscalatedRequests;
+    mutex _inFlightEscalatedRequestsMutex;
+
+    // A cumulative count of the duplicate escalated requests detected since startup, reported in the `Status` command.
+    atomic<uint64_t> _duplicateEscalatedRequestCount{0};
+
     // A set of command names that will always be run with QUORUM consistency level.
     // Specified by the `-synchronousCommands` command-line switch.
     set<string> _syncCommands;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -373,13 +373,13 @@ private:
     multimap<uint64_t, uint64_t> _futureCommitCommandTimeouts;
     recursive_mutex _futureCommitCommandMutex;
 
-    // Tracks the ids of escalated requests currently in flight on the leader. It's used to detect (and, for now, only
-    // log) a duplicate escalated request that arrives at the leader while the same request is still being processed,
-    // which causes write amplification.
+    // Tracks the ids of escalated requests currently in flight on the leader. It's used to
+    // detect a duplicate escalated request that arrives at the leader while the same request is still being processed
     set<string> _inFlightEscalatedRequests;
     mutex _inFlightEscalatedRequestsMutex;
 
     // A cumulative count of the duplicate escalated requests detected since startup, reported in the `Status` command.
+    // This is mostly useful to enable testing on this approach.
     atomic<uint64_t> _duplicateEscalatedRequestCount{0};
 
     // A set of command names that will always be run with QUORUM consistency level.

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -373,9 +373,11 @@ private:
     multimap<uint64_t, uint64_t> _futureCommitCommandTimeouts;
     recursive_mutex _futureCommitCommandMutex;
 
-    // Tracks the ids of escalated requests currently in flight on the leader. It's used to
-    // detect a duplicate escalated request that arrives at the leader while the same request is still being processed
-    set<string> _inFlightEscalatedRequests;
+    // Tracks a content fingerprint for each escalated request currently in flight on the leader. It's used to detect a
+    // duplicate escalated request that arrives while the same request is still being processed. Duplicates happen
+    // because PHP re-sends the same write to a different follower when one times out (see Client.php::call), and each
+    // follower mints its own command id, so the id can't identify the duplicate; the request's content can.
+    set<size_t> _inFlightEscalatedRequests;
     mutex _inFlightEscalatedRequestsMutex;
 
     // A cumulative count of the duplicate escalated requests detected since startup, reported in the `Status` command.
@@ -465,6 +467,19 @@ private:
 
     // Setup a new command from a bare request.
     unique_ptr<BedrockCommand> buildCommandFromRequest(SData&& request, Socket& s, bool shouldTreatAsLocalhost);
+
+    // Computes a content fingerprint for a request, used to detect duplicate writes on the leader. It hashes the
+    // method line, the request headers, and the body, but skips the transport headers a follower stamps on while
+    // escalating (which differ between two copies of the same write). Two copies of one logical write - same
+    // `requestID` and payload - produce the same fingerprint, whether one was escalated and the other sent directly.
+    static size_t escalatedRequestFingerprint(const SData& request);
+
+    // Tracks/untracks an in-flight write on the leader by content fingerprint, so we can detect a duplicate copy
+    // arriving while the first is still being processed (write amplification). trackInFlightWrite returns the
+    // fingerprint - pass it to untrackInFlightWrite once the write completes - and logs plus counts a duplicate. Both
+    // are called for escalated (private command port) and direct-to-leader (public command port) arrivals.
+    size_t trackInFlightWrite(const SData& request);
+    void untrackInFlightWrite(size_t fingerprint);
 
     // This is a monotonically incrementing integer just used to uniquely identify socket threads.
     atomic<uint64_t> _socketThreadNumber;

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -374,14 +374,12 @@ private:
     recursive_mutex _futureCommitCommandMutex;
 
     // Tracks a content fingerprint for each escalated request currently in flight on the leader. It's used to detect a
-    // duplicate escalated request that arrives while the same request is still being processed. Duplicates happen
-    // because PHP re-sends the same write to a different follower when one times out (see Client.php::call), and each
-    // follower mints its own command id, so the id can't identify the duplicate; the request's content can.
+    // duplicate escalated request that arrives while the same request is still being processed.
     set<size_t> _inFlightEscalatedRequests;
     mutex _inFlightEscalatedRequestsMutex;
 
     // A cumulative count of the duplicate escalated requests detected since startup, reported in the `Status` command.
-    // This is mostly useful to enable testing on this approach.
+    // This is mostly useful to enable automated tests on this approach.
     atomic<uint64_t> _duplicateEscalatedRequestCount{0};
 
     // A set of command names that will always be run with QUORUM consistency level.
@@ -470,14 +468,11 @@ private:
 
     // Computes a content fingerprint for a request, used to detect duplicate writes on the leader. It hashes the
     // method line, the request headers, and the body, but skips the transport headers a follower stamps on while
-    // escalating (which differ between two copies of the same write). Two copies of one logical write - same
-    // `requestID` and payload - produce the same fingerprint, whether one was escalated and the other sent directly.
+    // escalating, which differ between two copies of the same write.
     static size_t escalatedRequestFingerprint(const SData& request);
 
     // Tracks/untracks an in-flight write on the leader by content fingerprint, so we can detect a duplicate copy
-    // arriving while the first is still being processed (write amplification). trackInFlightWrite returns the
-    // fingerprint - pass it to untrackInFlightWrite once the write completes - and logs plus counts a duplicate. Both
-    // are called for escalated (private command port) and direct-to-leader (public command port) arrivals.
+    // arriving while the first is still being processed.
     size_t trackInFlightWrite(const SData& request);
     void untrackInFlightWrite(size_t fingerprint);
 

--- a/test/clustertest/tests/EscalateTest.cpp
+++ b/test/clustertest/tests/EscalateTest.cpp
@@ -108,10 +108,11 @@ struct EscalateTest : tpunit::TestFixture
         ASSERT_EQUAL(results[0].methodLine, "200 OK");
     }
 
-    // A follower that escalates the same request to the leader more than once while a copy is still being processed
-    // causes write amplification. The leader detects these duplicates (matching on the command id) and reports a
-    // running count via `Status`. Here we escalate two copies of one request sharing the same id, overlapping in time
-    // via a slow process step, and verify the leader noticed the duplicate.
+    // In production, PHP re-sends the same write to a different follower when one times out, so the leader can receive
+    // two escalations of one logical write - identical `requestID` and payload but distinct command ids - while the
+    // first is still processing, causing write amplification. The leader detects these by content fingerprint and
+    // reports a running count via `Status`. Here we escalate two identical copies of one write sharing a `requestID`,
+    // overlapping in time via a slow process step, and verify the leader noticed the duplicate.
     void duplicateEscalatedRequestDetected()
     {
         // Node 0 is the leader (which tracks duplicates), node 1 a follower (which we escalate from).
@@ -123,12 +124,11 @@ struct EscalateTest : tpunit::TestFixture
         // Read the leader's current duplicate count so the assertion is independent of any earlier tests.
         uint64_t countBefore = SToUInt64(SParseJSONObject(leader.executeWaitVerifyContent(SData("Status"), "200", true))["duplicateEscalatedRequestCount"]);
 
-        // Two identical write commands sharing one id. The leader reuses the escalated request's id, so both copies
-        // land under the same id. The slow process step keeps the first copy in flight long enough for the second to
-        // arrive while the first is still being processed on the leader.
+        // Two identical writes sharing one `requestID`. Their command ids differ, but the content fingerprint matches.
+        // The slow process step keeps the first copy in flight long enough for the second to arrive while the first is still being processed.
         SData cmd("idcollision");
         cmd["writeConsistency"] = "ASYNC";
-        cmd["ID"] = "duplicate_escalation_test";
+        cmd["requestID"] = "duplicate_escalation_test";
         cmd["ProcessSleep"] = "1000";
         cmd["value"] = "duplicate";
 

--- a/test/clustertest/tests/EscalateTest.cpp
+++ b/test/clustertest/tests/EscalateTest.cpp
@@ -114,23 +114,14 @@ struct EscalateTest : tpunit::TestFixture
     // via a slow process step, and verify the leader noticed the duplicate.
     void duplicateEscalatedRequestDetected()
     {
-        // Find the leader (which tracks duplicates) and a follower (which we escalate from).
-        BedrockTester* leader = nullptr;
-        BedrockTester* follower = nullptr;
-        for (size_t i = 0; i < 3; i++) {
-            BedrockTester& node = tester->getTester(i);
-            string state = SParseJSONObject(node.executeWaitVerifyContent(SData("Status"), "200", true))["state"];
-            if (state == "LEADING") {
-                leader = &node;
-            } else if (state == "FOLLOWING" && !follower) {
-                follower = &node;
-            }
-        }
-        ASSERT_TRUE(leader);
-        ASSERT_TRUE(follower);
+        // Node 0 is the leader (which tracks duplicates), node 1 a follower (which we escalate from).
+        BedrockTester& leader = tester->getTester(0);
+        BedrockTester& follower = tester->getTester(1);
+        ASSERT_TRUE(leader.waitForState("LEADING"));
+        ASSERT_TRUE(follower.waitForState("FOLLOWING"));
 
         // Read the leader's current duplicate count so the assertion is independent of any earlier tests.
-        uint64_t countBefore = SToUInt64(SParseJSONObject(leader->executeWaitVerifyContent(SData("Status"), "200", true))["duplicateEscalatedRequestCount"]);
+        uint64_t countBefore = SToUInt64(SParseJSONObject(leader.executeWaitVerifyContent(SData("Status"), "200", true))["duplicateEscalatedRequestCount"]);
 
         // Two identical write commands sharing one id. The leader reuses the escalated request's id, so both copies
         // land under the same id. The slow process step keeps the first copy in flight long enough for the second to
@@ -142,13 +133,13 @@ struct EscalateTest : tpunit::TestFixture
         cmd["value"] = "duplicate";
 
         // Send both at once (one per connection) so they escalate to the leader concurrently.
-        auto results = follower->executeWaitMultipleData({cmd, cmd}, 2);
+        auto results = follower.executeWaitMultipleData({cmd, cmd}, 2);
         ASSERT_EQUAL(results.size(), 2);
         ASSERT_EQUAL(results[0].methodLine, "200 OK");
         ASSERT_EQUAL(results[1].methodLine, "200 OK");
 
         // The leader should have detected at least one duplicate.
-        uint64_t countAfter = SToUInt64(SParseJSONObject(leader->executeWaitVerifyContent(SData("Status"), "200", true))["duplicateEscalatedRequestCount"]);
+        uint64_t countAfter = SToUInt64(SParseJSONObject(leader.executeWaitVerifyContent(SData("Status"), "200", true))["duplicateEscalatedRequestCount"]);
         ASSERT_GREATER_THAN(countAfter, countBefore);
     }
 } __EscalateTest;

--- a/test/clustertest/tests/EscalateTest.cpp
+++ b/test/clustertest/tests/EscalateTest.cpp
@@ -108,11 +108,6 @@ struct EscalateTest : tpunit::TestFixture
         ASSERT_EQUAL(results[0].methodLine, "200 OK");
     }
 
-    // In production, PHP re-sends the same write to a different follower when one times out, so the leader can receive
-    // two escalations of one logical write - identical `requestID` and payload but distinct command ids - while the
-    // first is still processing, causing write amplification. The leader detects these by content fingerprint and
-    // reports a running count via `Status`. Here we escalate two identical copies of one write sharing a `requestID`,
-    // overlapping in time via a slow process step, and verify the leader noticed the duplicate.
     void duplicateEscalatedRequestDetected()
     {
         // Node 0 is the leader (which tracks duplicates), node 1 a follower (which we escalate from).

--- a/test/clustertest/tests/EscalateTest.cpp
+++ b/test/clustertest/tests/EscalateTest.cpp
@@ -9,7 +9,8 @@ struct EscalateTest : tpunit::TestFixture
                                          TEST(EscalateTest::test),
                                          TEST(EscalateTest::testSerializedData),
                                          TEST(EscalateTest::testSerializedDataException),
-                                         TEST(EscalateTest::socketReuse))
+                                         TEST(EscalateTest::socketReuse),
+                                         TEST(EscalateTest::duplicateEscalatedRequestDetected))
     {
     }
 
@@ -105,5 +106,49 @@ struct EscalateTest : tpunit::TestFixture
         // Send the command again. It shouldn't fail with a broken socket.
         results = brtester.executeWaitMultipleData({cmd});
         ASSERT_EQUAL(results[0].methodLine, "200 OK");
+    }
+
+    // A follower that escalates the same request to the leader more than once while a copy is still being processed
+    // causes write amplification. The leader detects these duplicates (matching on the command id) and reports a
+    // running count via `Status`. Here we escalate two copies of one request sharing the same id, overlapping in time
+    // via a slow process step, and verify the leader noticed the duplicate.
+    void duplicateEscalatedRequestDetected()
+    {
+        // Find the leader (which tracks duplicates) and a follower (which we escalate from).
+        BedrockTester* leader = nullptr;
+        BedrockTester* follower = nullptr;
+        for (size_t i = 0; i < 3; i++) {
+            BedrockTester& node = tester->getTester(i);
+            string state = SParseJSONObject(node.executeWaitVerifyContent(SData("Status"), "200", true))["state"];
+            if (state == "LEADING") {
+                leader = &node;
+            } else if (state == "FOLLOWING" && !follower) {
+                follower = &node;
+            }
+        }
+        ASSERT_TRUE(leader);
+        ASSERT_TRUE(follower);
+
+        // Read the leader's current duplicate count so the assertion is independent of any earlier tests.
+        uint64_t countBefore = SToUInt64(SParseJSONObject(leader->executeWaitVerifyContent(SData("Status"), "200", true))["duplicateEscalatedRequestCount"]);
+
+        // Two identical write commands sharing one id. The leader reuses the escalated request's id, so both copies
+        // land under the same id. The slow process step keeps the first copy in flight long enough for the second to
+        // arrive while the first is still being processed on the leader.
+        SData cmd("idcollision");
+        cmd["writeConsistency"] = "ASYNC";
+        cmd["ID"] = "duplicate_escalation_test";
+        cmd["ProcessSleep"] = "1000";
+        cmd["value"] = "duplicate";
+
+        // Send both at once (one per connection) so they escalate to the leader concurrently.
+        auto results = follower->executeWaitMultipleData({cmd, cmd}, 2);
+        ASSERT_EQUAL(results.size(), 2);
+        ASSERT_EQUAL(results[0].methodLine, "200 OK");
+        ASSERT_EQUAL(results[1].methodLine, "200 OK");
+
+        // The leader should have detected at least one duplicate.
+        uint64_t countAfter = SToUInt64(SParseJSONObject(leader->executeWaitVerifyContent(SData("Status"), "200", true))["duplicateEscalatedRequestCount"]);
+        ASSERT_GREATER_THAN(countAfter, countBefore);
     }
 } __EscalateTest;


### PR DESCRIPTION
### Details

Duplicate escalated write requests may reach the leader and be executed more than once, causing write amplification (identified during fire analysis).

This is a protective, observability-first step: on the leader, we now track the ids of escalated requests currently in flight and detect when the same request arrives again while a previous copy is still being processed. For now duplicates are only **logged** (via `SWARN`) — they are **not** dropped — so we can first confirm whether/how often this actually happens in production.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/649211

### Tests

Added `EscalateTest::duplicateEscalatedRequestDetected`, which escalates two identical write commands sharing one id from a follower (kept overlapping in flight on the leader via a slow process step) and verifies the leader's `duplicateEscalatedRequestCount` increased.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
