### PR TITLE
Add journalEntries view

### DIFF
--- a/docs/blockchain.md
+++ b/docs/blockchain.md
@@ -11,7 +11,7 @@ To be clear, Bedrock is not a "public" blockchain, like Bitcoin -- it is not des
 ## The Journal
 Under the hood it works like this:
 
-* There is an internal table named `journal`, that has three columns:
+* Journal entries have three columns:
     * `id` - Simple monotonic index
     * `query` - The query to commit to the database
     * `hash` - A SHA1 hash of `query`, combined with the previous `hash`
@@ -32,5 +32,7 @@ The sum of all this ensures that all of the cluster stays in perfect sync (and r
 The above skips over a couple important details:
 
 * There are actually multiple `journal` tables, one for each thread (which by default, is equal to the number of cores on the machine).  This is because Bedrock does multi-threaded writes, and given that every commit adds a row to the end of this table, it is very prone to write conflicts.  We address this by "sharding" the table, and then querying them all in a `UNION` whenever we need to view it as one.
+
+* Bedrock exposes the read-only `journalEntries` view for querying all physical journal tables together. For example, use `SELECT * FROM journalEntries WHERE id = 123;` instead of manually building a `UNION ALL` across `journal`, `journal0000`, `journal0001`, and the remaining shards.
 
 * We don't actually retain all 4B+ rows to the journal.  Rather, we do full backups at least nightly, and instead just keep several days of history in the journal, trimming as we go. 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -213,7 +213,6 @@ vector<string> SQLite::initializeJournal(sqlite3* db, int minJournalTables)
         }
     }
 
-    // Expose one read-only surface for ad-hoc journal queries without changing the critical internal journal queries.
     string journalEntriesQuery;
     for (const string& journalName : journalNames) {
         if (!journalEntriesQuery.empty()) {

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -212,6 +212,41 @@ vector<string> SQLite::initializeJournal(sqlite3* db, int minJournalTables)
             break;
         }
     }
+
+    // Expose one read-only surface for ad-hoc journal queries without changing the critical internal journal queries.
+    string journalEntriesQuery;
+    for (const string& journalName : journalNames) {
+        if (!journalEntriesQuery.empty()) {
+            journalEntriesQuery += " UNION ALL ";
+        }
+        journalEntriesQuery += "SELECT id, query, hash FROM " + journalName;
+    }
+    const string journalEntriesViewQuery = "CREATE VIEW journalEntries AS " + journalEntriesQuery;
+
+    // Avoid changing the schema on every restart, but refresh the view if the set of journal tables changes.
+    SQResult journalEntriesView;
+    SASSERT(!SQuery(db, "SELECT type, sql FROM sqlite_master WHERE name = 'journalEntries'", journalEntriesView));
+    if (journalEntriesView.empty()) {
+        SASSERT(!SQuery(db, journalEntriesViewQuery));
+        SHMMM("Created journalEntries view.");
+    } else {
+        SASSERT(journalEntriesView.size() == 1);
+        SASSERT(journalEntriesView[0][0] == "view");
+        if (journalEntriesView[0][1] != journalEntriesViewQuery) {
+            SASSERT(!SQuery(db, "BEGIN IMMEDIATE"));
+            int result = SQuery(db, "DROP VIEW journalEntries");
+            if (!result) {
+                result = SQuery(db, journalEntriesViewQuery);
+            }
+            if (result) {
+                SASSERT(!SQuery(db, "ROLLBACK"));
+                SASSERT(!result);
+            }
+            SASSERT(!SQuery(db, "COMMIT"));
+            SHMMM("Updated journalEntries view.");
+        }
+    }
+
     return journalNames;
 }
 

--- a/test/clustertest/tests/BoundParametersTest.cpp
+++ b/test/clustertest/tests/BoundParametersTest.cpp
@@ -56,25 +56,9 @@ struct BoundParametersTest : tpunit::TestFixture
     // the fly so the returned text is the original SQL regardless of whether journal compression is on.
     string readJournalText(BedrockTester& node, uint64_t commitID)
     {
-        SData listCmd("Query");
-        listCmd["Format"] = "json";
-        listCmd["Query"] = "SELECT tbl_name FROM sqlite_master WHERE tbl_name LIKE 'journal%' ORDER BY tbl_name;";
-        auto listResults = node.executeWaitMultipleData({listCmd});
-        SQResult tables;
-        tables.deserialize(listResults[0].content);
-
-        string sql;
-        for (size_t i = 0; i < tables.size(); i++) {
-            if (!sql.empty()) {
-                sql += " UNION ";
-            }
-            sql += "SELECT decompress(query) FROM " + tables[i][0] + " WHERE id = " + SQ(commitID);
-        }
-        sql += ";";
-
         SData command("Query");
         command["Format"] = "json";
-        command["Query"] = sql;
+        command["Query"] = "SELECT decompress(query) FROM journalEntries WHERE id = " + SQ(commitID) + ";";
         auto results = node.executeWaitMultipleData({command});
         if (results[0].methodLine != "200 OK" || results[0].content.empty()) {
             return "";

--- a/test/clustertest/tests/CompressionTest.cpp
+++ b/test/clustertest/tests/CompressionTest.cpp
@@ -104,28 +104,9 @@ struct CompressionTest : tpunit::TestFixture
     // All reads go through the server so that UDFs and dictionaries are available.
     string queryJournal(BedrockTester& node, const string& selectExpression, uint64_t commitID)
     {
-        // Build a UNION query across all journal tables.
-        // First, get the list of journal table names from the server.
-        SData tableCmd("Query");
-        tableCmd["Format"] = "json";
-        tableCmd["Query"] = "SELECT tbl_name FROM sqlite_master WHERE tbl_name LIKE 'journal%' ORDER BY tbl_name;";
-        auto tableResults = node.executeWaitMultipleData({tableCmd});
-        SQResult tables;
-        tables.deserialize(tableResults[0].content);
-
-        // Build UNION query across all journal tables.
-        string sql;
-        for (size_t i = 0; i < tables.size(); i++) {
-            if (!sql.empty()) {
-                sql += " UNION ";
-            }
-            sql += "SELECT " + selectExpression + " FROM " + tables[i][0] + " WHERE id = " + SQ(commitID);
-        }
-        sql += ";";
-
         SData command("Query");
         command["Format"] = "json";
-        command["Query"] = sql;
+        command["Query"] = "SELECT " + selectExpression + " FROM journalEntries WHERE id = " + SQ(commitID) + ";";
         auto results = node.executeWaitMultipleData({command});
         if (results[0].methodLine == "200 OK" && !results[0].content.empty()) {
             SQResult result;


### PR DESCRIPTION
### Details

Adds a view `journalEntries` to UNION all journal tables so it is easier to write custom queries targeting all journal tables

<details>
<summary>The view (click to view it)</summary>

```sql
CREATE VIEW journalEntries AS
SELECT
    id,
    query,
    hash
FROM
    journal
UNION
ALL
SELECT
    id,
    query,
    hash
FROM
    journal0000
UNION
ALL
SELECT
    id,
    query,
    hash
FROM
    journal0001
UNION
ALL
SELECT
    id,
    query,
    hash
FROM
    journal0002
UNION
ALL
SELECT
    id,
    query,
    hash
FROM
    journal0003
UNION
ALL
SELECT
    id,
    query,
    hash
FROM
    journal0004
UNION
ALL
....
```

</details>

The code here should keep the view up to date with all journal tables if the table number ever changes.

Currently this is done in the readdb.sh here: https://github.com/Expensify/Salt/blob/554c37ac5d10959f8d2ae6890a925c50ec614f13/shared_pkgs/bedrock/files/readdb.sh#L309-L355

I think we can drop that special code and param `-j` from readdb.sh if we create this view.



### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/661721

### Tests

1. Compile Bedrock
2. Restart bedrock
3. Verify that the `journalEntries` view is created correctly in the bedrock db
3. Compile Auth using this version of bedrock
3. Restart auth
3. Verify that the `journalEntries` view is created correctly in the auth db

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
