### PR TITLE
Tag compress()/decompress() as SQLITE_INNOCUOUS

### DIFF
--- a/plugins/Compression.cpp
+++ b/plugins/Compression.cpp
@@ -42,6 +42,7 @@ void BedrockPlugin_Compression::initializeFromDB(SQLite& db)
 
 void BedrockPlugin_Compression::upgradeDatabase(SQLite& db)
 {
+    // Beware: rows in this table are write-once. See the warning in Compression.h.
     bool created;
     SASSERT(db.verifyTable("zstdDictionaries",
         "CREATE TABLE zstdDictionaries ("
@@ -70,6 +71,8 @@ ZSTD_DDict* BedrockPlugin_Compression::getDecompressionDictionary(size_t id)
     return nullptr;
 }
 
+// Beware: dictionaries are immutable. See the warning in Compression.h — changing an existing dictionary
+// corrupts both the data compressed against it and any index built on decompress().
 void BedrockPlugin_Compression::loadDictionariesFromDB(SQLite& db)
 {
     SQResult result;

--- a/plugins/Compression.cpp
+++ b/plugins/Compression.cpp
@@ -257,9 +257,14 @@ static void sqliteDecompress(sqlite3_context* ctx, int argc, sqlite3_value** arg
 
 void BedrockPlugin_Compression::registerSQLite(sqlite3* db)
 {
-    sqlite3_create_function_v2(db, "compress", 2, SQLITE_UTF8 | SQLITE_DETERMINISTIC,
+    // SQLITE_INNOCUOUS: neither function has side effects, which SQLite requires before it will allow them in a
+    // schema object (index expressions, generated columns, etc.) while trusted_schema is off.
+    // SQLITE_DETERMINISTIC: both functions return the same result for the same arguments, which SQLite requires
+    // before it will use an index built on them. This holds only because dictionaries are immutable — see the
+    // warning on loadDictionariesFromDB().
+    sqlite3_create_function_v2(db, "compress", 2, SQLITE_UTF8 | SQLITE_DETERMINISTIC | SQLITE_INNOCUOUS,
                                nullptr, ::sqliteCompress, nullptr, nullptr, nullptr);
-    sqlite3_create_function_v2(db, "decompress", 1, SQLITE_UTF8 | SQLITE_DETERMINISTIC,
+    sqlite3_create_function_v2(db, "decompress", 1, SQLITE_UTF8 | SQLITE_DETERMINISTIC | SQLITE_INNOCUOUS,
                                nullptr, ::sqliteDecompress, nullptr, nullptr, nullptr);
 }
 

--- a/plugins/Compression.h
+++ b/plugins/Compression.h
@@ -25,6 +25,11 @@ public:
 
     // Loads all dictionaries from the zstdDictionaries table into compiled in-memory maps.
     // Called once at startup from the sync thread, before any queries run.
+    //
+    // Beware: dictionaries are immutable. Changing or removing an existing row in zstdDictionaries makes every
+    // value compressed against it unreadable, and because compress()/decompress() are registered as
+    // SQLITE_DETERMINISTIC, it also silently corrupts every index built on decompress(). Only ever add new
+    // dictionary IDs.
     static void loadDictionariesFromDB(SQLite& db);
 
     // Register the compress(data, dictID) and decompress(data) SQLite UDFs.


### PR DESCRIPTION
### Details

Our `decompress()` UDF gets used in index expressions, and sqlite refuses to parse a schema containing an application-defined function used that way unless the function is tagged `SQLITE_INNOCUOUS` (or `trusted_schema` is on, which the sqlite3 CLI turns off). That's what's producing `malformed database schema (reportActionsStripeTransferIDDecompress) - unsafe use of decompress()`. So tag both `compress()` and `decompress()` innocuous — neither of them has side effects, which is all that flag claims.

Bedrock itself doesn't hit the parse error today (the library defaults `trusted_schema` on), but the flags should match what the [CLI build](https://github.com/Expensify/Salt/pull/17199) does, and the tag is correct either way.

I asked drh about this and he pointed out the sharp edge in the `SQLITE_DETERMINISTIC` tag we already have: the moment a dictionary changes underneath us, every index built on `decompress()` silently goes corrupt. Dictionaries are already effectively write-once — changing one makes all the data compressed against it unreadable — but nothing in the code said so, so I added comments to that effect wherever we touch the dictionaries. His words: "This will help avoid disaster 5 or 10 years from now when somebody new (or an agent) comes along and wants to 'improve' that code."

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/674000

### Tests

Compiles clean. Beyond that I wrote a throwaway program against our own `sqlite3.o` that registers a stub `decompress()` with each combination of flags, sets `SQLITE_DBCONFIG_TRUSTED_SCHEMA` off the way the CLI does, and tries to create a partial index using it:

```
no flags                     create index: unsafe use of decompress()
DETERMINISTIC                create index: unsafe use of decompress()
DETERMINISTIC|INNOCUOUS      create index: OK
DETERMINISTIC|INNOCUOUS      reparse schema: OK
```

So `INNOCUOUS` is exactly the missing piece, and `DETERMINISTIC` on its own isn't enough. (Without `DETERMINISTIC` and with `trusted_schema` on you get `non-deterministic functions prohibited in partial index WHERE clauses` instead, which is why we already had it.)

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
