### PR TITLE
Report the errno from the syscall that actually failed

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -2262,6 +2262,9 @@ bool S_recvappend(int s, SFastBuffer& recvBuffer)
         }
     }
 
+    // Save errno from the recvfrom() that ended the loop, before the string building below can overwrite it.
+    const int recvErrno = errno;
+
     // See how we finished
     if (numRecv == 0) {
         return false; // Graceful shutdown; socket closed
@@ -2269,7 +2272,7 @@ bool S_recvappend(int s, SFastBuffer& recvBuffer)
     // Some kind of error -- what happened?
     stringstream addrStr;
     addrStr << fromAddr;
-    return SCheckNetworkErrorType("recv", addrStr.str(), S_errno);
+    return SCheckNetworkErrorType("recv", addrStr.str(), recvErrno);
 }
 
 // --------------------------------------------------------------------------
@@ -2291,9 +2294,15 @@ bool S_sendconsume(int s, SFastBuffer& sendBuffer)
 
     // Send as much as we can
     ssize_t numSent = send(s, sendBuffer.c_str(), sendBuffer.size(), MSG_NOSIGNAL);
+
+    // Save errno before anything else runs. Both strerror() and getpeername() can overwrite it, and the order in
+    // which function arguments are evaluated is unspecified, so reading errno inline at a call site can yield the
+    // errno of a sibling argument instead of the one from send().
+    const int sendErrno = errno;
+
     string errorMessage;
     if (numSent == -1) {
-        errorMessage = " Error: "s + strerror(errno);
+        errorMessage = " Error: "s + strerror(sendErrno);
     }
 
     if (numSent > 0) {
@@ -2307,13 +2316,13 @@ bool S_sendconsume(int s, SFastBuffer& sendBuffer)
 
     // If we failed to send with over 1GB in the buffer, return false, even if the error would normally be non-fatal.
     if (sendBuffer.size() > 1024 * 1024 * 1024) {
-        SWARN("send() failed with response '" << strerror(errno) << "' (#" << errno << "), and buffer size: "
+        SWARN("send() failed with response '" << strerror(sendErrno) << "' (#" << sendErrno << "), and buffer size: "
               << sendBuffer.size() << ", closing.");
         return false;
     }
 
     // Error, what kind?
-    return SCheckNetworkErrorType("send", SGetPeerName(s), S_errno);
+    return SCheckNetworkErrorType("send", SGetPeerName(s), sendErrno);
 }
 
 void SFDset(fd_map& fdm, int socket, short evts)
@@ -2383,14 +2392,21 @@ string SGetHostName()
 // --------------------------------------------------------------------------
 string SGetPeerName(int s)
 {
+    // Callers commonly use this to describe a socket while reporting an error from a different syscall, so this
+    // must leave errno exactly as it found it.
+    const int callerErrno = errno;
+
     // Just call the function that does this
     sockaddr_in addr{};
     socklen_t socklen = sizeof(addr);
     int result = getpeername(s, (sockaddr*) &addr, &socklen);
+    const int peerNameErrno = errno;
+    errno = callerErrno;
+
     if (result == 0) {
         return SToStr(addr);
     } else {
-        return "(errno#" + SToStr(S_errno) + ")";
+        return "(errno#" + SToStr(peerNameErrno) + ")";
     }
 }
 

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -60,7 +60,8 @@ struct LibStuff : tpunit::TestFixture
                                      TEST(LibStuff::testSQueryBoundParameterInjections),
                                      TEST(LibStuff::SRedactSensitiveValuesTest),
                                      TEST(LibStuff::SComposeHTTPTest),
-                                     TEST(LibStuff::testEncodeDecodeURIComponent)
+                                     TEST(LibStuff::testEncodeDecodeURIComponent),
+                                     TEST(LibStuff::testSGetPeerNamePreservesErrno)
     )
     {
     }
@@ -1160,5 +1161,24 @@ struct LibStuff : tpunit::TestFixture
         // UTF-8: ü (U+00FC) = bytes 0xC3 0xBC → %C3%BC
         ASSERT_EQUAL(SEncodeURIComponent("\xC3\xBC"), "%C3%BC");
         ASSERT_EQUAL(SDecodeURIComponent(SEncodeURIComponent("\xC3\xBC")), "\xC3\xBC");
+    }
+
+    void testSGetPeerNamePreservesErrno()
+    {
+        // Callers pass SGetPeerName(s) and errno as sibling arguments while reporting a failure from send() or
+        // recv(). Argument evaluation order is unspecified, so if getpeername() were allowed to overwrite errno the
+        // caller could report ENOTCONN instead of the real error and treat a recoverable failure as fatal.
+        int s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        ASSERT_TRUE(s >= 0);
+
+        // An unconnected socket makes getpeername() fail, which is the case that sets errno.
+        errno = EAGAIN;
+        const string peerName = SGetPeerName(s);
+        ASSERT_EQUAL(errno, EAGAIN);
+
+        // The failing errno still reaches the description.
+        ASSERT_EQUAL(peerName, "(errno#" + SToStr(ENOTCONN) + ")");
+
+        close(s);
     }
 } __LibStuff;


### PR DESCRIPTION
### Details

`S_sendconsume` passed `SGetPeerName(s)` and `errno` as sibling arguments to `SCheckNetworkErrorType`. Argument evaluation order is unspecified in C++, and clang evaluates left to right, so `getpeername()` — which fails with `ENOTCONN` on a socket that is still connecting — overwrote `errno` before it was read.

A `send()` that failed with a recoverable `EAGAIN` was therefore reported as a fatal `ENOTCONN` and the socket was closed. This is the source of `send((errno#107)) failed with response 'Transport endpoint is not connected' (#107), closing.`, where both the peer name and the errno come from the same failed `getpeername()`.

Affects any path reaching raw `S_sendconsume` — the proxy `CONNECT` in `SHTTPSProxySocket::send`, and plaintext sockets such as auth→webrock. Direct HTTPS is unaffected because it uses `ssl->sendConsume()`.

Three changes:

- Capture `errno` immediately after `send()` in `S_sendconsume` and use it throughout.
- Capture `errno` immediately after the failing `recvfrom()` in `S_recvappend`.
- Make `SGetPeerName` restore the caller's `errno` so it cannot clobber an unrelated failure.

### Fixed Issues

Fixes https://github.com/Expensify/Expensify/issues/668981

### Tests

1. Build the test binary with `make -j12 test`.
2. Run `./test -only LibStuff` and confirm 36 tests pass.
3. Comment out the `errno = callerErrno;` line in `SGetPeerName`, rebuild, and re-run — `LibStuff::testSGetPeerNamePreservesErrno` fails.
4. Restore the line, rebuild, and confirm it passes again.
5. Run the full suite with `./test` and compare against main — 203 passed / 15 failed with this change, 202 passed / 15 failed on main. The 15 `GetJobTest` failures are pre-existing and unrelated.

Compiler behaviour was verified separately: clang-18 at both `-O0` and `-O2` evaluates left to right and reproduces the clobber, g++-13 does not. Bedrock is built with clang-18 (`Salt/build/pkgs.sls`).

Auth was compiled against this branch: 64/64 steps, zero errors, `auth.a` and `auth.so` linked against the rebuilt `libstuff.a`.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
