### PR TITLE
[WIP] Downgrade SQLite engine to 2026-05-12 build (012a04ed) to isolate OOM regression

### DIFF
--- a/libstuff/sqlite3.h
+++ b/libstuff/sqlite3.h
@@ -148,10 +148,10 @@ extern "C" {
 */
 #define SQLITE_VERSION        "3.54.0"
 #define SQLITE_VERSION_NUMBER 3054000
-#define SQLITE_SOURCE_ID      "2026-07-09 16:12:25 45f6fccc2ed3e0b6d6f72cf3aeb849a77eace5f8675f40d3fff-experimental"
-#define SQLITE_SCM_BRANCH     "unknown"
-#define SQLITE_SCM_TAGS       "unknown"
-#define SQLITE_SCM_DATETIME   "2026-07-09T16:12:25.329Z"
+#define SQLITE_SOURCE_ID      "2026-05-12 17:42:11 012a04edd0ab7001f2635eeb766089201cbe372d54e5008e7138a5dbe522bf06"
+#define SQLITE_SCM_BRANCH     "hctree-bedrock"
+#define SQLITE_SCM_TAGS       ""
+#define SQLITE_SCM_DATETIME   "2026-05-12T17:42:11.503Z"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -2210,19 +2210,6 @@ struct sqlite3_mem_methods {
 ** recommended case) then the integer is always filled with zero, regardless
 ** if its initial value.
 ** </dl>
-**
-** [[SQLITE_CONFIG_SHAREDLOG_MAXSIZE]]
-** <dt>SQLITE_CONFIG_SHAREDLOG_MAXSIZE
-** <dd>This option is used to set the maximum size of a BEGIN CONCURRENT
-** shared-log in bytes. The default value is 1GiB (1*1024*1024*1024). The
-** argument to this configuration option must be a 64-bit signed integer
-** (type sqlite3_int64) to use as the new limit. A negative parameter
-** restores the default value, a value of zero disabled shared-logs
-** altogether. There is no way to configure unlimited memory usage, but
-** applications may instead configure a very large value (e.g. 1TiB).
-** Shared-log entries are automatically discarded when their associated
-** transactions are checkpointed, which prevents the shared-log from growing
-** indefinitely in this case.
 */
 #define SQLITE_CONFIG_SINGLETHREAD         1  /* nil */
 #define SQLITE_CONFIG_MULTITHREAD          2  /* nil */
@@ -2254,7 +2241,6 @@ struct sqlite3_mem_methods {
 #define SQLITE_CONFIG_SORTERREF_SIZE      28  /* int nByte */
 #define SQLITE_CONFIG_MEMDB_MAXSIZE       29  /* sqlite3_int64 */
 #define SQLITE_CONFIG_ROWID_IN_VIEW       30  /* int* */
-#define SQLITE_CONFIG_SHAREDLOG_MAXSIZE   31  /* sqlite3_int64 */
 
 /*
 ** CAPI3REF: Database Connection Configuration Options

--- a/libstuff/sqlite3ext.h
+++ b/libstuff/sqlite3ext.h
@@ -375,9 +375,6 @@ struct sqlite3_api_routines {
   void (*str_truncate)(sqlite3_str*,int);
   void (*str_free)(sqlite3_str*);
   int (*carray_bind)(sqlite3_stmt*,int,void*,int,int,void(*)(void*));
-  int (*carray_bind_v2)(sqlite3_stmt*,int,void*,int,int,void(*)(void*),void*);
-  /* Version 3.54.0 and later */
-  sqlite3_int64 (*incomplete)(const char*);
 };
 
 /*
@@ -720,9 +717,6 @@ typedef int (*sqlite3_loadext_entry)(
 #define sqlite3_str_truncate           sqlite3_api->str_truncate
 #define sqlite3_str_free               sqlite3_api->str_free
 #define sqlite3_carray_bind            sqlite3_api->carray_bind
-#define sqlite3_carray_bind_v2         sqlite3_api->carray_bind_v2
-/* Version 3.54.0 and later */
-#define sqlite3_incomplete             sqlite3_api->incomplete
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)


### PR DESCRIPTION
## Explanation of Change
- Reverts the SQLite amalgamation (`libstuff/sqlite3.c`, `libstuff/sqlite3.h`, `libstuff/sqlite3ext.h`) from the current build **`45f6fccc` (2026-07-09)** back to **`012a04ed` (2026-05-12)**, taken from commit `c6d195fd` ("new sqlite version from dan"). Code taken from the before this June 5th [PR](https://github.com/Expensify/Bedrock/pull/2628/changes).
- `SQLITE_VERSION` is unchanged (`3.54.0`) — only the hctree/engine **build (SOURCE_ID)** changes. No other files touched.

## Why
- The monthly "Account Manager Retention Report" — a large read-only `SELECT` run via `readdb`/`CustomQuery`, doing ~12,763 full-table scans under `BEGIN CONCURRENT` — has run for ~3 years and now aborts with out-of-memory: `{SQLITE} Code: 7, Message: statement aborts at ...: out of memory` → `402 Bad query`.
- Fleet-wide `CustomQuery` out-of-memory events were **0 through June, onset 2026-07-06**. App-side Bedrock changes in the window were cleared (logging / rate-limiting / write-path locking). The only memory-relevant change underneath this path is the SQLite/hctree **engine**, which was bumped 3× between the report's last success (`012a04ed`, May 12) and failure (`69941fdc`, Jun 17).
- `012a04ed` is the last engine build the report ran on cleanly, so this reverts to it.

## Tests
- Deploy this branch to **a single non-critical follower** (not leader / secondary-leader).
- Re-run the report query on that node.
- **OOM disappears → confirms the engine bump is the cause.** OOM persists → engine is exonerated; look elsewhere.

## Caveat
- The amalgamation is reverted ~2 months while keeping current Bedrock C++. Watch CI for any compile incompatibility.
