### PR TITLE
Add socket timeout test diagnostics

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1959,6 +1959,7 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking, int* 
 {
     // Try to set up the socket
     int s = -1;
+    int socketError = 0;
     try {
         // First, just parse the host
         string domain;
@@ -2009,6 +2010,7 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking, int* 
             s = (int) socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
         }
         if (s == -1) {
+            socketError = S_errno;
             STHROW("couldn't open");
         }
 
@@ -2018,7 +2020,12 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking, int* 
         if (!isBlocking) {
             // Set non-blocking
             int flags = fcntl(s, F_GETFL);
-            if ((flags < 0) || fcntl(s, F_SETFL, flags | O_NONBLOCK)) {
+            if (flags < 0) {
+                socketError = S_errno;
+                STHROW("couldn't set non-blocking");
+            }
+            if (fcntl(s, F_SETFL, flags | O_NONBLOCK)) {
+                socketError = S_errno;
                 STHROW("couldn't set non-blocking");
             }
         }
@@ -2028,6 +2035,7 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking, int* 
             // Enable port reuse (so we don't have TIME_WAIT binding issues) and
             u_long enable = 1;
             if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char*) &enable, sizeof(enable))) {
+                socketError = S_errno;
                 STHROW("couldn't set REUSEADDR");
             }
 
@@ -2038,11 +2046,13 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking, int* 
             addr.sin_port = htons(port);
             addr.sin_addr.s_addr = ip;
             if (::bind(s, (sockaddr*) &addr, sizeof(addr))) {
+                socketError = S_errno;
                 STHROW("couldn't bind");
             }
 
             // Start listening, if TCP
             if (isTCP && listen(s, SOMAXCONN)) {
+                socketError = S_errno;
                 STHROW("couldn't listen");
             }
         } else {
@@ -2063,6 +2073,7 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking, int* 
                         break;
 
                     default:
+                        socketError = S_errno;
                         STHROW("couldn't connect");
                 }
             }
@@ -2071,7 +2082,7 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking, int* 
         // Success, ready to go.
         return s;
     } catch (const SException& e) {
-        int error = S_errno;
+        int error = socketError ? socketError : S_errno;
         // Failed to open
         SWARN("Failed to open " << (isTCP ? "TCP" : "UDP") << (isPort ? " port" : " socket") << " '" << host
               << "': " << e.what() << "(errno=" << error << " '" << strerror(error) << "')");

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -1955,7 +1955,7 @@ string SGUnzip(const string& content)
 /////////////////////////////////////////////////////////////////////////////
 
 // --------------------------------------------------------------------------
-int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking)
+int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking, int* errorCode)
 {
     // Try to set up the socket
     int s = -1;
@@ -2071,9 +2071,13 @@ int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking)
         // Success, ready to go.
         return s;
     } catch (const SException& e) {
+        int error = S_errno;
         // Failed to open
         SWARN("Failed to open " << (isTCP ? "TCP" : "UDP") << (isPort ? " port" : " socket") << " '" << host
-              << "': " << e.what() << "(errno=" << S_errno << " '" << strerror(S_errno) << "')");
+              << "': " << e.what() << "(errno=" << error << " '" << strerror(error) << "')");
+        if (errorCode) {
+            *errorCode = error;
+        }
         if (s != -1) {
             S_close(&s);
         }

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -633,7 +633,7 @@ void SFDset(fd_map& fdm, int socket, short evts);
 bool SFDAnySet(fd_map& fdm, int socket, short evts);
 
 // Socket helpers
-int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking);
+int S_socket(const string& host, bool isTCP, bool isPort, bool isBlocking, int* errorCode = nullptr);
 int S_close(int* socket);
 int S_accept(int port, sockaddr_in& fromAddr, bool isBlocking);
 ssize_t S_recvfrom(int s, char* recvBuffer, int recvBufferSize, sockaddr_in& fromAddr);

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -427,11 +427,14 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
                                     controlPortReachable = controlSocket != -1;
                                 }
                                 S_close(&controlSocket);
-                                cout << "executeWaitMultipleData(): ran out of time waiting for socket on '" << host
-                                << "' after error " << lastSocketError << " ('" << strerror(lastSocketError)
-                                << "'), server PID " << _serverPID << " is " << (serverAlive ? "alive" : "not alive")
-                                << ", control port is " << (controlPortReachable ? "reachable" : "unreachable")
-                                << " (error " << controlSocketError << " '" << strerror(controlSocketError) << "')" << endl;
+                                {
+                                    SAUTOLOCK(listLock);
+                                    cout << "executeWaitMultipleData(): ran out of time waiting for socket on '" << host
+                                    << "' after error " << lastSocketError << " ('" << strerror(lastSocketError)
+                                    << "'), server PID " << _serverPID << " is " << (serverAlive ? "alive" : "not alive")
+                                    << ", control port is " << (controlPortReachable ? "reachable" : "unreachable")
+                                    << " (error " << controlSocketError << " '" << strerror(controlSocketError) << "')" << endl;
+                                }
                             }
                             return;
                         }

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -389,6 +389,7 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
     for (int i = 0; i < connections; i++) {
         threads.emplace_back([&](){
             int socket = -1;
+            int lastSocketError = 0;
 
             // This continues until there are no more requests to process.
             bool timedOut = false;
@@ -401,7 +402,7 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
                 while (true) {
                     // If there's no socket, create a socket.
                     if (socket == -1) {
-                        socket = S_socket((control ? _args["-controlPort"] : _args["-serverHost"]), true, false, true);
+                        socket = S_socket((control ? _args["-controlPort"] : _args["-serverHost"]), true, false, true, &lastSocketError);
                     }
 
                     // If that failed, we'll continue our main loop and try again.
@@ -415,7 +416,17 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
                                 *errorCode = 2;
                             }
                             if (timeout) {
-                                cout << "executeWaitMultipleData(): ran out of time waiting for socket" << endl;
+                                const string& host = control ? _args["-controlPort"] : _args["-serverHost"];
+                                bool serverAlive = _serverPID && (kill(_serverPID, 0) == 0 || errno == EPERM);
+                                int controlSocketError = 0;
+                                int controlSocket = control ? -1 : S_socket(_args["-controlPort"], true, false, true, &controlSocketError);
+                                bool controlPortReachable = control || controlSocket != -1;
+                                S_close(&controlSocket);
+                                cout << "executeWaitMultipleData(): ran out of time waiting for socket on '" << host
+                                     << "' after error " << lastSocketError << " ('" << strerror(lastSocketError)
+                                     << "'), server PID " << _serverPID << " is " << (serverAlive ? "alive" : "not alive")
+                                     << ", control port is " << (controlPortReachable ? "reachable" : "unreachable")
+                                     << " (error " << controlSocketError << " '" << strerror(controlSocketError) << "')" << endl;
                             }
                             return;
                         }

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -423,10 +423,10 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
                                 bool controlPortReachable = control || controlSocket != -1;
                                 S_close(&controlSocket);
                                 cout << "executeWaitMultipleData(): ran out of time waiting for socket on '" << host
-                                     << "' after error " << lastSocketError << " ('" << strerror(lastSocketError)
-                                     << "'), server PID " << _serverPID << " is " << (serverAlive ? "alive" : "not alive")
-                                     << ", control port is " << (controlPortReachable ? "reachable" : "unreachable")
-                                     << " (error " << controlSocketError << " '" << strerror(controlSocketError) << "')" << endl;
+                                << "' after error " << lastSocketError << " ('" << strerror(lastSocketError)
+                                << "'), server PID " << _serverPID << " is " << (serverAlive ? "alive" : "not alive")
+                                << ", control port is " << (controlPortReachable ? "reachable" : "unreachable")
+                                << " (error " << controlSocketError << " '" << strerror(controlSocketError) << "')" << endl;
                             }
                             return;
                         }

--- a/test/lib/BedrockTester.cpp
+++ b/test/lib/BedrockTester.cpp
@@ -418,9 +418,14 @@ vector<SData> BedrockTester::executeWaitMultipleData(vector<SData> requests, int
                             if (timeout) {
                                 const string& host = control ? _args["-controlPort"] : _args["-serverHost"];
                                 bool serverAlive = _serverPID && (kill(_serverPID, 0) == 0 || errno == EPERM);
-                                int controlSocketError = 0;
-                                int controlSocket = control ? -1 : S_socket(_args["-controlPort"], true, false, true, &controlSocketError);
-                                bool controlPortReachable = control || controlSocket != -1;
+                                int controlSocketError = lastSocketError;
+                                int controlSocket = -1;
+                                bool controlPortReachable = false;
+                                if (!control) {
+                                    controlSocketError = 0;
+                                    controlSocket = S_socket(_args["-controlPort"], true, false, true, &controlSocketError);
+                                    controlPortReachable = controlSocket != -1;
+                                }
                                 S_close(&controlSocket);
                                 cout << "executeWaitMultipleData(): ran out of time waiting for socket on '" << host
                                 << "' after error " << lastSocketError << " ('" << strerror(lastSocketError)


### PR DESCRIPTION
### Details
Capture the socket errno, server-PID liveness, and control-port reachability when a test client cannot connect to Bedrock for 20 seconds. This distinguishes listener lifecycle failures from descriptor exhaustion before attempting a real fix.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/653978

### Tests
1. Run `make -j16` in Bedrock.
2. Run `make -j16` in Auth against the rebuilt Bedrock library.
3. Run `./authtest -threads 32 -logLevel INFO -enableHctree` from `Auth/test`.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
