### PR TITLE
Use timeSpent instead of _readElapsed to decide if we should log or not

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -659,7 +659,7 @@ bool SQLite::read(const string& query, const map<string, Parameter>& params, SQR
 
     // If we're not inside a transaction, this doesn't get added to our normal transaction timing.
     // This log line will happen a lot. Let's log only when it takes more than 100ms to complete.
-    if (!_insideTransaction && _readElapsed > 100'000) {
+    if (!_insideTransaction && timeSpent > 100'000) {
         SINFO("Read with auto-transaction timing info", {
             {"totalTransactionElapsed", to_string(timeSpent / 1000)},
         });


### PR DESCRIPTION
### Details
Changes the variable to log for the transaction time, not total time spent.


### Fixed Issues
Fixes https://github.com/Expensify/Bedrock/pull/2672#discussion_r3597504818

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
