### PR TITLE
Create new getReadQueryCount acessor

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1519,6 +1519,11 @@ uint64_t SQLite::getDBCountAtStart() const
     return _dbCountAtStart;
 }
 
+int64_t SQLite::getReadQueryCount() const
+{
+    return _readQueryCount;
+}
+
 void SQLite::setCommitEnabled(bool enable)
 {
     _sharedData.setCommitEnabled(enable);

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -329,9 +329,13 @@ public:
     uint64_t getDBCountAtStart() const;
 
     // Read-only accessor for the number of read queries attempted in the current transaction (metrics/tests only).
-    // Virtual so RemoteSQLite can report the reads it forwards to the server instead of the local (unused) counter.
-    virtual int64_t getReadQueryCount() const;
+    int64_t getReadQueryCount() const;
 
+protected:
+    // For subclasses that override read() to record a read against the shared counter.
+    void incrementReadQueryCount() const { _readQueryCount++; }
+
+public:
     int64_t getLastConflictIdentifier() const;
 
     string getLastConflictLocation() const;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -328,6 +328,10 @@ public:
     // public read-only accessor for _dbCountAtStart.
     uint64_t getDBCountAtStart() const;
 
+    // Read-only accessor for the number of read queries attempted in the current transaction (metrics/tests only).
+    // Virtual so RemoteSQLite can report the reads it forwards to the server instead of the local (unused) counter.
+    virtual int64_t getReadQueryCount() const;
+
     int64_t getLastConflictIdentifier() const;
 
     string getLastConflictLocation() const;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -333,7 +333,10 @@ public:
 
 protected:
     // For subclasses that override read() to record a read against the shared counter.
-    void incrementReadQueryCount() const { _readQueryCount++; }
+    void incrementReadQueryCount() const
+    {
+        _readQueryCount++;
+    }
 
 public:
     int64_t getLastConflictIdentifier() const;

--- a/test/lib/RemoteSQLite.cpp
+++ b/test/lib/RemoteSQLite.cpp
@@ -35,6 +35,7 @@ bool RemoteSQLite::_runRemoteQuery(const string& query, const map<string, Parame
 
 bool RemoteSQLite::read(const string& query, SQResult& result, bool skipInfoWarn) const
 {
+    _forwardedReadCount++;
     return _runRemoteQuery(query, {}, result);
 }
 
@@ -51,11 +52,13 @@ bool RemoteSQLite::writeIdempotent(const string& query, SQResult& result)
 
 bool RemoteSQLite::read(const string& query, const map<string, Parameter>& params, SQResult& result, bool skipInfoWarn) const
 {
+    _forwardedReadCount++;
     return _runRemoteQuery(query, params, result);
 }
 
 string RemoteSQLite::read(const string& query, const map<string, Parameter>& params) const
 {
+    _forwardedReadCount++;
     SQResult result;
     if (!_runRemoteQuery(query, params, result)) {
         return "";
@@ -94,4 +97,9 @@ bool RemoteSQLite::write(const string& query, const map<string, Parameter>& para
 bool RemoteSQLite::write(const string& query, const map<string, Parameter>& params, SQResult& result)
 {
     return _runRemoteQuery(query, params, result);
+}
+
+int64_t RemoteSQLite::getReadQueryCount() const
+{
+    return _forwardedReadCount;
 }

--- a/test/lib/RemoteSQLite.cpp
+++ b/test/lib/RemoteSQLite.cpp
@@ -35,7 +35,7 @@ bool RemoteSQLite::_runRemoteQuery(const string& query, const map<string, Parame
 
 bool RemoteSQLite::read(const string& query, SQResult& result, bool skipInfoWarn) const
 {
-    _forwardedReadCount++;
+    incrementReadQueryCount();
     return _runRemoteQuery(query, {}, result);
 }
 
@@ -52,13 +52,13 @@ bool RemoteSQLite::writeIdempotent(const string& query, SQResult& result)
 
 bool RemoteSQLite::read(const string& query, const map<string, Parameter>& params, SQResult& result, bool skipInfoWarn) const
 {
-    _forwardedReadCount++;
+    incrementReadQueryCount();
     return _runRemoteQuery(query, params, result);
 }
 
 string RemoteSQLite::read(const string& query, const map<string, Parameter>& params) const
 {
-    _forwardedReadCount++;
+    incrementReadQueryCount();
     SQResult result;
     if (!_runRemoteQuery(query, params, result)) {
         return "";
@@ -97,9 +97,4 @@ bool RemoteSQLite::write(const string& query, const map<string, Parameter>& para
 bool RemoteSQLite::write(const string& query, const map<string, Parameter>& params, SQResult& result)
 {
     return _runRemoteQuery(query, params, result);
-}
-
-int64_t RemoteSQLite::getReadQueryCount() const
-{
-    return _forwardedReadCount;
 }

--- a/test/lib/RemoteSQLite.h
+++ b/test/lib/RemoteSQLite.h
@@ -30,15 +30,8 @@ public:
     bool write(const string& query, const map<string, Parameter>& params) override;
     bool write(const string& query, const map<string, Parameter>& params, SQResult& result) override;
 
-    // Reads run on the remote server, so the base class counter never advances. Report the number of
-    // read queries this proxy has forwarded instead, so tests can assert on read round-trips.
-    int64_t getReadQueryCount() const override;
-
 private:
     mutable BedrockTester* _tester;
-
-    // Number of read queries forwarded to the server; each forwarded read is one round-trip.
-    mutable int64_t _forwardedReadCount = 0;
 
     // Build a Query command with named bound parameters serialized into `sql-param-<name>` headers and
     // send it via the tester's executeWaitMultipleData. This bypasses BedrockTester::readDB's

--- a/test/lib/RemoteSQLite.h
+++ b/test/lib/RemoteSQLite.h
@@ -30,8 +30,15 @@ public:
     bool write(const string& query, const map<string, Parameter>& params) override;
     bool write(const string& query, const map<string, Parameter>& params, SQResult& result) override;
 
+    // Reads run on the remote server, so the base class counter never advances. Report the number of
+    // read queries this proxy has forwarded instead, so tests can assert on read round-trips.
+    int64_t getReadQueryCount() const override;
+
 private:
     mutable BedrockTester* _tester;
+
+    // Number of read queries forwarded to the server; each forwarded read is one round-trip.
+    mutable int64_t _forwardedReadCount = 0;
 
     // Build a Query command with named bound parameters serialized into `sql-param-<name>` headers and
     // send it via the tester's executeWaitMultipleData. This bypasses BedrockTester::readDB's


### PR DESCRIPTION
### Details
Add a new acessor `getReadQueryCount` so we can count the number of read queries a test does using `db.getReadQueryCount` in an Auth test.

### Fixed Issues
Requirement to fix https://github.com/Expensify/Expensify/issues/659611

### Tests
Compiled everything and ran all Auth tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
