### PR TITLE
Remove the count-based blocking-queue rate limiter

### DIFF
--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -19,34 +19,10 @@ BedrockBlockingCommandQueue::BedrockBlockingCommandQueue() :
 void BedrockBlockingCommandQueue::push(unique_ptr<BedrockCommand>&& command)
 {
     const string identifier = command->blockingQueueRateLimitIdentifier;
-    const size_t maxPerIdentifier = _maxPerIdentifier.load();
-    const bool shouldCheckCount = maxPerIdentifier > 0 && !identifier.empty();
 
     // Reject before enqueuing if the identifier is over the allowed time spent in the blocking queue.
     if (isIdentifierOverTimeLimit(identifier, command->request.methodLine)) {
         STHROW("503 Blocking queue rate limited (time)");
-    }
-
-    if (shouldCheckCount) {
-        lock_guard<decltype(_rateLimitMutex)> lock(_rateLimitMutex);
-
-        // Clear counts if the blocking queue has been empty for 30 seconds.
-        uint64_t emptyTime = _emptyTime.load();
-        if (emptyTime > 0 && STimeNow() - emptyTime >= 30'000'000) {
-            _identifierCounts.clear();
-        }
-
-        size_t& count = _identifierCounts[identifier];
-        count++;
-
-        if (count > maxPerIdentifier) {
-            SINFO("Blocking queue rate limit: rejecting '" << command->request.methodLine
-                  << "' for identifier '" << identifier << "' (count=" << count
-                  << ", threshold=" << maxPerIdentifier << ")");
-            // TODO: enable enforcement after monitoring confirms thresholds are correct in production.
-            // count--;
-            // STHROW("503 Blocking queue rate limited");
-        }
     }
 
     // A command is entering the queue, so it is no longer empty. Clear the empty timestamp so
@@ -57,20 +33,15 @@ void BedrockBlockingCommandQueue::push(unique_ptr<BedrockCommand>&& command)
         // Base class acquires its own (non-recursive) `_queueMutex`.
         BedrockCommandQueue::push(move(command));
     } catch (...) {
-        // The command never entered the queue. Roll back the count increment and restore the
-        // empty timestamp so the 30-second auto-reset timer isn't lost. Time accumulator was
-        // not touched on push, so there's nothing to roll back there.
+        // The command never entered the queue. Restore the empty timestamp so the
+        // 30-second auto-reset timer isn't lost.
         _emptyTime.store(previousEmptyTime);
-        if (shouldCheckCount) {
-            lock_guard<decltype(_rateLimitMutex)> lock(_rateLimitMutex);
-            _decrementIdentifierCount(identifier);
-        }
         throw;
     }
 }
 
 /**
- * Dequeues command and inspects _queue to update rate limit counts and _emptyTime
+ * Dequeues command and inspects _queue to update _emptyTime, and rejects the command if its identifier is over the time limit.
  * Called by `BedrockCommandQueue::get()` with the base `_queueMutex` held. Calling any base method that reacquires `_queueMutex` would deadlock.
  */
 unique_ptr<BedrockCommand> BedrockBlockingCommandQueue::_dequeue()
@@ -78,12 +49,6 @@ unique_ptr<BedrockCommand> BedrockBlockingCommandQueue::_dequeue()
     auto command = BedrockCommandQueue::_dequeue();
 
     const string blockingIdentifier = command->blockingQueueRateLimitIdentifier;
-
-    // Decrement rate limit count when a command leaves the queue.
-    if (!blockingIdentifier.empty() && _maxPerIdentifier.load() > 0) {
-        lock_guard<decltype(_rateLimitMutex)> lock(_rateLimitMutex);
-        _decrementIdentifierCount(command->blockingQueueRateLimitIdentifier);
-    }
 
     if (_queue.empty() && _emptyTime.load() == 0) {
         _emptyTime.store(STimeNow());
@@ -108,8 +73,7 @@ void BedrockBlockingCommandQueue::clear()
 size_t BedrockBlockingCommandQueue::clearRateLimits()
 {
     lock_guard<decltype(_rateLimitMutex)> lock(_rateLimitMutex);
-    size_t size = _identifierCounts.size();
-    _identifierCounts.clear();
+    size_t size = _identifierTimes.size();
     _identifierTimes.clear();
     _emptyTime.store(0);
     return size;
@@ -117,29 +81,16 @@ size_t BedrockBlockingCommandQueue::clearRateLimits()
 
 STable BedrockBlockingCommandQueue::getState()
 {
-    map<string, size_t> countsCopy;
     map<string, uint64_t> timesCopy;
     {
         lock_guard<decltype(_rateLimitMutex)> lock(_rateLimitMutex);
 
         uint64_t emptyTime = _emptyTime.load();
         if (emptyTime > 0 && STimeNow() - emptyTime >= 30'000'000) {
-            _identifierCounts.clear();
             _identifierTimes.clear();
         }
 
-        countsCopy = _identifierCounts;
         timesCopy = _identifierTimes;
-    }
-
-    size_t maxPerIdentifier = _maxPerIdentifier.load();
-    size_t blockedCount = 0;
-    STable countsTable;
-    for (const auto& p : countsCopy) {
-        countsTable[p.first] = to_string(p.second);
-        if (p.second > maxPerIdentifier) {
-            blockedCount++;
-        }
     }
 
     uint64_t maxTimePerIdentifier = _maxTimePerIdentifier.load();
@@ -153,22 +104,12 @@ STable BedrockBlockingCommandQueue::getState()
     }
 
     STable content;
-    content["blockingRateLimitThreshold"] = to_string(maxPerIdentifier);
-    content["blockedIdentifiers"] = to_string(blockedCount);
-    if (!countsTable.empty()) {
-        content["blockingQueueIdentifierCounts"] = SComposeJSONObject(countsTable);
-    }
     content["blockingTimeRateLimitThresholdMs"] = to_string(maxTimePerIdentifier / 1000);
     content["blockedTimeIdentifiers"] = to_string(blockedTimeCount);
     if (!timesTable.empty()) {
         content["blockingQueueIdentifierTimesMs"] = SComposeJSONObject(timesTable);
     }
     return content;
-}
-
-size_t BedrockBlockingCommandQueue::setMaxRequestsPerIdentifier(size_t value)
-{
-    return _maxPerIdentifier.exchange(value);
 }
 
 uint64_t BedrockBlockingCommandQueue::setMaxTimePerIdentifier(uint64_t valueUS)
@@ -223,16 +164,4 @@ bool BedrockBlockingCommandQueue::isIdentifierOverTimeLimit(const string& identi
     }
 
     return false;
-}
-
-void BedrockBlockingCommandQueue::_decrementIdentifierCount(const string& identifier)
-{
-    auto it = _identifierCounts.find(identifier);
-    if (it != _identifierCounts.end()) {
-        if (it->second <= 1) {
-            _identifierCounts.erase(it);
-        } else {
-            it->second--;
-        }
-    }
 }

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -30,9 +30,6 @@ public:
     // Return a table of rate limiting status info for the Status command.
     STable getState();
 
-    // Set the max commands per identifier threshold. Returns the previous value.
-    size_t setMaxRequestsPerIdentifier(size_t value);
-
     // Set the max accumulated worker-0 execution time (microseconds) per identifier. Returns the previous value.
     uint64_t setMaxTimePerIdentifier(uint64_t valueUS);
 
@@ -46,22 +43,16 @@ public:
     bool isIdentifierOverTimeLimit(const string& identifier, const string& methodLine);
 
 protected:
-    // Called by get() while _queueMutex is held; atomically decrements per-identifier counts
-    // and records when the queue becomes empty.
+    // Called by get() while _queueMutex is held; records when the queue becomes empty and rejects a
+    // dequeued command whose identifier is over the time limit.
     unique_ptr<BedrockCommand> _dequeue() override;
 
 private:
-    // Decrement the count for `identifier` in `_identifierCounts`, erasing the entry if it reaches zero.
-    // Caller must hold `_rateLimitMutex`.
-    void _decrementIdentifierCount(const string& identifier);
-
-    // Guards `_identifierCounts`. Separate from the base class `_queueMutex` because the base
+    // Guards `_identifierTimes`. Separate from the base class `_queueMutex` because the base
     // mutex is non-recursive and is held while `_dequeue` runs.
     mutex _rateLimitMutex;
 
-    map<string, size_t> _identifierCounts;
     map<string, uint64_t> _identifierTimes;
-    atomic<size_t> _maxPerIdentifier{10};
     atomic<uint64_t> _maxTimePerIdentifier{60'000'000}; // 60 seconds, in microseconds
     atomic<uint64_t> _maxTimePerIdentifierToLog{10'000'000}; // 10 seconds, in microseconds
     atomic<uint64_t> _emptyTime{0};

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1974,7 +1974,6 @@ bool BedrockServer::_isControlCommand(const unique_ptr<BedrockCommand>& command)
         SIEquals(command->request.methodLine, "BlockWrites") ||
         SIEquals(command->request.methodLine, "UnblockWrites") ||
         SIEquals(command->request.methodLine, "SetMaxSocketThreads") ||
-        SIEquals(command->request.methodLine, "SetBlockingQueueRateLimit") ||
         SIEquals(command->request.methodLine, "SetBlockingQueueTimeRateLimit") ||
         SIEquals(command->request.methodLine, "ClearBlockingQueue") ||
         SIEquals(command->request.methodLine, "SetPriority") ||
@@ -2097,18 +2096,6 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
         }
     } else if (SIEquals(command->request.methodLine, "SetConflictPageLocks")) {
         _enableConflictPageLocks = command->request.test("enable");
-    } else if (SIEquals(command->request.methodLine, "SetBlockingQueueRateLimit")) {
-        if (command->request.isSet("MaxRequestsPerIdentifier")) {
-            int64_t maxPerIdentifier = command->request.calc64("MaxRequestsPerIdentifier");
-            if (maxPerIdentifier >= 0) {
-                size_t previous = _blockingCommandQueue.setMaxRequestsPerIdentifier(maxPerIdentifier);
-                response["previousMaxBlockingQueuePerIdentifier"] = to_string(previous);
-                SINFO("Setting blocking queue max per identifier to " << maxPerIdentifier);
-            }
-        }
-        if (command->request.test("ClearBlocks")) {
-            _blockingCommandQueue.clearRateLimits();
-        }
     } else if (SIEquals(command->request.methodLine, "SetBlockingQueueTimeRateLimit")) {
         if (command->request.isSet("MaxTimePerIdentifierMs")) {
             int64_t maxTimeMs = command->request.calc64("MaxTimePerIdentifierMs");

--- a/test/clustertest/tests/BlockingQueueRateLimitTest.cpp
+++ b/test/clustertest/tests/BlockingQueueRateLimitTest.cpp
@@ -8,7 +8,6 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
                               BEFORE_CLASS(BlockingQueueRateLimitTest::setup),
                               BEFORE(BlockingQueueRateLimitTest::before),
                               TEST(BlockingQueueRateLimitTest::testControlCommands),
-                              TEST(BlockingQueueRateLimitTest::testRateLimiting),
                               TEST(BlockingQueueRateLimitTest::testTimeRateLimiting),
                               AFTER_CLASS(BlockingQueueRateLimitTest::teardown))
     {
@@ -30,10 +29,9 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
     {
         BedrockTester& leader = tester->getTester(0);
 
-        // ClearBlocks should reset all identifier counts.
-        SData resetBlockingQueue("SetBlockingQueueRateLimit");
+        // ClearBlocks should reset all identifier rate limit state.
+        SData resetBlockingQueue("SetBlockingQueueTimeRateLimit");
         resetBlockingQueue["ClearBlocks"] = "true";
-        resetBlockingQueue["MaxRequestsPerIdentifier"] = "0";
         leader.executeWaitVerifyContent(resetBlockingQueue, "200", true);
 
         // Reset state on leader.
@@ -43,103 +41,26 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
 
         SData status("Status");
         STable json = SParseJSONObject(leader.executeWaitVerifyContent(status, "200", true));
-        ASSERT_EQUAL(json["blockedIdentifiers"], "0");
+        ASSERT_EQUAL(json["blockedTimeIdentifiers"], "0");
     }
 
     void testControlCommands()
     {
         BedrockTester& leader = tester->getTester(0);
 
-        // Set the blocking rate limit threshold and verify it shows up in Status.
-        SData setLimit("SetBlockingQueueRateLimit");
-        setLimit["MaxRequestsPerIdentifier"] = "5";
-        leader.executeWaitVerifyContent(setLimit, "200", true);
-
-        SData status("Status");
-        STable json = SParseJSONObject(leader.executeWaitVerifyContent(status, "200", true));
-        ASSERT_EQUAL(json["blockingRateLimitThreshold"], "5");
-
-        SData setBlockingQueueRateLimit("SetBlockingQueueRateLimit");
-        setBlockingQueueRateLimit["MaxRequestsPerIdentifier"] = "1";
-        leader.executeWaitVerifyContent(setBlockingQueueRateLimit, "200", true);
-
+        // Set the blocking queue time rate limit threshold and verify it shows up in Status.
         SData setBlockingQueueTimeRateLimit("SetBlockingQueueTimeRateLimit");
         setBlockingQueueTimeRateLimit["MaxTimePerIdentifierMs"] = "1";
         leader.executeWaitVerifyContent(setBlockingQueueTimeRateLimit, "200", true);
 
-        json = SParseJSONObject(leader.executeWaitVerifyContent(status, "200", true));
+        SData status("Status");
+        STable json = SParseJSONObject(leader.executeWaitVerifyContent(status, "200", true));
         ASSERT_EQUAL(json["blockingTimeRateLimitThresholdMs"], "1");
-        ASSERT_EQUAL(json["blockingRateLimitThreshold"], "1");
-    }
-
-    void testRateLimiting()
-    {
-        // Only the leader processes writes (followers escalate), so only the leader needs these settings.
-        BedrockTester& leader = tester->getTester(0);
-
-        SData setConflict("SetConflictParams");
-        setConflict["MaxConflictRetries"] = "1";
-        leader.executeWaitVerifyContent(setConflict, "200", true);
-
-        SData setLimit("SetBlockingQueueRateLimit");
-        setLimit["MaxRequestsPerIdentifier"] = "2";
-        leader.executeWaitVerifyContent(setLimit, "200", true);
-
-        // Remove the time limit so we're sure we're testing just the count limit.
-        SData setBlockingQueueTimeRateLimit("SetBlockingQueueTimeRateLimit");
-        setBlockingQueueTimeRateLimit["MaxTimePerIdentifierMs"] = "0";
-        leader.executeWaitVerifyContent(setBlockingQueueTimeRateLimit, "200", true);
-
-        // Spawn 3 threads, each sending 200 idcollision commands to a different node,
-        // all with the same blockingQueueRateLimitIdentifier. This generates write conflicts that push
-        // commands into the blocking queue, triggering rate limiting.
-        atomic<int> count503(0);
-        atomic<int> count200(0);
-        list<thread> threads;
-
-        for (int i : {0, 1, 2}) {
-            threads.emplace_back([this, i, &count503, &count200]() {
-                BedrockTester& node = tester->getTester(i);
-
-                vector<SData> requests;
-                for (int j = 0; j < 200; j++) {
-                    SData cmd("idcollision b2");
-                    cmd["blockingQueueRateLimitIdentifier"] = "testuser";
-                    cmd["writeConsistency"] = "ASYNC";
-                    cmd["value"] = "node" + to_string(i) + "-" + to_string(j);
-                    requests.push_back(cmd);
-                }
-
-                auto results = node.executeWaitMultipleData(requests);
-                for (auto& result : results) {
-                    int status = SToInt(result.methodLine);
-                    if (status == 503) {
-                        count503.fetch_add(1);
-                    } else if (status == 200) {
-                        count200.fetch_add(1);
-                    }
-                }
-            });
-        }
-
-        for (thread& t : threads) {
-            t.join();
-        }
-
-        ASSERT_EQUAL(count200.load() + count503.load(), 600);
-
-        // We're not rejecting for counts right now, so this should return 0
-        ASSERT_EQUAL(count503.load(), 0);
     }
 
     void testTimeRateLimiting()
     {
         BedrockTester& leader = tester->getTester(0);
-
-        // Remove the count limit so we're sure we're testing just the time limit.
-        SData setLimit("SetBlockingQueueRateLimit");
-        setLimit["MaxRequestsPerIdentifier"] = "0";
-        leader.executeWaitVerifyContent(setLimit, "200", true);
 
         // Set the time limit to 10ms so that we can trigger it with a few commands.
         SData setBlockingQueueTimeRateLimit("SetBlockingQueueTimeRateLimit");
@@ -195,7 +116,7 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
         ASSERT_TRUE(json.find("blockingQueueIdentifierTimesMs") != json.end());
         ASSERT_TRUE(SToInt(json["blockedTimeIdentifiers"]) >= 1);
 
-        // ClearBlocks resets time and count state together.
+        // ClearBlocks resets the time rate limit state.
         SData clearBlocks("SetBlockingQueueTimeRateLimit");
         clearBlocks["ClearBlocks"] = "true";
         leader.executeWaitVerifyContent(clearBlocks, "200", true);


### PR DESCRIPTION
### Details
This PR removes the count based rate limit since we will use only time based going forward.

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/662853

### Tests
Just removing code and automated tests related to it.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
