### PR TITLE
Mark compress and decompress SQLITE_INNOCUOUS

### DIFF
--- a/plugins/Compression.cpp
+++ b/plugins/Compression.cpp
@@ -257,9 +257,14 @@ static void sqliteDecompress(sqlite3_context* ctx, int argc, sqlite3_value** arg
 
 void BedrockPlugin_Compression::registerSQLite(sqlite3* db)
 {
-    sqlite3_create_function_v2(db, "compress", 2, SQLITE_UTF8 | SQLITE_DETERMINISTIC,
+    // SQLITE_INNOCUOUS lets these appear in indexes, views and triggers on a connection with
+    // trusted_schema turned off. Without it, once an index reads decompress(), such a connection
+    // rejects INSERT, UPDATE, REINDEX, PRAGMA integrity_check and VACUUM on the indexed table with
+    // "unsafe use of decompress()". The sqlite3 command line turns trusted_schema off by default,
+    // so that would break querying and maintaining a database snapshot.
+    sqlite3_create_function_v2(db, "compress", 2, SQLITE_UTF8 | SQLITE_DETERMINISTIC | SQLITE_INNOCUOUS,
                                nullptr, ::sqliteCompress, nullptr, nullptr, nullptr);
-    sqlite3_create_function_v2(db, "decompress", 1, SQLITE_UTF8 | SQLITE_DETERMINISTIC,
+    sqlite3_create_function_v2(db, "decompress", 1, SQLITE_UTF8 | SQLITE_DETERMINISTIC | SQLITE_INNOCUOUS,
                                nullptr, ::sqliteDecompress, nullptr, nullptr, nullptr);
 }
 


### PR DESCRIPTION
### Details

Auth is about to index `reportActions.message` through `decompress()` for the DB compression project, and while verifying the query plans I found that `SQLITE_DETERMINISTIC` alone isn't enough to make that safe.

`SQLITE_DETERMINISTIC` is what lets a function appear in an index expression at all. But SQLite has a second gate: on a connection with `trusted_schema` off, a function is only allowed inside a schema object (index, view, trigger) if it's also tagged `SQLITE_INNOCUOUS`. We don't touch `trusted_schema` in Bedrock, and the C API defaults it on, so bedrock itself is fine either way. The problem is the `sqlite3` command line, which defaults it **off**.

So once the index exists, here's what a DBA gets on a snapshot. I reproduced this in the VM with a scratch DB and a stand-in `decompress()`, index definition copied from the Auth branch:

```
=== trusted_schema=OFF: plain SELECT not touching the index ===
1
=== trusted_schema=OFF: INSERT (must maintain the index) ===
Parse error near line 21: unsafe use of decompress()
=== trusted_schema=OFF: UPDATE of message ===
Parse error near line 25: unsafe use of decompress()
=== trusted_schema=OFF: REINDEX ===
Parse error near line 29: unsafe use of decompress()
=== trusted_schema=OFF: integrity_check ===
Parse error near line 33: unsafe use of decompress()
=== trusted_schema=OFF: VACUUM ===
Error near line 36: unsafe use of decompress()
```

Plain SELECTs that avoid the index still work, which is the annoying part — it looks fine until you try to write anything, reindex, or run an integrity check. `VACUUM` and `PRAGMA integrity_check` failing is the bit that bothered me most, since those are routine.

Adding the flag fixes all of them:

```
=== trusted_schema=OFF: INSERT (must maintain the index) ===
insert ok
=== trusted_schema=OFF: UPDATE of message ===
update ok
=== trusted_schema=OFF: REINDEX ===
reindex ok
=== trusted_schema=OFF: integrity_check ===
ok
=== trusted_schema=OFF: VACUUM ===
vacuum ok
```

This change just adds `SQLITE_INNOCUOUS` to both registrations. The functions genuinely are innocuous in the sense the docs mean — no side effects, no access to anything outside their arguments and the dictionary table.

There's a matching change needed in the statically-linked CLI extension in Salt, since it registers the same two functions with the same flags: https://github.com/Expensify/Salt/pull/17171

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/601964

### Tests

Compiled auth against these changes, per the reminder below — builds clean, and the Auth test suite behaves the same as before.

`CompressionTest` currently fails all 3 of its tests, but it fails identically on `main`, so it's pre-existing and not from this change:

```
   exception #1 from CompressionTest::testCompressionDisabled with cause: From command Query, expected 200, but got '402 Bad query'. Initially thrown from: DB.cpp:139
   exception #1 from CompressionTest::testCompressionEnabled with cause: From command Query, expected 200, but got '402 Bad query'. Initially thrown from: DB.cpp:139
   exception #1 from CompressionTest::testAllNodesCompressed with cause: From command Query, expected 200, but got '402 Bad query'. Initially thrown from: DB.cpp:139
[ TEST RESULTS ] Passed: 0, Failed: 3
```

I checked out `main`, rebuilt, and got the same three failures with the same cause, so I didn't chase it here. Worth a separate look though.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
