### PR TITLE
Revert "Make the default nextRun for jobs when not passed have ms precision"

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -603,7 +603,7 @@ void BedrockJobsCommand::process(SQLite& db)
             const string& currentTime = SCURRENT_TIMESTAMP();
 
             // If no "firstRun" was provided, use right now
-            const string& safeFirstRun = !SContains(job, "firstRun") || job["firstRun"].empty() ? SQ(SCURRENT_TIMESTAMP_MS()) : SQ(job["firstRun"]);
+            const string& safeFirstRun = !SContains(job, "firstRun") || job["firstRun"].empty() ? currentTime : SQ(job["firstRun"]);
 
             // If no data was provided, use an empty object
             const string& safeData = !SContains(job, "data") || job["data"].empty() ? SQ("{}") : SQ(job["data"]);
@@ -748,7 +748,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=" + SQ(request.calc("jobPriority")) + " "
-                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
+                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND +name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults + ";";
@@ -760,7 +760,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=1000 "
-                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
+                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
@@ -771,7 +771,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=850 "
-                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
+                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
@@ -782,7 +782,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=750 "
-                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
+                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
@@ -793,7 +793,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=500 "
-                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
+                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
@@ -804,7 +804,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=250 "
-                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
+                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +
@@ -815,7 +815,7 @@ void BedrockJobsCommand::process(SQLite& db)
                 "FROM jobs "
                 "WHERE state IN ('QUEUED', 'RUNQUEUED') "
                 "AND priority=0 "
-                "AND " + SQ(SCURRENT_TIMESTAMP_MS()) + ">=nextRun "
+                "AND " + SCURRENT_TIMESTAMP() + ">=nextRun "
                 "AND name " + (nameList.size() > 1 ? "IN (" + SQList(nameList) + ")" : "GLOB " + SQ(request["name"])) + " " +
                 string(!mockRequest ? " AND JSON_EXTRACT(data, '$.mockRequest') IS NULL " : "") +
                 "ORDER BY nextRun ASC LIMIT " + safeNumResults +

--- a/test/tests/jobs/CreateJobTest.cpp
+++ b/test/tests/jobs/CreateJobTest.cpp
@@ -68,8 +68,8 @@ struct CreateJobTest : tpunit::TestFixture
         ASSERT_EQUAL(originalJob[0][1], response["jobID"]);
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
         ASSERT_EQUAL(originalJob[0][3], jobName);
-        // nextRun should equal created but without the ms precision
-        ASSERT_EQUAL(originalJob[0][4].substr(0, 19), originalJob[0][0]);
+        // nextRun should equal created
+        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], "{}");
@@ -92,8 +92,8 @@ struct CreateJobTest : tpunit::TestFixture
         ASSERT_EQUAL(originalJob[0][1], response["jobID"]);
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
         ASSERT_EQUAL(originalJob[0][3], jobName);
-        // nextRun should equal created but without the ms precision
-        ASSERT_EQUAL(originalJob[0][4].substr(0, 19), originalJob[0][0]);
+        // nextRun should equal created
+        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], "{}");
@@ -118,8 +118,8 @@ struct CreateJobTest : tpunit::TestFixture
         ASSERT_EQUAL(originalJob[0][1], response["jobID"]);
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
         ASSERT_EQUAL(originalJob[0][3], jobName);
-        // nextRun should equal created but without the ms precision
-        ASSERT_EQUAL(originalJob[0][4].substr(0, 19), originalJob[0][0]);
+        // nextRun should equal created
+        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], "{}");
@@ -172,8 +172,8 @@ struct CreateJobTest : tpunit::TestFixture
         ASSERT_EQUAL(originalJob[0][1], response["jobID"]);
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
         ASSERT_EQUAL(originalJob[0][3], jobName);
-        // nextRun should equal created but without the ms precision
-        ASSERT_EQUAL(originalJob[0][4].substr(0, 19), originalJob[0][0]);
+        // nextRun should equal created
+        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], repeat);
         ASSERT_EQUAL(originalJob[0][7], "{}");
@@ -379,8 +379,7 @@ struct CreateJobTest : tpunit::TestFixture
         ASSERT_EQUAL(originalJob[0][1], jobID);
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
         ASSERT_EQUAL(originalJob[0][3], jobName);
-        // nextRun should equal created but without the ms precision
-        ASSERT_EQUAL(originalJob[0][4].substr(0, 19), originalJob[0][0]);
+        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], repeatValue);
         ASSERT_EQUAL(originalJob[0][7], "{}");
@@ -494,8 +493,8 @@ struct CreateJobTest : tpunit::TestFixture
         tester->readDB("SELECT created, jobID, state, name, nextRun, lastRun, repeat, data, priority, parentJobID, retryAfter FROM jobs WHERE jobID = " + jobID + ";", originalJob);
         ASSERT_EQUAL(originalJob[0][1], jobID);
         ASSERT_EQUAL(originalJob[0][2], "QUEUED");
-        // nextRun should equal created but without the ms precision
-        ASSERT_EQUAL(originalJob[0][4].substr(0, 19), originalJob[0][0]);
+        ASSERT_EQUAL(originalJob[0][3], jobName);
+        ASSERT_EQUAL(originalJob[0][4], originalJob[0][0]);
         ASSERT_EQUAL(originalJob[0][5], "");
         ASSERT_EQUAL(originalJob[0][6], "");
         ASSERT_EQUAL(originalJob[0][7], "{}");


### PR DESCRIPTION
Reverts Expensify/Bedrock#2693

See the [Slack conversation here](https://expensify.slack.com/archives/C03TQ48KC/p1785356139769739?thread_ts=1785353285.725229&cid=C03TQ48KC) for an explanation of the problem.