### PR TITLE
Add `shouldClearRepeat` param to `UpdateJob`

### DIFF
--- a/plugins/Jobs.cpp
+++ b/plugins/Jobs.cpp
@@ -1080,7 +1080,8 @@ void BedrockJobsCommand::process(SQLite& db)
         if (!db.writeIdempotent("UPDATE jobs "
                                 "SET data=" +
                                 SQ(newData) +
-                                (request["repeat"].size() ? ", repeat=" + SQ(SToUpper(request["repeat"])) : "") +
+                                (SToInt(request["shouldClearRepeat"]) ? ", repeat=''" :
+                                 request["repeat"].size() ? ", repeat=" + SQ(SToUpper(request["repeat"])) : "") +
                                 (!newNextRun.empty() ? ", nextRun=" + newNextRun : "") +
                                 (request.isSet("jobPriority") ? ", priority=" + SQ(request.calc64("jobPriority")) + " " : "") +
                                 "WHERE jobID=" +

--- a/test/tests/jobs/UpdateJobTest.cpp
+++ b/test/tests/jobs/UpdateJobTest.cpp
@@ -121,6 +121,7 @@ struct UpdateJobTest : tpunit::TestFixture
         ASSERT_NOT_EQUAL(currentJob[0][2], oldPriority);
         ASSERT_EQUAL(currentJob[0][3], "2020-01-01 00:00:00");
     }
+
     void clearRepeatWithShouldClearRepeat()
     {
         // Create a repeating job

--- a/test/tests/jobs/UpdateJobTest.cpp
+++ b/test/tests/jobs/UpdateJobTest.cpp
@@ -11,6 +11,7 @@ struct UpdateJobTest : tpunit::TestFixture
                               TEST(UpdateJobTest::updateJob),
                               TEST(UpdateJobTest::updateStringValueLookingLikeNumber),
                               TEST(UpdateJobTest::updateMockedJob),
+                              TEST(UpdateJobTest::clearRepeatWithShouldClearRepeat),
                               AFTER_CLASS(UpdateJobTest::tearDownClass))
     {
     }
@@ -119,5 +120,33 @@ struct UpdateJobTest : tpunit::TestFixture
         ASSERT_EQUAL(currentJob[0][2], "1000");
         ASSERT_NOT_EQUAL(currentJob[0][2], oldPriority);
         ASSERT_EQUAL(currentJob[0][3], "2020-01-01 00:00:00");
+    }
+    void clearRepeatWithShouldClearRepeat()
+    {
+        // Create a repeating job
+        SData command("CreateJob");
+        command["name"] = "repeating-job";
+        command["repeat"] = "HOURLY";
+        STable response = tester->executeWaitVerifyContentTable(command);
+        string jobID = response["jobID"];
+        ASSERT_GREATER_THAN(stol(jobID), 0);
+
+        // Confirm repeat is set
+        SQResult before;
+        tester->readDB("SELECT repeat FROM jobs WHERE jobID = " + jobID + ";", before);
+        ASSERT_EQUAL(before[0][0], "HOURLY");
+
+        // UpdateJob with shouldClearRepeat=1 — should set repeat to "" in the DB
+        command.clear();
+        command.methodLine = "UpdateJob";
+        command["jobID"] = jobID;
+        command["data"] = "{}";
+        command["shouldClearRepeat"] = "1";
+        tester->executeWaitVerifyContent(command);
+
+        // Verify repeat is now cleared
+        SQResult after;
+        tester->readDB("SELECT repeat FROM jobs WHERE jobID = " + jobID + ";", after);
+        ASSERT_EQUAL(after[0][0], "");
     }
 } __UpdateJobTest;


### PR DESCRIPTION
`UpdateJob` skips updating the repeat column when `repeat=""` because of a `size() > 0` check. That's normally fine, but it means you can't intentionally clear a job's repeat schedule by passing an empty string.

Adding `shouldClearRepeat=1` as an explicit flag instead. Changing the empty-string behavior would be risky since SData can end up with `repeat=""` by default if a caller ever accesses that field, which would silently wipe the repeat on jobs that shouldn't be touched.

Context: https://github.com/Expensify/Auth/pull/23409 (cancels RUNNING scheduled agent jobs by stripping their repeat expression, was passing `repeat=""` which turned out to be a no-op).