### PR TITLE
Track all commit waits, including no wait

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -890,7 +890,7 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
             // If we never waited at all, we record that.
             waited = false;
         }
-        while (true && !lockAcquired) {
+        while (!lockAcquired) {
             lockAcquired = _sharedData.commitLock.try_lock_until(nextLockTimeout);
             if (lockAcquired || chrono::steady_clock::now() >= finalLockTimeout) {
                 break;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -884,7 +884,13 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
         }
 
         bool lockAcquired = false;
-        while (true) {
+        lockAcquired = _sharedData.commitLock.try_lock();
+        bool waited = true;
+        if (lockAcquired) {
+            // If we never waited at all, we record that.
+            waited = false;
+        }
+        while (true && !lockAcquired) {
             lockAcquired = _sharedData.commitLock.try_lock_until(nextLockTimeout);
             if (lockAcquired || chrono::steady_clock::now() >= finalLockTimeout) {
                 break;
@@ -899,6 +905,7 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
                 nextLockTimeout = finalLockTimeout;
             }
         }
+        auto elapsed = chrono::steady_clock::now() - start;
 
         bool abortPtrWasSet = _shouldAbortPtr && *_shouldAbortPtr;
         if (abortPtr) {
@@ -921,9 +928,10 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
             return false;
         }
 
-        auto elapsed = chrono::steady_clock::now() - start;
-        if (elapsed > 5ms) {
+        if (waited) {
             SINFO("Waited " << chrono::duration_cast<chrono::microseconds>(elapsed) << "us for commit lock.");
+        } else {
+            SINFO("Acquired commit lock immediately.");
         }
         _sharedData._commitLockTimer.start("SHARED");
         _mutexLocked = true;


### PR DESCRIPTION
### Details
For diagnostic purposes, we want to see how much time we can remove from committing with HC-Tree not requiring waiting on a commit lock.

### Fixed Issues
Fixes GH_LINK

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
