### PR TITLE
Add different error messages for user vs command triggered 503

### DIFF
--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -23,14 +23,14 @@ uint64_t BedrockBlockingCommandQueue::_now() const
 
 void BedrockBlockingCommandQueue::push(unique_ptr<BedrockCommand>&& command)
 {
-    const char* dimension = _getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
-    if (dimension) {
+    const string dimension = _getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
+    if (!dimension.empty()) {
         SINFO("Blocking queue rate limited command rejected", {
             {"dimension", dimension},
             {"identifier", command->blockingQueueRateLimitIdentifier},
             {"command", command->request.methodLine}
         });
-        STHROW("503 Blocking queue rate limited (" + string(dimension) + ")");
+        STHROW("503 Blocking queue rate limited (" + dimension + ")");
     }
 
     // Base class acquires its own `_queueMutex`.
@@ -42,14 +42,14 @@ unique_ptr<BedrockCommand> BedrockBlockingCommandQueue::_dequeue()
     auto command = BedrockCommandQueue::_dequeue();
 
     // Marking it complete skips processing in `BedrockServer::runCommand`, which replies to already-complete commands.
-    const char* dimension = _getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
-    if (dimension) {
+    const string dimension = _getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
+    if (!dimension.empty()) {
         SINFO("Blocking queue rate limited command rejected", {
             {"dimension", dimension},
             {"identifier", command->blockingQueueRateLimitIdentifier},
             {"command", command->request.methodLine}
         });
-        command->response.methodLine = "503 Blocking queue rate limited (" + string(dimension) + ")";
+        command->response.methodLine = "503 Blocking queue rate limited (" + dimension + ")";
         command->complete = true;
     }
 
@@ -142,10 +142,10 @@ void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, 
 
 bool BedrockBlockingCommandQueue::isBlocked(const string& identifier, const string& commandName)
 {
-    return _getBlockingDimension(identifier, commandName);
+    return !_getBlockingDimension(identifier, commandName).empty();
 }
 
-const char* BedrockBlockingCommandQueue::_getBlockingDimension(const string& identifier, const string& commandName)
+string BedrockBlockingCommandQueue::_getBlockingDimension(const string& identifier, const string& commandName)
 {
     // Hot path: called by push() and by _dequeue() under the base `_queueMutex`. Keep it O(1) by reading only
     // the precomputed block deadline. The windowed time is summed in recordExecutionTime, off the blocking thread.
@@ -156,7 +156,7 @@ const char* BedrockBlockingCommandQueue::_getBlockingDimension(const string& ide
     if (_isBlocked(_commandStates, commandName, now)) {
         return "command";
     }
-    return nullptr;
+    return "";
 }
 
 shared_ptr<BedrockBlockingCommandQueue::IdentifierState> BedrockBlockingCommandQueue::_getOrCreateState(StateMap& map, const string& key)

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -140,11 +140,6 @@ void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, 
     _recordAndCheck(_commandStates, commandName, _commandThresholdUS.load(), now, elapsedUS, "command");
 }
 
-bool BedrockBlockingCommandQueue::isBlocked(const string& identifier, const string& commandName)
-{
-    return !_getBlockingDimension(identifier, commandName).empty();
-}
-
 string BedrockBlockingCommandQueue::_getBlockingDimension(const string& identifier, const string& commandName)
 {
     // Hot path: called by push() and by _dequeue() under the base `_queueMutex`. Keep it O(1) by reading only

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -23,8 +23,15 @@ uint64_t BedrockBlockingCommandQueue::_now() const
 
 void BedrockBlockingCommandQueue::push(unique_ptr<BedrockCommand>&& command)
 {
-    if (isBlocked(command->blockingQueueRateLimitIdentifier, command->request.methodLine)) {
-        STHROW("503 Blocking queue rate limited (time)");
+    const BlockingDimension blockedDimension = _getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
+    if (blockedDimension != BlockingDimension::NONE) {
+        const string dimension = _getBlockingDimensionName(blockedDimension);
+        SINFO("Blocking queue rate limited command rejected", {
+            {"dimension", dimension},
+            {"identifier", command->blockingQueueRateLimitIdentifier},
+            {"command", command->request.methodLine}
+        });
+        STHROW(_getRateLimitMessage(blockedDimension));
     }
 
     // Base class acquires its own `_queueMutex`.
@@ -36,8 +43,15 @@ unique_ptr<BedrockCommand> BedrockBlockingCommandQueue::_dequeue()
     auto command = BedrockCommandQueue::_dequeue();
 
     // Marking it complete skips processing in `BedrockServer::runCommand`, which replies to already-complete commands.
-    if (isBlocked(command->blockingQueueRateLimitIdentifier, command->request.methodLine)) {
-        command->response.methodLine = "503 Blocking queue rate limited (time)";
+    const BlockingDimension blockedDimension = _getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
+    if (blockedDimension != BlockingDimension::NONE) {
+        const string dimension = _getBlockingDimensionName(blockedDimension);
+        SINFO("Blocking queue rate limited command rejected", {
+            {"dimension", dimension},
+            {"identifier", command->blockingQueueRateLimitIdentifier},
+            {"command", command->request.methodLine}
+        });
+        command->response.methodLine = _getRateLimitMessage(blockedDimension);
         command->complete = true;
     }
 
@@ -130,10 +144,41 @@ void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, 
 
 bool BedrockBlockingCommandQueue::isBlocked(const string& identifier, const string& commandName)
 {
+    return _getBlockingDimension(identifier, commandName) != BlockingDimension::NONE;
+}
+
+BedrockBlockingCommandQueue::BlockingDimension BedrockBlockingCommandQueue::_getBlockingDimension(const string& identifier, const string& commandName)
+{
     // Hot path: called by push() and by _dequeue() under the base `_queueMutex`. Keep it O(1) by reading only
     // the precomputed block deadline. The windowed time is summed in recordExecutionTime, off the blocking thread.
     const uint64_t now = _now();
-    return _isBlocked(_identifierStates, identifier, now) || _isBlocked(_commandStates, commandName, now);
+    if (_isBlocked(_identifierStates, identifier, now)) {
+        return BlockingDimension::IDENTIFIER;
+    }
+    if (_isBlocked(_commandStates, commandName, now)) {
+        return BlockingDimension::COMMAND;
+    }
+    return BlockingDimension::NONE;
+}
+
+const char* BedrockBlockingCommandQueue::_getBlockingDimensionName(BlockingDimension dimension)
+{
+    switch (dimension) {
+        case BlockingDimension::IDENTIFIER:
+            return "identifier";
+
+        case BlockingDimension::COMMAND:
+            return "command";
+
+        case BlockingDimension::NONE:
+        default:
+            return "time";
+    }
+}
+
+string BedrockBlockingCommandQueue::_getRateLimitMessage(BlockingDimension dimension)
+{
+    return "503 Blocking queue rate limited (" + string(_getBlockingDimensionName(dimension)) + ")";
 }
 
 shared_ptr<BedrockBlockingCommandQueue::IdentifierState> BedrockBlockingCommandQueue::_getOrCreateState(StateMap& map, const string& key)

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -23,7 +23,7 @@ uint64_t BedrockBlockingCommandQueue::_now() const
 
 void BedrockBlockingCommandQueue::push(unique_ptr<BedrockCommand>&& command)
 {
-    const string dimension = _getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
+    const string dimension = getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
     if (!dimension.empty()) {
         SINFO("Blocking queue rate limited command rejected", {
             {"dimension", dimension},
@@ -42,7 +42,7 @@ unique_ptr<BedrockCommand> BedrockBlockingCommandQueue::_dequeue()
     auto command = BedrockCommandQueue::_dequeue();
 
     // Marking it complete skips processing in `BedrockServer::runCommand`, which replies to already-complete commands.
-    const string dimension = _getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
+    const string dimension = getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
     if (!dimension.empty()) {
         SINFO("Blocking queue rate limited command rejected", {
             {"dimension", dimension},
@@ -140,7 +140,7 @@ void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, 
     _recordAndCheck(_commandStates, commandName, _commandThresholdUS.load(), now, elapsedUS, "command");
 }
 
-string BedrockBlockingCommandQueue::_getBlockingDimension(const string& identifier, const string& commandName)
+string BedrockBlockingCommandQueue::getBlockingDimension(const string& identifier, const string& commandName)
 {
     // Hot path: called by push() and by _dequeue() under the base `_queueMutex`. Keep it O(1) by reading only
     // the precomputed block deadline. The windowed time is summed in recordExecutionTime, off the blocking thread.

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -23,15 +23,14 @@ uint64_t BedrockBlockingCommandQueue::_now() const
 
 void BedrockBlockingCommandQueue::push(unique_ptr<BedrockCommand>&& command)
 {
-    const BlockingDimension blockedDimension = _getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
-    if (blockedDimension != BlockingDimension::NONE) {
-        const string dimension = _getBlockingDimensionName(blockedDimension);
+    const char* dimension = _getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
+    if (dimension) {
         SINFO("Blocking queue rate limited command rejected", {
             {"dimension", dimension},
             {"identifier", command->blockingQueueRateLimitIdentifier},
             {"command", command->request.methodLine}
         });
-        STHROW(_getRateLimitMessage(blockedDimension));
+        STHROW("503 Blocking queue rate limited (" + string(dimension) + ")");
     }
 
     // Base class acquires its own `_queueMutex`.
@@ -43,15 +42,14 @@ unique_ptr<BedrockCommand> BedrockBlockingCommandQueue::_dequeue()
     auto command = BedrockCommandQueue::_dequeue();
 
     // Marking it complete skips processing in `BedrockServer::runCommand`, which replies to already-complete commands.
-    const BlockingDimension blockedDimension = _getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
-    if (blockedDimension != BlockingDimension::NONE) {
-        const string dimension = _getBlockingDimensionName(blockedDimension);
+    const char* dimension = _getBlockingDimension(command->blockingQueueRateLimitIdentifier, command->request.methodLine);
+    if (dimension) {
         SINFO("Blocking queue rate limited command rejected", {
             {"dimension", dimension},
             {"identifier", command->blockingQueueRateLimitIdentifier},
             {"command", command->request.methodLine}
         });
-        command->response.methodLine = _getRateLimitMessage(blockedDimension);
+        command->response.methodLine = "503 Blocking queue rate limited (" + string(dimension) + ")";
         command->complete = true;
     }
 
@@ -144,41 +142,21 @@ void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, 
 
 bool BedrockBlockingCommandQueue::isBlocked(const string& identifier, const string& commandName)
 {
-    return _getBlockingDimension(identifier, commandName) != BlockingDimension::NONE;
+    return _getBlockingDimension(identifier, commandName);
 }
 
-BedrockBlockingCommandQueue::BlockingDimension BedrockBlockingCommandQueue::_getBlockingDimension(const string& identifier, const string& commandName)
+const char* BedrockBlockingCommandQueue::_getBlockingDimension(const string& identifier, const string& commandName)
 {
     // Hot path: called by push() and by _dequeue() under the base `_queueMutex`. Keep it O(1) by reading only
     // the precomputed block deadline. The windowed time is summed in recordExecutionTime, off the blocking thread.
     const uint64_t now = _now();
     if (_isBlocked(_identifierStates, identifier, now)) {
-        return BlockingDimension::IDENTIFIER;
+        return "identifier";
     }
     if (_isBlocked(_commandStates, commandName, now)) {
-        return BlockingDimension::COMMAND;
+        return "command";
     }
-    return BlockingDimension::NONE;
-}
-
-const char* BedrockBlockingCommandQueue::_getBlockingDimensionName(BlockingDimension dimension)
-{
-    switch (dimension) {
-        case BlockingDimension::IDENTIFIER:
-            return "identifier";
-
-        case BlockingDimension::COMMAND:
-            return "command";
-
-        case BlockingDimension::NONE:
-        default:
-            return "time";
-    }
-}
-
-string BedrockBlockingCommandQueue::_getRateLimitMessage(BlockingDimension dimension)
-{
-    return "503 Blocking queue rate limited (" + string(_getBlockingDimensionName(dimension)) + ")";
+    return nullptr;
 }
 
 shared_ptr<BedrockBlockingCommandQueue::IdentifierState> BedrockBlockingCommandQueue::_getOrCreateState(StateMap& map, const string& key)

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -40,7 +40,7 @@ public:
     void recordExecutionTime(const string& identifier, const string& commandName, uint64_t elapsedUS);
 
     // Return the active rate-limit dimension, or an empty string. Identifier blocks take precedence when both dimensions are active.
-    string _getBlockingDimension(const string& identifier, const string& commandName);
+    string getBlockingDimension(const string& identifier, const string& commandName);
 
 protected:
     // Dequeues a command and rejects it if its identifier or command name is rate limited.

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -99,8 +99,8 @@ private:
     // push and dequeue hot paths stay cheap (dequeue runs under the base `_queueMutex`).
     static bool _isBlocked(StateMap& map, const string& key, uint64_t now);
 
-    // Return the active rate-limit dimension. Identifier blocks take precedence when both dimensions are active.
-    const char* _getBlockingDimension(const string& identifier, const string& commandName);
+    // Return the active rate-limit dimension, or an empty string. Identifier blocks take precedence when both dimensions are active.
+    string _getBlockingDimension(const string& identifier, const string& commandName);
 
     // Log (without blocking) when an identifier's windowed time crosses this, for monitoring heavy identifiers
     // that are still under their block threshold.

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -53,6 +53,13 @@ protected:
     virtual uint64_t _now() const;
 
 private:
+    enum class BlockingDimension
+    {
+        NONE,
+        IDENTIFIER,
+        COMMAND
+    };
+
     // A command that finished on the blocking queue. Both times are in microseconds.
     struct RecentlyFinishedCommand
     {
@@ -98,6 +105,12 @@ private:
     // True if `key` in `map` is inside an active block at `now`. O(1): reads only the block deadline, so the
     // push and dequeue hot paths stay cheap (dequeue runs under the base `_queueMutex`).
     static bool _isBlocked(StateMap& map, const string& key, uint64_t now);
+
+    // Return the active rate-limit dimension. Identifier blocks take precedence when both dimensions are active.
+    BlockingDimension _getBlockingDimension(const string& identifier, const string& commandName);
+
+    static const char* _getBlockingDimensionName(BlockingDimension dimension);
+    static string _getRateLimitMessage(BlockingDimension dimension);
 
     // Log (without blocking) when an identifier's windowed time crosses this, for monitoring heavy identifiers
     // that are still under their block threshold.

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -53,13 +53,6 @@ protected:
     virtual uint64_t _now() const;
 
 private:
-    enum class BlockingDimension
-    {
-        NONE,
-        IDENTIFIER,
-        COMMAND
-    };
-
     // A command that finished on the blocking queue. Both times are in microseconds.
     struct RecentlyFinishedCommand
     {
@@ -107,10 +100,7 @@ private:
     static bool _isBlocked(StateMap& map, const string& key, uint64_t now);
 
     // Return the active rate-limit dimension. Identifier blocks take precedence when both dimensions are active.
-    BlockingDimension _getBlockingDimension(const string& identifier, const string& commandName);
-
-    static const char* _getBlockingDimensionName(BlockingDimension dimension);
-    static string _getRateLimitMessage(BlockingDimension dimension);
+    const char* _getBlockingDimension(const string& identifier, const string& commandName);
 
     // Log (without blocking) when an identifier's windowed time crosses this, for monitoring heavy identifiers
     // that are still under their block threshold.

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -39,10 +39,8 @@ public:
     // sample against the identifier (when `identifier` is non-empty) and against the command name.
     void recordExecutionTime(const string& identifier, const string& commandName, uint64_t elapsedUS);
 
-    // True if `identifier` or `commandName` is over its blocking-queue time limit within the window, or is
-    // still inside an active block. When a dimension newly trips, it is blocked for the block duration.
-    // Logs a "Blocking queue rate limit" line when a dimension blocks.
-    bool isBlocked(const string& identifier, const string& commandName);
+    // Return the active rate-limit dimension, or an empty string. Identifier blocks take precedence when both dimensions are active.
+    string _getBlockingDimension(const string& identifier, const string& commandName);
 
 protected:
     // Dequeues a command and rejects it if its identifier or command name is rate limited.
@@ -98,9 +96,6 @@ private:
     // True if `key` in `map` is inside an active block at `now`. O(1): reads only the block deadline, so the
     // push and dequeue hot paths stay cheap (dequeue runs under the base `_queueMutex`).
     static bool _isBlocked(StateMap& map, const string& key, uint64_t now);
-
-    // Return the active rate-limit dimension, or an empty string. Identifier blocks take precedence when both dimensions are active.
-    string _getBlockingDimension(const string& identifier, const string& commandName);
 
     // Log (without blocking) when an identifier's windowed time crosses this, for monitoring heavy identifiers
     // that are still under their block threshold.

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -2,7 +2,7 @@
 #include <test/lib/tpunit++.hpp>
 
 // A queue whose clock the test controls, so window and block behavior is deterministic. All times below are
-// microseconds. The tests drive the public API only (record + isBlocked + the setters).
+// microseconds. The tests drive the public API and control the clock.
 struct TestBlockingCommandQueue : public BedrockBlockingCommandQueue
 {
     static unique_ptr<BedrockCommand> makeCommand(const string& identifier, const string& commandName)
@@ -56,10 +56,10 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 30);
-        ASSERT_FALSE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
 
         queue.recordExecutionTime("acct1", "cmd", 30);
-        ASSERT_TRUE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "identifier");
     }
 
     void testUnderThresholdNotBlocked()
@@ -71,7 +71,7 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 40);
-        ASSERT_FALSE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
     }
 
     void testIdentifiersAreIndependent()
@@ -83,8 +83,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
-        ASSERT_TRUE(queue.isBlocked("acct1", "cmd"));
-        ASSERT_FALSE(queue.isBlocked("acct2", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "identifier");
+        ASSERT_EQUAL(queue._getBlockingDimension("acct2", "cmd"), "");
     }
 
     void testCommandDimensionIgnoresIdentifier()
@@ -97,9 +97,9 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
-        ASSERT_TRUE(queue.isBlocked("acct1", "cmd"));
-        ASSERT_TRUE(queue.isBlocked("acct2", "cmd"));
-        ASSERT_FALSE(queue.isBlocked("acct1", "otherCmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "command");
+        ASSERT_EQUAL(queue._getBlockingDimension("acct2", "cmd"), "command");
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "otherCmd"), "");
     }
 
     void testPushReportsRateLimitDimensions()
@@ -185,7 +185,7 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("", "cmd", 60);
-        ASSERT_TRUE(queue.isBlocked("", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("", "cmd"), "command");
     }
 
     void testWindowExpiry()
@@ -200,13 +200,13 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
 
         // One 40us sample, under the 50us threshold on its own.
         queue.recordExecutionTime("acct1", "cmd", 40);
-        ASSERT_FALSE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
 
         // A full window later, record another 40us. The first has aged out, so the window holds only 40us
         // (< 50). If it still counted, the two would sum to 80 and block.
         queue.setNow(1150);
         queue.recordExecutionTime("acct1", "cmd", 40);
-        ASSERT_FALSE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
     }
 
     void testPartialCredit()
@@ -221,13 +221,13 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
 
         // 30us sample, under the 35us threshold.
         queue.recordExecutionTime("acct1", "cmd", 30);
-        ASSERT_FALSE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
 
         // 80us later, only window - age = 100 - 80 = 20us of the first sample still counts. With a new 10us
         // sample the window holds 20 + 10 = 30us (< 35). Counting the full 30 + 10 = 40 would block.
         queue.setNow(1080);
         queue.recordExecutionTime("acct1", "cmd", 10);
-        ASSERT_FALSE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
     }
 
     void testBlockDurationHoldsThenClears()
@@ -240,15 +240,15 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
-        ASSERT_TRUE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "identifier");
 
         // The sample has aged out of the window, but the block still holds for its fixed duration.
         queue.setNow(1200);
-        ASSERT_TRUE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "identifier");
 
         // After the block duration, with nothing left in the window, it clears.
         queue.setNow(1600);
-        ASSERT_FALSE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
     }
 
     void testDisabledThresholdsNeverBlock()
@@ -260,7 +260,7 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 1000000);
-        ASSERT_FALSE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
     }
 
     void testClearResets()
@@ -273,9 +273,9 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
-        ASSERT_TRUE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "identifier");
 
         queue.clearRateLimits();
-        ASSERT_FALSE(queue.isBlocked("acct1", "cmd"));
+        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
     }
 } __BlockingCommandQueueTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -5,6 +5,14 @@
 // microseconds. The tests drive the public API only (record + isBlocked + the setters).
 struct TestBlockingCommandQueue : public BedrockBlockingCommandQueue
 {
+    static unique_ptr<BedrockCommand> makeCommand(const string& identifier, const string& commandName)
+    {
+        SData request(commandName);
+        auto command = make_unique<BedrockCommand>(SQLiteCommand(move(request)), nullptr);
+        command->blockingQueueRateLimitIdentifier = identifier;
+        return command;
+    }
+
     void setNow(uint64_t now)
     {
         _testNow = now;
@@ -27,6 +35,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
                                                      TEST(BlockingCommandQueueTest::testUnderThresholdNotBlocked),
                                                      TEST(BlockingCommandQueueTest::testIdentifiersAreIndependent),
                                                      TEST(BlockingCommandQueueTest::testCommandDimensionIgnoresIdentifier),
+                                                     TEST(BlockingCommandQueueTest::testPushReportsRateLimitDimensions),
+                                                     TEST(BlockingCommandQueueTest::testDequeueReportsRateLimitDimensions),
                                                      TEST(BlockingCommandQueueTest::testEmptyIdentifierSkipsIdentifierDimension),
                                                      TEST(BlockingCommandQueueTest::testWindowExpiry),
                                                      TEST(BlockingCommandQueueTest::testPartialCredit),
@@ -90,6 +100,79 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         ASSERT_TRUE(queue.isBlocked("acct1", "cmd"));
         ASSERT_TRUE(queue.isBlocked("acct2", "cmd"));
         ASSERT_FALSE(queue.isBlocked("acct1", "otherCmd"));
+    }
+
+    void testPushReportsRateLimitDimensions()
+    {
+        TestBlockingCommandQueue identifierQueue;
+        identifierQueue.setIdentifierThreshold(50);
+        identifierQueue.setCommandThreshold(0);
+        identifierQueue.setNow(1000);
+        identifierQueue.recordExecutionTime("acct1", "cmd", 60);
+
+        bool identifierRejected = false;
+        try {
+            identifierQueue.push(identifierQueue.makeCommand("acct1", "cmd"));
+        } catch (const SException& e) {
+            identifierRejected = true;
+            ASSERT_EQUAL(string(e.what()), "503 Blocking queue rate limited (identifier)");
+        }
+        ASSERT_TRUE(identifierRejected);
+
+        TestBlockingCommandQueue commandQueue;
+        commandQueue.setIdentifierThreshold(0);
+        commandQueue.setCommandThreshold(50);
+        commandQueue.setNow(1000);
+        commandQueue.recordExecutionTime("acct1", "cmd", 60);
+
+        bool commandRejected = false;
+        try {
+            commandQueue.push(commandQueue.makeCommand("acct2", "cmd"));
+        } catch (const SException& e) {
+            commandRejected = true;
+            ASSERT_EQUAL(string(e.what()), "503 Blocking queue rate limited (command)");
+        }
+        ASSERT_TRUE(commandRejected);
+
+        TestBlockingCommandQueue bothDimensionsQueue;
+        bothDimensionsQueue.setIdentifierThreshold(50);
+        bothDimensionsQueue.setCommandThreshold(50);
+        bothDimensionsQueue.setNow(1000);
+        bothDimensionsQueue.recordExecutionTime("acct1", "cmd", 60);
+
+        bool bothDimensionsRejected = false;
+        try {
+            bothDimensionsQueue.push(bothDimensionsQueue.makeCommand("acct1", "cmd"));
+        } catch (const SException& e) {
+            bothDimensionsRejected = true;
+            ASSERT_EQUAL(string(e.what()), "503 Blocking queue rate limited (identifier)");
+        }
+        ASSERT_TRUE(bothDimensionsRejected);
+    }
+
+    void testDequeueReportsRateLimitDimensions()
+    {
+        TestBlockingCommandQueue identifierQueue;
+        identifierQueue.setIdentifierThreshold(50);
+        identifierQueue.setCommandThreshold(0);
+        identifierQueue.setNow(1000);
+        identifierQueue.push(identifierQueue.makeCommand("acct1", "cmd"));
+        identifierQueue.recordExecutionTime("acct1", "cmd", 60);
+
+        auto identifierCommand = identifierQueue.get(1'000'000);
+        ASSERT_TRUE(identifierCommand->complete);
+        ASSERT_EQUAL(identifierCommand->response.methodLine, "503 Blocking queue rate limited (identifier)");
+
+        TestBlockingCommandQueue commandQueue;
+        commandQueue.setIdentifierThreshold(0);
+        commandQueue.setCommandThreshold(50);
+        commandQueue.setNow(1000);
+        commandQueue.push(commandQueue.makeCommand("acct2", "cmd"));
+        commandQueue.recordExecutionTime("acct1", "cmd", 60);
+
+        auto command = commandQueue.get(1'000'000);
+        ASSERT_TRUE(command->complete);
+        ASSERT_EQUAL(command->response.methodLine, "503 Blocking queue rate limited (command)");
     }
 
     void testEmptyIdentifierSkipsIdentifierDimension()

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -56,10 +56,10 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 30);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
 
         queue.recordExecutionTime("acct1", "cmd", 30);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "identifier");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "identifier");
     }
 
     void testUnderThresholdNotBlocked()
@@ -71,7 +71,7 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 40);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
     }
 
     void testIdentifiersAreIndependent()
@@ -83,8 +83,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "identifier");
-        ASSERT_EQUAL(queue._getBlockingDimension("acct2", "cmd"), "");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "identifier");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct2", "cmd"), "");
     }
 
     void testCommandDimensionIgnoresIdentifier()
@@ -97,9 +97,9 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "command");
-        ASSERT_EQUAL(queue._getBlockingDimension("acct2", "cmd"), "command");
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "otherCmd"), "");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "command");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct2", "cmd"), "command");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "otherCmd"), "");
     }
 
     void testPushReportsRateLimitDimensions()
@@ -185,7 +185,7 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("", "cmd", 60);
-        ASSERT_EQUAL(queue._getBlockingDimension("", "cmd"), "command");
+        ASSERT_EQUAL(queue.getBlockingDimension("", "cmd"), "command");
     }
 
     void testWindowExpiry()
@@ -200,13 +200,13 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
 
         // One 40us sample, under the 50us threshold on its own.
         queue.recordExecutionTime("acct1", "cmd", 40);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
 
         // A full window later, record another 40us. The first has aged out, so the window holds only 40us
         // (< 50). If it still counted, the two would sum to 80 and block.
         queue.setNow(1150);
         queue.recordExecutionTime("acct1", "cmd", 40);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
     }
 
     void testPartialCredit()
@@ -221,13 +221,13 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
 
         // 30us sample, under the 35us threshold.
         queue.recordExecutionTime("acct1", "cmd", 30);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
 
         // 80us later, only window - age = 100 - 80 = 20us of the first sample still counts. With a new 10us
         // sample the window holds 20 + 10 = 30us (< 35). Counting the full 30 + 10 = 40 would block.
         queue.setNow(1080);
         queue.recordExecutionTime("acct1", "cmd", 10);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
     }
 
     void testBlockDurationHoldsThenClears()
@@ -240,15 +240,15 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "identifier");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "identifier");
 
         // The sample has aged out of the window, but the block still holds for its fixed duration.
         queue.setNow(1200);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "identifier");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "identifier");
 
         // After the block duration, with nothing left in the window, it clears.
         queue.setNow(1600);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
     }
 
     void testDisabledThresholdsNeverBlock()
@@ -260,7 +260,7 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 1000000);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
     }
 
     void testClearResets()
@@ -273,9 +273,9 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "identifier");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "identifier");
 
         queue.clearRateLimits();
-        ASSERT_EQUAL(queue._getBlockingDimension("acct1", "cmd"), "");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
     }
 } __BlockingCommandQueueTest;


### PR DESCRIPTION
### Details

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/673310

### Tests
Auto
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
