### PR TITLE
Add SQLite::writeLocalUnreplicated

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -820,6 +820,36 @@ bool SQLite::writeUnmodified(const string& query, const map<string, Parameter>& 
     return _writeIdempotent(query, params, ignore, true);
 }
 
+bool SQLite::writeLocalUnreplicated(const string& query)
+{
+    // Beginning a transaction here would break whatever transaction the handle is already running, so refuse instead.
+    if (_insideTransaction) {
+        SALERT("writeLocalUnreplicated called on a handle that is inside a transaction, skipping.");
+        return false;
+    }
+
+    // Held in shared mode for the same reason the journal trim in `prepare` holds it: BlockWrites needs to be able to
+    // stop this.
+    shared_lock<shared_mutex> lock(_sharedData.writeLock);
+
+    if (SQuery(_db, "BEGIN CONCURRENT")) {
+        return false;
+    }
+
+    if (SQuery(_db, query)) {
+        SQuery(_db, "ROLLBACK");
+        return false;
+    }
+
+    // A commit that landed while we were writing shows up here as SQLITE_BUSY_SNAPSHOT.
+    if (SQuery(_db, "COMMIT")) {
+        SQuery(_db, "ROLLBACK");
+        return false;
+    }
+
+    return true;
+}
+
 bool SQLite::_writeIdempotent(const string& query, const map<string, Parameter>& params, SQResult& result, bool alwaysKeepQueries)
 {
     if (!_insideTransaction) {

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -163,6 +163,15 @@ public:
     bool writeUnmodified(const string& query);
     bool writeUnmodified(const string& query, const map<string, Parameter>& params);
 
+    // Runs a write in its own transaction that is neither journaled nor replicated. The change is local to this
+    // node's database file, so this is only legal for queries whose effect no other node depends on. Deleting rows
+    // that every node is independently allowed to delete is the motivating case.
+    // This does not take the commit lock, so it can run while other threads commit. It uses BEGIN CONCURRENT for
+    // that reason: if another commit lands underneath it, the COMMIT returns SQLITE_BUSY_SNAPSHOT, this rolls back
+    // and returns false, and the caller is expected to try again later rather than retry in place.
+    // The caller must own a handle that is not inside a transaction, because this begins and ends one of its own.
+    bool writeLocalUnreplicated(const string& query);
+
     // Enable or disable update-noop mode.
     void setUpdateNoopMode(bool enabled);
     bool getUpdateNoopMode() const;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -164,7 +164,7 @@ public:
     bool writeUnmodified(const string& query, const map<string, Parameter>& params);
 
     // Writes done with this are not added to the journal nor replicated. The intended use of this is for
-    // truncating old journal entries.
+    // truncating old journal entries. This function will not call runAfterCommit callbacks.
     bool writeLocalUnreplicated(const string& query);
 
     // Enable or disable update-noop mode.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -164,12 +164,7 @@ public:
     bool writeUnmodified(const string& query, const map<string, Parameter>& params);
 
     // Runs a write in its own transaction that is neither journaled nor replicated. The change is local to this
-    // node's database file, so this is only legal for queries whose effect no other node depends on. Deleting rows
-    // that every node is independently allowed to delete is the motivating case.
-    // This does not take the commit lock, so it can run while other threads commit. It uses BEGIN CONCURRENT for
-    // that reason: if another commit lands underneath it, the COMMIT returns SQLITE_BUSY_SNAPSHOT, this rolls back
-    // and returns false, and the caller is expected to try again later rather than retry in place.
-    // The caller must own a handle that is not inside a transaction, because this begins and ends one of its own.
+    // node's database file, so this should only be used for queries whose effect no other node depends on.
     bool writeLocalUnreplicated(const string& query);
 
     // Enable or disable update-noop mode.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -163,8 +163,8 @@ public:
     bool writeUnmodified(const string& query);
     bool writeUnmodified(const string& query, const map<string, Parameter>& params);
 
-    // Runs a write in its own transaction that is neither journaled nor replicated. The change is local to this
-    // node's database file, so this should only be used for queries whose effect no other node depends on.
+    // Writes done with this are not added to the journal nor replicated. The intended use of this is for
+    // truncating old journal entries.
     bool writeLocalUnreplicated(const string& query);
 
     // Enable or disable update-noop mode.

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -8,6 +8,7 @@
 
 #include <libstuff/SQResult.h>
 #include <libstuff/SThread.h>
+#include <sqlitecluster/SQLitePool.h>
 
 extern int* __pointerToFakeIntArray;
 
@@ -93,6 +94,7 @@ unique_ptr<BedrockCommand> BedrockPlugin_TestPlugin::getCommand(SQLiteCommand&& 
     static set<string> supportedCommands = {
         "testcommand",
         "getaftercommitcount",
+        "deletetestrowunreplicated",
         "testescalate",
         "broadcastwithtimeouts",
         "storeboradcasttimeouts",
@@ -240,7 +242,17 @@ bool TestPluginCommand::peek(SQLite& db)
         usleep(request.calc("PeekSleep") * 1000);
     }
 
-    if (SStartsWith(request.methodLine, "getaftercommitcount")) {
+    if (SStartsWith(request.methodLine, "deletetestrowunreplicated")) {
+        // Takes its own handle from the pool rather than using this command's, which is the way a background thread
+        // would call this: the write begins and ends a transaction of its own, so it needs a handle that is not
+        // already inside one.
+        shared_ptr<SQLitePool> dbPool = plugin().server.getDBPool();
+        SQLiteScopedHandle handle(*dbPool, dbPool->getIndex());
+        const bool deleted = handle.db().writeLocalUnreplicated("DELETE FROM test WHERE id = " + SQ(request.calc64("id")) + ";");
+        response.content = SComposeJSONObject({{"deleted", deleted ? "true" : "false"}});
+        response.methodLine = "200 OK";
+        return true;
+    } else if (SStartsWith(request.methodLine, "getaftercommitcount")) {
         // Peek runs on whichever node received this, so a follower answers for itself instead of escalating.
         response.content = SComposeJSONObject({{"afterCommitCount", SToStr(plugin().afterCommitCount.load())}});
         response.methodLine = "200 OK";

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -30,11 +30,54 @@ BedrockPlugin_TestPlugin::BedrockPlugin_TestPlugin(BedrockServer& s) :
     BedrockPlugin(s, &BedrockPlugin_TestPlugin::afterCommitCallback),
     httpsManager(new TestHTTPSManager(*this)), _maxID(-1)
 {
+    unreplicatedDeleterThread = make_unique<thread>([this]() {
+        SInitialize("TestUnreplicatedDeleter");
+        while (true) {
+            int64_t id = 0;
+            {
+                unique_lock<mutex> lock(unreplicatedDeleterMutex);
+                unreplicatedDeleterCV.wait(lock, [this]() {
+                    return unreplicatedDeleterStop || !unreplicatedDeleteQueue.empty();
+                });
+                if (unreplicatedDeleterStop) {
+                    return;
+                }
+                id = unreplicatedDeleteQueue.front();
+                unreplicatedDeleteQueue.pop_front();
+            }
+
+            // Work only ever arrives from a command, so the pool exists by the time we get here.
+            shared_ptr<SQLitePool> dbPool = server.getDBPool();
+            if (!dbPool) {
+                SWARN("No DB pool for the unreplicated deleter, dropping id " << id);
+                continue;
+            }
+            SQLiteScopedHandle handle(*dbPool, dbPool->getIndex());
+            if (!handle.db().writeLocalUnreplicated("DELETE FROM test WHERE id = " + SQ(id) + ";")) {
+                SWARN("Unreplicated delete of id " << id << " did not succeed.");
+            }
+        }
+    });
 }
 
 void BedrockPlugin_TestPlugin::afterCommitCallback()
 {
     afterCommitCount++;
+}
+
+void BedrockPlugin_TestPlugin::serverStopping()
+{
+    {
+        lock_guard<mutex> lock(unreplicatedDeleterMutex);
+        unreplicatedDeleterStop = true;
+    }
+    unreplicatedDeleterCV.notify_one();
+
+    // Joined outside the lock so the thread can take it on its way out.
+    if (unreplicatedDeleterThread) {
+        unreplicatedDeleterThread->join();
+        unreplicatedDeleterThread = nullptr;
+    }
 }
 
 BedrockPlugin_TestPlugin::~BedrockPlugin_TestPlugin()
@@ -243,13 +286,13 @@ bool TestPluginCommand::peek(SQLite& db)
     }
 
     if (SStartsWith(request.methodLine, "deletetestrowunreplicated")) {
-        // Takes its own handle from the pool rather than using this command's, which is the way a background thread
-        // would call this: the write begins and ends a transaction of its own, so it needs a handle that is not
-        // already inside one.
-        shared_ptr<SQLitePool> dbPool = plugin().server.getDBPool();
-        SQLiteScopedHandle handle(*dbPool, dbPool->getIndex());
-        const bool deleted = handle.db().writeLocalUnreplicated("DELETE FROM test WHERE id = " + SQ(request.calc64("id")) + ";");
-        response.content = SComposeJSONObject({{"deleted", deleted ? "true" : "false"}});
+        // Hands the work to the deleter thread rather than doing it here. A command already holds an open transaction
+        // on its own handle, which is not the context writeLocalUnreplicated is meant to be called from.
+        {
+            lock_guard<mutex> lock(plugin().unreplicatedDeleterMutex);
+            plugin().unreplicatedDeleteQueue.push_back(request.calc64("id"));
+        }
+        plugin().unreplicatedDeleterCV.notify_one();
         response.methodLine = "200 OK";
         return true;
     } else if (SStartsWith(request.methodLine, "getaftercommitcount")) {

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -53,9 +53,8 @@ public:
 
     static void afterCommitCallback();
 
-    // Deletes rows through writeLocalUnreplicated from a long-lived thread of its own, which is the shape Auth's
-    // OnyxDeleter uses: no command transaction is open on this thread, and it takes a pool handle per cycle rather
-    // than holding one, so nothing is held across a detach.
+    // Deletes rows through writeLocalUnreplicated from a long-lived thread of its own. This will be used to
+    // test that writeLocalUnreplicated can run while other threads are committing.
     unique_ptr<thread> unreplicatedDeleterThread;
     mutex unreplicatedDeleterMutex;
     condition_variable unreplicatedDeleterCV;

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -1,4 +1,7 @@
 #pragma once
+#include <condition_variable>
+#include <thread>
+
 #include <libstuff/libstuff.h>
 #include <BedrockPlugin.h>
 #include <BedrockServer.h>
@@ -49,6 +52,17 @@ public:
     inline static atomic<uint64_t> afterCommitCount{0};
 
     static void afterCommitCallback();
+
+    // Deletes rows through writeLocalUnreplicated from a long-lived thread of its own, which is the shape Auth's
+    // OnyxDeleter uses: no command transaction is open on this thread, and it takes a pool handle per cycle rather
+    // than holding one, so nothing is held across a detach.
+    unique_ptr<thread> unreplicatedDeleterThread;
+    mutex unreplicatedDeleterMutex;
+    condition_variable unreplicatedDeleterCV;
+    list<int64_t> unreplicatedDeleteQueue;
+    bool unreplicatedDeleterStop = false;
+
+    void serverStopping();
 };
 
 class TestPluginCommand : public BedrockCommand {

--- a/test/clustertest/tests/WriteLocalUnreplicatedClusterTest.cpp
+++ b/test/clustertest/tests/WriteLocalUnreplicatedClusterTest.cpp
@@ -64,7 +64,7 @@ struct WriteLocalUnreplicatedClusterTest : tpunit::TestFixture
         }
         ASSERT_EQUAL(countRowsWithID(leader, id), 0);
 
-        // The row should still exist on the follower, because the delete was never journaled and so never shipped. 
+        // The row should still exist on the follower, because the delete was never journaled and so never shipped.
         // Give replication some time, so this is a real absence of replication rather than a race we happened to win.
         usleep(1'000'000);
         ASSERT_EQUAL(countRowsWithID(follower, id), 1);

--- a/test/clustertest/tests/WriteLocalUnreplicatedClusterTest.cpp
+++ b/test/clustertest/tests/WriteLocalUnreplicatedClusterTest.cpp
@@ -52,12 +52,15 @@ struct WriteLocalUnreplicatedClusterTest : tpunit::TestFixture
         }
         ASSERT_EQUAL(countRowsWithID(follower, id), 1);
 
-        // Delete it on the leader through writeLocalUnreplicated.
+        // Delete it on the leader through writeLocalUnreplicated. The command hands the work to the plugin's deleter
+        // thread, so poll for the result rather than expecting it to have happened by the time the response lands.
         SData deleteCommand("deletetestrowunreplicated");
         deleteCommand["id"] = SToStr(id);
-        ASSERT_EQUAL(leader.executeWaitVerifyContentTable(deleteCommand)["deleted"], "true");
+        leader.executeWaitVerifyContent(deleteCommand);
 
-        // Gone from the leader.
+        for (int i = 0; i < 100 && countRowsWithID(leader, id) != 0; i++) {
+            usleep(100'000);
+        }
         ASSERT_EQUAL(countRowsWithID(leader, id), 0);
 
         // Still on the follower, because the delete was never journaled and so never shipped. Give replication the

--- a/test/clustertest/tests/WriteLocalUnreplicatedClusterTest.cpp
+++ b/test/clustertest/tests/WriteLocalUnreplicatedClusterTest.cpp
@@ -1,0 +1,75 @@
+#include <libstuff/SData.h>
+#include <libstuff/SQResult.h>
+#include <test/clustertest/BedrockClusterTester.h>
+
+struct WriteLocalUnreplicatedClusterTest : tpunit::TestFixture
+{
+    WriteLocalUnreplicatedClusterTest()
+        : tpunit::TestFixture("WriteLocalUnreplicatedCluster",
+                              BEFORE_CLASS(WriteLocalUnreplicatedClusterTest::setup),
+                              AFTER_CLASS(WriteLocalUnreplicatedClusterTest::teardown),
+                              TEST(WriteLocalUnreplicatedClusterTest::doesNotReachPeers))
+    {
+    }
+
+    BedrockClusterTester* tester;
+
+    void setup()
+    {
+        tester = new BedrockClusterTester();
+    }
+
+    void teardown()
+    {
+        delete tester;
+    }
+
+    int64_t countRowsWithID(BedrockTester& node, int64_t id)
+    {
+        SQResult result;
+        node.readDB("SELECT COUNT(*) FROM test WHERE id = " + SQ(id) + ";", result);
+        return SToInt64(result[0][0]);
+    }
+
+    void doesNotReachPeers()
+    {
+        BedrockTester& leader = tester->getTester(0);
+        BedrockTester& follower = tester->getTester(1);
+        ASSERT_TRUE(leader.waitForState("LEADING"));
+        ASSERT_TRUE(follower.waitForState("FOLLOWING"));
+
+        // Write a row the normal way, so it replicates to the follower.
+        leader.executeWaitVerifyContent(SData("bigquery"));
+
+        SQResult result;
+        leader.readDB("SELECT MAX(id) FROM test;", result);
+        const int64_t id = SToInt64(result[0][0]);
+
+        // Both nodes have it before we start.
+        ASSERT_EQUAL(countRowsWithID(leader, id), 1);
+        for (int i = 0; i < 100 && countRowsWithID(follower, id) == 0; i++) {
+            usleep(100'000);
+        }
+        ASSERT_EQUAL(countRowsWithID(follower, id), 1);
+
+        // Delete it on the leader through writeLocalUnreplicated.
+        SData deleteCommand("deletetestrowunreplicated");
+        deleteCommand["id"] = SToStr(id);
+        ASSERT_EQUAL(leader.executeWaitVerifyContentTable(deleteCommand)["deleted"], "true");
+
+        // Gone from the leader.
+        ASSERT_EQUAL(countRowsWithID(leader, id), 0);
+
+        // Still on the follower, because the delete was never journaled and so never shipped. Give replication the
+        // same window it got above, so this is a real absence of replication rather than a race we happened to win.
+        for (int i = 0; i < 10; i++) {
+            usleep(100'000);
+        }
+        ASSERT_EQUAL(countRowsWithID(follower, id), 1);
+
+        // And the cluster is still healthy: the leader can still commit normally afterwards.
+        leader.executeWaitVerifyContent(SData("bigquery"));
+        ASSERT_TRUE(leader.waitForState("LEADING"));
+        ASSERT_TRUE(follower.waitForState("FOLLOWING"));
+    }
+} __WriteLocalUnreplicatedClusterTest;

--- a/test/clustertest/tests/WriteLocalUnreplicatedClusterTest.cpp
+++ b/test/clustertest/tests/WriteLocalUnreplicatedClusterTest.cpp
@@ -38,11 +38,6 @@ struct WriteLocalUnreplicatedClusterTest : tpunit::TestFixture
         ASSERT_TRUE(leader.waitForState("LEADING"));
         ASSERT_TRUE(follower.waitForState("FOLLOWING"));
 
-        // Write two rows the normal way, so they replicate to the follower. The row we delete below has to be the
-        // older of the two: idcollision picks its primary key with MAX(id) + 1, so deleting the highest id here would
-        // hand the same key back to the next insert. That insert succeeds on the leader, which no longer has the row,
-        // and then breaks the follower, which does. Keeping a higher row alive on both nodes avoids that, and is a
-        // concrete example of what "no other node depends on this row" has to mean in practice.
         leader.executeWaitVerifyContent(SData("idcollision"));
 
         SQResult result;
@@ -69,11 +64,9 @@ struct WriteLocalUnreplicatedClusterTest : tpunit::TestFixture
         }
         ASSERT_EQUAL(countRowsWithID(leader, id), 0);
 
-        // Still on the follower, because the delete was never journaled and so never shipped. Give replication the
-        // same window it got above, so this is a real absence of replication rather than a race we happened to win.
-        for (int i = 0; i < 10; i++) {
-            usleep(100'000);
-        }
+        // The row should still exist on the follower, because the delete was never journaled and so never shipped. 
+        // Give replication some time, so this is a real absence of replication rather than a race we happened to win.
+        usleep(1'000'000);
         ASSERT_EQUAL(countRowsWithID(follower, id), 1);
 
         // And the cluster is still healthy: the leader can still commit normally afterwards.

--- a/test/clustertest/tests/WriteLocalUnreplicatedClusterTest.cpp
+++ b/test/clustertest/tests/WriteLocalUnreplicatedClusterTest.cpp
@@ -39,7 +39,7 @@ struct WriteLocalUnreplicatedClusterTest : tpunit::TestFixture
         ASSERT_TRUE(follower.waitForState("FOLLOWING"));
 
         // Write a row the normal way, so it replicates to the follower.
-        leader.executeWaitVerifyContent(SData("bigquery"));
+        leader.executeWaitVerifyContent(SData("idcollision"));
 
         SQResult result;
         leader.readDB("SELECT MAX(id) FROM test;", result);
@@ -68,7 +68,7 @@ struct WriteLocalUnreplicatedClusterTest : tpunit::TestFixture
         ASSERT_EQUAL(countRowsWithID(follower, id), 1);
 
         // And the cluster is still healthy: the leader can still commit normally afterwards.
-        leader.executeWaitVerifyContent(SData("bigquery"));
+        leader.executeWaitVerifyContent(SData("idcollision"));
         ASSERT_TRUE(leader.waitForState("LEADING"));
         ASSERT_TRUE(follower.waitForState("FOLLOWING"));
     }

--- a/test/clustertest/tests/WriteLocalUnreplicatedClusterTest.cpp
+++ b/test/clustertest/tests/WriteLocalUnreplicatedClusterTest.cpp
@@ -38,12 +38,18 @@ struct WriteLocalUnreplicatedClusterTest : tpunit::TestFixture
         ASSERT_TRUE(leader.waitForState("LEADING"));
         ASSERT_TRUE(follower.waitForState("FOLLOWING"));
 
-        // Write a row the normal way, so it replicates to the follower.
+        // Write two rows the normal way, so they replicate to the follower. The row we delete below has to be the
+        // older of the two: idcollision picks its primary key with MAX(id) + 1, so deleting the highest id here would
+        // hand the same key back to the next insert. That insert succeeds on the leader, which no longer has the row,
+        // and then breaks the follower, which does. Keeping a higher row alive on both nodes avoids that, and is a
+        // concrete example of what "no other node depends on this row" has to mean in practice.
         leader.executeWaitVerifyContent(SData("idcollision"));
 
         SQResult result;
         leader.readDB("SELECT MAX(id) FROM test;", result);
         const int64_t id = SToInt64(result[0][0]);
+
+        leader.executeWaitVerifyContent(SData("idcollision"));
 
         // Both nodes have it before we start.
         ASSERT_EQUAL(countRowsWithID(leader, id), 1);

--- a/test/tests/WriteLocalUnreplicatedTest.cpp
+++ b/test/tests/WriteLocalUnreplicatedTest.cpp
@@ -1,3 +1,4 @@
+#include <thread>
 #include <unistd.h>
 
 #include <libstuff/libstuff.h>
@@ -24,7 +25,8 @@ struct WriteLocalUnreplicatedTest : tpunit::TestFixture
     WriteLocalUnreplicatedTest()
         : tpunit::TestFixture("WriteLocalUnreplicated",
                               TEST(WriteLocalUnreplicatedTest::leavesCommitCountAndJournalUntouched),
-                              TEST(WriteLocalUnreplicatedTest::rollsBackOnFailedQuery))
+                              TEST(WriteLocalUnreplicatedTest::rollsBackOnFailedQuery),
+                              TEST(WriteLocalUnreplicatedTest::survivesConcurrentCommits))
     {
     }
 
@@ -95,4 +97,50 @@ struct WriteLocalUnreplicatedTest : tpunit::TestFixture
         ASSERT_EQUAL(countRows(db), 0);
     }
 
+    void survivesConcurrentCommits()
+    {
+        WriteLocalUnreplicatedTempDBFile dbFile;
+        SQLite db(dbFile.filename, 1000, 1000, 1);
+        SQLite committer(db);
+
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+        db.write("CREATE TABLE testTable(id INTEGER PRIMARY KEY, value INTEGER);");
+        db.write("CREATE TABLE unreplicatedTable(id INTEGER PRIMARY KEY, value INTEGER);");
+        db.prepare();
+        ASSERT_EQUAL(db.commit(), SQLITE_OK);
+
+        // Commit on one handle while the other runs unreplicated writes. A commit that lands mid-write makes the
+        // COMMIT return SQLITE_BUSY_SNAPSHOT, which must come back as `false` rather than throwing or corrupting the
+        // handle. Whether that race actually happens on any given run is not guaranteed, so this asserts the outcome
+        // is always well formed rather than asserting a conflict occurred.
+        atomic<bool> stop(false);
+        thread committerThread([&]() {
+            int id = 0;
+            while (!stop) {
+                committer.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+                committer.write("INSERT INTO testTable VALUES(" + SToStr(++id) + ", 1);");
+                committer.prepare();
+                if (committer.commit() != SQLITE_OK) {
+                    committer.rollback();
+                }
+            }
+        });
+
+        int64_t succeeded = 0;
+        for (int i = 1; i <= 200; i++) {
+            if (db.writeLocalUnreplicated("INSERT INTO unreplicatedTable VALUES(" + SToStr(i) + ", 1);")) {
+                succeeded++;
+            }
+        }
+
+        stop = true;
+        committerThread.join();
+
+        // Every write that reported success is present, and no write that reported failure left anything behind.
+        SQResult result;
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED);
+        db.read("SELECT COUNT(*) FROM unreplicatedTable;", result);
+        db.rollback();
+        ASSERT_EQUAL(SToInt64(result[0][0]), succeeded);
+    }
 } __WriteLocalUnreplicatedTest;

--- a/test/tests/WriteLocalUnreplicatedTest.cpp
+++ b/test/tests/WriteLocalUnreplicatedTest.cpp
@@ -23,7 +23,8 @@ struct WriteLocalUnreplicatedTest : tpunit::TestFixture
 {
     WriteLocalUnreplicatedTest()
         : tpunit::TestFixture("WriteLocalUnreplicated",
-                              TEST(WriteLocalUnreplicatedTest::leavesCommitCountAndJournalUntouched))
+                              TEST(WriteLocalUnreplicatedTest::leavesCommitCountAndJournalUntouched),
+                              TEST(WriteLocalUnreplicatedTest::rollsBackOnFailedQuery))
     {
     }
 
@@ -68,6 +69,30 @@ struct WriteLocalUnreplicatedTest : tpunit::TestFixture
         // But nothing about it was recorded as a commit, so there is nothing to ship to a peer.
         ASSERT_EQUAL(db.getCommitCount(), commitCountBefore);
         ASSERT_EQUAL(countJournalRows(db), journalRowsBefore);
+    }
+
+    void rollsBackOnFailedQuery()
+    {
+        WriteLocalUnreplicatedTempDBFile dbFile;
+        SQLite db(dbFile.filename, 1000, 1000, 1);
+
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+        db.write("CREATE TABLE testTable(id INTEGER PRIMARY KEY, value INTEGER);");
+        db.prepare();
+        ASSERT_EQUAL(db.commit(), SQLITE_OK);
+
+        ASSERT_FALSE(db.writeLocalUnreplicated("DELETE FROM aTableThatDoesNotExist;"));
+
+        // The failed call must not leave the handle stuck inside its transaction, so a normal commit still works.
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+        db.write("INSERT INTO testTable VALUES(1, 1);");
+        db.prepare();
+        ASSERT_EQUAL(db.commit(), SQLITE_OK);
+        ASSERT_EQUAL(countRows(db), 1);
+
+        // And a later unreplicated write on the same handle still works.
+        ASSERT_TRUE(db.writeLocalUnreplicated("DELETE FROM testTable WHERE id = 1;"));
+        ASSERT_EQUAL(countRows(db), 0);
     }
 
 } __WriteLocalUnreplicatedTest;

--- a/test/tests/WriteLocalUnreplicatedTest.cpp
+++ b/test/tests/WriteLocalUnreplicatedTest.cpp
@@ -1,0 +1,73 @@
+#include <unistd.h>
+
+#include <libstuff/libstuff.h>
+#include <sqlitecluster/SQLite.h>
+#include <test/lib/BedrockTester.h>
+
+struct WriteLocalUnreplicatedTempDBFile
+{
+    char filename[17] = "br_wlu_dbXXXXXXX";
+    WriteLocalUnreplicatedTempDBFile()
+    {
+        int fd = mkstemp(filename);
+        close(fd);
+    }
+
+    ~WriteLocalUnreplicatedTempDBFile()
+    {
+        unlink(filename);
+    }
+};
+
+struct WriteLocalUnreplicatedTest : tpunit::TestFixture
+{
+    WriteLocalUnreplicatedTest()
+        : tpunit::TestFixture("WriteLocalUnreplicated",
+                              TEST(WriteLocalUnreplicatedTest::leavesCommitCountAndJournalUntouched))
+    {
+    }
+
+    // The test DBs below are built with minJournalTables = 1, which creates exactly these three.
+    int64_t countJournalRows(SQLite& db)
+    {
+        SQResult result;
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED);
+        db.read("SELECT (SELECT COUNT(*) FROM journal) + (SELECT COUNT(*) FROM journal0000) + (SELECT COUNT(*) FROM journal0001);", result);
+        db.rollback();
+        return SToInt64(result[0][0]);
+    }
+
+    int64_t countRows(SQLite& db)
+    {
+        SQResult result;
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED);
+        db.read("SELECT COUNT(*) FROM testTable;", result);
+        db.rollback();
+        return SToInt64(result[0][0]);
+    }
+
+    void leavesCommitCountAndJournalUntouched()
+    {
+        WriteLocalUnreplicatedTempDBFile dbFile;
+        SQLite db(dbFile.filename, 1000, 1000, 1);
+
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+        db.write("CREATE TABLE testTable(id INTEGER PRIMARY KEY, value INTEGER);");
+        db.write("INSERT INTO testTable VALUES(1, 1);");
+        db.prepare();
+        ASSERT_EQUAL(db.commit(), SQLITE_OK);
+
+        const uint64_t commitCountBefore = db.getCommitCount();
+        const int64_t journalRowsBefore = countJournalRows(db);
+
+        ASSERT_TRUE(db.writeLocalUnreplicated("DELETE FROM testTable WHERE id = 1;"));
+
+        // The row is really gone from this node's database.
+        ASSERT_EQUAL(countRows(db), 0);
+
+        // But nothing about it was recorded as a commit, so there is nothing to ship to a peer.
+        ASSERT_EQUAL(db.getCommitCount(), commitCountBefore);
+        ASSERT_EQUAL(countJournalRows(db), journalRowsBefore);
+    }
+
+} __WriteLocalUnreplicatedTest;


### PR DESCRIPTION
### Details

Adds `SQLite::writeLocalUnreplicated`, a write that runs in its own transaction and is neither journaled nor replicated.

This commits without the commit lock. It's intended to be used to delete journal entries, which is not expected to conflict on deletion. The function will return a true in case it succeeded, false if it failed, and the caller will need to decide what to do if it did fail.

It also uses `BEGIN CONCURRENT` / query / `COMMIT` via raw `SQuery`, so it never touches `_insideTransaction`, `_uncommittedQuery`, `_uncommittedHash`, `commitCount`, or the journal.

2/4 PRs to allow unreplicated deletes on nodes. 



### Fixed Issues
For https://github.com/Expensify/Expensify/issues/671183

### Tests

New automated tests.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
