### PR TITLE
Treat missing HCTree pages as EOF

### DIFF
--- a/libstuff/sqlite3.c
+++ b/libstuff/sqlite3.c
@@ -294111,7 +294111,11 @@ SQLITE_PRIVATE void sqlite3HctDbCsrKey(HctDbCsr *pCsr, i64 *piKey){
 ** Return true if the cursor is at EOF. Otherwise false.
 */
 SQLITE_PRIVATE int sqlite3HctDbCsrEof(HctDbCsr *pCsr){
-  return pCsr==0 || pCsr->iCell<0;
+  if( pCsr==0 || pCsr->iCell<0 ) return 1;
+  if( pCsr->nRange ){
+    return pCsr->aRange[pCsr->nRange-1].pg.aOld==0;
+  }
+  return pCsr->pg.aOld==0;
 }
 
 /*


### PR DESCRIPTION
### Details

1. HCTree released or lost the page the cursor was pointing at.
2. The cursor still retained its old row number.
3. Its “am I at the end?” check looked only at the row number.
4. Since the row number was valid-looking, HCTree incorrectly concluded that the cursor still pointed to a real row.
5. It then tried to read that row from a page that no longer existed.
6. That invalid memory access caused a segmentation fault, crashing the Bedrock test server.
7. Later Auth test commands could no longer connect to the crashed server, producing the 20-second socket timeout.
The proposed fix changes the EOF check so a cursor is also considered finished/invalid when its current page is missing. That prevents validation from reading through a missing page.

### Fixed Issues

https://github.com/Expensify/Expensify/issues/653978

### Tests
1. Run `make -j16` in Bedrock.
2. Run `make -j16` in Auth against the rebuilt Bedrock library.
3. Run `./authtest -threads 32 -logLevel INFO -enableHctree -only RevertSplitTransaction -repeatCount 5` from `Auth/test`.
4. Confirm all 165 tests pass with no HCTree crash or socket-timeout cascade.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
