### PR TITLE
Drain committed transactions while synchronizing

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1810,6 +1810,9 @@ void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message)
         SDEBUG("Committing current transaction because _recvSynchronize: " << _db.getUncommittedQuery());
         _db.commit(stateName(_state));
 
+        // Clear the list of committed transactions. We're synchronizing, so we don't need to send these.
+        _db.popCommittedTransactions();
+
         --commitsRemaining;
     }
 


### PR DESCRIPTION
### Details

See here https://expensify.slack.com/archives/C094TGUTZ/p1787613071893499?thread_ts=1787608283.747719&cid=C094TGUTZ

When the leader has been syncing for a long time due to a restore, there is a long delay after standing up and before leading where the cluster cannot handle any requests because committed transactions are never drained while syncing.

Copying what is done here https://github.com/Expensify/Bedrock/blob/598513ba238b5a7750fabe684275838482e459f5/sqlitecluster/SQLiteNode.cpp#L2064-L2065

I believe this same issue happens when a node transitions from syncing to following, but there is less of an impact because the cluster still has a leader


### Fixed Issues
https://github.com/Expensify/Expensify/issues/674307

### Tests