### PR TITLE
Add afterCommit callbacks to SQLite

### DIFF
--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -4,7 +4,7 @@
 
 map<string, function<BedrockPlugin* (BedrockServer&)>> BedrockPlugin::g_registeredPluginList;
 
-BedrockPlugin::BedrockPlugin(BedrockServer& s) : server(s)
+BedrockPlugin::BedrockPlugin(BedrockServer& s, function<void()> afterCommitCallback) : server(s), afterCommitCallback(afterCommitCallback)
 {
 }
 
@@ -66,10 +66,6 @@ STable BedrockPlugin::getInfo()
 const string& BedrockPlugin::getName() const
 {
     SERROR("No name defined by this plugin, aborting.");
-}
-
-void BedrockPlugin::afterCommitCallback()
-{
 }
 
 bool BedrockPlugin::preventAttach()

--- a/BedrockPlugin.cpp
+++ b/BedrockPlugin.cpp
@@ -68,6 +68,10 @@ const string& BedrockPlugin::getName() const
     SERROR("No name defined by this plugin, aborting.");
 }
 
+void BedrockPlugin::afterCommitCallback()
+{
+}
+
 bool BedrockPlugin::preventAttach()
 {
     return false;

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -73,6 +73,10 @@ public:
     {
     }
 
+    // This will be called every time a commit is successfully finished, both in leader and
+    // follower nodes.
+    virtual void afterCommitCallback();
+
     virtual bool preventAttach();
 
     // Called when a client or plugin requests that the BedrockServer detaches from the database.

--- a/BedrockPlugin.h
+++ b/BedrockPlugin.h
@@ -23,7 +23,7 @@ public:
     static void verifyAttributeBool(const SData& request, const string& name, bool require = true);
     static void verifyAttributeDate(const SData& request, const char* key, bool require);
 
-    BedrockPlugin(BedrockServer& s);
+    BedrockPlugin(BedrockServer& s, function<void()> afterCommitCallback = {});
     virtual ~BedrockPlugin();
 
     // Returns a version string indicating the version of this plugin. This needs to be implemented in a thread-safe
@@ -73,10 +73,6 @@ public:
     {
     }
 
-    // This will be called every time a commit is successfully finished, both in leader and
-    // follower nodes.
-    virtual void afterCommitCallback();
-
     virtual bool preventAttach();
 
     // Called when a client or plugin requests that the BedrockServer detaches from the database.
@@ -118,4 +114,8 @@ public:
 
     // Reference to the BedrockServer object that owns this plugin.
     BedrockServer& server;
+
+    // This will be called every time a commit is successfully finished, both in leader and
+    // follower nodes.
+    const function<void()> afterCommitCallback;
 };

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -79,21 +79,6 @@ shared_ptr<SQLitePool> BedrockServer::getDBPool()
     return _dbPool;
 }
 
-void BedrockServer::registerAfterCommitCallback(function<void()>&& callback)
-{
-    lock_guard<decltype(_afterCommitCallbackMutex)> lock(_afterCommitCallbackMutex);
-
-    // Kept even after being handed off, so they can be handed to a different SharedData if the pool is re-created
-    // against a different resolved filename.
-    _afterCommitCallbacks.push_back(callback);
-
-    if (_dbPool) {
-        // Registering on the base handle is enough, the callback list lives in the SharedData that every handle to
-        // this database file shares.
-        _dbPool->getBase().registerAfterCommitCallback(move(callback));
-    }
-}
-
 void BedrockServer::sync()
 {
     // Parse out the number of worker threads we'll use. The DB needs to know this because it will expect a
@@ -120,18 +105,18 @@ void BedrockServer::sync()
     // We use fewer FDs on test machines that have other resource restrictions in place.
 
     SQLite::journalZstdDictionaryID = args.calc("-journalZstdDictionaryID");
-    SINFO("Setting dbPool size to: " << _dbPoolSize);
-    _dbPool = make_shared<SQLitePool>(_dbPoolSize, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), journalTables, mmapSizeGB, args.isSet("-newDBsUseHctree"), args["-checkpointMode"]);
-    SQLite& db = _dbPool->getBase();
-
-    // Hand over any callbacks that plugins registered before this pool existed
-    {
-        lock_guard<decltype(_afterCommitCallbackMutex)> lock(_afterCommitCallbackMutex);
-        for (const auto& callback : _afterCommitCallbacks) {
-            function<void()> callbackCopy = callback;
-            db.registerAfterCommitCallback(move(callbackCopy));
-        }
+    // Every plugin gets one of these. The base implementation does nothing, so plugins that don't care about commits
+    // cost an empty virtual call each, which is nothing next to the commit that just happened.
+    vector<function<void()>> callbacks;
+    for (const auto& plugin : plugins) {
+        callbacks.emplace_back([pluginPtr = plugin.second]() {
+            pluginPtr->afterCommitCallback();
+        });
     }
+
+    SINFO("Setting dbPool size to: " << _dbPoolSize);
+    _dbPool = make_shared<SQLitePool>(_dbPoolSize, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), journalTables, mmapSizeGB, args.isSet("-newDBsUseHctree"), args["-checkpointMode"], callbacks);
+    SQLite& db = _dbPool->getBase();
 
     // Allow plugins to read from the DB at startup.
     for (auto plugin : plugins) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -81,6 +81,13 @@ shared_ptr<SQLitePool> BedrockServer::getDBPool()
 
 void BedrockServer::registerAfterCommitCallback(function<void()>&& callback)
 {
+    lock_guard<decltype(_afterCommitCallbackMutex)> lock(_afterCommitCallbackMutex);
+    if (!_afterCommitCallbacksForwarded) {
+        // The pool doesn't exist yet, so hold onto this until sync() creates it.
+        _pendingAfterCommitCallbacks.push_back(move(callback));
+        return;
+    }
+
     // Registering on the base handle is enough, the callback list lives in the SharedData that every handle to this
     // database file shares.
     _dbPool->getBase().registerAfterCommitCallback(move(callback));
@@ -115,6 +122,19 @@ void BedrockServer::sync()
     SINFO("Setting dbPool size to: " << _dbPoolSize);
     _dbPool = make_shared<SQLitePool>(_dbPoolSize, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), journalTables, mmapSizeGB, args.isSet("-newDBsUseHctree"), args["-checkpointMode"]);
     SQLite& db = _dbPool->getBase();
+
+    // Hand over any callbacks that plugins registered before this pool existed. This runs only the first time we get
+    // here, because the SharedData holding them is keyed by filename and survives the pool being re-created.
+    {
+        lock_guard<decltype(_afterCommitCallbackMutex)> lock(_afterCommitCallbackMutex);
+        if (!_afterCommitCallbacksForwarded) {
+            for (auto& callback : _pendingAfterCommitCallbacks) {
+                db.registerAfterCommitCallback(move(callback));
+            }
+            _pendingAfterCommitCallbacks.clear();
+            _afterCommitCallbacksForwarded = true;
+        }
+    }
 
     // Allow plugins to read from the DB at startup.
     for (auto plugin : plugins) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -79,6 +79,13 @@ shared_ptr<SQLitePool> BedrockServer::getDBPool()
     return _dbPool;
 }
 
+void BedrockServer::registerAfterCommitCallback(function<void()>&& callback)
+{
+    // Registering on the base handle is enough, the callback list lives in the SharedData that every handle to this
+    // database file shares.
+    _dbPool->getBase().registerAfterCommitCallback(move(callback));
+}
+
 void BedrockServer::sync()
 {
     // Parse out the number of worker threads we'll use. The DB needs to know this because it will expect a

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -107,9 +107,9 @@ void BedrockServer::sync()
     SQLite::journalZstdDictionaryID = args.calc("-journalZstdDictionaryID");
     vector<function<void()>> callbacks;
     for (const auto& plugin : plugins) {
-        callbacks.emplace_back([pluginPtr = plugin.second]() {
-            pluginPtr->afterCommitCallback();
-        });
+        if (plugin.second->afterCommitCallback) {
+            callbacks.emplace_back(plugin.second->afterCommitCallback);
+        }
     }
     SINFO("Setting dbPool size to: " << _dbPoolSize);
     _dbPool = make_shared<SQLitePool>(_dbPoolSize, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), journalTables, mmapSizeGB, args.isSet("-newDBsUseHctree"), args["-checkpointMode"], callbacks);

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -82,15 +82,16 @@ shared_ptr<SQLitePool> BedrockServer::getDBPool()
 void BedrockServer::registerAfterCommitCallback(function<void()>&& callback)
 {
     lock_guard<decltype(_afterCommitCallbackMutex)> lock(_afterCommitCallbackMutex);
-    if (!_afterCommitCallbacksForwarded) {
-        // The pool doesn't exist yet, so hold onto this until sync() creates it.
-        _pendingAfterCommitCallbacks.push_back(move(callback));
-        return;
-    }
 
-    // Registering on the base handle is enough, the callback list lives in the SharedData that every handle to this
-    // database file shares.
-    _dbPool->getBase().registerAfterCommitCallback(move(callback));
+    // Kept even after being handed off, so they can be handed to a different SharedData if the pool is re-created
+    // against a different resolved filename.
+    _afterCommitCallbacks.push_back(callback);
+
+    if (!_afterCommitCallbacksForwardedTo.empty()) {
+        // Registering on the base handle is enough, the callback list lives in the SharedData that every handle to
+        // this database file shares.
+        _dbPool->getBase().registerAfterCommitCallback(move(callback));
+    }
 }
 
 void BedrockServer::sync()
@@ -123,16 +124,16 @@ void BedrockServer::sync()
     _dbPool = make_shared<SQLitePool>(_dbPoolSize, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), journalTables, mmapSizeGB, args.isSet("-newDBsUseHctree"), args["-checkpointMode"]);
     SQLite& db = _dbPool->getBase();
 
-    // Hand over any callbacks that plugins registered before this pool existed. This runs only the first time we get
-    // here, because the SharedData holding them is keyed by filename and survives the pool being re-created.
+    // Hand over any callbacks that plugins registered before this pool existed. Skipped when this pool resolved to the
+    // same filename as the last one, because that means it shares the SharedData that already holds them.
     {
         lock_guard<decltype(_afterCommitCallbackMutex)> lock(_afterCommitCallbackMutex);
-        if (!_afterCommitCallbacksForwarded) {
-            for (auto& callback : _pendingAfterCommitCallbacks) {
-                db.registerAfterCommitCallback(move(callback));
+        if (_afterCommitCallbacksForwardedTo != db.getFilename()) {
+            for (const auto& callback : _afterCommitCallbacks) {
+                function<void()> callbackCopy = callback;
+                db.registerAfterCommitCallback(move(callbackCopy));
             }
-            _pendingAfterCommitCallbacks.clear();
-            _afterCommitCallbacksForwarded = true;
+            _afterCommitCallbacksForwardedTo = db.getFilename();
         }
     }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -87,7 +87,7 @@ void BedrockServer::registerAfterCommitCallback(function<void()>&& callback)
     // against a different resolved filename.
     _afterCommitCallbacks.push_back(callback);
 
-    if (!_afterCommitCallbacksForwardedTo.empty()) {
+    if (_dbPool) {
         // Registering on the base handle is enough, the callback list lives in the SharedData that every handle to
         // this database file shares.
         _dbPool->getBase().registerAfterCommitCallback(move(callback));
@@ -124,16 +124,12 @@ void BedrockServer::sync()
     _dbPool = make_shared<SQLitePool>(_dbPoolSize, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), journalTables, mmapSizeGB, args.isSet("-newDBsUseHctree"), args["-checkpointMode"]);
     SQLite& db = _dbPool->getBase();
 
-    // Hand over any callbacks that plugins registered before this pool existed. Skipped when this pool resolved to the
-    // same filename as the last one, because that means it shares the SharedData that already holds them.
+    // Hand over any callbacks that plugins registered before this pool existed
     {
         lock_guard<decltype(_afterCommitCallbackMutex)> lock(_afterCommitCallbackMutex);
-        if (_afterCommitCallbacksForwardedTo != db.getFilename()) {
-            for (const auto& callback : _afterCommitCallbacks) {
-                function<void()> callbackCopy = callback;
-                db.registerAfterCommitCallback(move(callbackCopy));
-            }
-            _afterCommitCallbacksForwardedTo = db.getFilename();
+        for (const auto& callback : _afterCommitCallbacks) {
+            function<void()> callbackCopy = callback;
+            db.registerAfterCommitCallback(move(callbackCopy));
         }
     }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -105,15 +105,12 @@ void BedrockServer::sync()
     // We use fewer FDs on test machines that have other resource restrictions in place.
 
     SQLite::journalZstdDictionaryID = args.calc("-journalZstdDictionaryID");
-    // Every plugin gets one of these. The base implementation does nothing, so plugins that don't care about commits
-    // cost an empty virtual call each, which is nothing next to the commit that just happened.
     vector<function<void()>> callbacks;
     for (const auto& plugin : plugins) {
         callbacks.emplace_back([pluginPtr = plugin.second]() {
             pluginPtr->afterCommitCallback();
         });
     }
-
     SINFO("Setting dbPool size to: " << _dbPoolSize);
     _dbPool = make_shared<SQLitePool>(_dbPoolSize, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), journalTables, mmapSizeGB, args.isSet("-newDBsUseHctree"), args["-checkpointMode"], callbacks);
     SQLite& db = _dbPool->getBase();

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -279,9 +279,18 @@ private:
 
     // Registers a callback to run after every successful commit, on both a leader and a follower. Intended to be
     // called by plugins at startup. See SQLite::registerAfterCommitCallback for the callback's requirements.
+    // Plugins are constructed before the DB pool exists, so callbacks registered that early are held here and handed
+    // to the pool once it is created.
     void registerAfterCommitCallback(function<void()>&& callback);
 
 private:
+    // After-commit callbacks registered before the DB pool existed, the lock guarding them, and whether they have
+    // been handed off yet. The handoff happens exactly once: the SQLite SharedData that ends up owning them is keyed
+    // by filename and outlives the pool, so re-creating the pool on re-attach must not register them a second time.
+    vector<function<void()>> _pendingAfterCommitCallbacks;
+    mutex _afterCommitCallbackMutex;
+    bool _afterCommitCallbacksForwarded = false;
+
     // The name of the sync thread.
     static constexpr auto _syncThreadName = "sync";
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -284,15 +284,11 @@ private:
     void registerAfterCommitCallback(function<void()>&& callback);
 
 private:
-    // After-commit callbacks registered before the DB pool existed, the lock guarding them, and the database filename
-    // we last handed them to. The SQLite SharedData that ends up owning them is keyed by resolved filename and
-    // outlives the pool, so re-creating the pool on re-attach must not register them against the same filename twice.
-    // It is keyed by filename rather than by a one-shot flag because the resolved name can change: SQLite resolves a
-    // relative path to itself while the file is missing and to its absolute form once it exists, so the first pool and
-    // a pool created after re-attach can land on two different SharedData objects.
+    // After-commit callbacks are registered before the DB pool exists, when the plugin is being registered. We'll
+    // store them in the BedrockServer class. That way, if the pool is re-created(on detach/reattach), we can
+    // register them again against the new pool.
     vector<function<void()>> _afterCommitCallbacks;
     mutex _afterCommitCallbackMutex;
-    string _afterCommitCallbacksForwardedTo;
 
     // The name of the sync thread.
     static constexpr auto _syncThreadName = "sync";

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -284,12 +284,15 @@ private:
     void registerAfterCommitCallback(function<void()>&& callback);
 
 private:
-    // After-commit callbacks registered before the DB pool existed, the lock guarding them, and whether they have
-    // been handed off yet. The handoff happens exactly once: the SQLite SharedData that ends up owning them is keyed
-    // by filename and outlives the pool, so re-creating the pool on re-attach must not register them a second time.
-    vector<function<void()>> _pendingAfterCommitCallbacks;
+    // After-commit callbacks registered before the DB pool existed, the lock guarding them, and the database filename
+    // we last handed them to. The SQLite SharedData that ends up owning them is keyed by resolved filename and
+    // outlives the pool, so re-creating the pool on re-attach must not register them against the same filename twice.
+    // It is keyed by filename rather than by a one-shot flag because the resolved name can change: SQLite resolves a
+    // relative path to itself while the file is missing and to its absolute form once it exists, so the first pool and
+    // a pool created after re-attach can land on two different SharedData objects.
+    vector<function<void()>> _afterCommitCallbacks;
     mutex _afterCommitCallbackMutex;
-    bool _afterCommitCallbacksForwarded = false;
+    string _afterCommitCallbacksForwardedTo;
 
     // The name of the sync thread.
     static constexpr auto _syncThreadName = "sync";

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -277,19 +277,7 @@ private:
     // Expose the DB pool to plugins.
     shared_ptr<SQLitePool> getDBPool();
 
-    // Registers a callback to run after every successful commit, on both a leader and a follower. Intended to be
-    // called by plugins at startup. See SQLite::registerAfterCommitCallback for the callback's requirements.
-    // Plugins are constructed before the DB pool exists, so callbacks registered that early are held here and handed
-    // to the pool once it is created.
-    void registerAfterCommitCallback(function<void()>&& callback);
-
 private:
-    // After-commit callbacks are registered before the DB pool exists, when the plugin is being registered. We'll
-    // store them in the BedrockServer class. That way, if the pool is re-created(on detach/reattach), we can
-    // register them again against the new pool.
-    vector<function<void()>> _afterCommitCallbacks;
-    mutex _afterCommitCallbackMutex;
-
     // The name of the sync thread.
     static constexpr auto _syncThreadName = "sync";
 

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -277,6 +277,10 @@ private:
     // Expose the DB pool to plugins.
     shared_ptr<SQLitePool> getDBPool();
 
+    // Registers a callback to run after every successful commit, on both a leader and a follower. Intended to be
+    // called by plugins at startup. See SQLite::registerAfterCommitCallback for the callback's requirements.
+    void registerAfterCommitCallback(function<void()>&& callback);
+
 private:
     // The name of the sync thread.
     static constexpr auto _syncThreadName = "sync";

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1688,7 +1688,15 @@ void SQLite::SharedData::runAfterCommitCallbacks()
 {
     shared_lock<decltype(_afterCommitCallbackLock)> lock(_afterCommitCallbackLock);
     for (const auto& callback : _afterCommitCallbacks) {
-        callback();
+        // The commit already happened, and SQLiteCore::commit is noexcept, so letting an exception out of here would
+        // terminate the process over a callback that has no bearing on whether the commit succeeded.
+        try {
+            callback();
+        } catch (const exception& e) {
+            SWARN("Ignoring exception from afterCommit callback: " << e.what());
+        } catch (...) {
+            SWARN("Ignoring unknown exception from afterCommit callback.");
+        }
     }
 }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -321,7 +321,7 @@ void SQLite::commonConstructorInitialization(bool hctree)
 }
 
 SQLite::SQLite(const string& filename, int cacheSize, int maxJournalSize,
-               int minJournalTables, int64_t mmapSizeGB, bool hctree, const string& checkpointMode) :
+               int minJournalTables, int64_t mmapSizeGB, bool hctree, const string& checkpointMode, vector<function<void()>> afterCommitCallbacks) :
     _filename(initializeFilename(filename)),
     _maxJournalSize(maxJournalSize),
     _hctree(validateDBFormat(_filename, hctree)),
@@ -332,6 +332,7 @@ SQLite::SQLite(const string& filename, int cacheSize, int maxJournalSize,
     // initialization will not be correct.
     _sharedData(initializeSharedData()),
     _transactionTimer("transaction timer"),
+    _afterCommitCallbacks(afterCommitCallbacks),
     _cacheSize(cacheSize),
     _mmapSizeGB(mmapSizeGB),
     _checkpointMode(getCheckpointModeFromString(checkpointMode))
@@ -347,6 +348,7 @@ SQLite::SQLite(const SQLite& from) :
     _journalNames(from._journalNames),
     _sharedData(from._sharedData),
     _transactionTimer("transaction timer"),
+    _afterCommitCallbacks(from._afterCommitCallbacks),
     _cacheSize(from._cacheSize),
     _mmapSizeGB(from._mmapSizeGB),
     _checkpointMode(from._checkpointMode)
@@ -1149,7 +1151,7 @@ int SQLite::commit(const string& description, const string& commandName, functio
 
         // Run these as early as possible after releasing the commit lock, so that anything waiting on a commit hears
         // about it before we spend time on the checkpoint below.
-        _sharedData.runAfterCommitCallbacks();
+        runAfterCommitCallbacks();
 
         if (preCheckpointCallback != nullptr) {
             (*preCheckpointCallback)();
@@ -1678,15 +1680,8 @@ map<uint64_t, pair<string, string>> SQLite::SharedData::popCommittedTransactions
     return result;
 }
 
-void SQLite::SharedData::registerAfterCommitCallback(function<void()>&& callback)
+void SQLite::runAfterCommitCallbacks() noexcept
 {
-    unique_lock<decltype(_afterCommitCallbackLock)> lock(_afterCommitCallbackLock);
-    _afterCommitCallbacks.push_back(move(callback));
-}
-
-void SQLite::SharedData::runAfterCommitCallbacks() noexcept
-{
-    shared_lock<decltype(_afterCommitCallbackLock)> lock(_afterCommitCallbackLock);
     for (const auto& callback : _afterCommitCallbacks) {
         try {
             callback();
@@ -1696,9 +1691,4 @@ void SQLite::SharedData::runAfterCommitCallbacks() noexcept
             SWARN("Ignoring unknown exception from afterCommit callback.");
         }
     }
-}
-
-void SQLite::registerAfterCommitCallback(function<void()>&& callback)
-{
-    _sharedData.registerAfterCommitCallback(move(callback));
 }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1673,3 +1673,22 @@ map<uint64_t, pair<string, string>> SQLite::SharedData::popCommittedTransactions
     _committedTransactions.clear();
     return result;
 }
+
+void SQLite::SharedData::registerAfterCommitCallback(function<void()>&& callback)
+{
+    unique_lock<decltype(_afterCommitCallbackLock)> lock(_afterCommitCallbackLock);
+    _afterCommitCallbacks.push_back(move(callback));
+}
+
+void SQLite::SharedData::runAfterCommitCallbacks()
+{
+    shared_lock<decltype(_afterCommitCallbackLock)> lock(_afterCommitCallbackLock);
+    for (const auto& callback : _afterCommitCallbacks) {
+        callback();
+    }
+}
+
+void SQLite::registerAfterCommitCallback(function<void()>&& callback)
+{
+    _sharedData.registerAfterCommitCallback(move(callback));
+}

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1147,6 +1147,10 @@ int SQLite::commit(const string& description, const string& commandName, functio
         _queryCache.clear();
         _sharedData.openTransactionCount--;
 
+        // Run these as early as possible after releasing the commit lock, so that anything waiting on a commit hears
+        // about it before we spend time on the checkpoint below.
+        _sharedData.runAfterCommitCallbacks();
+
         if (preCheckpointCallback != nullptr) {
             (*preCheckpointCallback)();
         }

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -1684,12 +1684,10 @@ void SQLite::SharedData::registerAfterCommitCallback(function<void()>&& callback
     _afterCommitCallbacks.push_back(move(callback));
 }
 
-void SQLite::SharedData::runAfterCommitCallbacks()
+void SQLite::SharedData::runAfterCommitCallbacks() noexcept
 {
     shared_lock<decltype(_afterCommitCallbackLock)> lock(_afterCommitCallbackLock);
     for (const auto& callback : _afterCommitCallbacks) {
-        // The commit already happened, and SQLiteCore::commit is noexcept, so letting an exception out of here would
-        // terminate the process over a callback that has no bearing on whether the commit succeeded.
         try {
             callback();
         } catch (const exception& e) {

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -221,8 +221,7 @@ public:
     int commit(const string& description = "UNSPECIFIED", const string& commandName = "", function<void()>* preCheckpointCallback = nullptr);
 
     // Registers a callback to run after every successful commit to this database, whether the commit came from a
-    // command running on the leader or from replication on a follower. Callbacks are shared across every handle to
-    // the same database file, so one registration covers all of them.
+    // command running on the leader or from replication on a follower.
     // The callback runs after the commit lock is released, but it still runs on the committing thread: it must not
     // block, and it must not touch the database.
     // There is no way to unregister, so callbacks must outlive every handle to this database.
@@ -442,9 +441,7 @@ private:
         // variety of operations (i.e., updating _committedTransactions, etc).
         recursive_mutex _internalStateMutex;
 
-        // Callbacks to run after each successful commit, and the lock guarding them. This is a separate lock from
-        // _internalStateMutex because it is taken on every commit and we never want a callback registration to wait
-        // behind unrelated shared-state changes.
+        // Callbacks to run after each successful commit.
         vector<function<void()>> _afterCommitCallbacks;
         shared_mutex _afterCommitCallbackLock;
     };

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -429,7 +429,7 @@ public:
         void registerAfterCommitCallback(function<void()>&& callback);
 
         // Runs every registered after-commit callback. Called with no locks held.
-        void runAfterCommitCallbacks();
+        void runAfterCommitCallbacks() noexcept;
 
 private:
         // The data required to replicate transactions, in two lists, depending on whether this has only been prepared

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -81,7 +81,8 @@ public:
     //
     // mmapSizeGB: address space to use for memory-mapped IO, in GB.
     SQLite(const string& filename, int cacheSize, int maxJournalSize, int minJournalTables,
-           int64_t mmapSizeGB = 0, bool hctree = false, const string& checkpointMode = "PASSIVE");
+           int64_t mmapSizeGB = 0, bool hctree = false, const string& checkpointMode = "PASSIVE",
+           vector<function<void()>> afterCommitCallbacks = {});
 
     // This constructor is not exactly a copy constructor. It creates an other SQLite object based on the first except
     // with a *different* journal table. This avoids a lot of locking around creating structures that we know already
@@ -219,13 +220,6 @@ public:
     // preCheckpointCallback is an optional callback that will be called before the checkpoint code runs, after the commit has completed. Note that if the commit fails, this is not called.
     // The main purpose of this is to allow replications in SQLiteNode to notify other waiting threads that the commit has finished even before the checkpoint is done.
     int commit(const string& description = "UNSPECIFIED", const string& commandName = "", function<void()>* preCheckpointCallback = nullptr);
-
-    // Registers a callback to run after every successful commit to this database, whether the commit came from a
-    // command running on the leader or from replication on a follower.
-    // The callback runs after the commit lock is released, but it still runs on the committing thread: it must not
-    // block, and it must not touch the database.
-    // There is no way to unregister, so callbacks must outlive every handle to this database.
-    void registerAfterCommitCallback(function<void()>&& callback);
 
     // Cancels the current transaction and rolls it back.
     void rollback(const string& commandName = "");
@@ -425,12 +419,6 @@ public:
         // This can be locked in exclusive mode to prevent all writes. This exists to support the `BlockWrites` command.
         shared_mutex writeLock;
 
-        // Adds a callback to run after every successful commit. See SQLite::registerAfterCommitCallback.
-        void registerAfterCommitCallback(function<void()>&& callback);
-
-        // Runs every registered after-commit callback. Called with no locks held.
-        void runAfterCommitCallbacks() noexcept;
-
 private:
         // The data required to replicate transactions, in two lists, depending on whether this has only been prepared
         // or if it's been committed.
@@ -440,10 +428,6 @@ private:
         // This mutex is locked when we need to change the state of the _shareData object. It is shared between a
         // variety of operations (i.e., updating _committedTransactions, etc).
         recursive_mutex _internalStateMutex;
-
-        // Callbacks to run after each successful commit.
-        vector<function<void()>> _afterCommitCallbacks;
-        shared_mutex _afterCommitCallbackLock;
     };
 
     // Initializers to support RAII-style allocation in constructors.
@@ -588,6 +572,13 @@ private:
     // Check out various error cases that can interrupt a query.
     // We check them all together because we need to make sure we atomically pick a single one to handle.
     void _checkInterruptErrors(const string& error) const;
+
+    // Callbacks to run after each successful commit. Set at construction and copied to every handle derived from
+    // this one, so they need no locking.
+    const vector<function<void()>> _afterCommitCallbacks;
+
+    // Runs every after-commit callback. Called with no locks held.
+    void runAfterCommitCallbacks() noexcept;
 
     // Called internally by _sqliteAuthorizerCallback to authorize columns for a query.
     //

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -220,6 +220,14 @@ public:
     // The main purpose of this is to allow replications in SQLiteNode to notify other waiting threads that the commit has finished even before the checkpoint is done.
     int commit(const string& description = "UNSPECIFIED", const string& commandName = "", function<void()>* preCheckpointCallback = nullptr);
 
+    // Registers a callback to run after every successful commit to this database, whether the commit came from a
+    // command running on the leader or from replication on a follower. Callbacks are shared across every handle to
+    // the same database file, so one registration covers all of them.
+    // The callback runs after the commit lock is released, but it still runs on the committing thread: it must not
+    // block, and it must not touch the database.
+    // There is no way to unregister, so callbacks must outlive every handle to this database.
+    void registerAfterCommitCallback(function<void()>&& callback);
+
     // Cancels the current transaction and rolls it back.
     void rollback(const string& commandName = "");
 
@@ -418,6 +426,12 @@ public:
         // This can be locked in exclusive mode to prevent all writes. This exists to support the `BlockWrites` command.
         shared_mutex writeLock;
 
+        // Adds a callback to run after every successful commit. See SQLite::registerAfterCommitCallback.
+        void registerAfterCommitCallback(function<void()>&& callback);
+
+        // Runs every registered after-commit callback. Called with no locks held.
+        void runAfterCommitCallbacks();
+
 private:
         // The data required to replicate transactions, in two lists, depending on whether this has only been prepared
         // or if it's been committed.
@@ -427,6 +441,12 @@ private:
         // This mutex is locked when we need to change the state of the _shareData object. It is shared between a
         // variety of operations (i.e., updating _committedTransactions, etc).
         recursive_mutex _internalStateMutex;
+
+        // Callbacks to run after each successful commit, and the lock guarding them. This is a separate lock from
+        // _internalStateMutex because it is taken on every commit and we never want a callback registration to wait
+        // behind unrelated shared-state changes.
+        vector<function<void()>> _afterCommitCallbacks;
+        shared_mutex _afterCommitCallbackLock;
     };
 
     // Initializers to support RAII-style allocation in constructors.

--- a/sqlitecluster/SQLitePool.cpp
+++ b/sqlitecluster/SQLitePool.cpp
@@ -9,9 +9,10 @@ SQLitePool::SQLitePool(size_t maxDBs,
                        int minJournalTables,
                        int64_t mmapSizeGB,
                        bool hctree,
-                       const string& checkpointMode)
+                       const string& checkpointMode,
+                       vector<function<void()>> afterCommitCallbacks)
     : _maxDBs(max(maxDBs, 1ul)),
-    _baseDB(filename, cacheSize, maxJournalSize, minJournalTables, mmapSizeGB, hctree, checkpointMode),
+    _baseDB(filename, cacheSize, maxJournalSize, minJournalTables, mmapSizeGB, hctree, checkpointMode, afterCommitCallbacks),
     _objects(_maxDBs, nullptr)
 {
 }

--- a/sqlitecluster/SQLitePool.h
+++ b/sqlitecluster/SQLitePool.h
@@ -7,8 +7,8 @@ class SQLitePool {
 public:
     // Create a pool of DB handles.
     SQLitePool(size_t maxDBs, const string& filename, int cacheSize, int maxJournalSize, int minJournalTables,
-                int64_t mmapSizeGB = 0, bool hctree = false, const string& checkpointMode = "PASSIVE",
-                vector<function<void()>> afterCommitCallbacks = {});
+               int64_t mmapSizeGB = 0, bool hctree = false, const string& checkpointMode = "PASSIVE",
+               vector<function<void()>> afterCommitCallbacks = {});
     ~SQLitePool();
 
     // Get the base object (the first one created, which uses the `journal` table). Note that if called by multiple

--- a/sqlitecluster/SQLitePool.h
+++ b/sqlitecluster/SQLitePool.h
@@ -7,7 +7,8 @@ class SQLitePool {
 public:
     // Create a pool of DB handles.
     SQLitePool(size_t maxDBs, const string& filename, int cacheSize, int maxJournalSize, int minJournalTables,
-               int64_t mmapSizeGB = 0, bool hctree = false, const string& checkpointMode = "PASSIVE");
+                int64_t mmapSizeGB = 0, bool hctree = false, const string& checkpointMode = "PASSIVE",
+                vector<function<void()>> afterCommitCallbacks = {});
     ~SQLitePool();
 
     // Get the base object (the first one created, which uses the `journal` table). Note that if called by multiple

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -26,12 +26,12 @@ extern "C" BedrockPlugin* BEDROCK_PLUGIN_REGISTER_TESTPLUGIN(BedrockServer& s)
 }
 
 BedrockPlugin_TestPlugin::BedrockPlugin_TestPlugin(BedrockServer& s) :
-    BedrockPlugin(s), httpsManager(new TestHTTPSManager(*this)), _maxID(-1), afterCommitCount(0)
+    BedrockPlugin(s, &BedrockPlugin_TestPlugin::afterCommitCallback),
+    httpsManager(new TestHTTPSManager(*this)), _maxID(-1)
 {
 }
 
-void BedrockPlugin_TestPlugin::afterCommitCallback()
-{
+void BedrockPlugin_TestPlugin::afterCommitCallback() {
     afterCommitCount++;
 }
 

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -239,7 +239,7 @@ bool TestPluginCommand::peek(SQLite& db)
 
     if (SStartsWith(request.methodLine, "getaftercommitcount")) {
         // Peek runs on whichever node received this, so a follower answers for itself instead of escalating.
-        response["afterCommitCount"] = SToStr(plugin().afterCommitCount.load());
+        response.content = SComposeJSONObject({{"afterCommitCount", SToStr(plugin().afterCommitCount.load())}});
         response.methodLine = "200 OK";
         return true;
     } else if (SStartsWith(request.methodLine, "testcommand")) {

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -31,7 +31,8 @@ BedrockPlugin_TestPlugin::BedrockPlugin_TestPlugin(BedrockServer& s) :
 {
 }
 
-void BedrockPlugin_TestPlugin::afterCommitCallback() {
+void BedrockPlugin_TestPlugin::afterCommitCallback()
+{
     afterCommitCount++;
 }
 

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -28,9 +28,11 @@ extern "C" BedrockPlugin* BEDROCK_PLUGIN_REGISTER_TESTPLUGIN(BedrockServer& s)
 BedrockPlugin_TestPlugin::BedrockPlugin_TestPlugin(BedrockServer& s) :
     BedrockPlugin(s), httpsManager(new TestHTTPSManager(*this)), _maxID(-1), afterCommitCount(0)
 {
-    s.registerAfterCommitCallback([this]() {
-        afterCommitCount++;
-    });
+}
+
+void BedrockPlugin_TestPlugin::afterCommitCallback()
+{
+    afterCommitCount++;
 }
 
 BedrockPlugin_TestPlugin::~BedrockPlugin_TestPlugin()

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -26,8 +26,11 @@ extern "C" BedrockPlugin* BEDROCK_PLUGIN_REGISTER_TESTPLUGIN(BedrockServer& s)
 }
 
 BedrockPlugin_TestPlugin::BedrockPlugin_TestPlugin(BedrockServer& s) :
-    BedrockPlugin(s), httpsManager(new TestHTTPSManager(*this)), _maxID(-1)
+    BedrockPlugin(s), httpsManager(new TestHTTPSManager(*this)), _maxID(-1), afterCommitCount(0)
 {
+    s.registerAfterCommitCallback([this]() {
+        afterCommitCount++;
+    });
 }
 
 BedrockPlugin_TestPlugin::~BedrockPlugin_TestPlugin()
@@ -86,6 +89,7 @@ unique_ptr<BedrockCommand> BedrockPlugin_TestPlugin::getCommand(SQLiteCommand&& 
 {
     static set<string> supportedCommands = {
         "testcommand",
+        "getaftercommitcount",
         "testescalate",
         "broadcastwithtimeouts",
         "storeboradcasttimeouts",
@@ -233,7 +237,12 @@ bool TestPluginCommand::peek(SQLite& db)
         usleep(request.calc("PeekSleep") * 1000);
     }
 
-    if (SStartsWith(request.methodLine, "testcommand")) {
+    if (SStartsWith(request.methodLine, "getaftercommitcount")) {
+        // Peek runs on whichever node received this, so a follower answers for itself instead of escalating.
+        response["afterCommitCount"] = SToStr(plugin().afterCommitCount.load());
+        response.methodLine = "200 OK";
+        return true;
+    } else if (SStartsWith(request.methodLine, "testcommand")) {
         if (!request["response"].empty()) {
             response.methodLine = request["response"];
         } else {

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -47,6 +47,9 @@ public:
     // Counts the after-commit callbacks this node has seen, so a test can check that they fire on a follower
     // applying a replicated commit, not just on the leader.
     atomic<uint64_t> afterCommitCount;
+
+    // Counts commits on this node, including replicated ones applied by a follower.
+    void afterCommitCallback();
 };
 
 class TestPluginCommand : public BedrockCommand {

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -49,7 +49,6 @@ public:
     inline static atomic<uint64_t> afterCommitCount{0};
 
     static void afterCommitCallback();
-
 };
 
 class TestPluginCommand : public BedrockCommand {

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -46,10 +46,10 @@ public:
 
     // Counts the after-commit callbacks this node has seen, so a test can check that they fire on a follower
     // applying a replicated commit, not just on the leader.
-    atomic<uint64_t> afterCommitCount;
+    inline static atomic<uint64_t> afterCommitCount{0};
 
-    // Counts commits on this node, including replicated ones applied by a follower.
-    void afterCommitCallback();
+    static void afterCommitCallback();
+
 };
 
 class TestPluginCommand : public BedrockCommand {

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -43,6 +43,10 @@ public:
 
     // Tests setting of an ID value in stateChanged after an upgrade is completed.
     atomic<int64_t> _maxID;
+
+    // Counts the after-commit callbacks this node has seen, so a test can check that they fire on a follower
+    // applying a replicated commit, not just on the leader.
+    atomic<uint64_t> afterCommitCount;
 };
 
 class TestPluginCommand : public BedrockCommand {

--- a/test/clustertest/tests/AfterCommitCallbackClusterTest.cpp
+++ b/test/clustertest/tests/AfterCommitCallbackClusterTest.cpp
@@ -1,0 +1,56 @@
+#include <libstuff/SData.h>
+#include <test/clustertest/BedrockClusterTester.h>
+
+struct AfterCommitCallbackClusterTest : tpunit::TestFixture
+{
+    AfterCommitCallbackClusterTest()
+        : tpunit::TestFixture("AfterCommitCallbackCluster",
+                              BEFORE_CLASS(AfterCommitCallbackClusterTest::setup),
+                              AFTER_CLASS(AfterCommitCallbackClusterTest::teardown),
+                              TEST(AfterCommitCallbackClusterTest::firesOnFollowerReplication))
+    {
+    }
+
+    BedrockClusterTester* tester;
+
+    void setup()
+    {
+        tester = new BedrockClusterTester();
+    }
+
+    void teardown()
+    {
+        delete tester;
+    }
+
+    uint64_t getAfterCommitCount(BedrockTester& node)
+    {
+        SData command("getaftercommitcount");
+        return SToUInt64(node.executeWaitVerifyContentTable(command)["afterCommitCount"]);
+    }
+
+    void firesOnFollowerReplication()
+    {
+        BedrockTester& leader = tester->getTester(0);
+        BedrockTester& follower = tester->getTester(1);
+        ASSERT_TRUE(leader.waitForState("LEADING"));
+        ASSERT_TRUE(follower.waitForState("FOLLOWING"));
+
+        const uint64_t followerCountBefore = getAfterCommitCount(follower);
+
+        // Write on the leader. The follower never runs this command, it only applies the replicated transaction, so
+        // any increase in its count came from replication.
+        SData write("idcollision");
+        write["writeConsistency"] = "ASYNC";
+        leader.executeWaitVerifyContent(write);
+
+        // Replication is asynchronous, so poll rather than assuming the follower has caught up.
+        uint64_t followerCountAfter = followerCountBefore;
+        for (int i = 0; i < 100 && followerCountAfter <= followerCountBefore; i++) {
+            usleep(100'000);
+            followerCountAfter = getAfterCommitCount(follower);
+        }
+
+        ASSERT_GREATER_THAN(followerCountAfter, followerCountBefore);
+    }
+} __AfterCommitCallbackClusterTest;

--- a/test/clustertest/tests/AfterCommitCallbackClusterTest.cpp
+++ b/test/clustertest/tests/AfterCommitCallbackClusterTest.cpp
@@ -36,6 +36,7 @@ struct AfterCommitCallbackClusterTest : tpunit::TestFixture
         ASSERT_TRUE(leader.waitForState("LEADING"));
         ASSERT_TRUE(follower.waitForState("FOLLOWING"));
 
+        const uint64_t leaderCountBefore = getAfterCommitCount(leader);
         const uint64_t followerCountBefore = getAfterCommitCount(follower);
 
         // Write on the leader. The follower never runs this command, it only applies the replicated transaction, so
@@ -44,13 +45,21 @@ struct AfterCommitCallbackClusterTest : tpunit::TestFixture
         write["writeConsistency"] = "ASYNC";
         leader.executeWaitVerifyContent(write);
 
+        // The leader committed the command itself, so its count moves first. Checking it separately tells a failure
+        // where callbacks never fire at all apart from one where they fire but replication doesn't trigger them.
+        uint64_t leaderCountAfter = leaderCountBefore;
+        for (int i = 0; i < 100 && leaderCountAfter <= leaderCountBefore; i++) {
+            usleep(100'000);
+            leaderCountAfter = getAfterCommitCount(leader);
+        }
+        ASSERT_GREATER_THAN(leaderCountAfter, leaderCountBefore);
+
         // Replication is asynchronous, so poll rather than assuming the follower has caught up.
         uint64_t followerCountAfter = followerCountBefore;
         for (int i = 0; i < 100 && followerCountAfter <= followerCountBefore; i++) {
             usleep(100'000);
             followerCountAfter = getAfterCommitCount(follower);
         }
-
         ASSERT_GREATER_THAN(followerCountAfter, followerCountBefore);
     }
 } __AfterCommitCallbackClusterTest;

--- a/test/tests/AfterCommitCallbackTest.cpp
+++ b/test/tests/AfterCommitCallbackTest.cpp
@@ -32,12 +32,12 @@ struct AfterCommitCallbackTest : tpunit::TestFixture
     void firesOncePerCommit()
     {
         AfterCommitCallbackTempDBFile dbFile;
-        SQLite db(dbFile.filename, 1000, 1000, 1);
 
+        // Declared before the handle so it outlives every callback that captures it.
         atomic<int> callCount(0);
-        db.registerAfterCommitCallback([&callCount]() {
-            callCount++;
-        });
+        SQLite db(dbFile.filename, 1000, 1000, 1, 0, false, "PASSIVE", {[&callCount]() {
+                callCount++;
+            }});
 
         db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
         db.write("CREATE TABLE testTable(id INTEGER PRIMARY KEY, value INTEGER);");
@@ -58,18 +58,19 @@ struct AfterCommitCallbackTest : tpunit::TestFixture
     void doesNotFireOnRollback()
     {
         AfterCommitCallbackTempDBFile dbFile;
-        SQLite db(dbFile.filename, 1000, 1000, 1);
+
+        atomic<int> callCount(0);
+        SQLite db(dbFile.filename, 1000, 1000, 1, 0, false, "PASSIVE", {[&callCount]() {
+                callCount++;
+            }});
 
         db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
         db.write("CREATE TABLE testTable(id INTEGER PRIMARY KEY, value INTEGER);");
         db.prepare();
         ASSERT_EQUAL(db.commit(), SQLITE_OK);
 
-        // Register only now, so the setup commit above can't be mistaken for the write we roll back.
-        atomic<int> callCount(0);
-        db.registerAfterCommitCallback([&callCount]() {
-            callCount++;
-        });
+        // Zeroed after setup, so the commit above can't be mistaken for the write we roll back.
+        callCount = 0;
 
         db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
         db.write("INSERT INTO testTable VALUES(1, 1);");
@@ -88,8 +89,12 @@ struct AfterCommitCallbackTest : tpunit::TestFixture
     {
         AfterCommitCallbackTempDBFile dbFile;
 
-        // Two handles to the same file share one SharedData, so `first` sees callbacks registered on either handle.
-        SQLite first(dbFile.filename, 1000, 1000, 1);
+        atomic<int> callCount(0);
+        SQLite first(dbFile.filename, 1000, 1000, 1, 0, false, "PASSIVE", {[&callCount]() {
+                callCount++;
+            }});
+
+        // A handle derived from another copies its callbacks, so both handles below count into callCount.
         SQLite second(first);
 
         first.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
@@ -98,10 +103,7 @@ struct AfterCommitCallbackTest : tpunit::TestFixture
         first.prepare();
         ASSERT_EQUAL(first.commit(), SQLITE_OK);
 
-        atomic<int> callCount(0);
-        first.registerAfterCommitCallback([&callCount]() {
-            callCount++;
-        });
+        callCount = 0;
 
         // Both handles update the same row from the same starting snapshot, so whichever commits second conflicts.
         first.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED);

--- a/test/tests/AfterCommitCallbackTest.cpp
+++ b/test/tests/AfterCommitCallbackTest.cpp
@@ -23,7 +23,8 @@ struct AfterCommitCallbackTest : tpunit::TestFixture
 {
     AfterCommitCallbackTest()
         : tpunit::TestFixture("AfterCommitCallback",
-                              TEST(AfterCommitCallbackTest::firesOncePerCommit))
+                              TEST(AfterCommitCallbackTest::firesOncePerCommit),
+                              TEST(AfterCommitCallbackTest::doesNotFireOnRollback))
     {
     }
 
@@ -51,6 +52,35 @@ struct AfterCommitCallbackTest : tpunit::TestFixture
             ASSERT_EQUAL(db.commit(), SQLITE_OK);
             ASSERT_EQUAL(callCount.load(), i + 1);
         }
+    }
+
+    void doesNotFireOnRollback()
+    {
+        AfterCommitCallbackTempDBFile dbFile;
+        SQLite db(dbFile.filename, 1000, 1000, 1);
+
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+        db.write("CREATE TABLE testTable(id INTEGER PRIMARY KEY, value INTEGER);");
+        db.prepare();
+        ASSERT_EQUAL(db.commit(), SQLITE_OK);
+
+        // Register only now, so the setup commit above can't be mistaken for the write we roll back.
+        atomic<int> callCount(0);
+        db.registerAfterCommitCallback([&callCount]() {
+            callCount++;
+        });
+
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+        db.write("INSERT INTO testTable VALUES(1, 1);");
+        db.rollback();
+        ASSERT_EQUAL(callCount.load(), 0);
+
+        // A transaction that is prepared and then rolled back also doesn't count.
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+        db.write("INSERT INTO testTable VALUES(2, 2);");
+        db.prepare();
+        db.rollback();
+        ASSERT_EQUAL(callCount.load(), 0);
     }
 
 } __AfterCommitCallbackTest;

--- a/test/tests/AfterCommitCallbackTest.cpp
+++ b/test/tests/AfterCommitCallbackTest.cpp
@@ -24,7 +24,8 @@ struct AfterCommitCallbackTest : tpunit::TestFixture
     AfterCommitCallbackTest()
         : tpunit::TestFixture("AfterCommitCallback",
                               TEST(AfterCommitCallbackTest::firesOncePerCommit),
-                              TEST(AfterCommitCallbackTest::doesNotFireOnRollback))
+                              TEST(AfterCommitCallbackTest::doesNotFireOnRollback),
+                              TEST(AfterCommitCallbackTest::doesNotFireOnConflict))
     {
     }
 
@@ -83,4 +84,38 @@ struct AfterCommitCallbackTest : tpunit::TestFixture
         ASSERT_EQUAL(callCount.load(), 0);
     }
 
+    void doesNotFireOnConflict()
+    {
+        AfterCommitCallbackTempDBFile dbFile;
+
+        // Two handles to the same file share one SharedData, so `first` sees callbacks registered on either handle.
+        SQLite first(dbFile.filename, 1000, 1000, 1);
+        SQLite second(first);
+
+        first.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+        first.write("CREATE TABLE testTable(id INTEGER PRIMARY KEY, value INTEGER);");
+        first.write("INSERT INTO testTable VALUES(1, 1);");
+        first.prepare();
+        ASSERT_EQUAL(first.commit(), SQLITE_OK);
+
+        atomic<int> callCount(0);
+        first.registerAfterCommitCallback([&callCount]() {
+            callCount++;
+        });
+
+        // Both handles update the same row from the same starting snapshot, so whichever commits second conflicts.
+        first.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED);
+        second.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED);
+        first.write("UPDATE testTable SET value = 2 WHERE id = 1;");
+        second.write("UPDATE testTable SET value = 3 WHERE id = 1;");
+
+        first.prepare();
+        ASSERT_EQUAL(first.commit(), SQLITE_OK);
+        ASSERT_EQUAL(callCount.load(), 1);
+
+        second.prepare();
+        ASSERT_EQUAL(second.commit(), SQLITE_BUSY_SNAPSHOT);
+        ASSERT_EQUAL(callCount.load(), 1);
+        second.rollback();
+    }
 } __AfterCommitCallbackTest;

--- a/test/tests/AfterCommitCallbackTest.cpp
+++ b/test/tests/AfterCommitCallbackTest.cpp
@@ -1,0 +1,56 @@
+#include <unistd.h>
+
+#include <libstuff/libstuff.h>
+#include <sqlitecluster/SQLite.h>
+#include <test/lib/BedrockTester.h>
+
+struct AfterCommitCallbackTempDBFile
+{
+    char filename[17] = "br_acc_dbXXXXXXX";
+    AfterCommitCallbackTempDBFile()
+    {
+        int fd = mkstemp(filename);
+        close(fd);
+    }
+
+    ~AfterCommitCallbackTempDBFile()
+    {
+        unlink(filename);
+    }
+};
+
+struct AfterCommitCallbackTest : tpunit::TestFixture
+{
+    AfterCommitCallbackTest()
+        : tpunit::TestFixture("AfterCommitCallback",
+                              TEST(AfterCommitCallbackTest::firesOncePerCommit))
+    {
+    }
+
+    void firesOncePerCommit()
+    {
+        AfterCommitCallbackTempDBFile dbFile;
+        SQLite db(dbFile.filename, 1000, 1000, 1);
+
+        atomic<int> callCount(0);
+        db.registerAfterCommitCallback([&callCount]() {
+            callCount++;
+        });
+
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+        db.write("CREATE TABLE testTable(id INTEGER PRIMARY KEY, value INTEGER);");
+        db.prepare();
+        ASSERT_EQUAL(db.commit(), SQLITE_OK);
+        ASSERT_EQUAL(callCount.load(), 1);
+
+        // Each subsequent commit adds exactly one more call.
+        for (int i = 1; i <= 5; i++) {
+            db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+            db.write("INSERT INTO testTable VALUES(" + SToStr(i) + ", " + SToStr(i) + ");");
+            db.prepare();
+            ASSERT_EQUAL(db.commit(), SQLITE_OK);
+            ASSERT_EQUAL(callCount.load(), i + 1);
+        }
+    }
+
+} __AfterCommitCallbackTest;


### PR DESCRIPTION
### Details

Adds an `afterCommit` callback mechanism so a plugin can be notified every time this node commits.

This is 1/4 PRs to introduce actions after commit to plugins.


- `SQLite::SharedData` holds the callback list, so one registration covers every handle to the same database file
- `SQLite::commit()` runs the callbacks in the success, after releasing the commitLock and before the checkpoint `BedrockServer::registerAfterCommitCallback()` forwards registration to the pool's base handle.

Plugins are constructed before the DB pool exists. `BedrockServer` builds its plugins in its own constructor, but `_dbPool` is not created until `sync()` runs. `BedrockServer` now holds early registrations and hands them to the pool once it is created. 

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/671183

### Tests

Added automated tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
