### PR TITLE
Refuse HTTPS requests on the blockingCommit thread

### DIFF
--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -118,13 +118,8 @@ void BedrockCommand::_waitForHTTPSRequests()
 {
     // The blockingCommit thread (worker 0) runs commands under an exclusive transaction, serialized against the whole
     // blocking queue. Waiting on an HTTPS request here would block that thread for the full network round-trip,
-    // stalling every command behind it. This catches commands that wait from within `peek()` (the throw propagates
-    // out and `BedrockCore::peekCommand` turns it into a clean failure), including Stripe and Hubspot, which bypass
-    // `SStandaloneHTTPSManager::_httpsSend` with their own implementations. The worker loop's own call to
-    // `waitForHTTPSRequests` pre-checks this same condition and fails the command without relying on the throw.
-    // We only refuse when there is genuine pending network work; blocking-queue commands with no HTTPS request must
-    // pass through untouched. Scheduled requests are started from the loop below, so throwing now stops them before
-    // the socket opens.
+    // stalling every command behind it. This will guarantee that we're throwing an error if the command calls
+    // waitForHTTPSRequests(db) in peek. If this is running between peek/process, the check will be in runCommand.
     if (isBlockingCommitThread && !areHttpsRequestsComplete()) {
         STHROW("500 Refused - HTTPS request attempted on blockingCommit thread");
     }

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -118,11 +118,13 @@ void BedrockCommand::_waitForHTTPSRequests()
 {
     // The blockingCommit thread (worker 0) runs commands under an exclusive transaction, serialized against the whole
     // blocking queue. Waiting on an HTTPS request here would block that thread for the full network round-trip,
-    // stalling every command behind it. This is the common funnel for every manager (including Stripe and Hubspot,
-    // which bypass SStandaloneHTTPSManager::_httpsSend with their own implementations), so refuse here. We only throw
-    // when there is genuine pending network work: most blocking-queue commands carry no HTTPS requests and must pass
-    // through untouched. Scheduled requests are started from the loop below, so throwing now stops them before the
-    // socket opens.
+    // stalling every command behind it. This catches commands that wait from within `peek()` (the throw propagates
+    // out and `BedrockCore::peekCommand` turns it into a clean failure), including Stripe and Hubspot, which bypass
+    // `SStandaloneHTTPSManager::_httpsSend` with their own implementations. The worker loop's own call to
+    // `waitForHTTPSRequests` pre-checks this same condition and fails the command without relying on the throw.
+    // We only refuse when there is genuine pending network work; blocking-queue commands with no HTTPS request must
+    // pass through untouched. Scheduled requests are started from the loop below, so throwing now stops them before
+    // the socket opens.
     if (isBlockingCommitThread && !areHttpsRequestsComplete()) {
         STHROW("500 Refused - HTTPS request attempted on blockingCommit thread");
     }

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -116,14 +116,6 @@ bool BedrockCommand::areHttpsRequestsComplete() const
 
 void BedrockCommand::_waitForHTTPSRequests()
 {
-    // The blockingCommit thread (worker 0) runs commands under an exclusive transaction, serialized against the whole
-    // blocking queue. Waiting on an HTTPS request here would block that thread for the full network round-trip,
-    // stalling every command behind it. This will guarantee that we're throwing an error if the command calls
-    // waitForHTTPSRequests(db) in peek. If this is running between peek/process, the check will be in runCommand.
-    if (isBlockingCommitThread && !areHttpsRequestsComplete()) {
-        STHROW("500 Refused - HTTPS request attempted on blockingCommit thread");
-    }
-
     uint64_t startTime = 0;
     while (!areHttpsRequestsComplete()) {
         // This uses the same starting point as in areHttpsRequestsComplete, for efficiency.

--- a/BedrockCommand.cpp
+++ b/BedrockCommand.cpp
@@ -116,6 +116,17 @@ bool BedrockCommand::areHttpsRequestsComplete() const
 
 void BedrockCommand::_waitForHTTPSRequests()
 {
+    // The blockingCommit thread (worker 0) runs commands under an exclusive transaction, serialized against the whole
+    // blocking queue. Waiting on an HTTPS request here would block that thread for the full network round-trip,
+    // stalling every command behind it. This is the common funnel for every manager (including Stripe and Hubspot,
+    // which bypass SStandaloneHTTPSManager::_httpsSend with their own implementations), so refuse here. We only throw
+    // when there is genuine pending network work: most blocking-queue commands carry no HTTPS requests and must pass
+    // through untouched. Scheduled requests are started from the loop below, so throwing now stops them before the
+    // socket opens.
+    if (isBlockingCommitThread && !areHttpsRequestsComplete()) {
+        STHROW("500 Refused - HTTPS request attempted on blockingCommit thread");
+    }
+
     uint64_t startTime = 0;
     while (!areHttpsRequestsComplete()) {
         // This uses the same starting point as in areHttpsRequestsComplete, for efficiency.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -689,6 +689,7 @@ void BedrockServer::worker(int threadId)
 {
     // Worker 0 is the "blockingCommit" thread.
     SInitialize(threadId ? "worker" + to_string(threadId) : "blockingCommit");
+    isBlockingCommitThread = (threadId == 0);
 
     // Command to work on. This default command is replaced when we find work to do.
     unique_ptr<BedrockCommand> command(nullptr);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -885,7 +885,17 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
         canWriteParallel = canWriteParallel && (command->writeConsistency == SQLiteNode::ASYNC);
 
         // If there are outstanding HTTPS requests on this command (from a previous call to `peek`) we process them here.
-        command->waitForHTTPSRequests();
+        // On the blockingCommit thread this throws rather than stalling the serialized queue on a network round-trip.
+        // That throw isn't caught by `peekCommand` here (we're outside it), so fail the command cleanly instead of
+        // letting the exception escape to the worker loop.
+        try {
+            command->waitForHTTPSRequests();
+        } catch (const SException& e) {
+            command->response.methodLine = e.what();
+            command->complete = true;
+            _reply(command);
+            return;
+        }
 
         // Get a DB handle to work on. This will automatically be returned when dbScope goes out of scope.
         if (!_dbPool) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -885,14 +885,6 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
         canWriteParallel = canWriteParallel && (command->writeConsistency == SQLiteNode::ASYNC);
 
         // If there are outstanding HTTPS requests on this command (from a previous call to `peek`) we process them here.
-        // The blockingCommit thread (worker 0) must not stall the serialized blocking queue on a network round-trip, so
-        // if this command has pending HTTPS requests, fail it cleanly here instead of waiting on them.
-        if (isBlockingCommitThread && !command->areHttpsRequestsComplete()) {
-            command->response.methodLine = "500 Refused - HTTPS request attempted on blockingCommit thread";
-            command->complete = true;
-            _reply(command);
-            return;
-        }
         command->waitForHTTPSRequests();
 
         // Get a DB handle to work on. This will automatically be returned when dbScope goes out of scope.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -885,17 +885,15 @@ void BedrockServer::runCommand(unique_ptr<BedrockCommand>&& _command, bool isBlo
         canWriteParallel = canWriteParallel && (command->writeConsistency == SQLiteNode::ASYNC);
 
         // If there are outstanding HTTPS requests on this command (from a previous call to `peek`) we process them here.
-        // On the blockingCommit thread this throws rather than stalling the serialized queue on a network round-trip.
-        // That throw isn't caught by `peekCommand` here (we're outside it), so fail the command cleanly instead of
-        // letting the exception escape to the worker loop.
-        try {
-            command->waitForHTTPSRequests();
-        } catch (const SException& e) {
-            command->response.methodLine = e.what();
+        // The blockingCommit thread (worker 0) must not stall the serialized blocking queue on a network round-trip, so
+        // if this command has pending HTTPS requests, fail it cleanly here instead of waiting on them.
+        if (isBlockingCommitThread && !command->areHttpsRequestsComplete()) {
+            command->response.methodLine = "500 Refused - HTTPS request attempted on blockingCommit thread";
             command->complete = true;
             _reply(command);
             return;
         }
+        command->waitForHTTPSRequests();
 
         // Get a DB handle to work on. This will automatically be returned when dbScope goes out of scope.
         if (!_dbPool) {

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -203,6 +203,13 @@ unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_creat
 
 unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_httpsSend(const string& url, const SData& request, bool allowProxy)
 {
+    // The blockingCommit thread runs commands under an exclusive transaction, serialized against the whole blocking
+    // queue. Firing an HTTPS request here would block that thread for the full network round-trip, stalling every
+    // command behind it. Refuse before opening the socket so the command fails instead of blocking.
+    if (isBlockingCommitThread) {
+        STHROW("500 Refused - HTTPS request attempted on blockingCommit thread");
+    }
+
     // Open a connection, optionally using SSL (if the URL is HTTPS). If that doesn't work, then just return a
     // completed transaction with an error response.
     string host, path;

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -183,7 +183,7 @@ SStandaloneHTTPSManager::Transaction::Transaction(SStandaloneHTTPSManager& manag
     manager(manager_),
     requestID(requestID.empty() ? SThreadLogPrefix : requestID)
 {
-    // The blockingCommit thread runs commands under an exclusive transaction, serialized against the whole blocking 
+    // The blockingCommit thread runs commands under an exclusive transaction, serialized against the whole blocking
     // queue. Starting an HTTPS request there would block that thread for the full network round-trip, stalling
     // every command behind it. Every outbound request builds exactly one Transaction before opening its
     // socket, so refusing here covers every manager uniformly, and the throw propagates out of peek to a clean failure.

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -183,6 +183,16 @@ SStandaloneHTTPSManager::Transaction::Transaction(SStandaloneHTTPSManager& manag
     manager(manager_),
     requestID(requestID.empty() ? SThreadLogPrefix : requestID)
 {
+    // The blockingCommit thread (worker 0) runs commands under an exclusive transaction, serialized against the whole
+    // blocking queue. Starting an HTTPS request there would block that thread for the full network round-trip,
+    // stalling every command behind it. Every outbound request builds exactly one Transaction before opening its
+    // socket (base _httpsSend, Stripe/Hubspot socketStarter, and so on), so refusing here covers every manager
+    // uniformly, and the throw propagates out of peek to a clean failure. Reconstructing already-completed requests in
+    // BedrockCommand::deserializeHTTPSRequests happens on the command-reception thread, never worker 0, so this does
+    // not reject those.
+    if (isBlockingCommitThread) {
+        STHROW("500 Refused - HTTPS request attempted on blockingCommit thread");
+    }
 }
 
 SStandaloneHTTPSManager::Transaction::~Transaction()
@@ -203,13 +213,6 @@ unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_creat
 
 unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_httpsSend(const string& url, const SData& request, bool allowProxy)
 {
-    // The blockingCommit thread runs commands under an exclusive transaction, serialized against the whole blocking
-    // queue. Firing an HTTPS request here would block that thread for the full network round-trip, stalling every
-    // command behind it. Refuse before opening the socket so the command fails instead of blocking.
-    if (isBlockingCommitThread) {
-        STHROW("500 Refused - HTTPS request attempted on blockingCommit thread");
-    }
-
     // Open a connection, optionally using SSL (if the URL is HTTPS). If that doesn't work, then just return a
     // completed transaction with an error response.
     string host, path;

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -183,13 +183,12 @@ SStandaloneHTTPSManager::Transaction::Transaction(SStandaloneHTTPSManager& manag
     manager(manager_),
     requestID(requestID.empty() ? SThreadLogPrefix : requestID)
 {
-    // The blockingCommit thread (worker 0) runs commands under an exclusive transaction, serialized against the whole
-    // blocking queue. Starting an HTTPS request there would block that thread for the full network round-trip,
-    // stalling every command behind it. Every outbound request builds exactly one Transaction before opening its
-    // socket (base _httpsSend, Stripe/Hubspot socketStarter, and so on), so refusing here covers every manager
-    // uniformly, and the throw propagates out of peek to a clean failure. Reconstructing already-completed requests in
-    // BedrockCommand::deserializeHTTPSRequests happens on the command-reception thread, never worker 0, so this does
-    // not reject those.
+    // The blockingCommit thread runs commands under an exclusive transaction, serialized against the whole blocking 
+    // queue. Starting an HTTPS request there would block that thread for the full network round-trip, stalling
+    // every command behind it. Every outbound request builds exactly one Transaction before opening its
+    // socket, so refusing here covers every manager uniformly, and the throw propagates out of peek to a clean failure.
+    // Reconstructing already-completed requests in BedrockCommand::deserializeHTTPSRequests happens on the
+    // command-reception thread, never worker 0, so this does not reject those.
     if (isBlockingCommitThread) {
         STHROW("500 Refused - HTTPS request attempted on blockingCommit thread");
     }

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -93,6 +93,7 @@ thread_local string SThreadLogParam{"we@dont.know"};
 thread_local string SThreadLogName;
 thread_local string SThreadLogCommand;
 thread_local bool isSyncThread;
+thread_local bool isBlockingCommitThread;
 
 // We store the process name passed in `SInitialize` to use in logging.
 thread_local string SProcessName;
@@ -115,6 +116,7 @@ atomic<void (*)(int priority, const char* format, ...)> SSyslogFunc = &syslog;
 void SInitialize(const string& threadName, const char* processName)
 {
     isSyncThread = false;
+    isBlockingCommitThread = false;
     // This is not really thread safe. It's guaranteed to run only once, because of the atomic flag, but it's not
     // guaranteed that a second caller to `SInitialize` will wait until this block has completed before attempting to
     // use the socket logging variables. This is handled by the fact that we call `SInitialize` in main() which waits

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -343,8 +343,9 @@ extern thread_local string SThreadLogCommand;
 
 extern thread_local bool isSyncThread;
 
-// True on worker 0, the serialized `blockingCommit` thread. Read by `SStandaloneHTTPSManager::_httpsSend` to refuse
-// starting an HTTPS request there, since blocking that thread on a network round-trip holds the whole blocking queue.
+// True on worker 0, the serialized `blockingCommit` thread. Read by the HTTPS request paths
+// (`SStandaloneHTTPSManager::_httpsSend` and `BedrockCommand::_waitForHTTPSRequests`) to refuse starting an HTTPS
+// request there, since blocking that thread on a network round-trip holds the whole blocking queue.
 extern thread_local bool isBlockingCommitThread;
 
 // Thread-local log prefix

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -343,9 +343,9 @@ extern thread_local string SThreadLogCommand;
 
 extern thread_local bool isSyncThread;
 
-// True on worker 0, the serialized `blockingCommit` thread. Read by the HTTPS request paths
-// (`SStandaloneHTTPSManager::_httpsSend` and `BedrockCommand::_waitForHTTPSRequests`) to refuse starting an HTTPS
-// request there, since blocking that thread on a network round-trip holds the whole blocking queue.
+// True on worker 0, the serialized `blockingCommit` thread. Read by `SStandaloneHTTPSManager::Transaction`'s
+// constructor to refuse starting an HTTPS request there, since blocking that thread on a network round-trip holds the
+// whole blocking queue.
 extern thread_local bool isBlockingCommitThread;
 
 // Thread-local log prefix

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -343,6 +343,10 @@ extern thread_local string SThreadLogCommand;
 
 extern thread_local bool isSyncThread;
 
+// True on worker 0, the serialized `blockingCommit` thread. Read by `SStandaloneHTTPSManager::_httpsSend` to refuse
+// starting an HTTPS request there, since blocking that thread on a network round-trip serializes the whole blocking queue.
+extern thread_local bool isBlockingCommitThread;
+
 // Thread-local log prefix
 void SLogSetThreadPrefix(const string& logPrefix);
 void SLogSetThreadName(const string& name);

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -344,7 +344,7 @@ extern thread_local string SThreadLogCommand;
 extern thread_local bool isSyncThread;
 
 // True on worker 0, the serialized `blockingCommit` thread. Read by `SStandaloneHTTPSManager::_httpsSend` to refuse
-// starting an HTTPS request there, since blocking that thread on a network round-trip serializes the whole blocking queue.
+// starting an HTTPS request there, since blocking that thread on a network round-trip holds the whole blocking queue.
 extern thread_local bool isBlockingCommitThread;
 
 // Thread-local log prefix

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -113,7 +113,8 @@ unique_ptr<BedrockCommand> BedrockPlugin_TestPlugin::getCommand(SQLiteCommand&& 
         "testPostProcessTimeout",
         "EscalateSerializedData",
         "ThreadException",
-        "httpswait"
+        "httpswait",
+        "httpsblockingcommit"
     };
     for (auto& cmdName : supportedCommands) {
         if (SStartsWith(baseCommand.request.methodLine, cmdName)) {
@@ -385,6 +386,24 @@ bool TestPluginCommand::peek(SQLite& db)
         }
         response.content = httpsRequests.back()->fullResponse.content;
         return true;
+    } else if (SStartsWith(request.methodLine, "httpsblockingcommit")) {
+        // Only queue an HTTPS request when we're running on the serialized blockingCommit thread (worker 0). On the
+        // normal worker threads this command is just a conflicting write (see `process`), which is what escalates it
+        // to the blocking queue. This mirrors commands like SendDataToHubspot, whose peek only queues a request once
+        // it re-runs on the blockingCommit thread. `httpsDontSend` leaves the request pending (no response), so it
+        // exercises the guard without any real network activity.
+        if (isBlockingCommitThread) {
+            SData newRequest("GET / HTTP/1.1");
+            newRequest["Host"] = "127.0.0.1";
+            httpsRequests.push_back(plugin().httpsManager->httpsDontSend("https://127.0.0.1:9999/", newRequest));
+
+            // With `waitInPeek`, wait here so the guard throws from within peek (caught by peekCommand). Otherwise
+            // return without waiting so the worker loop's pre-check refuses the command instead.
+            if (request["waitInPeek"] == "true") {
+                waitForHTTPSRequests(db);
+            }
+        }
+        return false;
     } else if (SStartsWith(request.methodLine, "chainedrequest")) {
         // Let's see what the user wanted to request.
         if (pendingResult) {
@@ -542,6 +561,16 @@ void TestPluginCommand::process(SQLite& db)
             response.methodLine = "200 OK";
         }
 
+        return;
+    } else if (SStartsWith(request.methodLine, "httpsblockingcommit")) {
+        // Conflict-generating write (like idcollision) so concurrent copies escalate to the blocking queue. Reaching
+        // `process` at all means peek did not queue an HTTPS request, i.e. we ran on a normal worker thread.
+        SQResult result;
+        db.read("SELECT MAX(id) FROM test", result);
+        SASSERT(result.size());
+        int nextID = SToInt(result[0][0]) + 1;
+        SASSERT(db.write("INSERT INTO TEST VALUES(" + SQ(nextID) + ", " + SQ(request["value"]) + ");"));
+        response.methodLine = "200 OK";
         return;
     } else if (SStartsWith(request.methodLine, "writebound")) {
         // Just like idcollision but uses named bound parameters so we can exercise the

--- a/test/clustertest/tests/HTTPSBlockingCommitTest.cpp
+++ b/test/clustertest/tests/HTTPSBlockingCommitTest.cpp
@@ -1,0 +1,100 @@
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
+
+// Verifies that a command which issues an optional HTTPS request from the serialized blockingCommit thread (worker 0)
+// is refused rather than allowed to stall the blocking queue on a network round-trip. See
+// https://github.com/Expensify/Expensify/issues/661688.
+//
+// The `httpsblockingcommit` test command only queues an HTTPS request when it runs on the blockingCommit thread; on the
+// normal worker threads it is a plain conflicting write. By setting MaxConflictRetries low and firing many concurrent
+// copies that collide on the same key, some commands are escalated to the blocking queue and re-run on worker 0, where
+// the guard must refuse them with "500 Refused".
+struct HTTPSBlockingCommitTest : tpunit::TestFixture
+{
+    HTTPSBlockingCommitTest()
+        : tpunit::TestFixture("HTTPSBlockingCommit",
+                              BEFORE_CLASS(HTTPSBlockingCommitTest::setup),
+                              TEST(HTTPSBlockingCommitTest::testRefusedViaPreCheck),
+                              TEST(HTTPSBlockingCommitTest::testRefusedViaPeekThrow),
+                              AFTER_CLASS(HTTPSBlockingCommitTest::teardown))
+    {
+    }
+
+    BedrockClusterTester* tester;
+
+    void setup()
+    {
+        tester = new BedrockClusterTester();
+
+        // Escalate to the blocking queue after a single conflict so we reliably reach worker 0 under contention.
+        SData setConflict("SetConflictParams");
+        setConflict["MaxConflictRetries"] = "1";
+        tester->getTester(0).executeWaitVerifyContent(setConflict, "200", true);
+    }
+
+    void teardown()
+    {
+        // Restore the default so we don't affect other tests sharing the fixture binary.
+        SData resetConflict("SetConflictParams");
+        resetConflict["MaxConflictRetries"] = "3";
+        tester->getTester(0).executeWaitVerifyContent(resetConflict, "200", true);
+
+        delete tester;
+    }
+
+    // Fires many concurrent, mutually-conflicting `httpsblockingcommit` commands across all nodes and asserts that at
+    // least one came back refused because it issued its HTTPS request on the blockingCommit thread. Every request must
+    // get a response (a normal 200 or a refusal); nothing should hang.
+    void runAndVerifyRefusals(bool waitInPeek)
+    {
+        const string refusedPrefix = "500 Refused - HTTPS request attempted on blockingCommit thread";
+        atomic<int> refused(0);
+        atomic<int> total(0);
+        list<thread> threads;
+
+        for (int i : {0, 1, 2}) {
+            threads.emplace_back([this, i, waitInPeek, refusedPrefix, &refused, &total]() {
+                BedrockTester& node = tester->getTester(i);
+
+                vector<SData> requests;
+                for (int j = 0; j < 100; j++) {
+                    SData cmd("httpsblockingcommit");
+                    cmd["writeConsistency"] = "ASYNC";
+                    cmd["value"] = "node" + to_string(i) + "-" + to_string(j);
+                    if (waitInPeek) {
+                        cmd["waitInPeek"] = "true";
+                    }
+                    requests.push_back(cmd);
+                }
+
+                auto results = node.executeWaitMultipleData(requests);
+                for (auto& result : results) {
+                    total.fetch_add(1);
+                    if (SStartsWith(result.methodLine, refusedPrefix)) {
+                        refused.fetch_add(1);
+                    }
+                }
+            });
+        }
+
+        for (thread& t : threads) {
+            t.join();
+        }
+
+        ASSERT_EQUAL(total.load(), 300);
+        ASSERT_TRUE(refused.load() > 0);
+    }
+
+    // Command returns false from peek without waiting; the worker loop's pre-check refuses it before waiting.
+    void testRefusedViaPreCheck()
+    {
+        runAndVerifyRefusals(false);
+    }
+
+    // Command waits from within peek; the throw in _waitForHTTPSRequests is caught by peekCommand and turned into the
+    // same refusal response.
+    void testRefusedViaPeekThrow()
+    {
+        runAndVerifyRefusals(true);
+    }
+} __HTTPSBlockingCommitTest;


### PR DESCRIPTION
### Details

Some Auth commands only fire their optional HTTPS request once they've been escalated to the serialized `blockingCommit` thread (worker 0), rather than during `peek()` on a regular worker thread. This happens when the earlier worker-thread `peek()` runs saw different data/conditions and queued no request, so Bedrock's "skip peek if there were httpsRequests" optimization doesn't apply — after the command conflicts >3 times (e.g. on the `nameValuePairsName` index) it lands in the blocking queue, and its `peek()` there finally issues the HTTP call.

Firing an HTTPS request from that single serialized thread holds it for the full network round-trip (and any retry storms), serializing the whole blocking queue behind one slow third-party call. In one trace there were 613 commands waiting behind a single `SendDataToHubspot` that spent ~8.5s in `peek()`.

This PR refuses to start an HTTPS request on the `blockingCommit` thread, failing the command cleanly instead of stalling the queue. It adds a `thread_local bool isBlockingCommitThread` flag (mirroring the existing `isSyncThread`), set for worker 0 in `BedrockServer::worker`, and guards a single choke-point:

- **`SStandaloneHTTPSManager::Transaction`'s constructor** throws `500 Refused` when `isBlockingCommitThread` is set. Every outbound request — regardless of manager — constructs exactly one `Transaction` before opening its socket, so this one guard covers them all. That matters because `Stripe::_httpsSend` and `Hubspot::_httpsSend` are their *own* methods (not overrides of the base) that open sockets via their own `socketStarter`; a guard in the base `_httpsSend` would miss them, and Hubspot is the primary offender here.

Because the `Transaction` is built during the `peek()` that issues the request, the throw:
- fires **before the socket opens** (the ctor runs before `new Socket` in every manager), and
- propagates out of `peek()` where `BedrockCore::peekCommand` turns it into a clean `500` reply — analogous to the existing sync-thread guard, but failing the instant a request would start rather than after `peek()` completes.

It only fires for requests *started* on the blocking thread. Reconstructing already-completed requests (`BedrockCommand::deserializeHTTPSRequests`, when a leader receives an escalated command) happens in `buildCommandFromRequest` on the command-reception thread — never worker 0 — so those are unaffected (verified by the passing Escalate tests).

Expected volume of failures is low (~400/week) and acceptable — better to fail these and address the fallout in follow-up issues than keep serializing the blocking queue behind slow external calls.

Note: this PR is the primary fix from the issue. The secondary metric-accuracy fix (`exclusiveTransactionLockTime`) will follow in a separate PR.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/661688

### Tests

Added `HTTPSBlockingCommitTest` (clustertest). It adds a `httpsblockingcommit` test command that queues an HTTPS request only when it runs on the blockingCommit thread and is otherwise a conflicting write, then fires many concurrent copies with `MaxConflictRetries=1` so some escalate to worker 0. It asserts that:
- the command that re-peeks on the blockingCommit thread comes back `500 Refused - HTTPS request attempted on blockingCommit thread` (covering both the wait-in-peek path and the return-false-then-worker-loop path), and
- every request still gets a response (nothing hangs).

Verified in the local VM:
1. `./clustertest -only HTTPSBlockingCommit` → Passed: 2, Failed: 0.
2. Regression: `./clustertest -only HTTPS,Escalate,BlockingQueueRateLimit` → all passed (normal HTTPS requests, escalation with reconstructed HTTPS requests, and blocking-queue mechanics all still work).

Manual/prod validation after deploy: re-run the issue's LogSearch for `thread:blockingCommit AND "for network requests"` — the count should drop to ~0, replaced by `500 Refused` at the expected low volume.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
