### PR TITLE
Expose stateChangeCount in the Status command

### DIFF
--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -1905,6 +1905,7 @@ void BedrockServer::_status(unique_ptr<BedrockCommand>& command)
             // Set some information about this node.
             content["CommitCount"] = to_string(_syncNodeCopy->getCommitCount());
             content["priority"] = to_string(_syncNodeCopy->getPriority());
+            content["stateChangeCount"] = to_string(_syncNodeCopy->getStateChangeCount());
             content["outstandingFramesToCheckpoint"] = to_string(_syncNodeCopy->getOutstandingFramesToCheckpoint());
             _syncNodeCopy = nullptr;
         } else {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -325,6 +325,11 @@ SQLiteNodeState SQLiteNode::getState() const
     return _state;
 }
 
+int SQLiteNode::getStateChangeCount() const
+{
+    return _stateChangeCount;
+}
+
 int SQLiteNode::getPriority() const
 {
     // Note: this can skip locking because it only accesses a single atomic variable, which makes it safe to call in

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -144,6 +144,10 @@ public:
     // Does not block.
     SQLiteNodeState getState() const;
 
+    // Returns the number of times this node has changed states since it started.
+    // Does not block.
+    int getStateChangeCount() const;
+
     // Returns true if we're LEADING with enough FOLLOWERs to commit a quorum transaction.
     // Can block.
     bool hasQuorum() const;
@@ -390,7 +394,7 @@ private:
     // This is an integer that increments every time we change states. This is useful for responses to state changes
     // (i.e., approving standup) to verify that the messages we're receiving are relevant to the current state change,
     // and not stale responses to old changes.
-    int _stateChangeCount;
+    atomic<int> _stateChangeCount;
 
     // This is the mutex we lock any time we change any internal state variables.
     mutable shared_mutex _stateMutex;


### PR DESCRIPTION
### Details
`_stateChangeCount` already exists — it's bumped in `_changeState` on every transition and stamped into the `STATE` messages we broadcast, so a node standing up can throw away `STANDUP_RESPONSE`s from a previous standup attempt. It's just never been visible from outside the process. It's a rally useful churn signal, so this exposes it in `Status` next to `state` and `priority`.

Note it counts *all* transitions, not just going leading. A node flapping SEARCHING -> SYNCHRONIZING -> WAITING -> FOLLOWING bumps it 4 times, so it tells you something happened, not what. It's also per-process and resets on restart. If we want "times this node has led" specifically that's a separate counter in the `newState == LEADING` branch of `_changeState`, which I didn't add here.

It was a bare `int`, and `Status` is served on a worker thread while `_changeState` runs on the sync thread, so it's now `atomic<int>`. `++_stateChangeCount` and the `STANDUP_RESPONSE` comparison work unchanged.

### Fixed Issues
Fixes GH_LINK

### Tests
Compiles clean in the VM. Brought up a single node and asked it twice:

```
state: LEADING | stateChangeCount: 2
```

2 is right for a node that went SEARCHING then LEADING.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
