### PR TITLE
Add reusable compiled regexes to libstuff

### DIFF
--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -3216,25 +3216,18 @@ bool SIsValidSQLiteDateModifier(const string& modifier)
 
 bool SREMatch(const string& regExp, const string& input, bool caseSensitive, bool partialMatch, vector<string>* matches, size_t startOffset, size_t* matchOffset)
 {
-    int errornumber = 0;
-    PCRE2_SIZE erroroffset = 0;
-    uint32_t matchFlags = 0;
+    return SREMatch(SRECompile(regExp, caseSensitive), input, partialMatch, matches, startOffset, matchOffset);
+}
 
+bool SREMatch(const SRECompiledRegex& regExp, const string& input, bool partialMatch, vector<string>* matches, size_t startOffset, size_t* matchOffset)
+{
     // These require full-string matches as that's the historical way this function works.
-    uint32_t compileFlags = partialMatch ? 0 : PCRE2_ANCHORED | PCRE2_ENDANCHORED;
-    if (!caseSensitive) {
-        compileFlags |= PCRE2_CASELESS;
-    }
-    pcre2_code* re = pcre2_compile((PCRE2_SPTR8) regExp.c_str(), PCRE2_ZERO_TERMINATED, compileFlags, &errornumber, &erroroffset, 0);
-    if (!re) {
-        STHROW("Bad regex: " + regExp);
-    }
-
+    uint32_t matchFlags = partialMatch ? 0 : PCRE2_ANCHORED | PCRE2_ENDANCHORED;
     pcre2_match_context* matchContext = pcre2_match_context_create(0);
     pcre2_set_depth_limit(matchContext, 1000);
-    pcre2_match_data* matchData = pcre2_match_data_create_from_pattern(re, 0);
+    pcre2_match_data* matchData = pcre2_match_data_create_from_pattern(static_cast<pcre2_code*>(regExp.regex), 0);
 
-    int result = pcre2_match(re, (PCRE2_SPTR8) input.c_str() + startOffset, input.size() - startOffset, 0, matchFlags, matchData, matchContext);
+    int result = pcre2_match(static_cast<pcre2_code*>(regExp.regex), (PCRE2_SPTR8) input.c_str() + startOffset, input.size() - startOffset, 0, matchFlags, matchData, matchContext);
 
     // Clear out existing matches.
     if (matches) {
@@ -3258,7 +3251,6 @@ bool SREMatch(const string& regExp, const string& input, bool caseSensitive, boo
         }
     }
 
-    pcre2_code_free(re);
     pcre2_match_context_free(matchContext);
     pcre2_match_data_free(matchData);
 
@@ -3267,11 +3259,16 @@ bool SREMatch(const string& regExp, const string& input, bool caseSensitive, boo
 
 vector<vector<string>> SREMatchAll(const string& regExp, const string& input, bool caseSensitive)
 {
+    return SREMatchAll(SRECompile(regExp, caseSensitive), input);
+}
+
+vector<vector<string>> SREMatchAll(const SRECompiledRegex& regExp, const string& input)
+{
     vector<vector<string>> returnValue;
     vector<string> matches;
     size_t startOffset = 0;
     size_t matchOffset = 0;
-    while (SREMatch(regExp, input, caseSensitive, true, &matches, startOffset, &matchOffset)) {
+    while (SREMatch(regExp, input, true, &matches, startOffset, &matchOffset)) {
         returnValue.push_back(matches);
         startOffset = matchOffset + matches[0].size();
     }
@@ -3279,22 +3276,56 @@ vector<vector<string>> SREMatchAll(const string& regExp, const string& input, bo
     return returnValue;
 }
 
-string SREReplace(const string& regExp, const string& input, const string& replacement, bool caseSensitive)
+SRECompiledRegex::SRECompiledRegex(void* regex) : regex(regex)
 {
-    char* output = nullptr;
-    size_t outSize = 0;
+}
+
+SRECompiledRegex::~SRECompiledRegex()
+{
+    pcre2_code_free(static_cast<pcre2_code*>(regex));
+}
+
+SRECompiledRegex::SRECompiledRegex(SRECompiledRegex&& other) noexcept : regex(other.regex)
+{
+    other.regex = nullptr;
+}
+
+SRECompiledRegex& SRECompiledRegex::operator=(SRECompiledRegex&& other) noexcept
+{
+    if (this != &other) {
+        pcre2_code_free(static_cast<pcre2_code*>(regex));
+        regex = other.regex;
+        other.regex = nullptr;
+    }
+    return *this;
+}
+
+SRECompiledRegex SRECompile(const string& regExp, bool caseSensitive)
+{
     int errornumber = 0;
     PCRE2_SIZE erroroffset = 0;
     uint32_t compileFlags = caseSensitive ? 0 : PCRE2_CASELESS;
-    uint32_t substituteFlags = PCRE2_SUBSTITUTE_GLOBAL | PCRE2_SUBSTITUTE_EXTENDED | PCRE2_SUBSTITUTE_OVERFLOW_LENGTH;
-    pcre2_code* re = pcre2_compile((PCRE2_SPTR8) regExp.c_str(), PCRE2_ZERO_TERMINATED, compileFlags, &errornumber, &erroroffset, 0);
-    if (!re) {
+    pcre2_code* regex = pcre2_compile((PCRE2_SPTR8) regExp.c_str(), PCRE2_ZERO_TERMINATED, compileFlags, &errornumber, &erroroffset, 0);
+    if (!regex) {
         STHROW("Bad regex: " + regExp);
     }
+    return SRECompiledRegex(regex);
+}
+
+string SREReplace(const string& regExp, const string& input, const string& replacement, bool caseSensitive)
+{
+    return SREReplace(SRECompile(regExp, caseSensitive), input, replacement);
+}
+
+string SREReplace(const SRECompiledRegex& regExp, const string& input, const string& replacement)
+{
+    char* output = nullptr;
+    size_t outSize = 0;
+    uint32_t substituteFlags = PCRE2_SUBSTITUTE_GLOBAL | PCRE2_SUBSTITUTE_EXTENDED | PCRE2_SUBSTITUTE_OVERFLOW_LENGTH;
     pcre2_match_context* matchContext = pcre2_match_context_create(0);
     pcre2_set_depth_limit(matchContext, 1000);
     for (int i = 0; i < 2; i++) {
-        int result = pcre2_substitute(re, (PCRE2_SPTR8) input.c_str(), input.size(), 0, substituteFlags, 0, matchContext, (PCRE2_SPTR8) replacement.c_str(), replacement.size(), (PCRE2_UCHAR*) output, &outSize);
+        int result = pcre2_substitute(static_cast<pcre2_code*>(regExp.regex), (PCRE2_SPTR8) input.c_str(), input.size(), 0, substituteFlags, 0, matchContext, (PCRE2_SPTR8) replacement.c_str(), replacement.size(), (PCRE2_UCHAR*) output, &outSize);
         if (i == 0 && result == PCRE2_ERROR_NOMEMORY) {
             // This is the expected case on the first run, there's not enough space to store the result, so we allocate the space and do it again.
             output = (char*) malloc(outSize);
@@ -3315,7 +3346,6 @@ string SREReplace(const string& regExp, const string& input, const string& repla
         free(output);
     }
 
-    pcre2_code_free(re);
     pcre2_match_context_free(matchContext);
 
     return outputString;

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -486,6 +486,28 @@ bool SEndsWith(const string& haystack, const string& needle);
 bool SConstantTimeEquals(const string& secret, const string& userInput);
 bool SConstantTimeIEquals(const string& secret, const string& userInput);
 
+class SRECompiledRegex {
+public:
+    ~SRECompiledRegex();
+    SRECompiledRegex(SRECompiledRegex&& other) noexcept;
+    SRECompiledRegex& operator=(SRECompiledRegex&& other) noexcept;
+
+    SRECompiledRegex(const SRECompiledRegex&) = delete;
+    SRECompiledRegex& operator=(const SRECompiledRegex&) = delete;
+
+private:
+    explicit SRECompiledRegex(void* regex);
+
+    void* regex;
+
+    friend SRECompiledRegex SRECompile(const string& regExp, bool caseSensitive);
+    friend bool SREMatch(const SRECompiledRegex& regExp, const string& input, bool partialMatch, vector<string>* matches, size_t startOffset, size_t* matchOffset);
+    friend string SREReplace(const SRECompiledRegex& regExp, const string& input, const string& replacement);
+};
+
+// Compiles a regular expression for reuse. Case sensitivity is fixed when the expression is compiled.
+SRECompiledRegex SRECompile(const string& regExp, bool caseSensitive = true);
+
 // Unless `partialMatch` is specified, perform a full regex match (the '^' and '$' symbols are implicit).
 //
 // If `matches` is supplied it will be cleared, and any matches to the expression will fill it. The first entry in matches will be the entire matched portion of the string,
@@ -496,13 +518,16 @@ bool SConstantTimeIEquals(const string& secret, const string& userInput);
 // If matchOffset is supplied, and a match is found, it will be set to the offset of the first character of the matched substring.
 // To find the end of the matched substring, you can do something like matchOffset + matches[0].size().
 bool SREMatch(const string& regExp, const string& input, bool caseSensitive = true, bool partialMatch = false, vector<string>* matches = nullptr, size_t startOffset = 0, size_t* matchOffset = nullptr);
+bool SREMatch(const SRECompiledRegex& regExp, const string& input, bool partialMatch = false, vector<string>* matches = nullptr, size_t startOffset = 0, size_t* matchOffset = nullptr);
 
 // Matches every instance of regExp in the input string. Returns a vector of vectors or strings.
 // The outer vector has one entry for each match found. The inner vectors contain first the entire matched substring, and following that, each match group
 vector<vector<string>> SREMatchAll(const string& regExp, const string& input, bool caseSensitive = true);
+vector<vector<string>> SREMatchAll(const SRECompiledRegex& regExp, const string& input);
 
 // Replaces all instances of the matched `regExp` with `replacement` in `input`.
 string SREReplace(const string& regExp, const string& input, const string& replacement, bool caseSensitive = true);
+string SREReplace(const SRECompiledRegex& regExp, const string& input, const string& replacement);
 
 // Redact values that should not be logged.
 void SRedactSensitiveValues(string& s);

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -760,6 +760,11 @@ struct LibStuff : tpunit::TestFixture
         ASSERT_EQUAL(matchList[0][1], "Whiskers");
         ASSERT_EQUAL(matchList[1][1], "Mittens");
         ASSERT_EQUAL(matchList[2][1], "Snowball");
+
+        SRECompiledRegex compiledRegex = SRECompile(R"(KITTY\s+(\w+))", false);
+        ASSERT_FALSE(SREMatch(compiledRegex, catNames));
+        ASSERT_TRUE(SREMatch(compiledRegex, catNames, true));
+        ASSERT_EQUAL(SREMatchAll(compiledRegex, catNames).size(), 3);
     }
 
     void SREReplaceTest()
@@ -782,6 +787,10 @@ struct LibStuff : tpunit::TestFixture
         string from2 = "a cat did something to a dog";
         string result4 = SREReplace("cat(.*)dog", from2, "chicken$1horse");
         ASSERT_EQUAL(result4, "a chicken did something to a horse");
+
+        SRECompiledRegex compiledRegex = SRECompile("CAT", false);
+        ASSERT_EQUAL(SREReplace(compiledRegex, from, "dinosaur"), expected);
+        ASSERT_EQUAL(SREReplace(compiledRegex, "another cat", "dinosaur"), "another dinosaur");
     }
 
     void testSReplace()


### PR DESCRIPTION
### Details

coming from https://github.com/Expensify/Auth/pull/23856#pullrequestreview-4997550522

Add an owning `SRECompiledRegex` type and `SRECompile` so callers can compile fixed regular expressions once and reuse them. Add overloads of `SREMatch`, `SREMatchAll`, and `SREReplace` that accept compiled expressions while preserving the existing string-based interfaces.

This allows Auth's comment HTML conversion to reuse static compiled expressions instead of either compiling them for every comment or adding heuristic string searches before each regex operation.

### Fixed Issues
For https://github.com/Expensify/Auth/pull/23856

### Tests

1. Build Auth against the modified Bedrock, verify reportactions are displayed correctly
2. Build https://github.com/Expensify/Auth/pull/23856 against the modified Bedrock, verify reportactions are displayed correctly

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
