### PR TITLE
Add scheduled HTTPS requests for retry backoff

### DIFF
--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -40,14 +40,9 @@ SStandaloneHTTPSManager::~SStandaloneHTTPSManager()
 {
 }
 
-const string& SStandaloneHTTPSManager::_getProxyAddressHTTPS() const
+unique_ptr<STCPManager::Socket> SStandaloneHTTPSManager::_createHTTPSProxySocket(const string& proxyAddress, const string& host, const string& requestID)
 {
-    return proxyAddressHTTPS;
-}
-
-STCPManager::Socket* SStandaloneHTTPSManager::_createHTTPSProxySocket(const string& proxyAddress, const string& host, const string& requestID)
-{
-    return new SHTTPSProxySocket(proxyAddress, host, requestID);
+    return make_unique<SHTTPSProxySocket>(proxyAddress, host, requestID);
 }
 
 int SStandaloneHTTPSManager::getHTTPResponseCode(const string& methodLine, const int defaultStatusCode)
@@ -221,14 +216,20 @@ unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_creat
 void SStandaloneHTTPSManager::_completeError(Transaction& transaction)
 {
     SHMMM("We had to create an error transaction instead of attempting a real one.");
+    delete transaction.s;
+    transaction.s = nullptr;
     transaction.response = 503;
     transaction.finished = STimeNow();
 }
 
-void SStandaloneHTTPSManager::_startHTTPSRequest(Transaction& transaction, const string& url, const SData& request, bool allowProxy)
+void SStandaloneHTTPSManager::_startHTTPSRequest(
+    Transaction& transaction,
+    const string& url,
+    const SData& request,
+    bool allowProxy,
+    const string& proxyAddress,
+    const HTTPSProxySocketFactory& createProxySocket)
 {
-    // Open a connection, optionally using SSL (if the URL is HTTPS). If that doesn't work, complete the transaction
-    // with an error response instead of throwing through the command scheduler.
     string host, path;
     if (!SParseURI(url, host, path)) {
         _completeError(transaction);
@@ -238,25 +239,14 @@ void SStandaloneHTTPSManager::_startHTTPSRequest(Transaction& transaction, const
         host += ":443";
     }
 
-    // If this is going to be an https transaction, create a certificate and give it to the socket.
-    Socket* s = nullptr;
+    bool isHttps = SStartsWith(url, "https://");
     bool usingProxy = false;
-    try {
-        // If a proxy is set, and it's allowed to use it, go through the proxy.
-        bool isHttps = SStartsWith(url, "https://");
-        const string& proxyAddress = transaction.manager._getProxyAddressHTTPS();
-        if (isHttps && allowProxy && proxyAddress.size()) {
-            string proxyHost, path;
-            SParseURI(proxyAddress, proxyHost, path);
-            SINFO("Proxying " << url << " through " << proxyHost);
-            s = transaction.manager._createHTTPSProxySocket(proxyHost, host, transaction.requestID);
-            usingProxy = true;
-        } else {
-            s = new Socket(host, isHttps);
-        }
-    } catch (const SException& exception) {
-        _completeError(transaction);
-        return;
+    string proxyHost;
+    if (isHttps && allowProxy && proxyAddress.size()) {
+        string proxyPath;
+        SParseURI(proxyAddress, proxyHost, proxyPath);
+        SINFO("Proxying " << url << " through " << proxyHost);
+        usingProxy = true;
     }
 
     // When using a proxy with CONNECT tunnels, remove "Connection: close" header to prevent
@@ -268,13 +258,28 @@ void SStandaloneHTTPSManager::_startHTTPSRequest(Transaction& transaction, const
     if (usingProxy) {
         modifiedRequest.nameValueMap.erase("Connection");
     }
-    transaction.s = s;
+    const string serializedRequest = modifiedRequest.serialize();
+
+    unique_ptr<Socket> socket;
+    try {
+        if (usingProxy) {
+            socket = createProxySocket(proxyHost, host, transaction.requestID);
+        } else {
+            socket = make_unique<Socket>(host, isHttps);
+        }
+    } catch (const SException&) {
+        _completeError(transaction);
+        return;
+    }
+
+    if (!socket) {
+        _completeError(transaction);
+        return;
+    }
+
     transaction.fullRequest = modifiedRequest;
-
-    // Ship it.
-    transaction.s->send(modifiedRequest.serialize());
-
-    // Keep track of the transaction.
+    transaction.s = socket.release();
+    transaction.s->send(serializedRequest);
 }
 
 unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_httpsSend(const string& url, const SData& request, bool allowProxy)
@@ -286,7 +291,7 @@ unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_https
     }
 
     unique_ptr<Transaction> transaction = make_unique<Transaction>(*this);
-    _startHTTPSRequest(*transaction, url, request, allowProxy);
+    _startHTTPSRequest(*transaction, url, request, allowProxy, proxyAddressHTTPS, _createHTTPSProxySocket);
     return transaction;
 }
 
@@ -300,7 +305,12 @@ unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_https
     transaction->fullRequest = request;
     transaction->scheduledStart = scheduledStartUS;
     transaction->startFunc = [url, allowProxy](Transaction& transaction) {
-        _startHTTPSRequest(transaction, url, transaction.fullRequest, allowProxy);
+        try {
+            _startHTTPSRequest(transaction, url, transaction.fullRequest, allowProxy, proxyAddressHTTPS, _createHTTPSProxySocket);
+        } catch (...) {
+            // Scheduled starts run from the HTTPS wait loop, outside the command exception boundary.
+            _completeError(transaction);
+        }
     };
     return transaction;
 }

--- a/libstuff/SHTTPSManager.cpp
+++ b/libstuff/SHTTPSManager.cpp
@@ -40,6 +40,16 @@ SStandaloneHTTPSManager::~SStandaloneHTTPSManager()
 {
 }
 
+const string& SStandaloneHTTPSManager::_getProxyAddressHTTPS() const
+{
+    return proxyAddressHTTPS;
+}
+
+STCPManager::Socket* SStandaloneHTTPSManager::_createHTTPSProxySocket(const string& proxyAddress, const string& host, const string& requestID)
+{
+    return new SHTTPSProxySocket(proxyAddress, host, requestID);
+}
+
 int SStandaloneHTTPSManager::getHTTPResponseCode(const string& methodLine, const int defaultStatusCode)
 {
     // This code looks for the first space in the methodLine, and then for the first non-space
@@ -203,26 +213,30 @@ unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_creat
 {
     // Sometimes we have to create transactions without an attempted connect. This could happen if we don't have the
     // host or service id yet.
-    SHMMM("We had to create an error transaction instead of attempting a real one.");
     unique_ptr<Transaction> transaction = make_unique<Transaction>(*this);
-    transaction->response = 503;
-    transaction->finished = STimeNow();
+    _completeError(*transaction);
     return transaction;
 }
 
-unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_httpsSend(const string& url, const SData& request, bool allowProxy)
+void SStandaloneHTTPSManager::_completeError(Transaction& transaction)
 {
-    // Open a connection, optionally using SSL (if the URL is HTTPS). If that doesn't work, then just return a
-    // completed transaction with an error response.
+    SHMMM("We had to create an error transaction instead of attempting a real one.");
+    transaction.response = 503;
+    transaction.finished = STimeNow();
+}
+
+void SStandaloneHTTPSManager::_startHTTPSRequest(Transaction& transaction, const string& url, const SData& request, bool allowProxy)
+{
+    // Open a connection, optionally using SSL (if the URL is HTTPS). If that doesn't work, complete the transaction
+    // with an error response instead of throwing through the command scheduler.
     string host, path;
     if (!SParseURI(url, host, path)) {
-        return _createErrorTransaction();
+        _completeError(transaction);
+        return;
     }
     if (!SContains(host, ":")) {
         host += ":443";
     }
-
-    unique_ptr<Transaction> transaction = make_unique<Transaction>(*this);
 
     // If this is going to be an https transaction, create a certificate and give it to the socket.
     Socket* s = nullptr;
@@ -230,17 +244,19 @@ unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_https
     try {
         // If a proxy is set, and it's allowed to use it, go through the proxy.
         bool isHttps = SStartsWith(url, "https://");
-        if (isHttps && allowProxy && proxyAddressHTTPS.size()) {
+        const string& proxyAddress = transaction.manager._getProxyAddressHTTPS();
+        if (isHttps && allowProxy && proxyAddress.size()) {
             string proxyHost, path;
-            SParseURI(proxyAddressHTTPS, proxyHost, path);
+            SParseURI(proxyAddress, proxyHost, path);
             SINFO("Proxying " << url << " through " << proxyHost);
-            s = new SHTTPSProxySocket(proxyHost, host, transaction->requestID);
+            s = transaction.manager._createHTTPSProxySocket(proxyHost, host, transaction.requestID);
             usingProxy = true;
         } else {
             s = new Socket(host, isHttps);
         }
     } catch (const SException& exception) {
-        return _createErrorTransaction();
+        _completeError(transaction);
+        return;
     }
 
     // When using a proxy with CONNECT tunnels, remove "Connection: close" header to prevent
@@ -252,13 +268,40 @@ unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_https
     if (usingProxy) {
         modifiedRequest.nameValueMap.erase("Connection");
     }
-    transaction->s = s;
-    transaction->fullRequest = modifiedRequest;
+    transaction.s = s;
+    transaction.fullRequest = modifiedRequest;
 
     // Ship it.
-    transaction->s->send(modifiedRequest.serialize());
+    transaction.s->send(modifiedRequest.serialize());
 
     // Keep track of the transaction.
+}
+
+unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_httpsSend(const string& url, const SData& request, bool allowProxy)
+{
+    // Preserve the established immediate path, including its URL validation before transaction construction.
+    string host, path;
+    if (!SParseURI(url, host, path)) {
+        return _createErrorTransaction();
+    }
+
+    unique_ptr<Transaction> transaction = make_unique<Transaction>(*this);
+    _startHTTPSRequest(*transaction, url, request, allowProxy);
+    return transaction;
+}
+
+unique_ptr<SStandaloneHTTPSManager::Transaction> SStandaloneHTTPSManager::_httpsSendAt(const string& url, const SData& request, uint64_t scheduledStartUS, bool allowProxy)
+{
+    if (!scheduledStartUS || scheduledStartUS <= STimeNow()) {
+        return _httpsSend(url, request, allowProxy);
+    }
+
+    unique_ptr<Transaction> transaction = make_unique<Transaction>(*this);
+    transaction->fullRequest = request;
+    transaction->scheduledStart = scheduledStartUS;
+    transaction->startFunc = [url, allowProxy](Transaction& transaction) {
+        _startHTTPSRequest(transaction, url, transaction.fullRequest, allowProxy);
+    };
     return transaction;
 }
 

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -55,10 +55,17 @@ protected:   // Child API
 
     // Methods
     unique_ptr<Transaction> _httpsSend(const string& url, const SData& request, bool allowProxy = false);
+    unique_ptr<Transaction> _httpsSendAt(const string& url, const SData& request, uint64_t scheduledStartUS, bool allowProxy = false);
     unique_ptr<Transaction> _createErrorTransaction();
     virtual bool _onRecv(Transaction& transaction);
 
     static string initProxyAddressHTTPS();
+    virtual const string& _getProxyAddressHTTPS() const;
+    virtual Socket* _createHTTPSProxySocket(const string& proxyAddress, const string& host, const string& requestID);
+
+private:
+    static void _startHTTPSRequest(Transaction& transaction, const string& url, const SData& request, bool allowProxy);
+    static void _completeError(Transaction& transaction);
 };
 
 class SHTTPSManager : public SStandaloneHTTPSManager {

--- a/libstuff/SHTTPSManager.h
+++ b/libstuff/SHTTPSManager.h
@@ -59,12 +59,14 @@ protected:   // Child API
     unique_ptr<Transaction> _createErrorTransaction();
     virtual bool _onRecv(Transaction& transaction);
 
+    // Keep proxy construction injectable without adding virtual methods to the plugin API.
+    using HTTPSProxySocketFactory = function<unique_ptr<Socket>(const string&, const string&, const string&)>;
+
     static string initProxyAddressHTTPS();
-    virtual const string& _getProxyAddressHTTPS() const;
-    virtual Socket* _createHTTPSProxySocket(const string& proxyAddress, const string& host, const string& requestID);
+    static void _startHTTPSRequest(Transaction& transaction, const string& url, const SData& request, bool allowProxy, const string& proxyAddress, const HTTPSProxySocketFactory& createProxySocket);
 
 private:
-    static void _startHTTPSRequest(Transaction& transaction, const string& url, const SData& request, bool allowProxy);
+    static unique_ptr<Socket> _createHTTPSProxySocket(const string& proxyAddress, const string& host, const string& requestID);
     static void _completeError(Transaction& transaction);
 };
 

--- a/test/clustertest/testplugin/TestPlugin.cpp
+++ b/test/clustertest/testplugin/TestPlugin.cpp
@@ -166,6 +166,7 @@ unique_ptr<BedrockCommand> BedrockPlugin_TestPlugin::getCommand(SQLiteCommand&& 
         "EscalateSerializedData",
         "ThreadException",
         "httpswait",
+        "httpsscheduled",
         "httpsblockingcommit",
         "reportcommitthread"
     };
@@ -453,6 +454,44 @@ bool TestPluginCommand::peek(SQLite& db)
             STHROW("500 expected 200 response");
         }
         response.content = httpsRequests.back()->fullResponse.content;
+        return true;
+    } else if (SStartsWith(request.methodLine, "httpsscheduled")) {
+        SData newRequest("GET / HTTP/1.1");
+        newRequest["Host"] = "example.com";
+        newRequest["X-Test-Marker"] = "deferred-cluster";
+        newRequest.content = "deferred-body";
+        uint64_t scheduledStartUS = STimeNow() + 100'000;
+        auto transaction = plugin().httpsManager->sendAt("https://example.com/", newRequest, scheduledStartUS);
+        if (transaction->s || transaction->response || transaction->scheduledStart != scheduledStartUS || !transaction->startFunc) {
+            STHROW("500 Scheduled HTTPS transaction was started too early");
+        }
+
+        bool dbInsideTransactionAtStart = true;
+        uint64_t startedAtUS = 0;
+        uint64_t startCount = 0;
+        function<void(SHTTPSManager::Transaction&)> originalStartFunc = move(transaction->startFunc);
+        SHTTPSManager::Transaction* transactionPtr = transaction.get();
+        transaction->startFunc = [&db, &dbInsideTransactionAtStart, &startedAtUS, &startCount, originalStartFunc = move(originalStartFunc)](SHTTPSManager::Transaction& transaction) mutable {
+            dbInsideTransactionAtStart = db.insideTransaction();
+            startedAtUS = STimeNow();
+            startCount++;
+            originalStartFunc(transaction);
+        };
+        httpsRequests.push_back(move(transaction));
+
+        waitForHTTPSRequests(db);
+        if (transactionPtr->response != 200) {
+            STHROW("500 Scheduled HTTPS request did not return 200");
+        }
+
+        response["scheduledStartUS"] = to_string(scheduledStartUS);
+        response["startedAtUS"] = to_string(startedAtUS);
+        response["startCount"] = to_string(startCount);
+        response["dbInsideTransactionAtStart"] = dbInsideTransactionAtStart ? "true" : "false";
+        response["dbInsideTransactionAfterWait"] = db.insideTransaction() ? "true" : "false";
+        response["markerPreserved"] = transactionPtr->fullRequest["X-Test-Marker"] == "deferred-cluster" ? "true" : "false";
+        response["bodyPreserved"] = transactionPtr->fullRequest.content == "deferred-body" ? "true" : "false";
+        response.content = transactionPtr->fullResponse.content;
         return true;
     } else if (SStartsWith(request.methodLine, "httpsblockingcommit")) {
         // Only queue an HTTPS request when we're running on the serialized blockingCommit thread (worker 0). On the
@@ -827,6 +866,11 @@ TestHTTPSManager::~TestHTTPSManager()
 unique_ptr<TestHTTPSManager::Transaction> TestHTTPSManager::send(const string& url, const SData& request)
 {
     return _httpsSend(url, request);
+}
+
+unique_ptr<TestHTTPSManager::Transaction> TestHTTPSManager::sendAt(const string& url, const SData& request, uint64_t scheduledStartUS)
+{
+    return _httpsSendAt(url, request, scheduledStartUS);
 }
 
 unique_ptr<TestHTTPSManager::Transaction> TestHTTPSManager::httpsDontSend(const string& url, const SData& request)

--- a/test/clustertest/testplugin/TestPlugin.h
+++ b/test/clustertest/testplugin/TestPlugin.h
@@ -13,6 +13,7 @@ public:
     }
 
     unique_ptr<Transaction> send(const string& url, const SData& request);
+    unique_ptr<Transaction> sendAt(const string& url, const SData& request, uint64_t scheduledStartUS);
     virtual bool _onRecv(Transaction& transaction) override;
 
     // Like _httpsSend in the base class, but doesn't actually send, so we can test timeouts.

--- a/test/clustertest/tests/HTTPSTest.cpp
+++ b/test/clustertest/tests/HTTPSTest.cpp
@@ -25,6 +25,7 @@ struct HTTPSTest : tpunit::TestFixture
                               AFTER_CLASS(HTTPSTest::teardown),
                               TEST(HTTPSTest::testMultipleRequests),
                               TEST(HTTPSTest::testWaitForHTTPSRequests),
+                              TEST(HTTPSTest::testScheduledRequest),
                               TEST(HTTPSTest::test))
     {
     }
@@ -57,6 +58,23 @@ struct HTTPSTest : tpunit::TestFixture
         SData request("httpswait");
         auto result = brtester.executeWaitMultipleData({request});
         ASSERT_TRUE(SStartsWith(result[0].methodLine, "200"));
+    }
+
+    void testScheduledRequest()
+    {
+        BedrockTester& brtester = tester->getTester(1);
+        SData request("httpsscheduled");
+        auto result = brtester.executeWaitMultipleData({request});
+        ASSERT_TRUE(SStartsWith(result[0].methodLine, "200"));
+
+        uint64_t scheduledStartUS = SToUInt64(result[0]["scheduledStartUS"]);
+        uint64_t startedAtUS = SToUInt64(result[0]["startedAtUS"]);
+        ASSERT_GREATER_THAN_EQUAL(startedAtUS, scheduledStartUS);
+        ASSERT_EQUAL(result[0]["startCount"], "1");
+        ASSERT_EQUAL(result[0]["dbInsideTransactionAtStart"], "false");
+        ASSERT_EQUAL(result[0]["dbInsideTransactionAfterWait"], "true");
+        ASSERT_EQUAL(result[0]["markerPreserved"], "true");
+        ASSERT_EQUAL(result[0]["bodyPreserved"], "true");
     }
 
     void test()

--- a/test/tests/SHTTPSManagerTest.cpp
+++ b/test/tests/SHTTPSManagerTest.cpp
@@ -26,6 +26,8 @@ private:
 class ExposedHTTPSManager : public SStandaloneHTTPSManager
 {
 public:
+    using HTTPSProxySocketFactory = SStandaloneHTTPSManager::HTTPSProxySocketFactory;
+
     unique_ptr<Transaction> sendNow(const string& url, const SData& request, bool allowProxy = false)
     {
         return _httpsSend(url, request, allowProxy);
@@ -35,30 +37,52 @@ public:
     {
         return _httpsSendAt(url, request, scheduledStartUS, allowProxy);
     }
+
+    unique_ptr<Transaction> sendWithProxyFactory(
+        const string& url,
+        const SData& request,
+        bool allowProxy,
+        const string& proxyAddress,
+        const HTTPSProxySocketFactory& createProxySocket)
+    {
+        auto transaction = make_unique<Transaction>(*this);
+        _startHTTPSRequest(*transaction, url, request, allowProxy, proxyAddress, createProxySocket);
+        return transaction;
+    }
+
+    void startWithProxyFactory(
+        Transaction& transaction,
+        const string& url,
+        const SData& request,
+        bool allowProxy,
+        const string& proxyAddress,
+        const HTTPSProxySocketFactory& createProxySocket)
+    {
+        _startHTTPSRequest(transaction, url, request, allowProxy, proxyAddress, createProxySocket);
+    }
 };
 
-class ProxyTestHTTPSManager : public ExposedHTTPSManager
+struct ProxyFactoryCapture
 {
-public:
+    struct Call
+    {
+        string proxyAddress;
+        string host;
+        string requestID;
+    };
+
     vector<string> sentRequests;
-    bool failProxy = false;
+    vector<Call> calls;
+    bool fail = false;
 
-protected:
-    const string& _getProxyAddressHTTPS() const override
+    unique_ptr<STCPManager::Socket> create(const string& proxyAddress, const string& host, const string& requestID)
     {
-        return proxyAddress;
-    }
-
-    STCPManager::Socket* _createHTTPSProxySocket(const string&, const string&, const string&) override
-    {
-        if (failProxy) {
+        calls.push_back({proxyAddress, host, requestID});
+        if (fail) {
             STHROW("500 Test proxy construction failure");
         }
-        return new CapturingSocket(sentRequests);
+        return make_unique<CapturingSocket>(sentRequests);
     }
-
-private:
-    const string proxyAddress = "proxy.example.com:443";
 };
 
 struct SHTTPSManagerTest : tpunit::TestFixture
@@ -68,6 +92,8 @@ struct SHTTPSManagerTest : tpunit::TestFixture
                               TEST(SHTTPSManagerTest::testFutureRequestIsSocketless),
                               TEST(SHTTPSManagerTest::testDueRequestUsesImmediatePath),
                               TEST(SHTTPSManagerTest::testScheduledSetupFailureCompletes),
+                              TEST(SHTTPSManagerTest::testScheduledSerializationFailureCompletes),
+                              TEST(SHTTPSManagerTest::testProxyFactoryFailureCompletes),
                               TEST(SHTTPSManagerTest::testProxyRequestParity))
     {
     }
@@ -125,13 +151,33 @@ struct SHTTPSManagerTest : tpunit::TestFixture
         ASSERT_TRUE(transaction->s == nullptr);
         ASSERT_EQUAL(transaction->response, 503);
         ASSERT_TRUE(transaction->finished != 0);
+    }
 
-        ProxyTestHTTPSManager proxyManager;
-        proxyManager.failProxy = true;
+    void testScheduledSerializationFailureCompletes()
+    {
+        ExposedHTTPSManager manager;
+        SData invalidRequest("GET\n");
+        auto serializationFailure = manager.sendAt("https://example.com/", invalidRequest, STimeNow() + 100'000);
+
+        ASSERT_NO_THROW(serializationFailure->startFunc(*serializationFailure));
+
+        ASSERT_TRUE(serializationFailure->s == nullptr);
+        ASSERT_EQUAL(serializationFailure->response, 503);
+        ASSERT_TRUE(serializationFailure->finished != 0);
+    }
+
+    void testProxyFactoryFailureCompletes()
+    {
+        ExposedHTTPSManager proxyManager;
+        ProxyFactoryCapture proxyFactory;
+        proxyFactory.fail = true;
+        SData request("GET / HTTP/1.1");
         request["Host"] = "example.com";
-        auto proxyFailure = proxyManager.sendAt("https://example.com/", request, STimeNow() + 100'000, true);
-
-        ASSERT_NO_THROW(proxyFailure->startFunc(*proxyFailure));
+        ExposedHTTPSManager::HTTPSProxySocketFactory failingFactory = [&proxyFactory](const string& proxyAddress, const string& host, const string& requestID) {
+            return proxyFactory.create(proxyAddress, host, requestID);
+        };
+        auto proxyFailure = proxyManager.sendWithProxyFactory(
+            "https://example.com/", request, true, "https://proxy.example.com:443", failingFactory);
 
         ASSERT_TRUE(proxyFailure->s == nullptr);
         ASSERT_EQUAL(proxyFailure->response, 503);
@@ -140,23 +186,36 @@ struct SHTTPSManagerTest : tpunit::TestFixture
 
     void testProxyRequestParity()
     {
-        ProxyTestHTTPSManager manager;
+        ExposedHTTPSManager manager;
+        ProxyFactoryCapture proxyFactory;
+        ExposedHTTPSManager::HTTPSProxySocketFactory factory = [&proxyFactory](const string& proxyAddress, const string& host, const string& requestID) {
+            return proxyFactory.create(proxyAddress, host, requestID);
+        };
         SData request("GET / HTTP/1.1");
         request["Host"] = "example.com";
         request["Connection"] = "close";
 
-        auto immediate = manager.sendNow("https://example.com/", request, true);
+        auto immediate = manager.sendWithProxyFactory(
+            "https://example.com/", request, true, "https://proxy.example.com:443", factory);
         auto deferred = manager.sendAt("https://example.com/", request, STimeNow() + 100'000, true);
 
-        ASSERT_EQUAL(manager.sentRequests.size(), 1);
-        ASSERT_TRUE(manager.sentRequests[0].find("Connection") == string::npos);
-        ASSERT_TRUE(immediate->fullRequest["Connection"].empty());
+        ASSERT_TRUE(deferred->s == nullptr);
         ASSERT_EQUAL(deferred->fullRequest["Connection"], "close");
 
-        deferred->startFunc(*deferred);
+        manager.startWithProxyFactory(
+            *deferred, "https://example.com/", deferred->fullRequest, true, "https://proxy.example.com:443", factory);
 
-        ASSERT_EQUAL(manager.sentRequests.size(), 2);
-        ASSERT_TRUE(manager.sentRequests[1].find("Connection") == string::npos);
+        ASSERT_EQUAL(proxyFactory.sentRequests.size(), 2);
+        ASSERT_EQUAL(proxyFactory.calls.size(), 2);
+        ASSERT_EQUAL(proxyFactory.calls[0].proxyAddress, "proxy.example.com:443");
+        ASSERT_EQUAL(proxyFactory.calls[0].host, "example.com:443");
+        ASSERT_FALSE(proxyFactory.calls[0].requestID.empty());
+        ASSERT_TRUE(proxyFactory.sentRequests[0].find("Connection") == string::npos);
+        ASSERT_TRUE(immediate->fullRequest["Connection"].empty());
         ASSERT_TRUE(deferred->fullRequest["Connection"].empty());
+        ASSERT_EQUAL(proxyFactory.calls[1].proxyAddress, proxyFactory.calls[0].proxyAddress);
+        ASSERT_EQUAL(proxyFactory.calls[1].host, proxyFactory.calls[0].host);
+        ASSERT_EQUAL(proxyFactory.calls[1].requestID, proxyFactory.calls[0].requestID);
+        ASSERT_TRUE(proxyFactory.sentRequests[1].find("Connection") == string::npos);
     }
 } __SHTTPSManagerTest;

--- a/test/tests/SHTTPSManagerTest.cpp
+++ b/test/tests/SHTTPSManagerTest.cpp
@@ -1,0 +1,162 @@
+#include "libstuff/SHTTPSManager.h"
+#include "libstuff/SData.h"
+#include "test/lib/tpunit++.hpp"
+
+class CapturingSocket : public STCPManager::Socket
+{
+public:
+    explicit CapturingSocket(vector<string>& sentRequests_)
+        : STCPManager::Socket(-1, STCPManager::Socket::CONNECTED), sentRequests(sentRequests_)
+    {
+    }
+
+    bool send(const string& buffer, size_t* bytesSentCount = nullptr) override
+    {
+        sentRequests.push_back(buffer);
+        if (bytesSentCount) {
+            *bytesSentCount = buffer.size();
+        }
+        return true;
+    }
+
+private:
+    vector<string>& sentRequests;
+};
+
+class ExposedHTTPSManager : public SStandaloneHTTPSManager
+{
+public:
+    unique_ptr<Transaction> sendNow(const string& url, const SData& request, bool allowProxy = false)
+    {
+        return _httpsSend(url, request, allowProxy);
+    }
+
+    unique_ptr<Transaction> sendAt(const string& url, const SData& request, uint64_t scheduledStartUS, bool allowProxy = false)
+    {
+        return _httpsSendAt(url, request, scheduledStartUS, allowProxy);
+    }
+};
+
+class ProxyTestHTTPSManager : public ExposedHTTPSManager
+{
+public:
+    vector<string> sentRequests;
+    bool failProxy = false;
+
+protected:
+    const string& _getProxyAddressHTTPS() const override
+    {
+        return proxyAddress;
+    }
+
+    STCPManager::Socket* _createHTTPSProxySocket(const string&, const string&, const string&) override
+    {
+        if (failProxy) {
+            STHROW("500 Test proxy construction failure");
+        }
+        return new CapturingSocket(sentRequests);
+    }
+
+private:
+    const string proxyAddress = "proxy.example.com:443";
+};
+
+struct SHTTPSManagerTest : tpunit::TestFixture
+{
+    SHTTPSManagerTest()
+        : tpunit::TestFixture("SHTTPSManager",
+                              TEST(SHTTPSManagerTest::testFutureRequestIsSocketless),
+                              TEST(SHTTPSManagerTest::testDueRequestUsesImmediatePath),
+                              TEST(SHTTPSManagerTest::testScheduledSetupFailureCompletes),
+                              TEST(SHTTPSManagerTest::testProxyRequestParity))
+    {
+    }
+
+    void testFutureRequestIsSocketless()
+    {
+        ExposedHTTPSManager manager;
+        SData request("GET / HTTP/1.1");
+        request["Host"] = "example.com";
+        request["X-Test-Marker"] = "deferred";
+        request.content = "deferred-body";
+
+        uint64_t scheduledStartUS = STimeNow() + 100'000;
+        auto transaction = manager.sendAt("https://example.com/", request, scheduledStartUS);
+
+        ASSERT_TRUE(transaction->s == nullptr);
+        ASSERT_EQUAL(transaction->response, 0);
+        ASSERT_EQUAL(transaction->scheduledStart, scheduledStartUS);
+        ASSERT_TRUE(transaction->startFunc);
+        ASSERT_EQUAL(transaction->fullRequest["X-Test-Marker"], "deferred");
+        ASSERT_EQUAL(transaction->fullRequest.content, "deferred-body");
+    }
+
+    void testDueRequestUsesImmediatePath()
+    {
+        ExposedHTTPSManager manager;
+        SData request("GET / HTTP/1.1");
+        request["Host"] = "example.com";
+
+        auto immediate = manager.sendNow("not a URI", request);
+        auto zero = manager.sendAt("not a URI", request, 0);
+        auto past = manager.sendAt("not a URI", request, STimeNow() - 1);
+        auto current = manager.sendAt("not a URI", request, STimeNow());
+
+        for (const auto& transaction : {immediate.get(), zero.get(), past.get(), current.get()}) {
+            ASSERT_TRUE(transaction->s == nullptr);
+            ASSERT_EQUAL(transaction->response, 503);
+            ASSERT_TRUE(transaction->finished != 0);
+            ASSERT_EQUAL(transaction->scheduledStart, 0);
+            ASSERT_FALSE(transaction->startFunc);
+        }
+    }
+
+    void testScheduledSetupFailureCompletes()
+    {
+        ExposedHTTPSManager manager;
+        SData request("GET / HTTP/1.1");
+
+        auto transaction = manager.sendAt("not a URI", request, STimeNow() + 100'000);
+        ASSERT_TRUE(transaction->s == nullptr);
+        ASSERT_EQUAL(transaction->response, 0);
+
+        ASSERT_NO_THROW(transaction->startFunc(*transaction));
+
+        ASSERT_TRUE(transaction->s == nullptr);
+        ASSERT_EQUAL(transaction->response, 503);
+        ASSERT_TRUE(transaction->finished != 0);
+
+        ProxyTestHTTPSManager proxyManager;
+        proxyManager.failProxy = true;
+        request["Host"] = "example.com";
+        auto proxyFailure = proxyManager.sendAt("https://example.com/", request, STimeNow() + 100'000, true);
+
+        ASSERT_NO_THROW(proxyFailure->startFunc(*proxyFailure));
+
+        ASSERT_TRUE(proxyFailure->s == nullptr);
+        ASSERT_EQUAL(proxyFailure->response, 503);
+        ASSERT_TRUE(proxyFailure->finished != 0);
+    }
+
+    void testProxyRequestParity()
+    {
+        ProxyTestHTTPSManager manager;
+        SData request("GET / HTTP/1.1");
+        request["Host"] = "example.com";
+        request["Connection"] = "close";
+
+        auto immediate = manager.sendNow("https://example.com/", request, true);
+        auto deferred = manager.sendAt("https://example.com/", request, STimeNow() + 100'000, true);
+
+        ASSERT_EQUAL(manager.sentRequests.size(), 1);
+        ASSERT_TRUE(manager.sentRequests[0].find("Connection") == string::npos);
+        ASSERT_TRUE(immediate->fullRequest["Connection"].empty());
+        ASSERT_EQUAL(deferred->fullRequest["Connection"], "close");
+
+        deferred->startFunc(*deferred);
+
+        ASSERT_EQUAL(manager.sentRequests.size(), 2);
+        ASSERT_TRUE(manager.sentRequests[1].find("Connection") == string::npos);
+        ASSERT_TRUE(deferred->fullRequest["Connection"].empty());
+    }
+} __SHTTPSManagerTest;


### PR DESCRIPTION
### Explanation of Change

`BedrockCommand::waitForHTTPSRequests` already supports waiting for a transaction scheduled in the future, but the generic HTTPS helper had no way to create one. Retry callers therefore had to wait before building the next request, keeping the database transaction open during the backoff.

This PR adds `_httpsSendAt`, which keeps future requests socketless until `scheduledStartUS`, then opens the connection and sends the original request. Requests scheduled for zero, the past, or the present continue through `_httpsSend`.

Deferred startup is exception-safe. Request serialization, socket creation, and sending are contained by transaction error handling, and failed startup completes with a `503` response. Sockets remain owned by `unique_ptr` until the transaction takes ownership, so setup failures cannot leak them.

Proxy behavior and request headers remain consistent with immediate requests. The proxy test seam is nonvirtual, so the plugin vtable and transaction object layout are unchanged.

<details>
<summary>Implementation notes</summary>

- Future requests store the complete request and a start callback. `waitForHTTPSRequests` invokes the callback after rolling back the active database transaction, then starts the request.
- The deferred callback catches startup failures that occur outside the command exception boundary and completes the transaction instead of allowing an exception to escape the worker.
- Proxy tests use a valid URI and verify the parsed proxy host, target host, request ID, and `Connection` header behavior for both immediate and deferred starts.
- This is the enabling Bedrock change. The follow-up Auth PR must be created after this change reaches Bedrock `main`.

</details>

### Fixed Issues

For https://github.com/Expensify/Expensify/issues/674630

### Tests

New automated tests added:

- `SHTTPSManagerTest` verifies future, due, malformed, deferred serialization failure, proxy factory failure, and proxy request behavior.
- `HTTPSTest::testScheduledRequest` verifies the deferred request lifecycle with database rollback and re-begin.

No manual tests. This is a backend transport change with no user-facing surface.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes

### Query Timings/Plans

N/A. No queries were added or modified.
