### PR TITLE
Replication migration deploy 2: leaders send TRANSACTION, followers send FOLLOWER_STATUS

### DIFF
--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -256,7 +256,7 @@ public:
     // Returns a concatenated string containing all the 'write' queries executed within the current, uncommitted
     // transaction. Before prepare() runs this is the raw SQL; after prepare() runs it holds the same bytes that were
     // written to the journal — a zstd frame when journalZstdDictionaryID is non-zero, or the raw SQL otherwise. The
-    // post-prepare form is what gets shipped to followers in BEGIN_TRANSACTION.
+    // post-prepare form is what gets shipped to followers in TRANSACTION.
     string getUncommittedQuery()
     {
         return _uncommittedQuery;
@@ -380,7 +380,7 @@ public:
         // When `SQLite::prepare` is called, we need to save a set of info that will be broadcast to peers when the
         // transaction is ultimately committed. This should be cleared out if the transaction is rolled back. The
         // query is in its post-prepare() form (a zstd frame when compression is enabled, raw SQL otherwise) and is
-        // shipped directly to followers in BEGIN_TRANSACTION.
+        // shipped directly to followers in TRANSACTION.
         void prepareTransactionInfo(uint64_t commitID, const string& query, const string& hash);
 
         // When a transaction that was prepared is committed, we move the data from the prepared list to the committed

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -54,8 +54,9 @@
 // NewHash:          Hash, but for "ID" instead of "CommitCount".
 //                   Proposal: rename to "currentTransactionHash".
 // NewCount:         Same as "ID" except without the "ASYNC_" prefix.
-// AsyncNotification: Set on an APPROVE_TRANSACTION that a follower sends periodically for an "ASYNC_" transaction. It
-//                   marks the message as a commit-count report rather than an approval of anything.
+// AsyncNotification: Set on an APPROVE_TRANSACTION that a follower running older code sends periodically for an
+//                   "ASYNC_" transaction. It marks the message as a commit-count report rather than an approval of
+//                   anything.
 // State:            The state of the peer sending the message (i.e., SEARCHING, LEADING).
 // Version:          The version string of the node sending the message.
 // Permafollower:    Boolean value (string "true" or "false") indicating if the node sending the message is a
@@ -1422,10 +1423,10 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
             // already done: every message carries CommitCount and Hash, and the code above recorded them with
             // `peer->setCommit()`. These branches exist only so the messages aren't logged as unrecognized.
             //
-            // FOLLOWER_STATUS is the message meant for this. APPROVE_TRANSACTION and DENY_TRANSACTION are what
-            // followers actually send today, and are still what a follower sends to a leader running older code, so
-            // they're accepted here too. Deliberately no validation: we no longer act on an approval, and throwing
-            // would cost us the peer connection for a message we're about to ignore either way.
+            // FOLLOWER_STATUS is the message meant for this, and what a follower sends. APPROVE_TRANSACTION and
+            // DENY_TRANSACTION are what a follower running older code sends, so they're accepted here too.
+            // Deliberately no validation: we no longer act on an approval, and throwing would cost us the peer
+            // connection for a message we're about to ignore either way.
         } else if (SIEquals(message.methodLine, "FORKED")) {
             peer->forked = true;
             PINFO("Peer said we're forked, believing them.");
@@ -2041,14 +2042,9 @@ void SQLiteNode::_handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SDa
 
 bool SQLiteNode::_handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const SData& message, uint64_t dequeueTime)
 {
-    // A `TRANSACTION` message carries the whole transaction, so we commit it ourselves as soon as we've applied it. A
-    // `BEGIN_TRANSACTION` leaves us holding a prepared transaction until leader tells us what to do with it.
-    const bool isMerged = SIEquals(message.methodLine, "TRANSACTION");
-
     uint64_t prepareStartTime = STimeNow();
-    // BEGIN_TRANSACTION: Sent by the LEADER to all subscribed followers to begin a new distributed transaction. Each
-    // follower begins a local transaction with this query and responds APPROVE_TRANSACTION. If the follower cannot start
-    // the transaction for any reason, it is broken somehow -- disconnect from the leader.
+    // If the follower cannot apply leader's transaction for any reason, it is broken somehow -- disconnect from the
+    // leader.
     // **FIXME**: What happens if LEADER steps down before sending BEGIN?
     // **FIXME**: What happens if LEADER steps down or disconnects after BEGIN?
     if (!message.isSet("ID")) {
@@ -2071,12 +2067,11 @@ bool SQLiteNode::_handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const S
         db.rollback();
     }
 
-    // Permafollowers never respond. Everyone else does, for one of two reasons.
-    //
-    // A merged TRANSACTION can only come from a leader new enough to understand FOLLOWER_STATUS, so on that path we
-    // report our commit count with the message meant for it, and never send an approval -- there is nothing left to
-    // approve. Every tenth is enough to keep leader roughly current.
-    if (_priority && isMerged) {
+    // There's nothing left to approve -- leader has already committed anything it sends us -- so all we owe it is a
+    // rough idea of how far along we are, which every message we send carries in its CommitCount header. Every tenth
+    // commit is enough to keep leader current, and it's a floor rather than a schedule: sending one more often than
+    // that is harmless. Permafollowers never respond at all.
+    if (_priority) {
         uint64_t currentCommitCount = db.getCommitCount();
         if (currentCommitCount % MIN_APPROVE_FREQUENCY == 0) {
             SData response("FOLLOWER_STATUS");
@@ -2084,31 +2079,8 @@ bool SQLiteNode::_handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const S
                 _sendToPeer(_leadPeer, response);
             }
         }
-    } else if (_priority) {
-        string verb = success ? "APPROVE_TRANSACTION" : "DENY_TRANSACTION";
-        uint64_t currentCommitCount = db.getCommitCount();
-        bool isAsync = SStartsWith(message["ID"], "ASYNC_");
-        bool asyncNotification = isAsync && (currentCommitCount % MIN_APPROVE_FREQUENCY == 0);
-        if (!isAsync || asyncNotification) {
-            // Not a permafollower, approve the transaction
-            PINFO(verb << " #" << currentCommitCount + 1 << " (" << message["NewHash"] << ").");
-            SData response(verb);
-            response["NewCount"] = SToStr(currentCommitCount + 1);
-            response["NewHash"] = success ? db.getUncommittedHash() : message["NewHash"];
-            response["ID"] = message["ID"];
-            if (asyncNotification) {
-                response["AsyncNotification"] = "true";
-            }
-            if (_leadPeer) {
-                _sendToPeer(_leadPeer, response);
-            } else {
-                SWARN("no leader? Still handling transaction, it may have been approved elsewhere.");
-            }
-        } else {
-            SDEBUG("Skipping " << verb << " for ASYNC command.");
-        }
     } else {
-        PINFO("Would approve/deny transaction #" << db.getCommitCount() + 1 << " (" << db.getUncommittedHash()
+        PINFO("Would report status at transaction #" << db.getCommitCount() + 1 << " (" << db.getUncommittedHash()
               << "), but a permafollower -- keeping quiet.");
     }
     uint64_t leaderSentTimestamp = message.calcU64("leaderSendTime");

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -2013,9 +2013,8 @@ bool SQLiteNode::_majoritySubscribed() const
 
 void SQLiteNode::_handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SData& message)
 {
-    // BEGIN_TRANSACTION: Sent by the LEADER to all subscribed followers to begin a new distributed transaction. Each
-    // follower begins a local transaction with this query and responds APPROVE_TRANSACTION. If the follower cannot start
-    // the transaction for any reason, it is broken somehow -- disconnect from the leader.
+    // Begins a local transaction with the query the leader broadcast. If the follower cannot start the transaction for
+    // any reason, it is broken somehow -- disconnect from the leader.
     // **FIXME**: What happens if LEADER steps down before sending BEGIN?
     // **FIXME**: What happens if LEADER steps down or disconnects after BEGIN?
     if (_state != SQLiteNodeState::FOLLOWING) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -34,13 +34,11 @@
 // *** REPLICATION MESSAGES ***
 // TRANSACTION:         A complete transaction: the follower applies it and commits it, with no second message needed.
 //                      A leader only ever broadcasts a transaction it has already committed itself, so there is nothing
-//                      it could later ask the follower to take back. Nothing sends this yet -- the receiver ships one
-//                      release ahead of the sender so that leaders can switch to it once every node understands it.
+//                      it could later ask the follower to take back. This is what a leader sends.
 // BEGIN_TRANSACTION:   Apply a transaction but don't commit it; wait to be told which way it went. The older,
-//                      two-message form of the above, and still what every leader sends today.
-// COMMIT_TRANSACTION:  Commit the transaction a BEGIN_TRANSACTION applied.
-// ROLLBACK_TRANSACTION: Discard the transaction a BEGIN_TRANSACTION applied. Nothing in this version sends it; see
-//                      `_handleRollbackTransaction` for why the receiver is still here.
+//                      two-message form of the above. Nothing in this version sends it; the receiver is still here
+//                      because a leader running older code does, and it goes away once none can.
+// COMMIT_TRANSACTION:  Commit the transaction a BEGIN_TRANSACTION applied. Same story as BEGIN_TRANSACTION.
 //
 // *** DOCUMENTATION OF MESSAGE FIELDS ***
 // Note: Yes, two of these fields start with lowercase chars.
@@ -390,26 +388,20 @@ void SQLiteNode::_sendOutstandingTransactions()
         }
         string& query = i.second.first;
         string& hash = i.second.second;
-        // Every transaction we send has already committed here, so BEGIN and COMMIT go out together. The "ASYNC_"
-        // prefix tells followers not to bother approving it, which is load-bearing: a follower sends a full
-        // APPROVE_TRANSACTION for any ID without it.
-        string idHeader = "ASYNC_" + to_string(id);
-        SData transaction("BEGIN_TRANSACTION");
+        // Every transaction we send has already committed here, so it goes out as a single TRANSACTION that the
+        // follower applies and commits on its own. The "ASYNC_" prefix on the ID tells followers not to bother
+        // approving it, which is load-bearing for a follower running older code: it sends a full APPROVE_TRANSACTION
+        // for any ID without it.
+        SData transaction("TRANSACTION");
         transaction["NewCount"] = to_string(id);
         transaction["NewHash"] = hash;
         transaction["leaderSendTime"] = sendTime;
-        transaction["ID"] = idHeader;
+        transaction["ID"] = "ASYNC_" + to_string(id);
         transaction.content = query;
 
         // Allows us to easily figure out how far behind followers are by analyzing the logs.
-        SINFO("Sending COMMIT for ASYNC transaction " << id << " to followers");
+        SINFO("Sending ASYNC transaction " << id << " to followers");
         _sendToAllPeers(transaction, true); // subscribed only
-
-        SData commit("COMMIT_TRANSACTION");
-        commit["ID"] = idHeader;
-        commit["NewCount"] = to_string(id);
-        commit["NewHash"] = hash;
-        _sendToAllPeers(commit, true); // subscribed only
         _lastSentTransactionID = id;
     }
 }
@@ -837,8 +829,8 @@ bool SQLiteNode::update()
         ///     concluded in the STANDINGDOWN) state.  The logic for this state
         ///     is as follows:
         ///
-        ///         broadcast BEGIN_TRANSACTION and COMMIT_TRANSACTION to subscribed followers for any
-        ///             transaction that a worker thread has committed but that we haven't sent yet
+        ///         broadcast TRANSACTION to subscribed followers for any transaction that a worker thread has
+        ///             committed but that we haven't sent yet
         ///         if( we're LEADING )
         ///             if( there is another LEADER )         goto STANDINGDOWN
         ///             if( there is a higher priority peer ) goto STANDINGDOWN

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -246,8 +246,6 @@ void SQLiteNode::_replicate()
             if (result != SQLITE_OK) {
                 STHROW("commit failed");
             }
-        } else if (SIEquals(command.methodLine, "ROLLBACK_TRANSACTION")) {
-            _handleRollbackTransaction(db, peer, command);
         } else {
             SWARN("Invalid command passed to _replicate: " << command.methodLine);
         }
@@ -960,8 +958,8 @@ bool SQLiteNode::update()
                 // Leader stepping down
                 SHMMM("Leader stepping down.");
 
-                // Are we in the middle of a commit? This should only happen if we received a `BEGIN_TRANSACTION` without a
-                // corresponding `COMMIT` or `ROLLBACK`, this isn't supposed to happen.
+                // Are we in the middle of a commit? This should only happen if we received a `BEGIN_TRANSACTION` from a
+                // leader running older code without a corresponding `COMMIT_TRANSACTION`, this isn't supposed to happen.
                 if (!_db.getUncommittedHash().empty()) {
                     SWARN("Leader stepped down with transaction in progress, rolling back.");
                     _db.rollback();
@@ -1389,7 +1387,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
                 _changeState(SQLiteNodeState::SEARCHING);
                 throw e;
             }
-        } else if (SIEquals(message.methodLine, "TRANSACTION") || SIEquals(message.methodLine, "BEGIN_TRANSACTION") || SIEquals(message.methodLine, "COMMIT_TRANSACTION") || SIEquals(message.methodLine, "ROLLBACK_TRANSACTION")) {
+        } else if (SIEquals(message.methodLine, "TRANSACTION") || SIEquals(message.methodLine, "BEGIN_TRANSACTION") || SIEquals(message.methodLine, "COMMIT_TRANSACTION")) {
             if (_state != SQLiteNodeState::FOLLOWING) {
                 // These messages are only valid while following, but we do not throw if we receive them in other states, as
                 // it's not neccesarily an error. Specifically, as we switch away from FOLLOWING, there may still be a stream
@@ -2132,28 +2130,6 @@ int SQLiteNode::_handleCommitTransaction(SQLite& db, SQLitePeer* peer, const uin
     db.logLastTransactionTiming(format("[performance] Committed follower transaction #{} ({}).", commandCommitCount, commandCommitHash), "SQLiteNode::_handleCommitTransaction");
 
     return result;
-}
-
-void SQLiteNode::_handleRollbackTransaction(SQLite& db, SQLitePeer* peer, const SData& message)
-{
-    // ROLLBACK_TRANSACTION: Sent to all subscribed followers by the leader when it determines that the current
-    // outstanding transaction should be rolled back. This completes a given distributed transaction.
-    //
-    // Nothing in this version sends this: a leader only broadcasts a transaction once it has committed it, so there's
-    // never anything to retract. It's retained because an un-upgraded leader still sends it, and dropping the handler
-    // would be worse than useless -- the message would fall through to `_replicate`'s unrecognized-command warning,
-    // the prepared transaction would stay open, and the next BEGIN_TRANSACTION would throw "already in a transaction"
-    // out of a thread with no catch, killing the process. Delete this once no leader can send it.
-    if (!message.isSet("ID")) {
-        STHROW("missing ID");
-    }
-    if (_state != SQLiteNodeState::FOLLOWING) {
-        STHROW("not following");
-    }
-    if (db.getUncommittedHash().empty()) {
-        SINFO("Received ROLLBACK_TRANSACTION with no outstanding transaction.");
-    }
-    db.rollback();
 }
 
 SQLiteNodeState SQLiteNode::leaderState() const

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -199,7 +199,6 @@ private:
     // false if the transaction couldn't be prepared, in which case it has been rolled back.
     bool _handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const SData& message, uint64_t dequeueTime);
     int _handleCommitTransaction(SQLite& db, SQLitePeer* peer, const uint64_t commandCommitCount, const string& commandCommitHash);
-    void _handleRollbackTransaction(SQLite& db, SQLitePeer* peer, const SData& message);
 
     // Called when we first establish a connection with a new peer
     void _onConnect(SQLitePeer* peer);
@@ -217,9 +216,9 @@ private:
     // thread queues onto `_replicateQueue`. Handling them in one thread in the order leader sent them is what keeps our
     // commit order matching leader's.
     //
-    // TRANSACTION applies and commits a transaction in one step, and is what leaders will send once every node can
-    // receive it. Until then they send BEGIN_TRANSACTION to apply one, followed by COMMIT_TRANSACTION to keep it or
-    // ROLLBACK_TRANSACTION to discard it. See the message list at the top of SQLiteNode.cpp.
+    // TRANSACTION applies and commits a transaction in one step, and is what a leader sends. BEGIN_TRANSACTION applies
+    // one and COMMIT_TRANSACTION commits it, which is what a leader running older code sends. See the message list at
+    // the top of SQLiteNode.cpp.
     //
     // This thread exits when `_replicateThreadShouldExitTime` passes, which is set when a node stops FOLLOWING.
     void _replicate();

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -169,8 +169,8 @@ public:
     int setPriority(int newPriority);
 
 private:
-    // The minimum frequency of APPROVE_TRANSACTION messages we'll send when following, back to leader, to indicate our own current synchronization state.
-    // This is expressed as "every Nth message", where e.g., if MIN_APPROVE_FREQUENCY is 10, we will respond to at least every 10th BEGIN_TRANSACTION message.
+    // The minimum frequency of FOLLOWER_STATUS messages we'll send when following, back to leader, to indicate our own current synchronization state.
+    // This is expressed as "every Nth message", where e.g., if MIN_APPROVE_FREQUENCY is 10, we will respond to at least every 10th TRANSACTION message.
     static const size_t MIN_APPROVE_FREQUENCY;
 
     static const vector<SQLitePeer*> _initPeers(const string& peerList);
@@ -195,10 +195,8 @@ private:
     // Handlers for transaction messages.
     void _handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SData& message);
 
-    // Applies the transaction in `message` to `db`, and reports our commit count back to leader. Returns false if the
-    // transaction couldn't be prepared, in which case it has been rolled back. How we report back depends on whether
-    // `message` is a `TRANSACTION`, which we commit ourselves, or a `BEGIN_TRANSACTION`, which we wait on a
-    // `COMMIT_TRANSACTION` for.
+    // Applies the transaction in `message` to `db`, and periodically reports our commit count back to leader. Returns
+    // false if the transaction couldn't be prepared, in which case it has been rolled back.
     bool _handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const SData& message, uint64_t dequeueTime);
     int _handleCommitTransaction(SQLite& db, SQLitePeer* peer, const uint64_t commandCommitCount, const string& commandCommitHash);
     void _handleRollbackTransaction(SQLite& db, SQLitePeer* peer, const SData& message);


### PR DESCRIPTION
### Details

Deploy 2 of 3 in the replication protocol migration. [Remove QUORUM commits](https://github.com/Expensify/Bedrock/pull/2716) was deploy 1, and it's out everywhere, which is the only precondition for this one.

Deploy 1 added receivers for the new messages without sending any of them. This deploy starts sending them:

- Leader sends a single `TRANSACTION` instead of the `BEGIN_TRANSACTION` + `COMMIT_TRANSACTION` pair. Every transaction leader broadcasts has already committed locally, so there was never a reason to hold the follower's copy open across two messages.
- Followers send `FOLLOWER_STATUS` instead of `APPROVE_TRANSACTION`, every `MIN_APPROVE_FREQUENCY`th commit. Nothing acts on an approval any more, so the only thing a follower owes leader is a rough idea of how far along it is, and every message already carries that in its `CommitCount` header. That collapsed the whole approve/deny block down to four lines, since there's no longer an ASYNC-vs-not distinction to make on the response path.
- Deleted the `ROLLBACK_TRANSACTION` receiver.

That last one is why this couldn't be merged into deploy 1. A leader running pre-deploy-1 code still sends `ROLLBACK_TRANSACTION` on a commit conflict, and a follower with no handler for it falls through to `_replicate`'s unrecognized-command warning and keeps its prepared transaction open. The next `BEGIN_TRANSACTION` then throws `already in a transaction` out of a thread with no `try`/`catch`, which means `set_terminate` and a dead process.

`BEGIN_TRANSACTION` and `COMMIT_TRANSACTION` receivers both stay, because during this rolling deploy an un-upgraded leader is still sending them. They go away in deploy 3, along with the `ASYNC_` prefix, the `APPROVE_TRANSACTION`/`DENY_TRANSACTION` pair, and the four rollback paths that only exist because a follower could hold a prepared transaction between two messages.

Worth noting for whoever reviews: nothing in the code enforces the ordering here. There's no replication protocol version on the wire to gate on — `LOGIN["Version"]` is an opaque build string that plugin versions feed into and `-versionOverride` replaces outright, so it can't be used to decide what a peer can receive. The method line is the discriminator, which is why `TRANSACTION` is a new name rather than a header on `BEGIN_TRANSACTION`.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/669612

### Tests

`ClusterUpgradeTest` is the interesting one — it's the only test that runs two different binaries against each other, and it picks the most recent release tag as the old side. That tag is `2026-08-14-373619`, which contains deploy 1, so this run actually exercised the deploy-1-leader / deploy-2-follower combination that this PR depends on:

```
Cloning into 'Bedrock'...
HEAD is now at 2627a74b Merge pull request #2722 from Expensify/main
```

```
vagrant@expensidev-2404:/vagrant/Bedrock/test/clustertest$ ./clustertest -threads 16
[ TEST RESULTS ] Passed: 77, Failed: 0
```

```
vagrant@expensidev-2404:/vagrant/Bedrock/test$ ./test -threads 16
[ TEST RESULTS ] Passed: 222, Failed: 1

Failures:
SSLTest::proxyTest
```

`proxyTest` fails on my VM because squid isn't running, not because of anything here.

It still only covers the one upgrade order it performs, so treat it as a floor rather than a proof.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
