### PR TITLE
Fix commit lock log

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -923,7 +923,7 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
 
         auto elapsed = chrono::steady_clock::now() - start;
         if (elapsed > 5ms) {
-            SINFO("Waited " << chrono::duration_cast<chrono::microseconds>(elapsed) << "us for commit lock.");
+            SINFO("Waited " << chrono::duration_cast<chrono::microseconds>(elapsed) << " for commit lock.");
         }
         _sharedData._commitLockTimer.start("SHARED");
         _mutexLocked = true;


### PR DESCRIPTION
### Details

### Fixed Issues
Context https://expensify.slack.com/archives/CC7NECV4L/p1785320601981849?thread_ts=1785276500.069159&cid=CC7NECV4L

### Tests
Commented the minimum 5ms for logging and checked the logs:
> 2026-07-29T10:30:59.581103+00:00 expensidev-2404 bedrock: 7kZ2p6 ionatan@expensify.com (SQLite.cpp:926) prepare [socket5_cmd] [info] Waited 1us for commit lock. ~~ command: 'UpdateRNVPLastReadTime'

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
