### PR TITLE
fix(cluster): preserve priority across reattachment

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -124,7 +124,7 @@ void BedrockServer::sync()
 
     // Initialize the shared pointer to our sync node object.
     atomic_store(&_syncNode, make_shared<SQLiteNode>(*this, _dbPool, args["-nodeName"], args["-nodeHost"],
-                                                            args["-peerList"], args.calc("-priority"), firstTimeout,
+                                                            args["-peerList"], _configuredPriority, firstTimeout,
                                                             _version, args["-commandPortPrivate"]));
 
     _clusterMessenger = make_shared<SQLiteClusterMessenger>(_syncNode);
@@ -1287,14 +1287,14 @@ void BedrockServer::_resetServer()
 }
 
 BedrockServer::BedrockServer(SQLiteNodeState state, const SData& args_)
-    : SQLiteServer(), args(args_), _syncNode(nullptr), _clusterMessenger(nullptr)
+    : SQLiteServer(), args(args_), _syncNode(nullptr), _configuredPriority(args.calc("-priority")), _clusterMessenger(nullptr)
 {
 }
 
 BedrockServer::BedrockServer(const SData& args_)
     : SQLiteServer(), shutdownWhileDetached(false), args(args_), _requestCount(0),
     _isCommandPortLikelyBlocked(false),
-    _syncLoopShouldBeRunning(true), _syncNode(nullptr), _clusterMessenger(nullptr), _shutdownState(RUNNING),
+    _syncLoopShouldBeRunning(true), _syncNode(nullptr), _configuredPriority(args.calc("-priority")), _clusterMessenger(nullptr), _shutdownState(RUNNING),
     _multiWriteEnabled(args.test("-enableMultiWrite")), _enableConflictPageLocks(args.test("-enableConflictPageLocks")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),
     _controlPort(nullptr), _commandPortPublic(nullptr), _commandPortPrivate(nullptr), _maxConflictRetries(3),
     _lastQuorumCommandTime(STimeNow()), _pluginsDetached(false), _socketThreadNumber(0),

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -345,6 +345,9 @@ private:
     // object.
     shared_ptr<SQLiteNode> _syncNode;
 
+    // The configured node priority persists across SQLiteNode instances created by detach/attach cycles.
+    atomic<int> _configuredPriority;
+
     // SStandaloneHTTPSManager for communication between SQLiteNodes for anything other than cluster state and
     // synchronization.
     shared_ptr<SQLiteClusterMessenger> _clusterMessenger;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -112,14 +112,14 @@ const vector<SQLitePeer*> SQLiteNode::_initPeers(const string& peerListString)
 }
 
 SQLiteNode::SQLiteNode(SQLiteServer& server, const shared_ptr<SQLitePool>& dbPool, const string& name,
-                       const string& host, const string& peerList, int priority, uint64_t firstTimeout,
+                       const string& host, const string& peerList, atomic<int>& configuredPriority, uint64_t firstTimeout,
                        const string& version, const string& commandPort)
     : STCPManager(),
     _commandAddress(commandPort),
     _name(name),
     _host(host),
     _peerList(_initPeers(peerList)),
-    _configuredPriority(priority),
+    _configuredPriority(configuredPriority),
     _port(_host.empty() ? nullptr : openPort(_host)),
     _version(version),
     _commitState(CommitState::UNINITIALIZED),

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -181,7 +181,7 @@ public:
 
     // Constructor/Destructor
     SQLiteNode(SQLiteServer& server, const shared_ptr<SQLitePool>& dbPool, const string& name, const string& host,
-               const string& peerList, int priority, uint64_t firstTimeout, const string& version,
+               const string& peerList, atomic<int>& configuredPriority, uint64_t firstTimeout, const string& version,
                const string& commandPort = "localhost:8890");
     ~SQLiteNode();
 
@@ -302,9 +302,9 @@ private:
     const string _host;
     const vector<SQLitePeer*> _peerList;
 
-    // When the node starts, it is not ready to serve requests without first connecting to the other nodes, and checking
-    // to make sure it's up-to-date. Store the configured priority here and use "-1" until we're ready to fully join the cluster.
-    atomic<int> _configuredPriority;
+    // When the node starts, it is not ready to serve requests without first connecting to the other nodes and checking
+    // that it is up-to-date. The server owns the configured priority so it survives detach/attach cycles.
+    atomic<int>& _configuredPriority;
 
     // Tracks whether this node has seen at least one peer running the same version as itself.
     // We use this along with _haveBeenWAITING to determine when to restore the node's original priority after startup.

--- a/test/clustertest/tests/DoubleDetachTest.cpp
+++ b/test/clustertest/tests/DoubleDetachTest.cpp
@@ -30,6 +30,11 @@ struct DoubleDetachTest : tpunit::TestFixture
         // Test a control command
         BedrockTester& follower = tester->getTester(1);
 
+        SData setPriorityCommand("SetPriority");
+        setPriorityCommand["priority"] = "85";
+        follower.executeWaitVerifyContent(setPriorityCommand, "200", true);
+        ASSERT_TRUE(follower.waitForStatusTerm("priority", "85"));
+
         // Detach
         SData detachCommand("Detach");
         follower.executeWaitVerifyContent(detachCommand, "203 DETACHING", true);
@@ -42,5 +47,6 @@ struct DoubleDetachTest : tpunit::TestFixture
         // Re-attach to make shutdown clean.
         SData attachCommand("Attach");
         follower.executeWaitVerifyContent(attachCommand, "204 ATTACHING", true);
+        ASSERT_TRUE(follower.waitForStatusTerm("priority", "85"));
     }
 } __DoubleDetachTest;

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -62,6 +62,7 @@ struct SQLiteNodeTest : tpunit::TestFixture
     char filename[17] = "br_sync_dbXXXXXX";
 
     TestServer server;
+    atomic<int> configuredPriority{1};
     string peerList = "host1.fake:15555?nodeName=peer1,host2.fake:16666?nodeName=peer2,host3.fake:17777?nodeName=peer3,host4.fake:18888?nodeName=peer4";
     shared_ptr<SQLitePool> dbPool;
 
@@ -80,7 +81,7 @@ struct SQLiteNodeTest : tpunit::TestFixture
 
     void testFindSyncPeer()
     {
-        SQLiteNode testNode(server, dbPool, "test", "localhost:19998", peerList, 1, 1000000000, "1.0");
+        SQLiteNode testNode(server, dbPool, "test", "localhost:19998", peerList, configuredPriority, 1000000000, "1.0");
 
         // Do a base test, with one peer with no latency.
         SQLitePeer* fastest = nullptr;
@@ -153,14 +154,14 @@ struct SQLiteNodeTest : tpunit::TestFixture
     void testGetPeerByName()
     {
         {
-            SQLiteNode testNode(server, dbPool, "test", "localhost:19998", peerList, 1, 1000000000, "1.0");
+            SQLiteNode testNode(server, dbPool, "test", "localhost:19998", peerList, configuredPriority, 1000000000, "1.0");
             ASSERT_EQUAL(testNode.getPeerByName("peer3")->name, "peer3");
             ASSERT_EQUAL(testNode.getPeerByName("peer9"), nullptr);
         }
         {
             // It also works when the peer list isn't pre-sorted
             string unsortedPeerList = "host1.fake:15555?nodeName=peerZ,host2.fake:16666?nodeName=peer1,host3.fake:17777?nodeName=peer0,host4.fake:18888?nodeName=peerBanana";
-            SQLiteNode testNode(server, dbPool, "test", "localhost:19998", unsortedPeerList, 1, 1000000000, "1.0");
+            SQLiteNode testNode(server, dbPool, "test", "localhost:19998", unsortedPeerList, configuredPriority, 1000000000, "1.0");
             ASSERT_EQUAL(testNode.getPeerByName("peer1")->name, "peer1");
             ASSERT_EQUAL(testNode.getPeerByName("peerBanana")->name, "peerBanana");
             ASSERT_EQUAL(testNode.getPeerByName("peer9"), nullptr);


### PR DESCRIPTION
### Details
@tylerkaraszewski @danieldoglas Please review. 

This preserves custom set priorities across `Detach` and `Attach`. We had an issue over the weekend where a custom configured leader was reset to a follower after running pdd-backup, that's because its priority was reset to its on disk priority on `Attach`. 

### Fixed Issues
Related https://github.com/Expensify/Expensify/issues/667422

### Tests
Added automated tests.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
