### PR TITLE
[bisect c1] blocking-queue dequeue hang

### DIFF
--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -199,6 +199,46 @@ void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, 
     _identifierTimes[identifier] += elapsedUS;
 }
 
+bool BedrockBlockingCommandQueue::isIdentifierOverTimeLimit(const string& identifier, const string& methodLine)
+{
+    const uint64_t maxTimePerIdentifier = _maxTimePerIdentifier.load();
+    if (maxTimePerIdentifier == 0 || identifier.empty()) {
+        return false;
+    }
+
+    lock_guard<decltype(_rateLimitMutex)> lock(_rateLimitMutex);
+
+    // Clear accumulated times if the blocking queue has been empty for 30 seconds.
+    uint64_t emptyTime = _emptyTime.load();
+    if (emptyTime > 0 && STimeNow() - emptyTime >= 30'000'000) {
+        _identifierTimes.clear();
+    }
+
+    auto it = _identifierTimes.find(identifier);
+    const uint64_t timeUS = (it == _identifierTimes.end()) ? 0 : it->second;
+
+    if (timeUS > maxTimePerIdentifier) {
+        SINFO("Blocking queue rate limit (time), rejecting", {
+            {"command", methodLine},
+            {"identifier", identifier},
+            {"timeMS", to_string(timeUS / 1000)},
+            {"thresholdMS", to_string(maxTimePerIdentifier / 1000)}
+        });
+        return true;
+    }
+
+    if (timeUS > _maxTimePerIdentifierToLog.load()) {
+        SINFO("Blocking queue rate limit (time), logging", {
+            {"command", methodLine},
+            {"identifier", identifier},
+            {"timeMS", to_string(timeUS / 1000)},
+            {"thresholdMS", to_string(maxTimePerIdentifier / 1000)}
+        });
+    }
+
+    return false;
+}
+
 void BedrockBlockingCommandQueue::_decrementIdentifierCount(const string& identifier)
 {
     auto it = _identifierCounts.find(identifier);

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -41,6 +41,17 @@ public:
     // cumulative per identifier until the empty-queue reset clears it — it is never decremented per command.
     void recordExecutionTime(const string& identifier, uint64_t elapsedUS);
 
+    // Check `identifier`'s accumulated worker-0 execution time against the time thresholds, logging a
+    // "Blocking queue rate limit (time)" line when over the log or enforce threshold. Returns true if
+    // over the enforce threshold, so the caller can reject the command (push() throws; the blockingCommit
+    // worker replies 503). Returns false when the threshold is disabled (== 0) or the identifier is empty.
+    // Applies the same 30-second empty-queue reset as push(). `methodLine` is used only for logging.
+    //
+    // push() checks time that is only recorded after a command finishes, so a burst enqueued before any of
+    // them finishes all pass push() with zero accumulated time. The worker re-checks at dequeue, before
+    // running a command, so the later commands are rejected once earlier ones have accumulated over the limit.
+    bool isIdentifierOverTimeLimit(const string& identifier, const string& methodLine);
+
 protected:
     // Called by get() while _queueMutex is held; atomically decrements per-identifier counts
     // and records when the queue becomes empty.


### PR DESCRIPTION
### Details
Temporary CI bisect PR (do not merge). Isolating which commit of the blocking-queue-dequeue change triggers the cluster-suite hang. Will be closed once CI results are in.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/662853

### Tests
CI only.
