### PR TITLE
Update CommitCount with PING/PONG

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -997,8 +997,9 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
             // If the peer has a CommitCount, and is not forked from us (in which case its commits are not usable),
             // update the commit count. This assists with being able to choose synchronization peers.
             // The check for the presence of commit count can be removed once PING and PONG broadcasting this is universally deployed.
-            if (!peer->forked && message.calcU64("CommitCount")) {
-                peer->setCommit(message.calcU64("CommitCount"), message["Hash"]);
+            uint64_t newCommitCount = message.calcU64("CommitCount");
+            if (!peer->forked && newCommitCount && newCommitCount > peer.getCommitCount()) {
+                peer->setCommit(newCommitCount, message["Hash"]);
             }
 
             return;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -998,7 +998,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
             // update the commit count. This assists with being able to choose synchronization peers.
             // The check for the presence of commit count can be removed once PING and PONG broadcasting this is universally deployed.
             uint64_t newCommitCount = message.calcU64("CommitCount");
-            if (!peer->forked && newCommitCount && newCommitCount > peer->getCommitCount()) {
+            if (!peer->forked && newCommitCount && newCommitCount > peer->commitCount) {
                 peer->setCommit(newCommitCount, message["Hash"]);
             }
 

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -980,18 +980,27 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
         SASSERTWARN(!message.empty());
         SDEBUG("Received sqlitenode message from peer " << peer->name << ": " << message.serialize());
 
-        // We let PING and PONG skip the other message validations, they're here just to know conenctedness and don't need
-        // info on the DB state.
-        if (SIEquals(message.methodLine, "PING")) {
-            SINFO("Received PING from peer '" << peer->name << "'. Sending PONG.");
-            SData pong("PONG");
-            pong["Timestamp"] = message["Timestamp"];
-            peer->sendMessage(pong);
-            return;
-        } else if (SIEquals(message.methodLine, "PONG")) {
-            // Latency must be > 0 because we treat 0 as "not connected".
-            peer->latency = max(STimeNow() - message.calc64("Timestamp"), 1ul);
-            SINFO("Received PONG from peer '" << peer->name << "' (" << peer->latency / 1000 << "ms latency)");
+        // Once PING and PONG including `_addPeerHeaders` is universally deployed, we can move the checks that are currently
+        // under the "Every other message" comment below above here.
+        if (SIEquals(message.methodLine, "PING") || SIEquals(message.methodLine, "PONG")) {
+            if (SIEquals(message.methodLine, "PING")) {
+                SINFO("Received PING from peer '" << peer->name << "'. Sending PONG.");
+                SData pong("PONG");
+                pong["Timestamp"] = message["Timestamp"];
+                peer->sendMessage(_addPeerHeaders(pong));
+            } else {
+                // Latency must be > 0 because we treat 0 as "not connected".
+                peer->latency = max(STimeNow() - message.calc64("Timestamp"), 1ul);
+                SINFO("Received PONG from peer '" << peer->name << "' (" << peer->latency / 1000 << "ms latency)");
+            }
+
+            // If the peer has a CommitCount, and is not forked from us (in which case its commits are not usable),
+            // update the commit count. This assists with being able to choose synchronization peers.
+            // The check for the presence of commit count can be removed once PING and PONG broadcasting this is universally deployed.
+            if (!peer->forked && message.calcU64("CommitCount")) {
+                peer->setCommit(message.calcU64("CommitCount"), message["Hash"]);
+            }
+
             return;
         }
 
@@ -2320,7 +2329,7 @@ void SQLiteNode::_sendPING(SQLitePeer* peer)
     SASSERT(peer);
     SData ping("PING");
     ping["Timestamp"] = SToStr(STimeNow());
-    peer->sendMessage(ping);
+    peer->sendMessage(_addPeerHeaders(ping));
 }
 
 SQLitePeer* SQLiteNode::getPeerByName(const string& name) const

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -998,7 +998,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
             // update the commit count. This assists with being able to choose synchronization peers.
             // The check for the presence of commit count can be removed once PING and PONG broadcasting this is universally deployed.
             uint64_t newCommitCount = message.calcU64("CommitCount");
-            if (!peer->forked && newCommitCount && newCommitCount > peer.getCommitCount()) {
+            if (!peer->forked && newCommitCount && newCommitCount > peer->getCommitCount()) {
                 peer->setCommit(newCommitCount, message["Hash"]);
             }
 


### PR DESCRIPTION
### Details
This adds `CommitCount` (and the other standard peer message headers - `Hash` and `CommandAddress`) to `PING` and `PONG` messages, and updates to the latest `CommitCount` from any of these messages, providing the peer is not forked from us.

The issue we saw was that:

db1.sjc was primary leader and was synchronizing.
db2.sjc was secondary leader and was synchronizing.

db2.sjc finished synchronizing and was expected to go LEADING, but did not, it was waiting on db1.sjc to stand up.

The reason that db2.sjc was waiting on db1.sjc was that db1.sjc had hit the check here, as designed:
https://github.com/Expensify/Bedrock/blob/e1a06fc0400269bed0d58c46842cb6f29cb51d9d/sqlitecluster/SQLiteNode.cpp#L1669-L1673

db1.sjc hit the `WAITING` state and so figured it had synchronized, and thus returned to it's normal configured priority, which was highest, and db2.sjc then was correctly waiting for it to stand up.

However, the reason that db1.sjc hit `WAITING`  exposes a bug, or at least shortcoming.

Partway through synchronizing, db1.sjc was disconnected from it's sync peer (db2.sjc). It then attempted to pick a new one, as designed, and chose db1.rno.

It attempted to sync from db1.rno, which itself is fine. The problem is that its state for what commit it thought db1.rno had was 4 hours old. This was the last message it had exchanged with `db1.rno` (aside from `PING` and `PONG`), which is normal when neither node is leading, and so it saw this old commit, and immediately thought it had caught up to db1.rno, and switched to `WAITING`.

It quickly realized that it was still behind, and switched back to `SYNCHRONIZING` but now with it's full priority set.

We previously didn't update `CommitCount` on `PING` and `PONG` messages, even though these should always be within 30 seconds of current. This change updates this, so that the `CommitCount` is always relatively fresh.

With this change, we shouldn't think we're caught up to a peer unless we're within 30 seconds of actually being caught up to that peer.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/677750

### Tests

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
