### PR TITLE
Don't leak the fd or throw out of postPoll when SSL setup fails

### DIFF
--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -261,9 +261,7 @@ bool STCPManager::Socket::_openSocket()
     }
 
     if (https) {
-        // SSSLState only closes the fd in its destructor, so if its constructor throws, the fd is still ours
-        // to close. Reporting failure by return value rather than letting the exception out also keeps it out
-        // of the poll loop, which reaches here by way of _connectAfterDNSResolution.
+        // SSSLState only closes the fd in its destructor, so if its constructor throws, the fd is still ours to close.
         try {
             ssl = new SSSLState(hostToResolve, s);
         } catch (const SException& e) {

--- a/libstuff/STCPManager.cpp
+++ b/libstuff/STCPManager.cpp
@@ -261,7 +261,18 @@ bool STCPManager::Socket::_openSocket()
     }
 
     if (https) {
-        ssl = new SSSLState(hostToResolve, s);
+        // SSSLState only closes the fd in its destructor, so if its constructor throws, the fd is still ours
+        // to close. Reporting failure by return value rather than letting the exception out also keeps it out
+        // of the poll loop, which reaches here by way of _connectAfterDNSResolution.
+        try {
+            ssl = new SSSLState(hostToResolve, s);
+        } catch (const SException& e) {
+            SWARN("Couldn't set up SSL for '" << hostToResolve << "' (" << addr << "): " << e.what());
+            S_close(&s);
+            state.store(State::CLOSED);
+            connectFailure = true;
+            return false;
+        }
     }
 
     return true;

--- a/libstuff/STCPManager.h
+++ b/libstuff/STCPManager.h
@@ -64,7 +64,7 @@ protected:
         void _connectAfterDNSResolution();
 
         // Opens the fd for `addr` and, for HTTPS sockets, its SSL state. Returns false and marks the socket
-        // closed and failed if the fd can't be opened.
+        // closed and failed if the fd can't be opened or the SSL state can't be set up.
         bool _openSocket();
 
         // Validates `host` and starts its lookup. `dnsResolution` is const, so it has to be built in


### PR DESCRIPTION
### Details

`Socket::_openSocket` assigns the new fd to `s` and then constructs the SSL state, so an `SSSLState` constructor failure comes out as an exception. That's wrong in a different way at each of its two callers. From [the address-taking constructor](https://github.com/Expensify/Bedrock/pull/2739) the object is never constructed, so `~Socket` never runs and the fd in `s` leaks. From `_connectAfterDNSResolution` the fd is fine — the object exists, so `~Socket` will get to it — but the throw unwinds out of `STCPManager::postPoll` into the poll loop. Neither is reachable today, since `SSocketPool::getSocket` is the only caller of the address constructor and passes `https = false`, and the DNS path asserts `SHostIsValid` up front, which is the same check `SSSLState` applies.

Both callers already treat a `false` return from `_openSocket` as "this socket is dead", so this just reports the failure that way instead of letting it out as an exception, which covers both of them with one `try`/`catch`. Closing the fd there is safe because `SSSLState` only releases it in [its destructor](https://github.com/Expensify/Bedrock/blob/ac15ed46bd24645a481c7ce9eb97643e79758b2d/libstuff/SSSLState.cpp#L120-L125), and that never runs when its constructor throws — so on every throw path the fd is definitively still ours and there's no double close. I'm catching `SException` only and not `...`, since a `bad_alloc` from that `new` means the process is dying and turning it into a quiet connect failure would just hide it.

Two related things I left alone and will file separately: `SHTTPSProxySocket::recv` builds its own `SSSLState` and has the same throw-out-of-`postPoll` hazard (no fd leak there, the object is fully constructed), and `SSSLState`'s own constructor leaks its `mbedtls_ssl_set_hostname` allocation if `mbedtls_ssl_setup` subsequently fails.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/675335

### Tests

An fd count can't be asserted reliably under `-threads 16`, since the other fixtures are opening and closing descriptors the whole time, so rather than commit a flaky test I checked it with a throwaway one and deleted it. `hostToResolve` of `""` fails `SParseHost`, so this throws 200 times out of 200 either way:

```cpp
const size_t before = countFDs();
for (int i = 0; i < 200; i++) {
    try {
        STCPManager::Socket sock(addr, true, "");
    } catch (const SException& e) {
        threw++;
    }
}
const size_t after = countFDs();
```

Without the fix:

```
    threw=200 fds before=63 after=205
```

With it:

```
    threw=200 fds before=35 after=5
```

(the drop is earlier tests' resolver threads winding down during the loop, which is also why the baseline isn't worth asserting on)

Existing tests otherwise:

```
expensidev-2404->Bedrock/test (tyler-fix-socket-fd-leak-on-ssl-failure) > ./test -threads 16
[ TEST RESULTS ] Passed: 316, Failed: 0
```

```
expensidev-2404->Bedrock/test/clustertest (tyler-fix-socket-fd-leak-on-ssl-failure) > ./clustertest -threads 16
[ TEST RESULTS ] Passed: 82, Failed: 0
```

Auth compiles clean against it.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
