### PR TITLE
Make the default nextRun for jobs when not passed have ms precision

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -603,7 +603,7 @@ void BedrockJobsCommand::process(SQLite& db)
             const string& currentTime = SCURRENT_TIMESTAMP();
 
             // If no "firstRun" was provided, use right now
-            const string& safeFirstRun = !SContains(job, "firstRun") || job["firstRun"].empty() ? currentTime : SQ(job["firstRun"]);
+            const string& safeFirstRun = !SContains(job, "firstRun") || job["firstRun"].empty() ? SQ(SCURRENT_TIMESTAMP_MS()) : SQ(job["firstRun"]);
 
             // If no data was provided, use an empty object
             const string& safeData = !SContains(job, "data") || job["data"].empty() ? SQ("{}") : SQ(job["data"]);

--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -748,7 +748,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=" + SQ(request.calc("jobPriority")) + " "
-                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
                 "AND +name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults + ";";
@@ -760,7 +760,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=1000 "
-                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
@@ -771,7 +771,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=850 "
-                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
@@ -782,7 +782,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=750 "
-                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
@@ -793,7 +793,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=500 "
-                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
@@ -804,7 +804,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=250 "
-                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
@@ -815,7 +815,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=0 "
-                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
+                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -68,8 +68,8 @@ struct CreateJobTest : tpunit::TestFixture
         ASSERT_EQUAL(originalJob[0][1], response["jobID"]);
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
         ASSERT_EQUAL(originalJob[0][3], jobName);
-        // nextRun should equal created
-        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
+        // nextRun should equal created but without the ms precision
+        ASSERT_EQUAL(originalJob[0][4].substr(0, 19), originalJob[0][0]);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], "{}");
@@ -92,8 +92,8 @@ struct CreateJobTest : tpunit::TestFixture
         ASSERT_EQUAL(originalJob[0][1], response["jobID"]);
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
         ASSERT_EQUAL(originalJob[0][3], jobName);
-        // nextRun should equal created
-        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
+        // nextRun should equal created but without the ms precision
+        ASSERT_EQUAL(originalJob[0][4].substr(0, 19), originalJob[0][0]);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], "{}");
@@ -118,8 +118,8 @@ struct CreateJobTest : tpunit::TestFixture
         ASSERT_EQUAL(originalJob[0][1], response["jobID"]);
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
         ASSERT_EQUAL(originalJob[0][3], jobName);
-        // nextRun should equal created
-        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
+        // nextRun should equal created but without the ms precision
+        ASSERT_EQUAL(originalJob[0][4].substr(0, 19), originalJob[0][0]);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], "{}");
@@ -172,8 +172,8 @@ struct CreateJobTest : tpunit::TestFixture
         ASSERT_EQUAL(originalJob[0][1], response["jobID"]);
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
         ASSERT_EQUAL(originalJob[0][3], jobName);
-        // nextRun should equal created
-        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
+        // nextRun should equal created but without the ms precision
+        ASSERT_EQUAL(originalJob[0][4].substr(0, 19), originalJob[0][0]);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], repeat);
         ASSERT_EQUAL(originalJob[0][7], "{}");
@@ -379,7 +379,8 @@ struct CreateJobTest : tpunit::TestFixture
         ASSERT_EQUAL(originalJob[0][1], jobID);
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
         ASSERT_EQUAL(originalJob[0][3], jobName);
-        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
+        // nextRun should equal created but without the ms precision
+        ASSERT_EQUAL(originalJob[0][4].substr(0, 19), originalJob[0][0]);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], repeatValue);
         ASSERT_EQUAL(originalJob[0][7], "{}");
@@ -493,8 +494,8 @@ struct CreateJobTest : tpunit::TestFixture
         tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID, retryAfter FROM jobs WHERE jobID = " + jobID + ";", originalJob);
         ASSERT_EQUAL(originalJob[0][1], jobID);
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
-        ASSERT_EQUAL(originalJob[0][3], jobName);
-        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
+        // nextRun should equal created but without the ms precision
+        ASSERT_EQUAL(originalJob[0][4].substr(0, 19), originalJob[0][0]);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], "{}");


### PR DESCRIPTION
### Details
When many jobs run in a very short timeframe and they all create onyx updates, we then create `SendFetchableOnyxUpdates` jobs for them. If those jobs run out of order, they force the App to call `GetMissingOnyxMessages` which means the SequentialQueue stays paused and App can't do other requests. If the updates arrive in order, then there's no need to call `GetMissingOnyxMessages` at all.
Since all `SendFetchableOnyxUpdates` jobs were created in the same second, the order is determined by the random jobID, which means that a job created first might run after a job created later. This adds ms precision so that jobs run in order.

### Fixed Issues
Context https://expensify.slack.com/archives/C08CZDJFJ77/p1785332347559139?thread_ts=1785235703.173929&cid=C08CZDJFJ77

### Tests
- Sent a comment in App
- Checked `SendFetchableOnyxUpdates` jobs had ms in the nextRun:
```
sqlite> select * from jobs;
      created              jobID        state                            name                                   nextRun         lastRun repeat                  data                  priority parentJobID retryAfter
------------------- ------------------- ------ -------------------------------------------------------- ----------------------- ------- ------ -------------------------------------- -------- ----------- -----------
2026-07-29 13:47:43 1011095460230348294 QUEUED www-prod/ProcessAgentZeroRequest?reportID=               2026-07-29 13:47:43                    {"reportID":213777350431729,"persona        750           0 +10 MINUTES
                                               213777350431729&persona=Concierge                                                               ":"Concierge","email":"ionatan@
                                                                                                                                               expensify.com","didChatJobExistWhenQue
                                                                                                                                               ued":false,"pageHTML":"","
                                                                                                                                               userAccountID":4,"triggeringRequestEla
                                                                                                                                               ...

2026-07-29 13:47:43 5128217579886465770 QUEUED www-prod/NotifyOfflineUsersAboutActivity?reportID=       2026-07-29 13:57:43                    {"reportID":213777350431729,"accountID      500           0
                                               213777350431729                                                                                 ":4,"targetAccountIDs":null,"
                                                                                                                                               actorAccountID":4,"_commitCounts":{"
                                                                                                                                               auth":42469,"webrock":126271}}

2026-07-29 13:47:43 5234437901448725819 QUEUED www-prod/SendFetchableOnyxUpdates?updates=               2026-07-29 13:47:43.769                {"pusherSocketID":"899894.703119","         750           0 +5 MINUTES
                                               7926cc6d5efa753877e69a7f80be730f                                                                updateIDs":["80284","80285","80286"],"
                                                                                                                                               originalRequestID":"kr0sId","logEmail
                                                                                                                                               ":"ionatan@expensify.com","
                                                                                                                                               _commitCounts":{"auth":42469,"webrock
                                                                                                                                               ...
```
- Run bwm and checked jobs were correctly processed
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
