### PR TITLE
Replication migration deploy 3: delete the old dialect

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1393,17 +1393,11 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
             } else {
                 SINFO("Discarding replication message, stopping FOLLOWING");
             }
-        } else if (SIEquals(message.methodLine, "FOLLOWER_STATUS") ||
-                   SIEquals(message.methodLine, "APPROVE_TRANSACTION") ||
-                   SIEquals(message.methodLine, "DENY_TRANSACTION")) {
-            // These all tell the leader how much data a follower has, and nothing else that we act on. The work is
-            // already done: every message carries CommitCount and Hash, and the code above recorded them with
-            // `peer->setCommit()`. These branches exist only so the messages aren't logged as unrecognized.
-            //
-            // FOLLOWER_STATUS is the message meant for this, and what a follower sends. APPROVE_TRANSACTION and
-            // DENY_TRANSACTION are what a follower running older code sends, so they're accepted here too.
-            // Deliberately no validation: we no longer act on an approval, and throwing would cost us the peer
-            // connection for a message we're about to ignore either way.
+        } else if (SIEquals(message.methodLine, "FOLLOWER_STATUS")) {
+            // This tells the leader how much data a follower has, and nothing else that we act on. The work is already
+            // done: every message carries CommitCount and Hash, and the code above recorded them with
+            // `peer->setCommit()`. This branch exists only so the message isn't logged as unrecognized. Deliberately no
+            // validation: throwing would cost us the peer connection for a message we're about to ignore either way.
         } else if (SIEquals(message.methodLine, "FORKED")) {
             peer->forked = true;
             PINFO("Peer said we're forked, believing them.");

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -34,11 +34,8 @@
 // *** REPLICATION MESSAGES ***
 // TRANSACTION:         A complete transaction: the follower applies it and commits it, with no second message needed.
 //                      A leader only ever broadcasts a transaction it has already committed itself, so there is nothing
-//                      it could later ask the follower to take back. This is what a leader sends.
-// BEGIN_TRANSACTION:   Apply a transaction but don't commit it; wait to be told which way it went. The older,
-//                      two-message form of the above. Nothing in this version sends it; the receiver is still here
-//                      because a leader running older code does, and it goes away once none can.
-// COMMIT_TRANSACTION:  Commit the transaction a BEGIN_TRANSACTION applied. Same story as BEGIN_TRANSACTION.
+//                      it could later ask the follower to take back, and a follower never holds a prepared transaction
+//                      between two messages.
 //
 // *** DOCUMENTATION OF MESSAGE FIELDS ***
 // Note: Yes, two of these fields start with lowercase chars.
@@ -220,8 +217,7 @@ void SQLiteNode::_replicate()
         // At this point, we're guaranteed to have a message. Process it and then run again.
         if (SIEquals(command.methodLine, "TRANSACTION")) {
             // A whole transaction in one message: apply it, then commit it, with no window in between where we're
-            // holding a prepared transaction waiting to hear what to do with it. Nothing sends this yet -- it's here so
-            // that leaders can start sending it in a later release, once every node can receive it.
+            // holding a prepared transaction waiting to hear what to do with it.
             auto start = chrono::steady_clock::now();
             _handleBeginTransaction(db, peer, command);
             if (!_handlePrepareTransaction(db, peer, command, dequeueTime)) {
@@ -235,17 +231,6 @@ void SQLiteNode::_replicate()
             }
             auto duration = chrono::steady_clock::now() - start;
             SINFO("[performance] Replicated transaction in " << chrono::duration_cast<chrono::microseconds>(duration).count() << "us.");
-        } else if (SIEquals(command.methodLine, "BEGIN_TRANSACTION")) {
-            auto start = chrono::steady_clock::now();
-            _handleBeginTransaction(db, peer, command);
-            _handlePrepareTransaction(db, peer, command, dequeueTime);
-            auto duration = chrono::steady_clock::now() - start;
-            SINFO("[performance] Wrote replicate transaction in " << chrono::duration_cast<chrono::microseconds>(duration).count() << "us.");
-        } else if (SIEquals(command.methodLine, "COMMIT_TRANSACTION")) {
-            int result = _handleCommitTransaction(db, peer, command.calcU64("NewCount"), command["NewHash"]);
-            if (result != SQLITE_OK) {
-                STHROW("commit failed");
-            }
         } else {
             SWARN("Invalid command passed to _replicate: " << command.methodLine);
         }
@@ -1387,9 +1372,9 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
                 _changeState(SQLiteNodeState::SEARCHING);
                 throw e;
             }
-        } else if (SIEquals(message.methodLine, "TRANSACTION") || SIEquals(message.methodLine, "BEGIN_TRANSACTION") || SIEquals(message.methodLine, "COMMIT_TRANSACTION")) {
+        } else if (SIEquals(message.methodLine, "TRANSACTION")) {
             if (_state != SQLiteNodeState::FOLLOWING) {
-                // These messages are only valid while following, but we do not throw if we receive them in other states, as
+                // This message is only valid while following, but we do not throw if we receive it in another state, as
                 // it's not neccesarily an error. Specifically, as we switch away from FOLLOWING, there may still be a stream
                 // of transactions being broadcast. We do not attempt to handle these, as we keep careful count of which
                 // replication threads are currently running, and reset the replication state tracking when we're not following.
@@ -2092,8 +2077,7 @@ bool SQLiteNode::_handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const S
 
 int SQLiteNode::_handleCommitTransaction(SQLite& db, SQLitePeer* peer, const uint64_t commandCommitCount, const string& commandCommitHash)
 {
-    // COMMIT_TRANSACTION: Sent to all subscribed followers by the leader when it determines that the current
-    // outstanding transaction should be committed to the database. This completes a given distributed transaction.
+    // Commits the transaction that `_handlePrepareTransaction` just prepared, which completes replicating it.
     if (_state != SQLiteNodeState::FOLLOWING) {
         STHROW("not following");
     }
@@ -2108,7 +2092,7 @@ int SQLiteNode::_handleCommitTransaction(SQLite& db, SQLitePeer* peer, const uin
         STHROW("hash mismatch:" + commandCommitHash + "!=" + db.getUncommittedHash() + ";");
     }
 
-    SDEBUG("Committing current transaction because COMMIT_TRANSACTION: " << db.getUncommittedQuery());
+    SDEBUG("Committing current transaction because TRANSACTION: " << db.getUncommittedQuery());
 
     int result = db.commit(stateName(_state));
     if (result == SQLITE_BUSY_SNAPSHOT) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -197,12 +197,8 @@ void SQLiteNode::_replicate()
         if (isQueueEmpty || (shouldExit && shouldExit < STimeNow())) {
             // There are no commands to process.
             if (shouldExit) {
-                if (db.insideTransaction()) {
-                    SINFO("Finished replication mid-transaction, missing COMMIT_TRANSACTION, rolling back.");
-                    db.rollback();
-                }
-
-                // Done with replication.
+                // Done with replication. Each iteration below either commits or throws, so there's never a transaction
+                // open on this handle between two of them, and this is only reachable between two of them.
                 return;
             } else {
                 // The queue is empty but we're not exiting so go back to the top and wait.
@@ -936,13 +932,6 @@ bool SQLiteNode::update()
             if (_leadPeer.load()->state != SQLiteNodeState::LEADING && _leadPeer.load()->state != SQLiteNodeState::STANDINGDOWN) {
                 // Leader stepping down
                 SHMMM("Leader stepping down.");
-
-                // Are we in the middle of a commit? This should only happen if we received a `BEGIN_TRANSACTION` from a
-                // leader running older code without a corresponding `COMMIT_TRANSACTION`, this isn't supposed to happen.
-                if (!_db.getUncommittedHash().empty()) {
-                    SWARN("Leader stepped down with transaction in progress, rolling back.");
-                    _db.rollback();
-                }
                 _changeState(SQLiteNodeState::SEARCHING);
                 return true; // Re-update
             }
@@ -1174,20 +1163,6 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
                     peer->subscribed = false;
                 } else if (to == SQLiteNodeState::STANDINGUP) {
                     _sendStandupResponse(peer, message);
-                } else if (from == SQLiteNodeState::STANDINGDOWN) {
-                    // STANDINGDOWN: When a peer stands down we double-check to make sure we don't have any outstanding
-                    // transaction (and if we do, we warn and rollback).
-                    if (!_db.getUncommittedHash().empty()) {
-                        // Crap, we were waiting for a response that will apparently never come. I guess roll it back? This
-                        // should never happen, however, as the leader shouldn't STANDOWN unless all subscribed followers
-                        // (including us) have already unsubscribed, and we wouldn't do that in the middle of a
-                        // transaction. But just in case...
-                        SASSERTWARN(_state == SQLiteNodeState::FOLLOWING);
-                        PWARN("Was expecting a response for transaction #"
-                              << _db.getCommitCount() + 1 << " (" << _db.getUncommittedHash()
-                              << ") but stood down prematurely, rolling back and hoping for the best.");
-                        _db.rollback();
-                    }
                 }
             }
         } else if (SIEquals(message.methodLine, "STANDUP_RESPONSE")) {
@@ -1462,24 +1437,14 @@ void SQLiteNode::_onDisconnect(SQLitePeer* peer)
 
     /// - Verify we didn't just lose contact with our leader.  This should
     ///   only be possible if we're SUBSCRIBING or FOLLOWING.  If we did lose our
-    ///   leader, roll back any uncommitted transaction and go SEARCHING.
+    ///   leader, go SEARCHING.
     ///
     if (peer == _leadPeer) {
-        // We've lost our leader: make sure we aren't waiting for
-        // transaction response and re-SEARCH
+        // We've lost our leader: re-SEARCH
         PWARN("Lost our LEADER, re-SEARCHING.");
         SASSERTWARN(_state == SQLiteNodeState::SUBSCRIBING || _state == SQLiteNodeState::FOLLOWING);
         {
             _leadPeer = nullptr;
-        }
-        if (!_db.getUncommittedHash().empty()) {
-            // We're in the middle of a transaction and waiting for it to
-            // approve or deny, but we'll never get its response.  Roll it
-            // back and synchronize when we reconnect.
-            PHMMM("Was expecting a response for transaction #" << _db.getCommitCount() + 1 << " ("
-                  << _db.getUncommittedHash()
-                  << ") but disconnected prematurely; rolling back.");
-            _db.rollback();
         }
         _changeState(SQLiteNodeState::SEARCHING);
     }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -44,16 +44,12 @@
 //                   and not to communicate any information about a specific transaction in progress.
 // Hash:             The hash corresponding to the value in CommitCount.
 // ID:               The ID of the transaction currently being operated on. It is the same type of information as
-//                   "CommitCount", but not necessarily for the most recent transaction in the DB. A leader prefixes it
-//                   with "ASYNC_", which tells the follower not to send a full approval for the transaction. That's
-//                   every transaction a current leader sends; the unprefixed form only arrives from a leader running
-//                   older code.
+//                   "CommitCount", but not necessarily for the most recent transaction in the DB. Now that nothing
+//                   prefixes it, this duplicates "NewCount" exactly. It's still sent because a follower running older
+//                   code throws "missing ID" without it.
 // NewHash:          Hash, but for "ID" instead of "CommitCount".
 //                   Proposal: rename to "currentTransactionHash".
-// NewCount:         Same as "ID" except without the "ASYNC_" prefix.
-// AsyncNotification: Set on an APPROVE_TRANSACTION that a follower running older code sends periodically for an
-//                   "ASYNC_" transaction. It marks the message as a commit-count report rather than an approval of
-//                   anything.
+// NewCount:         Same as "ID".
 // State:            The state of the peer sending the message (i.e., SEARCHING, LEADING).
 // Version:          The version string of the node sending the message.
 // Permafollower:    Boolean value (string "true" or "false") indicating if the node sending the message is a
@@ -373,18 +369,16 @@ void SQLiteNode::_sendOutstandingTransactions()
         string& query = i.second.first;
         string& hash = i.second.second;
         // Every transaction we send has already committed here, so it goes out as a single TRANSACTION that the
-        // follower applies and commits on its own. The "ASYNC_" prefix on the ID tells followers not to bother
-        // approving it, which is load-bearing for a follower running older code: it sends a full APPROVE_TRANSACTION
-        // for any ID without it.
+        // follower applies and commits on its own.
         SData transaction("TRANSACTION");
         transaction["NewCount"] = to_string(id);
         transaction["NewHash"] = hash;
         transaction["leaderSendTime"] = sendTime;
-        transaction["ID"] = "ASYNC_" + to_string(id);
+        transaction["ID"] = to_string(id);
         transaction.content = query;
 
         // Allows us to easily figure out how far behind followers are by analyzing the logs.
-        SINFO("Sending ASYNC transaction " << id << " to followers");
+        SINFO("Sending transaction " << id << " to followers");
         _sendToAllPeers(transaction, true); // subscribed only
         _lastSentTransactionID = id;
     }

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -216,9 +216,8 @@ private:
     // thread queues onto `_replicateQueue`. Handling them in one thread in the order leader sent them is what keeps our
     // commit order matching leader's.
     //
-    // TRANSACTION applies and commits a transaction in one step, and is what a leader sends. BEGIN_TRANSACTION applies
-    // one and COMMIT_TRANSACTION commits it, which is what a leader running older code sends. See the message list at
-    // the top of SQLiteNode.cpp.
+    // TRANSACTION, the only message this handles, applies and commits a transaction in one step. See the message list
+    // at the top of SQLiteNode.cpp.
     //
     // This thread exits when `_replicateThreadShouldExitTime` passes, which is set when a node stops FOLLOWING.
     void _replicate();


### PR DESCRIPTION
Hold for https://github.com/Expensify/Bedrock/pull/2725 to be *deployed* everywhere, not just merged. As of writing it's on `main` but hasn't been tagged, so no node is running it yet.

### Details

Deploy 3 of 3, the one that deletes the old dialect. Deploy 1 was [Remove QUORUM commits](https://github.com/Expensify/Bedrock/pull/2716), deploy 2 was [#2725](https://github.com/Expensify/Bedrock/pull/2725).

- Deleted the `BEGIN_TRANSACTION` and `COMMIT_TRANSACTION` dispatch arms in `_replicate` and their `_onMESSAGE` enqueue arms. `_handleBeginTransaction`, `_handlePrepareTransaction` and `_handleCommitTransaction` all stay — the `TRANSACTION` path calls all three. It's the message names that go away, not the handlers.
- Deleted the `ASYNC_` transaction ID prefix. The `ID` header itself stays: a deploy-2 follower still throws `missing ID` without it, even though it now duplicates `NewCount` exactly. Collapsing those two into one is a wire change for a later deploy, not this one.
- Deleted the `APPROVE_TRANSACTION` / `DENY_TRANSACTION` receiver, and the `AsyncNotification` field docs with it. `MIN_APPROVE_FREQUENCY` stays, it paces `FOLLOWER_STATUS`.
- Deleted the four rollback paths that only existed because a follower could hold a prepared transaction between two messages: `_replicate`'s missing-COMMIT_TRANSACTION rollback on exit, the leader-stepped-down rollback in `update()`, the STANDINGDOWN rollback in the `STATE` handler, and the lost-our-leader rollback in `_onDisconnect`.

On that last group, one thing worth saying out loud since it makes them more clearly dead than the issue claims. Three of the four test `_db`, which is the sync thread's handle, but a follower replicates on a handle it takes from `_dbPool`. So even before any of this, a follower's prepared transaction was never visible to the code that was checking for it. They're dead twice over. The fourth one, in `_replicate`, is the one that operated on the right handle, and it's dead because every iteration of that loop now either commits or throws, and the exit check is only reachable between two iterations.

`_onDisconnect`'s comment was the one the issue called out as already describing a world that doesn't exist, and it did — it said we were waiting for leader to "approve or deny" a transaction.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/669612

`For` rather than `$` on purpose: this finishes the migration, but the "adjacent cleanups" checkboxes on that issue (the inert `writeConsistency` headers in `AuthTestHelper.cpp`, `UpgradeToCorporateTest.cpp` and `Client.php`, and the `batchReimbursements.sh` update) aren't in here and would get lost if merging this closed it. Happy to switch it to `$` and move those to their own issue if that's cleaner.

### Tests

`clustertest` on this branch has `ClusterUpgradeTest` failing, and that failure is the point, so I want to be clear about it rather than bury it.

The test builds the most recent release tag as the "old" side of the rolling restart. Right now that's `2026-08-14-373619`, which is deploy 1 — deploy 2 isn't tagged yet. So what the test currently runs is deploy-1 leader against a deploy-3 follower, which is exactly the out-of-order pairing this whole three-deploy dance exists to avoid:

```
    assertion failed: tester->getTester(node).waitForStatusTerm("CommitCount", to_string(leaderCommitCount)) resolved to FALSE
❌ !FAILED! ❌ ClusterUpgradeTest::test (126631ms 🐌)

[ TEST RESULTS ] Passed: 79, Failed: 1
```

Syslog from that run says what happened. `cluster_node_2` is the upgraded one:

```
2026-08-17T21:10:56.963738+00:00 expensidev-2404 bedrock10207: (SQLiteNode.cpp:1397) _onMESSAGE [sync] [info] {cluster_node_2/FOLLOWING} ->{cluster_node_0} unrecognized message: BEGIN_TRANSACTION
2026-08-17T21:11:57.208480+00:00 expensidev-2404 bedrock10207: (SQLiteNode.cpp:1397) _onMESSAGE [sync] [info] {cluster_node_2/FOLLOWING} ->{cluster_node_1} unrecognized message: BEGIN_TRANSACTION
```

A deploy-1 leader sends `BEGIN_TRANSACTION`, the follower has no arm for it, so it drops it and stops replicating, and the commit count it reports never catches up to leader's. Note it drops it at `_onMESSAGE` rather than enqueueing it, so it stalls quietly instead of dying — no `already in a transaction` out of an uncaught thread. Small mercy, and not one to rely on.

To check the pairing that will actually happen, I pinned the old side to deploy 2's merge commit locally:

```
-        // bedrockTagName = "2022-05-06";
+        bedrockTagName = "9a68a32a54eead058e10949e1b16252175f6e68e";
```

```
vagrant@expensidev-2404:/vagrant/Bedrock/test/clustertest$ ./clustertest -only ClusterUpgrade
[ TEST RESULTS ] Passed: 1, Failed: 0
```

That pin is not committed. Once deploy 2 gets tagged, the test picks it up on its own and this passes without anyone touching it — so the way to confirm this PR is ready to merge is to re-run `clustertest` and see `ClusterUpgrade` go green on its own.

Unit tests, unchanged from `main`:

```
vagrant@expensidev-2404:/vagrant/Bedrock/test$ ./test -threads 16
[ TEST RESULTS ] Passed: 222, Failed: 1

Failures:
SSLTest::proxyTest
```

`proxyTest` needs squid, which my VM doesn't run.

Auth compiles clean against this, `authtest` included:

```
vagrant@expensidev-2404:/vagrant/Auth$ make -j16
2026-08-17 21:18  280678096 ./test/authtest
2026-08-17 21:18  184626424 ./auth/auth.so
2026-08-17 21:18  516593758 ./auth/auth.a
```

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
