### PR TITLE
Enforce blocking-queue time limit at dequeue

### DIFF
--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -77,14 +77,23 @@ unique_ptr<BedrockCommand> BedrockBlockingCommandQueue::_dequeue()
 {
     auto command = BedrockCommandQueue::_dequeue();
 
+    const string blockingIdentifier = command->blockingQueueRateLimitIdentifier;
+
     // Decrement rate limit count when a command leaves the queue.
-    if (!command->blockingQueueRateLimitIdentifier.empty() && _maxPerIdentifier.load() > 0) {
+    if (!blockingIdentifier.empty() && _maxPerIdentifier.load() > 0) {
         lock_guard<decltype(_rateLimitMutex)> lock(_rateLimitMutex);
         _decrementIdentifierCount(command->blockingQueueRateLimitIdentifier);
     }
 
     if (_queue.empty() && _emptyTime.load() == 0) {
         _emptyTime.store(STimeNow());
+    }
+
+    // If this command has a blocking queue identifier, check if it's over the time limit. If so, fill the response methodLine with 503
+    // and set the command as completed. By doing so, we will skip processing the command in `BedrockServer::runCommand`.
+    if (!blockingIdentifier.empty() && isIdentifierOverTimeLimit(blockingIdentifier, command->request.methodLine)) {
+        command->response.methodLine = "503 Blocking queue rate limited (time)";
+        command->complete = true;
     }
 
     return command;

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -20,55 +20,32 @@ void BedrockBlockingCommandQueue::push(unique_ptr<BedrockCommand>&& command)
 {
     const string identifier = command->blockingQueueRateLimitIdentifier;
     const size_t maxPerIdentifier = _maxPerIdentifier.load();
-    const uint64_t maxTimePerIdentifier = _maxTimePerIdentifier.load();
-    const uint64_t maxTimePerIdentifierToLog = _maxTimePerIdentifierToLog.load();
     const bool shouldCheckCount = maxPerIdentifier > 0 && !identifier.empty();
-    const bool shouldCheckTime = maxTimePerIdentifier > 0 && !identifier.empty();
 
-    if (shouldCheckCount || shouldCheckTime) {
+    // Reject before enqueuing if this identifier is already over the accumulated worker-0 time limit.
+    if (isIdentifierOverTimeLimit(identifier, command->request.methodLine)) {
+        STHROW("503 Blocking queue rate limited (time)");
+    }
+
+    if (shouldCheckCount) {
         lock_guard<decltype(_rateLimitMutex)> lock(_rateLimitMutex);
 
-        // Clear counts and times if the blocking queue has been empty for 30 seconds.
+        // Clear counts if the blocking queue has been empty for 30 seconds.
         uint64_t emptyTime = _emptyTime.load();
         if (emptyTime > 0 && STimeNow() - emptyTime >= 30'000'000) {
             _identifierCounts.clear();
-            _identifierTimes.clear();
         }
 
-        if (shouldCheckCount) {
-            size_t& count = _identifierCounts[identifier];
-            count++;
+        size_t& count = _identifierCounts[identifier];
+        count++;
 
-            if (count > maxPerIdentifier) {
-                SINFO("Blocking queue rate limit: rejecting '" << command->request.methodLine
-                      << "' for identifier '" << identifier << "' (count=" << count
-                      << ", threshold=" << maxPerIdentifier << ")");
-                // TODO: enable enforcement after monitoring confirms thresholds are correct in production.
-                // count--;
-                // STHROW("503 Blocking queue rate limited");
-            }
-        }
-
-        if (shouldCheckTime) {
-            auto it = _identifierTimes.find(identifier);
-            const uint64_t timeUS = (it == _identifierTimes.end()) ? 0 : it->second;
-            if (timeUS > maxTimePerIdentifier) {
-                SINFO("Blocking queue rate limit (time), rejecting", {
-                    {"command", command->request.methodLine},
-                    {"identifier", identifier},
-                    {"timeMS", to_string(timeUS / 1000)},
-                    {"thresholdMS", to_string(maxTimePerIdentifier / 1000)}
-                });
-                STHROW("503 Blocking queue rate limited (time)");
-            }
-            if (timeUS > maxTimePerIdentifierToLog) {
-                SINFO("Blocking queue rate limit (time), logging", {
-                    {"command", command->request.methodLine},
-                    {"identifier", identifier},
-                    {"timeMS", to_string(timeUS / 1000)},
-                    {"thresholdMS", to_string(maxTimePerIdentifier / 1000)}
-                });
-            }
+        if (count > maxPerIdentifier) {
+            SINFO("Blocking queue rate limit: rejecting '" << command->request.methodLine
+                  << "' for identifier '" << identifier << "' (count=" << count
+                  << ", threshold=" << maxPerIdentifier << ")");
+            // TODO: enable enforcement after monitoring confirms thresholds are correct in production.
+            // count--;
+            // STHROW("503 Blocking queue rate limited");
         }
     }
 

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -23,7 +23,7 @@ void BedrockBlockingCommandQueue::push(unique_ptr<BedrockCommand>&& command)
     const bool shouldCheckCount = maxPerIdentifier > 0 && !identifier.empty();
 
     // Reject before enqueuing if the identifier is over the allowed time spent in the blocking queue.
-    if (_isIdentifierOverTimeLimit(identifier, command->request.methodLine)) {
+    if (isIdentifierOverTimeLimit(identifier, command->request.methodLine)) {
         STHROW("503 Blocking queue rate limited (time)");
     }
 
@@ -91,7 +91,7 @@ unique_ptr<BedrockCommand> BedrockBlockingCommandQueue::_dequeue()
 
     // If this command has a blocking queue identifier, check if it's over the time limit. If so, fill the response methodLine with 503
     // and set the command as completed. By doing so, we will skip processing the command in `BedrockServer::runCommand`.
-    if (!blockingIdentifier.empty() && _isIdentifierOverTimeLimit(blockingIdentifier, command->request.methodLine)) {
+    if (!blockingIdentifier.empty() && isIdentifierOverTimeLimit(blockingIdentifier, command->request.methodLine)) {
         command->response.methodLine = "503 Blocking queue rate limited (time)";
         command->complete = true;
     }
@@ -185,7 +185,7 @@ void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, 
     _identifierTimes[identifier] += elapsedUS;
 }
 
-bool BedrockBlockingCommandQueue::_isIdentifierOverTimeLimit(const string& identifier, const string& methodLine)
+bool BedrockBlockingCommandQueue::isIdentifierOverTimeLimit(const string& identifier, const string& methodLine)
 {
     const uint64_t maxTimePerIdentifier = _maxTimePerIdentifier.load();
     if (maxTimePerIdentifier == 0 || identifier.empty()) {

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -22,7 +22,7 @@ void BedrockBlockingCommandQueue::push(unique_ptr<BedrockCommand>&& command)
     const size_t maxPerIdentifier = _maxPerIdentifier.load();
     const bool shouldCheckCount = maxPerIdentifier > 0 && !identifier.empty();
 
-    // Reject before enqueuing if this identifier is already over the accumulated worker-0 time limit.
+    // Reject before enqueuing if the identifier is over the allowed time spent in the blocking queue.
     if (isIdentifierOverTimeLimit(identifier, command->request.methodLine)) {
         STHROW("503 Blocking queue rate limited (time)");
     }

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -199,6 +199,46 @@ void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, 
     _identifierTimes[identifier] += elapsedUS;
 }
 
+bool BedrockBlockingCommandQueue::isIdentifierOverTimeLimit(const string& identifier, const string& methodLine)
+{
+    const uint64_t maxTimePerIdentifier = _maxTimePerIdentifier.load();
+    if (maxTimePerIdentifier == 0 || identifier.empty()) {
+        return false;
+    }
+
+    lock_guard<decltype(_rateLimitMutex)> lock(_rateLimitMutex);
+
+    // Clear accumulated times if the blocking queue has been empty for 30 seconds.
+    uint64_t emptyTime = _emptyTime.load();
+    if (emptyTime > 0 && STimeNow() - emptyTime >= 30'000'000) {
+        _identifierTimes.clear();
+    }
+
+    auto it = _identifierTimes.find(identifier);
+    const uint64_t timeUS = (it == _identifierTimes.end()) ? 0 : it->second;
+
+    if (timeUS > maxTimePerIdentifier) {
+        SINFO("Blocking queue rate limit (time), rejecting", {
+            {"command", methodLine},
+            {"identifier", identifier},
+            {"timeMS", to_string(timeUS / 1000)},
+            {"thresholdMS", to_string(maxTimePerIdentifier / 1000)}
+        });
+        return true;
+    }
+
+    if (timeUS > _maxTimePerIdentifierToLog.load()) {
+        SINFO("Blocking queue rate limit (time), logging", {
+            {"command", methodLine},
+            {"identifier", identifier},
+            {"timeMS", to_string(timeUS / 1000)},
+            {"thresholdMS", to_string(maxTimePerIdentifier / 1000)}
+        });
+    }
+
+    return false;
+}
+
 void BedrockBlockingCommandQueue::_decrementIdentifierCount(const string& identifier)
 {
     auto it = _identifierCounts.find(identifier);

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -23,7 +23,7 @@ void BedrockBlockingCommandQueue::push(unique_ptr<BedrockCommand>&& command)
     const bool shouldCheckCount = maxPerIdentifier > 0 && !identifier.empty();
 
     // Reject before enqueuing if the identifier is over the allowed time spent in the blocking queue.
-    if (isIdentifierOverTimeLimit(identifier, command->request.methodLine)) {
+    if (_isIdentifierOverTimeLimit(identifier, command->request.methodLine)) {
         STHROW("503 Blocking queue rate limited (time)");
     }
 
@@ -91,7 +91,7 @@ unique_ptr<BedrockCommand> BedrockBlockingCommandQueue::_dequeue()
 
     // If this command has a blocking queue identifier, check if it's over the time limit. If so, fill the response methodLine with 503
     // and set the command as completed. By doing so, we will skip processing the command in `BedrockServer::runCommand`.
-    if (!blockingIdentifier.empty() && isIdentifierOverTimeLimit(blockingIdentifier, command->request.methodLine)) {
+    if (!blockingIdentifier.empty() && _isIdentifierOverTimeLimit(blockingIdentifier, command->request.methodLine)) {
         command->response.methodLine = "503 Blocking queue rate limited (time)";
         command->complete = true;
     }
@@ -185,7 +185,7 @@ void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, 
     _identifierTimes[identifier] += elapsedUS;
 }
 
-bool BedrockBlockingCommandQueue::isIdentifierOverTimeLimit(const string& identifier, const string& methodLine)
+bool BedrockBlockingCommandQueue::_isIdentifierOverTimeLimit(const string& identifier, const string& methodLine)
 {
     const uint64_t maxTimePerIdentifier = _maxTimePerIdentifier.load();
     if (maxTimePerIdentifier == 0 || identifier.empty()) {

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -41,15 +41,8 @@ public:
     // cumulative per identifier until the empty-queue reset clears it — it is never decremented per command.
     void recordExecutionTime(const string& identifier, uint64_t elapsedUS);
 
-    // Check `identifier`'s accumulated worker-0 execution time against the time thresholds, logging a
-    // "Blocking queue rate limit (time)" line when over the log or enforce threshold. Returns true if
-    // over the enforce threshold, so the caller can reject the command (push() throws; the blockingCommit
-    // worker replies 503). Returns false when the threshold is disabled (== 0) or the identifier is empty.
-    // Applies the same 30-second empty-queue reset as push(). `methodLine` is used only for logging.
-    //
-    // push() checks time that is only recorded after a command finishes, so a burst enqueued before any of
-    // them finishes all pass push() with zero accumulated time. The worker re-checks at dequeue, before
-    // running a command, so the later commands are rejected once earlier ones have accumulated over the limit.
+    // Check the identifier's accumulated blocking queue execution time against our thresholds, logging a tracking
+    // message and returning true if the threshold is exceeded. Returns false if the identifier is not over the limit.
     bool isIdentifierOverTimeLimit(const string& identifier, const string& methodLine);
 
 protected:

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -41,6 +41,10 @@ public:
     // cumulative per identifier until the empty-queue reset clears it — it is never decremented per command.
     void recordExecutionTime(const string& identifier, uint64_t elapsedUS);
 
+    // Check the identifier's accumulated blocking queue execution time against our thresholds, logging a tracking
+    // message and returning true if the threshold is exceeded. Returns false if the identifier is not over the limit.
+    bool isIdentifierOverTimeLimit(const string& identifier, const string& methodLine);
+
 protected:
     // Called by get() while _queueMutex is held; atomically decrements per-identifier counts
     // and records when the queue becomes empty.
@@ -50,10 +54,6 @@ private:
     // Decrement the count for `identifier` in `_identifierCounts`, erasing the entry if it reaches zero.
     // Caller must hold `_rateLimitMutex`.
     void _decrementIdentifierCount(const string& identifier);
-
-    // Check the identifier's accumulated blocking queue execution time against our thresholds, logging a tracking
-    // message and returning true if the threshold is exceeded. Returns false if the identifier is not over the limit.
-    bool _isIdentifierOverTimeLimit(const string& identifier, const string& methodLine);
 
     // Guards `_identifierCounts`. Separate from the base class `_queueMutex` because the base
     // mutex is non-recursive and is held while `_dequeue` runs.

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -41,10 +41,6 @@ public:
     // cumulative per identifier until the empty-queue reset clears it — it is never decremented per command.
     void recordExecutionTime(const string& identifier, uint64_t elapsedUS);
 
-    // Check the identifier's accumulated blocking queue execution time against our thresholds, logging a tracking
-    // message and returning true if the threshold is exceeded. Returns false if the identifier is not over the limit.
-    bool isIdentifierOverTimeLimit(const string& identifier, const string& methodLine);
-
 protected:
     // Called by get() while _queueMutex is held; atomically decrements per-identifier counts
     // and records when the queue becomes empty.
@@ -54,6 +50,10 @@ private:
     // Decrement the count for `identifier` in `_identifierCounts`, erasing the entry if it reaches zero.
     // Caller must hold `_rateLimitMutex`.
     void _decrementIdentifierCount(const string& identifier);
+
+    // Check the identifier's accumulated blocking queue execution time against our thresholds, logging a tracking
+    // message and returning true if the threshold is exceeded. Returns false if the identifier is not over the limit.
+    bool _isIdentifierOverTimeLimit(const string& identifier, const string& methodLine);
 
     // Guards `_identifierCounts`. Separate from the base class `_queueMutex` because the base
     // mutex is non-recursive and is held while `_dequeue` runs.

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -41,6 +41,17 @@ public:
     // cumulative per identifier until the empty-queue reset clears it — it is never decremented per command.
     void recordExecutionTime(const string& identifier, uint64_t elapsedUS);
 
+    // Check `identifier`'s accumulated worker-0 execution time against the time thresholds, logging a
+    // "Blocking queue rate limit (time)" line when over the log or enforce threshold. Returns true if
+    // over the enforce threshold, so the caller can reject the command (push() throws; the blockingCommit
+    // worker replies 503). Returns false when the threshold is disabled (== 0) or the identifier is empty.
+    // Applies the same 30-second empty-queue reset as push(). `methodLine` is used only for logging.
+    //
+    // push() checks time that is only recorded after a command finishes, so a burst enqueued before any of
+    // them finishes all pass push() with zero accumulated time. The worker re-checks at dequeue, before
+    // running a command, so the later commands are rejected once earlier ones have accumulated over the limit.
+    bool isIdentifierOverTimeLimit(const string& identifier, const string& methodLine);
+
 protected:
     // Called by get() while _queueMutex is held; atomically decrements per-identifier counts
     // and records when the queue becomes empty.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -716,6 +716,18 @@ void BedrockServer::worker(int threadId)
             // Capture the identifier and start time so we can attribute worker-0 execution time
             // back to the per-identifier rate-limit accumulator after the command finishes.
             const string blockingIdentifier = (threadId == 0) ? command->blockingQueueRateLimitIdentifier : "";
+
+            // Re-check the per-identifier time limit now that we're about to run this command. The push-time
+            // check compares time that is only recorded after a command finishes, so a burst enqueued before any
+            // of them finishes all pass push() with zero accumulated time. Reject here once earlier commands from
+            // this identifier have accumulated over the threshold, so we don't run the rest of the burst.
+            if (!blockingIdentifier.empty() && _blockingCommandQueue.isIdentifierOverTimeLimit(blockingIdentifier, command->request.methodLine)) {
+                command->response.methodLine = "503 Blocking queue rate limited (time)";
+                command->complete = true;
+                _reply(command);
+                continue;
+            }
+
             const uint64_t blockingStart = (threadId == 0 && !blockingIdentifier.empty()) ? STimeNow() : 0;
 
             runCommand(move(command), threadId == 0, false);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -717,14 +717,12 @@ void BedrockServer::worker(int threadId)
             // back to the per-identifier rate-limit accumulator after the command finishes.
             const string blockingIdentifier = (threadId == 0) ? command->blockingQueueRateLimitIdentifier : "";
 
-            // Re-check the per-identifier time limit now that we're about to run this command. The push-time
-            // check compares time that is only recorded after a command finishes, so a burst enqueued before any
-            // of them finishes all pass push() with zero accumulated time. Reject here once earlier commands from
-            // this identifier have accumulated over the threshold, so we don't run the rest of the burst.
+            // If this command has a blocking queue identifier, check if it's over the time limit. If so, respond with 503 and continue.
             if (!blockingIdentifier.empty() && _blockingCommandQueue.isIdentifierOverTimeLimit(blockingIdentifier, command->request.methodLine)) {
                 command->response.methodLine = "503 Blocking queue rate limited (time)";
                 command->complete = true;
                 _reply(command);
+                command = nullptr;
                 continue;
             }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -716,16 +716,6 @@ void BedrockServer::worker(int threadId)
             // Capture the identifier and start time so we can attribute worker-0 execution time
             // back to the per-identifier rate-limit accumulator after the command finishes.
             const string blockingIdentifier = (threadId == 0) ? command->blockingQueueRateLimitIdentifier : "";
-
-            // If this command has a blocking queue identifier, check if it's over the time limit. If so, respond with 503 and continue.
-            if (!blockingIdentifier.empty() && _blockingCommandQueue.isIdentifierOverTimeLimit(blockingIdentifier, command->request.methodLine)) {
-                command->response.methodLine = "503 Blocking queue rate limited (time)";
-                command->complete = true;
-                _reply(command);
-                command = nullptr;
-                continue;
-            }
-
             const uint64_t blockingStart = (threadId == 0 && !blockingIdentifier.empty()) ? STimeNow() : 0;
 
             runCommand(move(command), threadId == 0, false);

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -7,7 +7,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
 {
     BlockingCommandQueueTest() : tpunit::TestFixture("BlockingCommandQueue",
                                                      TEST(BlockingCommandQueueTest::testUnderLimitNotFlagged),
-                                                     TEST(BlockingCommandQueueTest::testTimeAccumulatesAcrossCommands))
+                                                     TEST(BlockingCommandQueueTest::testTimeAccumulatesAcrossCommands),
+                                                     TEST(BlockingCommandQueueTest::testIdentifiersAreIndependent))
     {
     }
 
@@ -34,5 +35,15 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
 
         queue.recordExecutionTime("acct1", 6'000);
         ASSERT_TRUE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
+    }
+
+    void testIdentifiersAreIndependent()
+    {
+        BedrockBlockingCommandQueue queue;
+        queue.setMaxTimePerIdentifier(10'000);
+
+        queue.recordExecutionTime("acct1", 20'000);
+        ASSERT_TRUE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
+        ASSERT_FALSE(queue.isIdentifierOverTimeLimit("acct2", "TestCommand"));
     }
 } __BlockingCommandQueueTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -6,7 +6,8 @@
 struct BlockingCommandQueueTest : tpunit::TestFixture
 {
     BlockingCommandQueueTest() : tpunit::TestFixture("BlockingCommandQueue",
-                                                     TEST(BlockingCommandQueueTest::testUnderLimitNotFlagged))
+                                                     TEST(BlockingCommandQueueTest::testUnderLimitNotFlagged),
+                                                     TEST(BlockingCommandQueueTest::testTimeAccumulatesAcrossCommands))
     {
     }
 
@@ -19,5 +20,19 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
 
         queue.recordExecutionTime("acct1", 5'000);
         ASSERT_FALSE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
+    }
+
+    void testTimeAccumulatesAcrossCommands()
+    {
+        // This is the burst case the dequeue check fixes: no single command is over the limit, but their accumulated
+        // time is. The push-time check only sees time recorded before push, so re-checking at dequeue catches this.
+        BedrockBlockingCommandQueue queue;
+        queue.setMaxTimePerIdentifier(10'000);
+
+        queue.recordExecutionTime("acct1", 6'000);
+        ASSERT_FALSE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
+
+        queue.recordExecutionTime("acct1", 6'000);
+        ASSERT_TRUE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
     }
 } __BlockingCommandQueueTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -1,0 +1,23 @@
+#include <BedrockBlockingCommandQueue.h>
+#include <test/lib/tpunit++.hpp>
+
+// Unit tests for BedrockBlockingCommandQueue::isIdentifierOverTimeLimit, the check the blockingCommit worker runs at
+// dequeue. These exercise the accumulator directly via recordExecutionTime, with no server, so they're deterministic.
+struct BlockingCommandQueueTest : tpunit::TestFixture
+{
+    BlockingCommandQueueTest() : tpunit::TestFixture("BlockingCommandQueue",
+                                                     TEST(BlockingCommandQueueTest::testUnderLimitNotFlagged))
+    {
+    }
+
+    void testUnderLimitNotFlagged()
+    {
+        BedrockBlockingCommandQueue queue;
+        queue.setMaxTimePerIdentifier(10'000);
+
+        ASSERT_FALSE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
+
+        queue.recordExecutionTime("acct1", 5'000);
+        ASSERT_FALSE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
+    }
+} __BlockingCommandQueueTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -9,7 +9,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
                                                      TEST(BlockingCommandQueueTest::testUnderLimitNotFlagged),
                                                      TEST(BlockingCommandQueueTest::testTimeAccumulatesAcrossCommands),
                                                      TEST(BlockingCommandQueueTest::testIdentifiersAreIndependent),
-                                                     TEST(BlockingCommandQueueTest::testEmptyIdentifierNeverFlagged))
+                                                     TEST(BlockingCommandQueueTest::testEmptyIdentifierNeverFlagged),
+                                                     TEST(BlockingCommandQueueTest::testDisabledThresholdNeverFlags))
     {
     }
 
@@ -56,5 +57,18 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         // An empty identifier means "no known account", so it is never rate limited.
         queue.recordExecutionTime("", 20'000);
         ASSERT_FALSE(queue.isIdentifierOverTimeLimit("", "TestCommand"));
+    }
+
+    void testDisabledThresholdNeverFlags()
+    {
+        BedrockBlockingCommandQueue queue;
+        queue.setMaxTimePerIdentifier(10'000);
+
+        queue.recordExecutionTime("acct1", 20'000);
+        ASSERT_TRUE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
+
+        // A threshold of 0 disables time rate limiting entirely.
+        queue.setMaxTimePerIdentifier(0);
+        ASSERT_FALSE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
     }
 } __BlockingCommandQueueTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -10,7 +10,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
                                                      TEST(BlockingCommandQueueTest::testTimeAccumulatesAcrossCommands),
                                                      TEST(BlockingCommandQueueTest::testIdentifiersAreIndependent),
                                                      TEST(BlockingCommandQueueTest::testEmptyIdentifierNeverFlagged),
-                                                     TEST(BlockingCommandQueueTest::testDisabledThresholdNeverFlags))
+                                                     TEST(BlockingCommandQueueTest::testDisabledThresholdNeverFlags),
+                                                     TEST(BlockingCommandQueueTest::testClearRateLimitsResets))
     {
     }
 
@@ -69,6 +70,18 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
 
         // A threshold of 0 disables time rate limiting entirely.
         queue.setMaxTimePerIdentifier(0);
+        ASSERT_FALSE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
+    }
+
+    void testClearRateLimitsResets()
+    {
+        BedrockBlockingCommandQueue queue;
+        queue.setMaxTimePerIdentifier(10'000);
+
+        queue.recordExecutionTime("acct1", 20'000);
+        ASSERT_TRUE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
+
+        queue.clearRateLimits();
         ASSERT_FALSE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
     }
 } __BlockingCommandQueueTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -1,8 +1,6 @@
 #include <BedrockBlockingCommandQueue.h>
 #include <test/lib/tpunit++.hpp>
 
-// Unit tests for BedrockBlockingCommandQueue::isIdentifierOverTimeLimit, the check the blockingCommit worker runs at
-// dequeue. These exercise the accumulator directly via recordExecutionTime, with no server, so they're deterministic.
 struct BlockingCommandQueueTest : tpunit::TestFixture
 {
     BlockingCommandQueueTest() : tpunit::TestFixture("BlockingCommandQueue",

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -8,7 +8,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
     BlockingCommandQueueTest() : tpunit::TestFixture("BlockingCommandQueue",
                                                      TEST(BlockingCommandQueueTest::testUnderLimitNotFlagged),
                                                      TEST(BlockingCommandQueueTest::testTimeAccumulatesAcrossCommands),
-                                                     TEST(BlockingCommandQueueTest::testIdentifiersAreIndependent))
+                                                     TEST(BlockingCommandQueueTest::testIdentifiersAreIndependent),
+                                                     TEST(BlockingCommandQueueTest::testEmptyIdentifierNeverFlagged))
     {
     }
 
@@ -45,5 +46,15 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.recordExecutionTime("acct1", 20'000);
         ASSERT_TRUE(queue.isIdentifierOverTimeLimit("acct1", "TestCommand"));
         ASSERT_FALSE(queue.isIdentifierOverTimeLimit("acct2", "TestCommand"));
+    }
+
+    void testEmptyIdentifierNeverFlagged()
+    {
+        BedrockBlockingCommandQueue queue;
+        queue.setMaxTimePerIdentifier(10'000);
+
+        // An empty identifier means "no known account", so it is never rate limited.
+        queue.recordExecutionTime("", 20'000);
+        ASSERT_FALSE(queue.isIdentifierOverTimeLimit("", "TestCommand"));
     }
 } __BlockingCommandQueueTest;


### PR DESCRIPTION
### Details
This PR adds a check when dequeueing commands from the blocking queue to confirm if the identifier is blocked at execution time.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/662853

### Tests
- Added unit tests for this case.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
