### PR TITLE
Make logLastTransactionTiming command param optional so that it gets automatically populated

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1176,13 +1176,13 @@ int SQLite::commit(const string& description, const string& commandName, functio
                 description,
                 SToStr(_sharedData.commitCount),
                 time,
-                (endPages - startPages),
+                   (endPages - startPages),
                 sz,
                 _readQueryCount,
                 _writeQueryCount,
                 _cacheHits,
                 _journalName,
-                (_hctree ? format(" HC-Tree pages added: {}", _pageCountDifference) : ""))
+                   (_hctree ? format(" HC-Tree pages added: {}", _pageCountDifference) : ""))
         );
         _readQueryCount = 0;
         _writeQueryCount = 0;
@@ -1281,7 +1281,7 @@ void SQLite::logLastTransactionTiming(const string& message, const string& comma
     // We don't want to add `commitLockElapsed` and `totalTransactionElapsed` to the total elapsed time since they overlap with parts of the transaction
     // and that could double-count certain times (i.e. `commitElapsed` occurs simultaneously with `commitLockElapsed`)
     uint64_t totalElapsed = _beginElapsed + _readElapsed + _writeElapsed + _prepareElapsed + _commitElapsed + _rollbackElapsed;
-    STable params ={
+    STable params = {
         {"totalElapsed", to_string(totalElapsed / 1000)},
         {"readElapsed", to_string(_readElapsed / 1000)},
         {"writeElapsed", to_string(_writeElapsed / 1000)},

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1176,14 +1176,14 @@ int SQLite::commit(const string& description, const string& commandName, functio
                 description,
                 SToStr(_sharedData.commitCount),
                 time,
-                   (endPages - startPages),
+                (endPages - startPages),
                 sz,
                 _readQueryCount,
                 _writeQueryCount,
                 _cacheHits,
                 _journalName,
-                   (_hctree ? format(" HC-Tree pages added: {}", _pageCountDifference) : "")),
-            commandName);
+                (_hctree ? format(" HC-Tree pages added: {}", _pageCountDifference) : ""))
+        );
         _readQueryCount = 0;
         _writeQueryCount = 0;
         _cacheHits = 0;
@@ -1269,10 +1269,7 @@ void SQLite::rollback(const string& commandName)
         SINFO("Rolling back but not inside transaction, ignoring.");
     }
     _queryCache.clear();
-    logLastTransactionTiming(
-        format("Transaction rollback with {} read queries attempted, {} write queries attempted, {} served from cache.", _readQueryCount, _writeQueryCount, _cacheHits),
-        commandName
-    );
+    logLastTransactionTiming(format("Transaction rollback with {} read queries attempted, {} write queries attempted, {} served from cache.", _readQueryCount, _writeQueryCount, _cacheHits));
     _readQueryCount = 0;
     _writeQueryCount = 0;
     _cacheHits = 0;
@@ -1284,8 +1281,7 @@ void SQLite::logLastTransactionTiming(const string& message, const string& comma
     // We don't want to add `commitLockElapsed` and `totalTransactionElapsed` to the total elapsed time since they overlap with parts of the transaction
     // and that could double-count certain times (i.e. `commitElapsed` occurs simultaneously with `commitLockElapsed`)
     uint64_t totalElapsed = _beginElapsed + _readElapsed + _writeElapsed + _prepareElapsed + _commitElapsed + _rollbackElapsed;
-    SINFO(message, {
-        {"command", commandName},
+    STable params ={
         {"totalElapsed", to_string(totalElapsed / 1000)},
         {"readElapsed", to_string(_readElapsed / 1000)},
         {"writeElapsed", to_string(_writeElapsed / 1000)},
@@ -1295,7 +1291,11 @@ void SQLite::logLastTransactionTiming(const string& message, const string& comma
         {"totalTransactionElapsed", to_string(_totalTransactionElapsed / 1000)},
         {"beginElapsed", to_string(_beginElapsed / 1000)},
         {"commitLockElapsed", to_string(_commitLockElapsed / 1000)},
-    });
+    };
+    if (!commandName.empty()) {
+        params["command"] = commandName;
+    }
+    SINFO(message, params);
 }
 
 bool SQLite::getCommit(uint64_t id, string* query, string* hash)

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -230,7 +230,7 @@ public:
     }
 
     // Returns the timing of the last command
-    void logLastTransactionTiming(const string& message, const string& commandName);
+    void logLastTransactionTiming(const string& message, const string& commandName = "");
 
     TRANSACTION_TYPE getLastTransactionType();
 


### PR DESCRIPTION
### Details

This change allows to [append the command name to the log line](https://github.com/Expensify/Bedrock/pull/2660/changes#diff-f70ecdf98cbec3fc1ca2b1ab6bab8daab9e8bcf1252ff6f42367a866717b281dR115) automatically.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/664321

### Tests
Same as https://github.com/Expensify/Auth/pull/23500

