### PR TITLE
Use exclusive locking

### DIFF
--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -562,7 +562,7 @@ bool SQLite::beginTransaction(SQLite::TRANSACTION_TYPE type, bool beginOnly)
     _insideTransaction = !SQuery(_db, beginQuery);
 
     // If we locked the mutex and then failed to begin, unlock it before returning
-    if(_mutexLocked && !_insideTransaction) {
+    if (_mutexLocked && !_insideTransaction) {
         _sharedData.commitLock.unlock();
     }
 

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -561,6 +561,11 @@ bool SQLite::beginTransaction(SQLite::TRANSACTION_TYPE type, bool beginOnly)
     string beginQuery = (beginOnly && _hctree) ? "BEGIN" : "BEGIN CONCURRENT";
     _insideTransaction = !SQuery(_db, beginQuery);
 
+    // If we locked the mutex and then failed to begin, unlock it before returning
+    if(_mutexLocked && !_insideTransaction) {
+        _sharedData.commitLock.unlock();
+    }
+
     _queryCache.clear();
     _tablesUsed.clear();
     _readQueryCount = 0;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1990,9 +1990,7 @@ void SQLiteNode::_handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SDa
         STHROW("already in a transaction");
     }
 
-    // Shared with single-threaded replication because this is the only thread writing, and thus we can't get conflicts,
-    // and using SHARED prevents us from blocking or being blocked by readers.
-    if (!db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED, true)) {
+    if (!db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE, true)) {
         STHROW("failed to begin transaction");
     }
 


### PR DESCRIPTION
### Details
Removes an inaccurate comment and uses `EXCLUSIVE` rather than `SHARED` locking for the replicate thread.
This fixes a conflict issue with the new onyx deleter thread.

See https://expensify.slack.com/archives/C0BTVRRD7C2/p1788209262153609?thread_ts=1788204421.010219&cid=C0BTVRRD7C2

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/671183

### Tests
Existing tests should all pass.
_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
