### PR TITLE
Auto-reject blocking queue commands when the thread saturates

### DIFF
--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -139,8 +139,18 @@ uint64_t BedrockBlockingCommandQueue::setBlockDuration(const uint64_t durationUS
 void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, const string& commandName, uint64_t elapsedUS)
 {
     const uint64_t now = _now();
-    _recordAndCheck(_identifierStates, identifier, _identifierThresholdUS.load(), now, elapsedUS, "identifier");
-    _recordAndCheck(_commandStates, commandName, _commandThresholdUS.load(), now, elapsedUS, "command");
+    const uint64_t windowUS = _windowUS.load();
+    const uint64_t blockDurationUS = _blockDurationUS.load();
+
+    const Limits identifierLimits = {windowUS, _identifierThresholdUS.load(), blockDurationUS, LOG_THRESHOLD_US};
+    if (!identifier.empty() && identifierLimits.thresholdUS) {
+        _recordAndCheck(*_getOrCreateState(_identifierStates, identifier), "identifier", identifier, identifierLimits, now, elapsedUS);
+    }
+
+    const Limits commandLimits = {windowUS, _commandThresholdUS.load(), blockDurationUS, LOG_THRESHOLD_US};
+    if (!commandName.empty() && commandLimits.thresholdUS) {
+        _recordAndCheck(*_getOrCreateState(_commandStates, commandName), "command", commandName, commandLimits, now, elapsedUS);
+    }
 }
 
 string BedrockBlockingCommandQueue::getBlockingDimension(const string& identifier, const string& commandName)
@@ -148,11 +158,17 @@ string BedrockBlockingCommandQueue::getBlockingDimension(const string& identifie
     // Hot path: called by push() and by _dequeue() under the base `_queueMutex`. Keep it O(1) by reading only
     // the precomputed block deadline. The windowed time is summed in recordExecutionTime, off the blocking thread.
     const uint64_t now = _now();
-    if (_isBlocked(_identifierStates, identifier, now)) {
-        return "identifier";
+    if (!identifier.empty()) {
+        auto state = _getState(_identifierStates, identifier);
+        if (state && _isBlocked(*state, now)) {
+            return "identifier";
+        }
     }
-    if (_isBlocked(_commandStates, commandName, now)) {
-        return "command";
+    if (!commandName.empty()) {
+        auto state = _getState(_commandStates, commandName);
+        if (state && _isBlocked(*state, now)) {
+            return "command";
+        }
     }
     return "";
 }
@@ -174,70 +190,56 @@ shared_ptr<BedrockBlockingCommandQueue::DimensionState> BedrockBlockingCommandQu
     return it == map.states.end() ? nullptr : it->second;
 }
 
-void BedrockBlockingCommandQueue::_recordAndCheck(StateMap& map, const string& key, uint64_t thresholdUS, uint64_t now, uint64_t elapsedUS, const string& dimension)
+void BedrockBlockingCommandQueue::_recordAndCheck(DimensionState& state, const string& dimension, const string& key, const Limits& limits, uint64_t now, uint64_t elapsedUS)
 {
-    if (key.empty() || thresholdUS == 0) {
-        return;
-    }
-
-    auto state = _getOrCreateState(map, key);
-    lock_guard<decltype(state->m)> lock(state->m);
+    lock_guard<decltype(state.m)> lock(state.m);
 
     // Already inside an active block: a block lasts a fixed duration and is not extended by further hits, so
     // there's nothing to record or recompute until it expires.
-    if (state->blockedUntil > now) {
+    if (state.blockedUntil > now) {
         return;
     }
 
-    state->commands.push_back({now, elapsedUS});
-
-    const uint64_t windowUS = _windowUS.load();
+    state.commands.push_back({now, elapsedUS});
 
     // Drop samples that finished before the current window and sum the ones that are still valid.
     uint64_t total = 0;
-    for (auto it = state->commands.begin(); it != state->commands.end();) {
+    for (auto it = state.commands.begin(); it != state.commands.end();) {
         const uint64_t timeSinceFinishedUS = now > it->finishTime ? now - it->finishTime : 0;
-        if (timeSinceFinishedUS >= windowUS) {
-            it = state->commands.erase(it);
+        if (timeSinceFinishedUS >= limits.windowUS) {
+            it = state.commands.erase(it);
             continue;
         }
 
         // Doing the line below will allow us to count for partial timings spent in a command. Let's say the window is 100s,
         // and we had a command that took 50s and finished 80s ago. We should only count 20s of that command, since the other
         // 30s are outside the window. So the result would be min(50s, 100 - 80) = min(50, 20) = 20s.
-        total += min(it->elapsedTime, windowUS - timeSinceFinishedUS);
+        total += min(it->elapsedTime, limits.windowUS - timeSinceFinishedUS);
         ++it;
     }
 
-    if (total > thresholdUS) {
-        state->blockedUntil = now + _blockDurationUS.load();
+    if (total > limits.thresholdUS) {
+        state.blockedUntil = now + limits.blockDurationUS;
         SINFO("Blocking queue rate limit reached, blocking", {
             {"dimension", dimension},
             {"identifier", key},
             {"timeMS", to_string(total / 1000)},
-            {"thresholdMS", to_string(thresholdUS / 1000)},
-            {"blockDurationMS", to_string(_blockDurationUS.load() / 1000)}
+            {"thresholdMS", to_string(limits.thresholdUS / 1000)},
+            {"blockDurationMS", to_string(limits.blockDurationUS / 1000)}
         });
-    } else if (total > LOG_THRESHOLD_US) {
+    } else if (limits.logThresholdUS && total > limits.logThresholdUS) {
         // Log-only monitoring: the identifier is heavy but still under its block threshold.
         SINFO("Blocking queue rate limit above logging threshold", {
             {"dimension", dimension},
             {"identifier", key},
             {"timeMS", to_string(total / 1000)},
-            {"thresholdMS", to_string(LOG_THRESHOLD_US / 1000)}
+            {"thresholdMS", to_string(limits.logThresholdUS / 1000)}
         });
     }
 }
 
-bool BedrockBlockingCommandQueue::_isBlocked(StateMap& map, const string& key, uint64_t now)
+bool BedrockBlockingCommandQueue::_isBlocked(DimensionState& state, uint64_t now)
 {
-    if (key.empty()) {
-        return false;
-    }
-    auto state = _getState(map, key);
-    if (!state) {
-        return false;
-    }
-    lock_guard<decltype(state->m)> lock(state->m);
-    return state->blockedUntil > now;
+    lock_guard<decltype(state.m)> lock(state.m);
+    return state.blockedUntil > now;
 }

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -157,17 +157,17 @@ string BedrockBlockingCommandQueue::getBlockingDimension(const string& identifie
     return "";
 }
 
-shared_ptr<BedrockBlockingCommandQueue::IdentifierState> BedrockBlockingCommandQueue::_getOrCreateState(StateMap& map, const string& key)
+shared_ptr<BedrockBlockingCommandQueue::DimensionState> BedrockBlockingCommandQueue::_getOrCreateState(StateMap& map, const string& key)
 {
     lock_guard<decltype(map.mapMutex)> lock(map.mapMutex);
     auto [it, inserted] = map.states.try_emplace(key);
     if (inserted) {
-        it->second = make_shared<IdentifierState>();
+        it->second = make_shared<DimensionState>();
     }
     return it->second;
 }
 
-shared_ptr<BedrockBlockingCommandQueue::IdentifierState> BedrockBlockingCommandQueue::_getState(StateMap& map, const string& key)
+shared_ptr<BedrockBlockingCommandQueue::DimensionState> BedrockBlockingCommandQueue::_getState(StateMap& map, const string& key)
 {
     lock_guard<decltype(map.mapMutex)> lock(map.mapMutex);
     auto it = map.states.find(key);

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -111,79 +111,73 @@ STable BedrockBlockingCommandQueue::getState()
     inspect(_commandStates, trackedCommands, blockedCommands);
 
     STable content;
-    content["blockingTimeWindowMS"] = to_string(_windowUS.load() / 1000);
-    content["blockingIdentifierThresholdMS"] = to_string(_identifierThresholdUS.load() / 1000);
-    content["blockingCommandThresholdMS"] = to_string(_commandThresholdUS.load() / 1000);
-    content["blockingBlockDurationMS"] = to_string(_blockDurationUS.load() / 1000);
+    content["blockingTimeWindowMS"] = to_string(_identifierLimits.windowUS.load() / 1000);
+    content["blockingIdentifierThresholdMS"] = to_string(_identifierLimits.thresholdUS.load() / 1000);
+    content["blockingCommandThresholdMS"] = to_string(_commandLimits.thresholdUS.load() / 1000);
+    content["blockingBlockDurationMS"] = to_string(_identifierLimits.blockDurationUS.load() / 1000);
     content["blockingTrackedIdentifiers"] = to_string(trackedIdentifiers);
     content["blockingBlockedIdentifiers"] = SComposeList(blockedIdentifiers);
     content["blockingTrackedCommands"] = to_string(trackedCommands);
     content["blockingBlockedCommands"] = SComposeList(blockedCommands);
-    content["blockingGlobalWindowMS"] = to_string(_globalWindowUS.load() / 1000);
-    content["blockingGlobalThresholdMS"] = to_string(_globalThresholdUS.load() / 1000);
-    content["blockingGlobalBlockDurationMS"] = to_string(_globalBlockDurationUS.load() / 1000);
+    content["blockingGlobalWindowMS"] = to_string(_globalLimits.windowUS.load() / 1000);
+    content["blockingGlobalThresholdMS"] = to_string(_globalLimits.thresholdUS.load() / 1000);
+    content["blockingGlobalBlockDurationMS"] = to_string(_globalLimits.blockDurationUS.load() / 1000);
     content["blockingGlobalBlocked"] = _isBlocked(_globalState, now) ? "true" : "false";
     return content;
 }
 
 uint64_t BedrockBlockingCommandQueue::setWindow(const uint64_t windowUS)
 {
-    return _windowUS.exchange(windowUS);
+    _commandLimits.windowUS.store(windowUS);
+    return _identifierLimits.windowUS.exchange(windowUS);
 }
 
 uint64_t BedrockBlockingCommandQueue::setIdentifierThreshold(const uint64_t thresholdUS)
 {
-    return _identifierThresholdUS.exchange(thresholdUS);
+    return _identifierLimits.thresholdUS.exchange(thresholdUS);
 }
 
 uint64_t BedrockBlockingCommandQueue::setCommandThreshold(const uint64_t thresholdUS)
 {
-    return _commandThresholdUS.exchange(thresholdUS);
+    return _commandLimits.thresholdUS.exchange(thresholdUS);
 }
 
 uint64_t BedrockBlockingCommandQueue::setBlockDuration(const uint64_t durationUS)
 {
-    return _blockDurationUS.exchange(durationUS);
+    _commandLimits.blockDurationUS.store(durationUS);
+    return _identifierLimits.blockDurationUS.exchange(durationUS);
 }
 
 uint64_t BedrockBlockingCommandQueue::setGlobalWindow(const uint64_t windowUS)
 {
-    return _globalWindowUS.exchange(windowUS);
+    return _globalLimits.windowUS.exchange(windowUS);
 }
 
 uint64_t BedrockBlockingCommandQueue::setGlobalThreshold(const uint64_t thresholdUS)
 {
-    return _globalThresholdUS.exchange(thresholdUS);
+    _globalLimits.logThresholdUS.store(thresholdUS * GLOBAL_LOG_PERCENT / 100);
+    return _globalLimits.thresholdUS.exchange(thresholdUS);
 }
 
 uint64_t BedrockBlockingCommandQueue::setGlobalBlockDuration(const uint64_t durationUS)
 {
-    return _globalBlockDurationUS.exchange(durationUS);
+    return _globalLimits.blockDurationUS.exchange(durationUS);
 }
 
 void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, const string& commandName, uint64_t elapsedUS)
 {
     const uint64_t now = _now();
-    const uint64_t windowUS = _windowUS.load();
-    const uint64_t blockDurationUS = _blockDurationUS.load();
 
-    const Limits identifierLimits = {windowUS, _identifierThresholdUS.load(), blockDurationUS, LOG_THRESHOLD_US};
-    if (!identifier.empty() && identifierLimits.thresholdUS) {
-        _recordAndCheck(*_getOrCreateState(_identifierStates, identifier), "identifier", identifier, identifierLimits, now, elapsedUS);
+    if (!identifier.empty() && _identifierLimits.thresholdUS.load()) {
+        _recordAndCheck(*_getOrCreateState(_identifierStates, identifier), "identifier", identifier, _identifierLimits, now, elapsedUS);
+    }
+    if (!commandName.empty() && _commandLimits.thresholdUS.load()) {
+        _recordAndCheck(*_getOrCreateState(_commandStates, commandName), "command", commandName, _commandLimits, now, elapsedUS);
     }
 
-    const Limits commandLimits = {windowUS, _commandThresholdUS.load(), blockDurationUS, LOG_THRESHOLD_US};
-    if (!commandName.empty() && commandLimits.thresholdUS) {
-        _recordAndCheck(*_getOrCreateState(_commandStates, commandName), "command", commandName, commandLimits, now, elapsedUS);
-    }
-
-    // Every command counts toward the global dimension, whoever sent it. Warn from 80% of the threshold so the
-    // threshold can be tuned against real traffic before it starts rejecting anything. The fixed 10 second log
-    // threshold the other dimensions use would log on almost every command here.
-    const uint64_t globalThresholdUS = _globalThresholdUS.load();
-    const Limits globalLimits = {_globalWindowUS.load(), globalThresholdUS, _globalBlockDurationUS.load(), globalThresholdUS / 5 * 4};
-    if (globalLimits.thresholdUS) {
-        _recordAndCheck(_globalState, "global", "", globalLimits, now, elapsedUS);
+    // Every command counts toward the global dimension, whoever sent it.
+    if (_globalLimits.thresholdUS.load()) {
+        _recordAndCheck(_globalState, "global", "", _globalLimits, now, elapsedUS);
     }
 }
 
@@ -229,6 +223,11 @@ shared_ptr<BedrockBlockingCommandQueue::DimensionState> BedrockBlockingCommandQu
 
 void BedrockBlockingCommandQueue::_recordAndCheck(DimensionState& state, const string& dimension, const string& key, const Limits& limits, uint64_t now, uint64_t elapsedUS)
 {
+    const uint64_t windowUS = limits.windowUS.load();
+    const uint64_t thresholdUS = limits.thresholdUS.load();
+    const uint64_t blockDurationUS = limits.blockDurationUS.load();
+    const uint64_t logThresholdUS = limits.logThresholdUS.load();
+
     lock_guard<decltype(state.m)> lock(state.m);
 
     // Already inside an active block: a block lasts a fixed duration and is not extended by further hits, so
@@ -243,7 +242,7 @@ void BedrockBlockingCommandQueue::_recordAndCheck(DimensionState& state, const s
     uint64_t total = 0;
     for (auto it = state.commands.begin(); it != state.commands.end();) {
         const uint64_t timeSinceFinishedUS = now > it->finishTime ? now - it->finishTime : 0;
-        if (timeSinceFinishedUS >= limits.windowUS) {
+        if (timeSinceFinishedUS >= windowUS) {
             it = state.commands.erase(it);
             continue;
         }
@@ -251,26 +250,26 @@ void BedrockBlockingCommandQueue::_recordAndCheck(DimensionState& state, const s
         // Doing the line below will allow us to count for partial timings spent in a command. Let's say the window is 100s,
         // and we had a command that took 50s and finished 80s ago. We should only count 20s of that command, since the other
         // 30s are outside the window. So the result would be min(50s, 100 - 80) = min(50, 20) = 20s.
-        total += min(it->elapsedTime, limits.windowUS - timeSinceFinishedUS);
+        total += min(it->elapsedTime, windowUS - timeSinceFinishedUS);
         ++it;
     }
 
-    if (total > limits.thresholdUS) {
-        state.blockedUntil = now + limits.blockDurationUS;
+    if (total > thresholdUS) {
+        state.blockedUntil = now + blockDurationUS;
         SINFO("Blocking queue rate limit reached, blocking", {
             {"dimension", dimension},
             {"identifier", key},
             {"timeMS", to_string(total / 1000)},
-            {"thresholdMS", to_string(limits.thresholdUS / 1000)},
-            {"blockDurationMS", to_string(limits.blockDurationUS / 1000)}
+            {"thresholdMS", to_string(thresholdUS / 1000)},
+            {"blockDurationMS", to_string(blockDurationUS / 1000)}
         });
-    } else if (limits.logThresholdUS && total > limits.logThresholdUS) {
+    } else if (logThresholdUS && total > logThresholdUS) {
         // Log-only monitoring: the dimension is heavy but still under its block threshold.
         SINFO("Blocking queue rate limit above logging threshold", {
             {"dimension", dimension},
             {"identifier", key},
             {"timeMS", to_string(total / 1000)},
-            {"thresholdMS", to_string(limits.logThresholdUS / 1000)}
+            {"thresholdMS", to_string(logThresholdUS / 1000)}
         });
     }
 }

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -78,6 +78,12 @@ size_t BedrockBlockingCommandQueue::clearRateLimits()
         size += _commandStates.states.size();
         _commandStates.states.clear();
     }
+    {
+        // The global dimension is a single state rather than a tracked key, so it isn't part of the count.
+        lock_guard<decltype(_globalState.m)> lock(_globalState.m);
+        _globalState.commands.clear();
+        _globalState.blockedUntil = 0;
+    }
     return size;
 }
 
@@ -113,6 +119,10 @@ STable BedrockBlockingCommandQueue::getState()
     content["blockingBlockedIdentifiers"] = SComposeList(blockedIdentifiers);
     content["blockingTrackedCommands"] = to_string(trackedCommands);
     content["blockingBlockedCommands"] = SComposeList(blockedCommands);
+    content["blockingGlobalWindowMS"] = to_string(_globalWindowUS.load() / 1000);
+    content["blockingGlobalThresholdMS"] = to_string(_globalThresholdUS.load() / 1000);
+    content["blockingGlobalBlockDurationMS"] = to_string(_globalBlockDurationUS.load() / 1000);
+    content["blockingGlobalBlocked"] = _isBlocked(_globalState, now) ? "true" : "false";
     return content;
 }
 
@@ -136,6 +146,21 @@ uint64_t BedrockBlockingCommandQueue::setBlockDuration(const uint64_t durationUS
     return _blockDurationUS.exchange(durationUS);
 }
 
+uint64_t BedrockBlockingCommandQueue::setGlobalWindow(const uint64_t windowUS)
+{
+    return _globalWindowUS.exchange(windowUS);
+}
+
+uint64_t BedrockBlockingCommandQueue::setGlobalThreshold(const uint64_t thresholdUS)
+{
+    return _globalThresholdUS.exchange(thresholdUS);
+}
+
+uint64_t BedrockBlockingCommandQueue::setGlobalBlockDuration(const uint64_t durationUS)
+{
+    return _globalBlockDurationUS.exchange(durationUS);
+}
+
 void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, const string& commandName, uint64_t elapsedUS)
 {
     const uint64_t now = _now();
@@ -151,6 +176,15 @@ void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, 
     if (!commandName.empty() && commandLimits.thresholdUS) {
         _recordAndCheck(*_getOrCreateState(_commandStates, commandName), "command", commandName, commandLimits, now, elapsedUS);
     }
+
+    // Every command counts toward the global dimension, whoever sent it. Warn from 80% of the threshold so the
+    // threshold can be tuned against real traffic before it starts rejecting anything. The fixed 10 second log
+    // threshold the other dimensions use would log on almost every command here.
+    const uint64_t globalThresholdUS = _globalThresholdUS.load();
+    const Limits globalLimits = {_globalWindowUS.load(), globalThresholdUS, _globalBlockDurationUS.load(), globalThresholdUS / 5 * 4};
+    if (globalLimits.thresholdUS) {
+        _recordAndCheck(_globalState, "global", "", globalLimits, now, elapsedUS);
+    }
 }
 
 string BedrockBlockingCommandQueue::getBlockingDimension(const string& identifier, const string& commandName)
@@ -158,6 +192,9 @@ string BedrockBlockingCommandQueue::getBlockingDimension(const string& identifie
     // Hot path: called by push() and by _dequeue() under the base `_queueMutex`. Keep it O(1) by reading only
     // the precomputed block deadline. The windowed time is summed in recordExecutionTime, off the blocking thread.
     const uint64_t now = _now();
+    if (_isBlocked(_globalState, now)) {
+        return "global";
+    }
     if (!identifier.empty()) {
         auto state = _getState(_identifierStates, identifier);
         if (state && _isBlocked(*state, now)) {
@@ -228,7 +265,7 @@ void BedrockBlockingCommandQueue::_recordAndCheck(DimensionState& state, const s
             {"blockDurationMS", to_string(limits.blockDurationUS / 1000)}
         });
     } else if (limits.logThresholdUS && total > limits.logThresholdUS) {
-        // Log-only monitoring: the identifier is heavy but still under its block threshold.
+        // Log-only monitoring: the dimension is heavy but still under its block threshold.
         SINFO("Blocking queue rate limit above logging threshold", {
             {"dimension", dimension},
             {"identifier", key},

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -204,24 +204,24 @@ string BedrockBlockingCommandQueue::getBlockingDimension(const string& identifie
     return "";
 }
 
-shared_ptr<BedrockBlockingCommandQueue::DimensionState> BedrockBlockingCommandQueue::_getOrCreateState(StateMap& map, const string& key)
+shared_ptr<BedrockBlockingCommandQueue::BlockingCategoryState> BedrockBlockingCommandQueue::_getOrCreateState(StateMap& map, const string& key)
 {
     lock_guard<decltype(map.mapMutex)> lock(map.mapMutex);
     auto [it, inserted] = map.states.try_emplace(key);
     if (inserted) {
-        it->second = make_shared<DimensionState>();
+        it->second = make_shared<BlockingCategoryState>();
     }
     return it->second;
 }
 
-shared_ptr<BedrockBlockingCommandQueue::DimensionState> BedrockBlockingCommandQueue::_getState(StateMap& map, const string& key)
+shared_ptr<BedrockBlockingCommandQueue::BlockingCategoryState> BedrockBlockingCommandQueue::_getState(StateMap& map, const string& key)
 {
     lock_guard<decltype(map.mapMutex)> lock(map.mapMutex);
     auto it = map.states.find(key);
     return it == map.states.end() ? nullptr : it->second;
 }
 
-void BedrockBlockingCommandQueue::_recordAndCheck(DimensionState& state, const string& dimension, const string& key, const Limits& limits, uint64_t now, uint64_t elapsedUS)
+void BedrockBlockingCommandQueue::_recordAndCheck(BlockingCategoryState& state, const string& dimension, const string& key, const Limits& limits, uint64_t now, uint64_t elapsedUS)
 {
     const uint64_t windowUS = limits.windowUS.load();
     const uint64_t thresholdUS = limits.thresholdUS.load();
@@ -274,7 +274,7 @@ void BedrockBlockingCommandQueue::_recordAndCheck(DimensionState& state, const s
     }
 }
 
-bool BedrockBlockingCommandQueue::_isBlocked(DimensionState& state, uint64_t now)
+bool BedrockBlockingCommandQueue::_isBlocked(BlockingCategoryState& state, uint64_t now)
 {
     lock_guard<decltype(state.m)> lock(state.m);
     return state.blockedUntil > now;

--- a/BedrockBlockingCommandQueue.cpp
+++ b/BedrockBlockingCommandQueue.cpp
@@ -79,7 +79,7 @@ size_t BedrockBlockingCommandQueue::clearRateLimits()
         _commandStates.states.clear();
     }
     {
-        // The global dimension is a single state rather than a tracked key, so it isn't part of the count.
+        // The global rate limiter has no key, so it isn't part of the count.
         lock_guard<decltype(_globalState.m)> lock(_globalState.m);
         _globalState.commands.clear();
         _globalState.blockedUntil = 0;
@@ -119,47 +119,47 @@ STable BedrockBlockingCommandQueue::getState()
     content["blockingBlockedIdentifiers"] = SComposeList(blockedIdentifiers);
     content["blockingTrackedCommands"] = to_string(trackedCommands);
     content["blockingBlockedCommands"] = SComposeList(blockedCommands);
-    content["blockingGlobalWindowMS"] = to_string(_globalLimits.windowUS.load() / 1000);
-    content["blockingGlobalThresholdMS"] = to_string(_globalLimits.thresholdUS.load() / 1000);
-    content["blockingGlobalBlockDurationMS"] = to_string(_globalLimits.blockDurationUS.load() / 1000);
-    content["blockingGlobalBlocked"] = _isBlocked(_globalState, now) ? "true" : "false";
+    content["globalRateLimiterWindowMS"] = to_string(_globalLimits.windowUS.load() / 1000);
+    content["globalRateLimiterThresholdMS"] = to_string(_globalLimits.thresholdUS.load() / 1000);
+    content["globalRateLimiterBlockDurationMS"] = to_string(_globalLimits.blockDurationUS.load() / 1000);
+    content["globalRateLimiterTriggered"] = _isBlocked(_globalState, now) ? "true" : "false";
     return content;
 }
 
-uint64_t BedrockBlockingCommandQueue::setWindow(const uint64_t windowUS)
+uint64_t BedrockBlockingCommandQueue::setSharedRateLimiterWindow(const uint64_t windowUS)
 {
     _commandLimits.windowUS.store(windowUS);
     return _identifierLimits.windowUS.exchange(windowUS);
 }
 
-uint64_t BedrockBlockingCommandQueue::setIdentifierThreshold(const uint64_t thresholdUS)
+uint64_t BedrockBlockingCommandQueue::setBlockingIdentifierThreshold(const uint64_t thresholdUS)
 {
     return _identifierLimits.thresholdUS.exchange(thresholdUS);
 }
 
-uint64_t BedrockBlockingCommandQueue::setCommandThreshold(const uint64_t thresholdUS)
+uint64_t BedrockBlockingCommandQueue::setBlockingCommandThreshold(const uint64_t thresholdUS)
 {
     return _commandLimits.thresholdUS.exchange(thresholdUS);
 }
 
-uint64_t BedrockBlockingCommandQueue::setBlockDuration(const uint64_t durationUS)
+uint64_t BedrockBlockingCommandQueue::setSharedRateLimiterBlockDuration(const uint64_t durationUS)
 {
     _commandLimits.blockDurationUS.store(durationUS);
     return _identifierLimits.blockDurationUS.exchange(durationUS);
 }
 
-uint64_t BedrockBlockingCommandQueue::setGlobalWindow(const uint64_t windowUS)
+uint64_t BedrockBlockingCommandQueue::setGlobalRateLimiterWindow(const uint64_t windowUS)
 {
     return _globalLimits.windowUS.exchange(windowUS);
 }
 
-uint64_t BedrockBlockingCommandQueue::setGlobalThreshold(const uint64_t thresholdUS)
+uint64_t BedrockBlockingCommandQueue::setGlobalRateLimiterThreshold(const uint64_t thresholdUS)
 {
     _globalLimits.logThresholdUS.store(thresholdUS * GLOBAL_LOG_PERCENT / 100);
     return _globalLimits.thresholdUS.exchange(thresholdUS);
 }
 
-uint64_t BedrockBlockingCommandQueue::setGlobalBlockDuration(const uint64_t durationUS)
+uint64_t BedrockBlockingCommandQueue::setGlobalRateLimiterBlockDuration(const uint64_t durationUS)
 {
     return _globalLimits.blockDurationUS.exchange(durationUS);
 }
@@ -175,7 +175,7 @@ void BedrockBlockingCommandQueue::recordExecutionTime(const string& identifier, 
         _recordAndCheck(*_getOrCreateState(_commandStates, commandName), "command", commandName, _commandLimits, now, elapsedUS);
     }
 
-    // Every command counts toward the global dimension, whoever sent it.
+    // Every command counts toward the global rate limiter, whoever sent it.
     if (_globalLimits.thresholdUS.load()) {
         _recordAndCheck(_globalState, "global", "", _globalLimits, now, elapsedUS);
     }
@@ -264,7 +264,7 @@ void BedrockBlockingCommandQueue::_recordAndCheck(DimensionState& state, const s
             {"blockDurationMS", to_string(blockDurationUS / 1000)}
         });
     } else if (logThresholdUS && total > logThresholdUS) {
-        // Log-only monitoring: the dimension is heavy but still under its block threshold.
+        // Heavy, but still under its block threshold.
         SINFO("Blocking queue rate limit above logging threshold", {
             {"dimension", dimension},
             {"identifier", key},

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -61,10 +61,10 @@ private:
     // An identifier's recently finished blocking-queue commands, oldest first.
     typedef deque<RecentlyFinishedCommand> RecentlyFinishedCommandList;
 
-    // Rate-limit state for one identifier (an identifier or a command name). Each entry has its own mutex, so
+    // Rate-limit state for one dimension: one identifier or one command name. Each entry has its own mutex, so
     // different identifiers never contend on one lock. `blockedUntil` is the time (microseconds) an active
     // block ends; 0 means not blocked.
-    struct IdentifierState
+    struct DimensionState
     {
         mutex m;
         RecentlyFinishedCommandList commands;
@@ -78,14 +78,14 @@ private:
     struct StateMap
     {
         mutable mutex mapMutex;
-        unordered_map<string, shared_ptr<IdentifierState>> states;
+        unordered_map<string, shared_ptr<DimensionState>> states;
     };
 
     // Return a shared_ptr to the state for `key` in `map`, creating it if absent. Holds map.mapMutex only briefly.
-    static shared_ptr<IdentifierState> _getOrCreateState(StateMap& map, const string& key);
+    static shared_ptr<DimensionState> _getOrCreateState(StateMap& map, const string& key);
 
     // Return the state for `key` in `map`, or nullptr if absent. Holds map.mapMutex only briefly.
-    static shared_ptr<IdentifierState> _getState(StateMap& map, const string& key);
+    static shared_ptr<DimensionState> _getState(StateMap& map, const string& key);
 
     // Append a sample that finished at `now` after `elapsedUS` for `key` in `map`, then re-evaluate the window
     // and block `key` for the block duration when its windowed time exceeds `thresholdUS`. A threshold of 0

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -72,8 +72,8 @@ private:
     typedef deque<RecentlyFinishedCommand> RecentlyFinishedCommandList;
 
     // Rate-limit state for one dimension: the whole queue, one identifier, or one command name. Each entry has
-    // its own mutex, so different identifiers never contend on one lock. `blockedUntil` is the time (microseconds) an active
-    // block ends; 0 means not blocked.
+    // its own mutex, so different identifiers never contend on one lock. `blockedUntil` is the time
+    // (microseconds) an active block ends; 0 means not blocked.
     struct DimensionState
     {
         mutex m;

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -81,21 +81,30 @@ private:
         unordered_map<string, shared_ptr<DimensionState>> states;
     };
 
+    // The tunables for one dimension, in microseconds. A `thresholdUS` of 0 disables the dimension. A
+    // `logThresholdUS` of 0 disables the log-only line for identifiers that are heavy but under the threshold.
+    struct Limits
+    {
+        uint64_t windowUS = 0;
+        uint64_t thresholdUS = 0;
+        uint64_t blockDurationUS = 0;
+        uint64_t logThresholdUS = 0;
+    };
+
     // Return a shared_ptr to the state for `key` in `map`, creating it if absent. Holds map.mapMutex only briefly.
     static shared_ptr<DimensionState> _getOrCreateState(StateMap& map, const string& key);
 
     // Return the state for `key` in `map`, or nullptr if absent. Holds map.mapMutex only briefly.
     static shared_ptr<DimensionState> _getState(StateMap& map, const string& key);
 
-    // Append a sample that finished at `now` after `elapsedUS` for `key` in `map`, then re-evaluate the window
-    // and block `key` for the block duration when its windowed time exceeds `thresholdUS`. A threshold of 0
-    // disables the dimension. `dimension` labels the log line emitted when it blocks. This is the O(window)
-    // work; it runs off the blocking thread (from recordExecutionTime), never under the base `_queueMutex`.
-    void _recordAndCheck(StateMap& map, const string& key, uint64_t thresholdUS, uint64_t now, uint64_t elapsedUS, const string& dimension);
+    // Append a sample that finished at `now` after `elapsedUS` to `state`, then re-evaluate the window and
+    // block for `limits.blockDurationUS` when the windowed time exceeds `limits.thresholdUS`. `dimension` and
+    // `key` label the log line. This is the O(window) work; it never runs under the base `_queueMutex`.
+    static void _recordAndCheck(DimensionState& state, const string& dimension, const string& key, const Limits& limits, uint64_t now, uint64_t elapsedUS);
 
-    // True if `key` in `map` is inside an active block at `now`. O(1): reads only the block deadline, so the
-    // push and dequeue hot paths stay cheap (dequeue runs under the base `_queueMutex`).
-    static bool _isBlocked(StateMap& map, const string& key, uint64_t now);
+    // True if `state` is inside an active block at `now`. O(1): reads only the block deadline, so the push and
+    // dequeue hot paths stay cheap (dequeue runs under the base `_queueMutex`).
+    static bool _isBlocked(DimensionState& state, uint64_t now);
 
     // Log (without blocking) when an identifier's windowed time crosses this, for monitoring heavy identifiers
     // that are still under their block threshold.

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -15,8 +15,9 @@ public:
     static void startTiming(unique_ptr<BedrockCommand>& command);
     static void stopTiming(unique_ptr<BedrockCommand>& command);
 
-    // Reject a command before enqueuing if its identifier or command name is rate limited. Overrides
-    // BedrockCommandQueue::push(). Throws SException("503 ...") when blocked; the caller catches and replies.
+    // Reject a command before enqueuing if the queue as a whole, its identifier, or its command name is rate
+    // limited. Overrides BedrockCommandQueue::push(). Throws SException("503 ...") when blocked; the caller
+    // catches and replies.
     void push(unique_ptr<BedrockCommand>&& command) override;
 
     // Clear the queue and all rate limiting state.
@@ -35,15 +36,24 @@ public:
     uint64_t setCommandThreshold(const uint64_t thresholdUS);
     uint64_t setBlockDuration(const uint64_t durationUS);
 
+    // The global dimension counts every command that runs on the blocking thread, so that a burst spread over
+    // many identifiers still trips it. It gets its own window, threshold and block duration because it
+    // measures total saturation of the thread rather than one identifier's share of it.
+    uint64_t setGlobalWindow(const uint64_t windowUS);
+    uint64_t setGlobalThreshold(const uint64_t thresholdUS);
+    uint64_t setGlobalBlockDuration(const uint64_t durationUS);
+
     // Record that a command finished on the blocking queue after `elapsedUS` of blocking time. Records the
-    // sample against the identifier (when `identifier` is non-empty) and against the command name.
+    // sample against the queue as a whole, against the identifier (when `identifier` is non-empty), and
+    // against the command name.
     void recordExecutionTime(const string& identifier, const string& commandName, uint64_t elapsedUS);
 
-    // Return the active rate-limit dimension, or an empty string. Identifier blocks take precedence when both dimensions are active.
+    // Return the active rate-limit dimension, or an empty string. A global block takes precedence over an
+    // identifier block, which takes precedence over a command block.
     string getBlockingDimension(const string& identifier, const string& commandName);
 
 protected:
-    // Dequeues a command and rejects it if its identifier or command name is rate limited.
+    // Dequeues a command and rejects it if the queue as a whole, its identifier, or its command name is rate limited.
     // Called by `BedrockCommandQueue::get()` with the base `_queueMutex` held. Calling any base method that reacquires `_queueMutex` would deadlock.
     unique_ptr<BedrockCommand> _dequeue() override;
 
@@ -61,8 +71,8 @@ private:
     // An identifier's recently finished blocking-queue commands, oldest first.
     typedef deque<RecentlyFinishedCommand> RecentlyFinishedCommandList;
 
-    // Rate-limit state for one dimension: one identifier or one command name. Each entry has its own mutex, so
-    // different identifiers never contend on one lock. `blockedUntil` is the time (microseconds) an active
+    // Rate-limit state for one dimension: the whole queue, one identifier, or one command name. Each entry has
+    // its own mutex, so different identifiers never contend on one lock. `blockedUntil` is the time (microseconds) an active
     // block ends; 0 means not blocked.
     struct DimensionState
     {
@@ -106,15 +116,22 @@ private:
     // dequeue hot paths stay cheap (dequeue runs under the base `_queueMutex`).
     static bool _isBlocked(DimensionState& state, uint64_t now);
 
-    // Log (without blocking) when an identifier's windowed time crosses this, for monitoring heavy identifiers
-    // that are still under their block threshold.
+    // Log (without blocking) when an identifier's or a command's windowed time crosses this, for monitoring
+    // heavy ones that are still under their block threshold.
     static constexpr uint64_t LOG_THRESHOLD_US = 10'000'000; // 10 seconds
 
     StateMap _identifierStates;
     StateMap _commandStates;
 
+    // The global dimension has no key, so it needs one state rather than a map of them.
+    DimensionState _globalState;
+
     atomic<uint64_t> _windowUS{180'000'000};          // 180 seconds
     atomic<uint64_t> _identifierThresholdUS{20'000'000}; // 20 seconds
     atomic<uint64_t> _commandThresholdUS{40'000'000}; // 40 seconds
     atomic<uint64_t> _blockDurationUS{60'000'000};    // 60 seconds
+
+    atomic<uint64_t> _globalWindowUS{60'000'000};        // 60 seconds
+    atomic<uint64_t> _globalThresholdUS{55'000'000};     // 55 seconds
+    atomic<uint64_t> _globalBlockDurationUS{60'000'000}; // 60 seconds
 };

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -91,14 +91,16 @@ private:
         unordered_map<string, shared_ptr<DimensionState>> states;
     };
 
-    // The tunables for one dimension, in microseconds. A `thresholdUS` of 0 disables the dimension. A
-    // `logThresholdUS` of 0 disables the log-only line for identifiers that are heavy but under the threshold.
+    // The tunables for one dimension, in microseconds. The blocking thread reads these while the
+    // SetBlockingQueueTimeRateLimit control command writes them from a worker, so each one is atomic. A
+    // `thresholdUS` of 0 disables the dimension. A `logThresholdUS` of 0 disables the log-only line for
+    // identifiers that are heavy but under the threshold.
     struct Limits
     {
-        uint64_t windowUS = 0;
-        uint64_t thresholdUS = 0;
-        uint64_t blockDurationUS = 0;
-        uint64_t logThresholdUS = 0;
+        atomic<uint64_t> windowUS;
+        atomic<uint64_t> thresholdUS;
+        atomic<uint64_t> blockDurationUS;
+        atomic<uint64_t> logThresholdUS;
     };
 
     // Return a shared_ptr to the state for `key` in `map`, creating it if absent. Holds map.mapMutex only briefly.
@@ -109,7 +111,8 @@ private:
 
     // Append a sample that finished at `now` after `elapsedUS` to `state`, then re-evaluate the window and
     // block for `limits.blockDurationUS` when the windowed time exceeds `limits.thresholdUS`. `dimension` and
-    // `key` label the log line. This is the O(window) work; it never runs under the base `_queueMutex`.
+    // `key` label the log line. Reads `limits` once up front, so a concurrent retune can't change the window
+    // partway through. This is the O(window) work; it never runs under the base `_queueMutex`.
     static void _recordAndCheck(DimensionState& state, const string& dimension, const string& key, const Limits& limits, uint64_t now, uint64_t elapsedUS);
 
     // True if `state` is inside an active block at `now`. O(1): reads only the block deadline, so the push and
@@ -120,18 +123,22 @@ private:
     // heavy ones that are still under their block threshold.
     static constexpr uint64_t LOG_THRESHOLD_US = 10'000'000; // 10 seconds
 
+    static constexpr uint64_t GLOBAL_THRESHOLD_US = 55'000'000; // 55 seconds
+
+    // The global dimension warns from this share of its threshold instead of the fixed one above, so the
+    // threshold can be tuned against real traffic before it rejects anything. Every command counts toward this
+    // dimension, so a fixed 10 seconds would log on almost all of them. setGlobalThreshold() keeps the two in step.
+    static constexpr uint64_t GLOBAL_LOG_PERCENT = 80;
+
     StateMap _identifierStates;
     StateMap _commandStates;
 
     // The global dimension has no key, so it needs one state rather than a map of them.
     DimensionState _globalState;
 
-    atomic<uint64_t> _windowUS{180'000'000};          // 180 seconds
-    atomic<uint64_t> _identifierThresholdUS{20'000'000}; // 20 seconds
-    atomic<uint64_t> _commandThresholdUS{40'000'000}; // 40 seconds
-    atomic<uint64_t> _blockDurationUS{60'000'000};    // 60 seconds
-
-    atomic<uint64_t> _globalWindowUS{60'000'000};        // 60 seconds
-    atomic<uint64_t> _globalThresholdUS{55'000'000};     // 55 seconds
-    atomic<uint64_t> _globalBlockDurationUS{60'000'000}; // 60 seconds
+    // The identifier and command dimensions share one window and one block duration, so setWindow() and
+    // setBlockDuration() write both of them.
+    Limits _identifierLimits{180'000'000, 20'000'000, 60'000'000, LOG_THRESHOLD_US};
+    Limits _commandLimits{180'000'000, 40'000'000, 60'000'000, LOG_THRESHOLD_US};
+    Limits _globalLimits{60'000'000, GLOBAL_THRESHOLD_US, 60'000'000, (GLOBAL_THRESHOLD_US * GLOBAL_LOG_PERCENT) / 100};
 };

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -15,9 +15,8 @@ public:
     static void startTiming(unique_ptr<BedrockCommand>& command);
     static void stopTiming(unique_ptr<BedrockCommand>& command);
 
-    // Reject a command before enqueuing if the queue as a whole, its identifier, or its command name is rate
-    // limited. Overrides BedrockCommandQueue::push(). Throws SException("503 ...") when blocked; the caller
-    // catches and replies.
+    // Reject a command before enqueuing if any rate limiter is blocking it. Overrides
+    // BedrockCommandQueue::push(). Throws SException("503 ...") when blocked; the caller catches and replies.
     void push(unique_ptr<BedrockCommand>&& command) override;
 
     // Clear the queue and all rate limiting state.
@@ -30,30 +29,30 @@ public:
     STable getState();
 
     // Configure the sliding window and thresholds, all in microseconds. A threshold of 0 disables that
-    // dimension. Each setter returns the previous value.
-    uint64_t setWindow(const uint64_t windowUS);
-    uint64_t setIdentifierThreshold(const uint64_t thresholdUS);
-    uint64_t setCommandThreshold(const uint64_t thresholdUS);
-    uint64_t setBlockDuration(const uint64_t durationUS);
+    // dimension. Each setter returns the previous value. The identifier and command dimensions share one
+    // window and one block duration.
+    uint64_t setSharedRateLimiterWindow(const uint64_t windowUS);
+    uint64_t setSharedRateLimiterBlockDuration(const uint64_t durationUS);
+    uint64_t setBlockingIdentifierThreshold(const uint64_t thresholdUS);
+    uint64_t setBlockingCommandThreshold(const uint64_t thresholdUS);
 
-    // The global dimension counts every command that runs on the blocking thread, so that a burst spread over
-    // many identifiers still trips it. It gets its own window, threshold and block duration because it
+    // The global rate limiter counts every command that runs on the blocking thread, so that a burst of commands with different
+    // identifiers still trips it. It gets its own window, threshold and block duration because it
     // measures total saturation of the thread rather than one identifier's share of it.
-    uint64_t setGlobalWindow(const uint64_t windowUS);
-    uint64_t setGlobalThreshold(const uint64_t thresholdUS);
-    uint64_t setGlobalBlockDuration(const uint64_t durationUS);
+    uint64_t setGlobalRateLimiterWindow(const uint64_t windowUS);
+    uint64_t setGlobalRateLimiterThreshold(const uint64_t thresholdUS);
+    uint64_t setGlobalRateLimiterBlockDuration(const uint64_t durationUS);
 
     // Record that a command finished on the blocking queue after `elapsedUS` of blocking time. Records the
-    // sample against the queue as a whole, against the identifier (when `identifier` is non-empty), and
-    // against the command name.
+    // sample against the global rate limiter, the command name, and the identifier when it is set.
     void recordExecutionTime(const string& identifier, const string& commandName, uint64_t elapsedUS);
 
-    // Return the active rate-limit dimension, or an empty string. A global block takes precedence over an
-    // identifier block, which takes precedence over a command block.
+    // Return the dimension blocking this command, or an empty string. The global rate limiter takes
+    // precedence, then the identifier, then the command.
     string getBlockingDimension(const string& identifier, const string& commandName);
 
 protected:
-    // Dequeues a command and rejects it if the queue as a whole, its identifier, or its command name is rate limited.
+    // Dequeues a command and rejects it if any rate limiter is blocking it.
     // Called by `BedrockCommandQueue::get()` with the base `_queueMutex` held. Calling any base method that reacquires `_queueMutex` would deadlock.
     unique_ptr<BedrockCommand> _dequeue() override;
 
@@ -71,9 +70,8 @@ private:
     // An identifier's recently finished blocking-queue commands, oldest first.
     typedef deque<RecentlyFinishedCommand> RecentlyFinishedCommandList;
 
-    // Rate-limit state for one dimension: the whole queue, one identifier, or one command name. Each entry has
-    // its own mutex, so different identifiers never contend on one lock. `blockedUntil` is the time
-    // (microseconds) an active block ends; 0 means not blocked.
+    // Rate-limit state for one dimension. Each entry has its own mutex, so different identifiers never contend
+    // on one lock. `blockedUntil` is when an active block ends, in microseconds; 0 means not blocked.
     struct DimensionState
     {
         mutex m;
@@ -91,10 +89,9 @@ private:
         unordered_map<string, shared_ptr<DimensionState>> states;
     };
 
-    // The tunables for one dimension, in microseconds. The blocking thread reads these while the
-    // SetBlockingQueueTimeRateLimit control command writes them from a worker, so each one is atomic. A
-    // `thresholdUS` of 0 disables the dimension. A `logThresholdUS` of 0 disables the log-only line for
-    // identifiers that are heavy but under the threshold.
+    // The tunables for one dimension, in microseconds. Each one is atomic because the blocking thread reads
+    // them while SetBlockingQueueTimeRateLimit writes them from a worker. A `thresholdUS` of 0 disables the
+    // dimension, and a `logThresholdUS` of 0 disables its log-only line.
     struct Limits
     {
         atomic<uint64_t> windowUS;
@@ -109,35 +106,34 @@ private:
     // Return the state for `key` in `map`, or nullptr if absent. Holds map.mapMutex only briefly.
     static shared_ptr<DimensionState> _getState(StateMap& map, const string& key);
 
-    // Append a sample that finished at `now` after `elapsedUS` to `state`, then re-evaluate the window and
-    // block for `limits.blockDurationUS` when the windowed time exceeds `limits.thresholdUS`. `dimension` and
-    // `key` label the log line. Reads `limits` once up front, so a concurrent retune can't change the window
-    // partway through. This is the O(window) work; it never runs under the base `_queueMutex`.
+    // Append a sample that finished at `now` after `elapsedUS` to `state`, then block it for the block
+    // duration when its windowed time exceeds the threshold. `dimension` and `key` label the log line. Reads
+    // `limits` once up front so a concurrent retune can't change the window partway through. This is the
+    // O(window) work; it never runs under the base `_queueMutex`.
     static void _recordAndCheck(DimensionState& state, const string& dimension, const string& key, const Limits& limits, uint64_t now, uint64_t elapsedUS);
 
     // True if `state` is inside an active block at `now`. O(1): reads only the block deadline, so the push and
     // dequeue hot paths stay cheap (dequeue runs under the base `_queueMutex`).
     static bool _isBlocked(DimensionState& state, uint64_t now);
 
-    // Log (without blocking) when an identifier's or a command's windowed time crosses this, for monitoring
-    // heavy ones that are still under their block threshold.
+    // Log an identifier or command that is over this but under its block threshold, so heavy ones are visible
+    // before they get blocked.
     static constexpr uint64_t LOG_THRESHOLD_US = 10'000'000; // 10 seconds
 
     static constexpr uint64_t GLOBAL_THRESHOLD_US = 55'000'000; // 55 seconds
 
-    // The global dimension warns from this share of its threshold instead of the fixed one above, so the
-    // threshold can be tuned against real traffic before it rejects anything. Every command counts toward this
-    // dimension, so a fixed 10 seconds would log on almost all of them. setGlobalThreshold() keeps the two in step.
+    // Every command counts toward the global rate limiter, so the fixed threshold above would log on almost
+    // all of them. It logs from this share of its own threshold instead.
     static constexpr uint64_t GLOBAL_LOG_PERCENT = 80;
 
     StateMap _identifierStates;
     StateMap _commandStates;
 
-    // The global dimension has no key, so it needs one state rather than a map of them.
+    // The global rate limiter has no key, so it needs one state rather than a map of them.
     DimensionState _globalState;
 
-    // The identifier and command dimensions share one window and one block duration, so setWindow() and
-    // setBlockDuration() write both of them.
+    // setSharedRateLimiterWindow() and setSharedRateLimiterBlockDuration() write both of the first two, which
+    // is what SetBlockingQueueTimeRateLimit exposes.
     Limits _identifierLimits{180'000'000, 20'000'000, 60'000'000, LOG_THRESHOLD_US};
     Limits _commandLimits{180'000'000, 40'000'000, 60'000'000, LOG_THRESHOLD_US};
     Limits _globalLimits{60'000'000, GLOBAL_THRESHOLD_US, 60'000'000, (GLOBAL_THRESHOLD_US * GLOBAL_LOG_PERCENT) / 100};

--- a/BedrockBlockingCommandQueue.h
+++ b/BedrockBlockingCommandQueue.h
@@ -70,9 +70,9 @@ private:
     // An identifier's recently finished blocking-queue commands, oldest first.
     typedef deque<RecentlyFinishedCommand> RecentlyFinishedCommandList;
 
-    // Rate-limit state for one dimension. Each entry has its own mutex, so different identifiers never contend
+    // Rate-limit state for one blocking category. Each entry has its own mutex, so different identifiers never contend
     // on one lock. `blockedUntil` is when an active block ends, in microseconds; 0 means not blocked.
-    struct DimensionState
+    struct BlockingCategoryState
     {
         mutex m;
         RecentlyFinishedCommandList commands;
@@ -86,7 +86,7 @@ private:
     struct StateMap
     {
         mutable mutex mapMutex;
-        unordered_map<string, shared_ptr<DimensionState>> states;
+        unordered_map<string, shared_ptr<BlockingCategoryState>> states;
     };
 
     // The tunables for one dimension, in microseconds. Each one is atomic because the blocking thread reads
@@ -101,20 +101,20 @@ private:
     };
 
     // Return a shared_ptr to the state for `key` in `map`, creating it if absent. Holds map.mapMutex only briefly.
-    static shared_ptr<DimensionState> _getOrCreateState(StateMap& map, const string& key);
+    static shared_ptr<BlockingCategoryState> _getOrCreateState(StateMap& map, const string& key);
 
     // Return the state for `key` in `map`, or nullptr if absent. Holds map.mapMutex only briefly.
-    static shared_ptr<DimensionState> _getState(StateMap& map, const string& key);
+    static shared_ptr<BlockingCategoryState> _getState(StateMap& map, const string& key);
 
     // Append a sample that finished at `now` after `elapsedUS` to `state`, then block it for the block
     // duration when its windowed time exceeds the threshold. `dimension` and `key` label the log line. Reads
     // `limits` once up front so a concurrent retune can't change the window partway through. This is the
     // O(window) work; it never runs under the base `_queueMutex`.
-    static void _recordAndCheck(DimensionState& state, const string& dimension, const string& key, const Limits& limits, uint64_t now, uint64_t elapsedUS);
+    static void _recordAndCheck(BlockingCategoryState& state, const string& dimension, const string& key, const Limits& limits, uint64_t now, uint64_t elapsedUS);
 
     // True if `state` is inside an active block at `now`. O(1): reads only the block deadline, so the push and
     // dequeue hot paths stay cheap (dequeue runs under the base `_queueMutex`).
-    static bool _isBlocked(DimensionState& state, uint64_t now);
+    static bool _isBlocked(BlockingCategoryState& state, uint64_t now);
 
     // Log an identifier or command that is over this but under its block threshold, so heavy ones are visible
     // before they get blocked.
@@ -130,7 +130,7 @@ private:
     StateMap _commandStates;
 
     // The global rate limiter has no key, so it needs one state rather than a map of them.
-    DimensionState _globalState;
+    BlockingCategoryState _globalState;
 
     // setSharedRateLimiterWindow() and setSharedRateLimiterBlockDuration() write both of the first two, which
     // is what SetBlockingQueueTimeRateLimit exposes.

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -445,7 +445,7 @@ void BedrockServer::worker(int threadId)
 
             // Capture the identifier and command name so we can attribute the blocking execution time back to the
             // rate limiter after the command finishes. We time every command run on the blocking thread, recording against
-            // its command name (always) and identifier (when set).
+            // the queue as a whole (always), its command name (always) and identifier (when set).
             const string blockingIdentifier = (threadId == 0) ? command->blockingQueueRateLimitIdentifier : "";
             const string commandName = command->request.methodLine;
             const uint64_t blockingStart = (threadId == 0) ? STimeNow() : 0;
@@ -1804,6 +1804,30 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
                 uint64_t previousUS = _blockingCommandQueue.setBlockDuration(static_cast<uint64_t>(durationMS) * 1000);
                 response["previousBlockingQueueBlockDurationMS"] = to_string(previousUS / 1000);
                 SINFO("Setting blocking queue block duration to " << durationMS << "ms");
+            }
+        }
+        if (command->request.isSet("globalWindowMS")) {
+            int64_t windowMS = command->request.calc64("globalWindowMS");
+            if (windowMS >= 0) {
+                uint64_t previousUS = _blockingCommandQueue.setGlobalWindow(static_cast<uint64_t>(windowMS) * 1000);
+                response["previousBlockingQueueGlobalWindowMS"] = to_string(previousUS / 1000);
+                SINFO("Setting blocking queue global window to " << windowMS << "ms");
+            }
+        }
+        if (command->request.isSet("globalThresholdMS")) {
+            int64_t thresholdMS = command->request.calc64("globalThresholdMS");
+            if (thresholdMS >= 0) {
+                uint64_t previousUS = _blockingCommandQueue.setGlobalThreshold(static_cast<uint64_t>(thresholdMS) * 1000);
+                response["previousBlockingQueueGlobalThresholdMS"] = to_string(previousUS / 1000);
+                SINFO("Setting blocking queue global threshold to " << thresholdMS << "ms");
+            }
+        }
+        if (command->request.isSet("globalBlockDurationMS")) {
+            int64_t durationMS = command->request.calc64("globalBlockDurationMS");
+            if (durationMS >= 0) {
+                uint64_t previousUS = _blockingCommandQueue.setGlobalBlockDuration(static_cast<uint64_t>(durationMS) * 1000);
+                response["previousBlockingQueueGlobalBlockDurationMS"] = to_string(previousUS / 1000);
+                SINFO("Setting blocking queue global block duration to " << durationMS << "ms");
             }
         }
         if (command->request.test("ClearBlocks")) {

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -445,7 +445,7 @@ void BedrockServer::worker(int threadId)
 
             // Capture the identifier and command name so we can attribute the blocking execution time back to the
             // rate limiter after the command finishes. We time every command run on the blocking thread, recording against
-            // the queue as a whole (always), its command name (always) and identifier (when set).
+            // the global rate limiter and its command name always, and its identifier when it is set.
             const string blockingIdentifier = (threadId == 0) ? command->blockingQueueRateLimitIdentifier : "";
             const string commandName = command->request.methodLine;
             const uint64_t blockingStart = (threadId == 0) ? STimeNow() : 0;
@@ -1777,7 +1777,7 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
         if (command->request.isSet("windowMS")) {
             int64_t windowMS = command->request.calc64("windowMS");
             if (windowMS >= 0) {
-                uint64_t previousUS = _blockingCommandQueue.setWindow(static_cast<uint64_t>(windowMS) * 1000);
+                uint64_t previousUS = _blockingCommandQueue.setSharedRateLimiterWindow(static_cast<uint64_t>(windowMS) * 1000);
                 response["previousBlockingQueueWindowMS"] = to_string(previousUS / 1000);
                 SINFO("Setting blocking queue rate limit window to " << windowMS << "ms");
             }
@@ -1785,7 +1785,7 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
         if (command->request.isSet("identifierThresholdMS")) {
             int64_t thresholdMS = command->request.calc64("identifierThresholdMS");
             if (thresholdMS >= 0) {
-                uint64_t previousUS = _blockingCommandQueue.setIdentifierThreshold(static_cast<uint64_t>(thresholdMS) * 1000);
+                uint64_t previousUS = _blockingCommandQueue.setBlockingIdentifierThreshold(static_cast<uint64_t>(thresholdMS) * 1000);
                 response["previousBlockingQueueIdentifierThresholdMS"] = to_string(previousUS / 1000);
                 SINFO("Setting blocking queue identifier threshold to " << thresholdMS << "ms");
             }
@@ -1793,7 +1793,7 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
         if (command->request.isSet("commandThresholdMS")) {
             int64_t thresholdMS = command->request.calc64("commandThresholdMS");
             if (thresholdMS >= 0) {
-                uint64_t previousUS = _blockingCommandQueue.setCommandThreshold(static_cast<uint64_t>(thresholdMS) * 1000);
+                uint64_t previousUS = _blockingCommandQueue.setBlockingCommandThreshold(static_cast<uint64_t>(thresholdMS) * 1000);
                 response["previousBlockingQueueCommandThresholdMS"] = to_string(previousUS / 1000);
                 SINFO("Setting blocking queue command threshold to " << thresholdMS << "ms");
             }
@@ -1801,33 +1801,33 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
         if (command->request.isSet("blockDurationMS")) {
             int64_t durationMS = command->request.calc64("blockDurationMS");
             if (durationMS >= 0) {
-                uint64_t previousUS = _blockingCommandQueue.setBlockDuration(static_cast<uint64_t>(durationMS) * 1000);
+                uint64_t previousUS = _blockingCommandQueue.setSharedRateLimiterBlockDuration(static_cast<uint64_t>(durationMS) * 1000);
                 response["previousBlockingQueueBlockDurationMS"] = to_string(previousUS / 1000);
                 SINFO("Setting blocking queue block duration to " << durationMS << "ms");
             }
         }
-        if (command->request.isSet("globalWindowMS")) {
-            int64_t windowMS = command->request.calc64("globalWindowMS");
+        if (command->request.isSet("globalRateLimiterWindowMS")) {
+            int64_t windowMS = command->request.calc64("globalRateLimiterWindowMS");
             if (windowMS >= 0) {
-                uint64_t previousUS = _blockingCommandQueue.setGlobalWindow(static_cast<uint64_t>(windowMS) * 1000);
-                response["previousBlockingQueueGlobalWindowMS"] = to_string(previousUS / 1000);
-                SINFO("Setting blocking queue global window to " << windowMS << "ms");
+                uint64_t previousUS = _blockingCommandQueue.setGlobalRateLimiterWindow(static_cast<uint64_t>(windowMS) * 1000);
+                response["previousGlobalRateLimiterWindowMS"] = to_string(previousUS / 1000);
+                SINFO("Setting blocking queue global rate limiter window to " << windowMS << "ms");
             }
         }
-        if (command->request.isSet("globalThresholdMS")) {
-            int64_t thresholdMS = command->request.calc64("globalThresholdMS");
+        if (command->request.isSet("globalRateLimiterThresholdMS")) {
+            int64_t thresholdMS = command->request.calc64("globalRateLimiterThresholdMS");
             if (thresholdMS >= 0) {
-                uint64_t previousUS = _blockingCommandQueue.setGlobalThreshold(static_cast<uint64_t>(thresholdMS) * 1000);
-                response["previousBlockingQueueGlobalThresholdMS"] = to_string(previousUS / 1000);
-                SINFO("Setting blocking queue global threshold to " << thresholdMS << "ms");
+                uint64_t previousUS = _blockingCommandQueue.setGlobalRateLimiterThreshold(static_cast<uint64_t>(thresholdMS) * 1000);
+                response["previousGlobalRateLimiterThresholdMS"] = to_string(previousUS / 1000);
+                SINFO("Setting blocking queue global rate limiter threshold to " << thresholdMS << "ms");
             }
         }
-        if (command->request.isSet("globalBlockDurationMS")) {
-            int64_t durationMS = command->request.calc64("globalBlockDurationMS");
+        if (command->request.isSet("globalRateLimiterBlockDurationMS")) {
+            int64_t durationMS = command->request.calc64("globalRateLimiterBlockDurationMS");
             if (durationMS >= 0) {
-                uint64_t previousUS = _blockingCommandQueue.setGlobalBlockDuration(static_cast<uint64_t>(durationMS) * 1000);
-                response["previousBlockingQueueGlobalBlockDurationMS"] = to_string(previousUS / 1000);
-                SINFO("Setting blocking queue global block duration to " << durationMS << "ms");
+                uint64_t previousUS = _blockingCommandQueue.setGlobalRateLimiterBlockDuration(static_cast<uint64_t>(durationMS) * 1000);
+                response["previousGlobalRateLimiterBlockDurationMS"] = to_string(previousUS / 1000);
+                SINFO("Setting blocking queue global rate limiter block duration to " << durationMS << "ms");
             }
         }
         if (command->request.test("ClearBlocks")) {

--- a/test/clustertest/tests/BlockingQueueRateLimitTest.cpp
+++ b/test/clustertest/tests/BlockingQueueRateLimitTest.cpp
@@ -9,6 +9,7 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
                               BEFORE(BlockingQueueRateLimitTest::before),
                               TEST(BlockingQueueRateLimitTest::testControlCommands),
                               TEST(BlockingQueueRateLimitTest::testTimeRateLimiting),
+                              TEST(BlockingQueueRateLimitTest::testGlobalRateLimiting),
                               AFTER_CLASS(BlockingQueueRateLimitTest::teardown))
     {
     }
@@ -39,9 +40,16 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
         resetConflict["MaxConflictRetries"] = "3";
         leader.executeWaitVerifyContent(resetConflict, "200", true);
 
+        // The global dimension is on by default. Disable it so it can't reject anything in the tests that
+        // aren't about it; testGlobalRateLimiting turns it back on.
+        SData disableGlobal("SetBlockingQueueTimeRateLimit");
+        disableGlobal["globalThresholdMS"] = "0";
+        leader.executeWaitVerifyContent(disableGlobal, "200", true);
+
         SData status("Status");
         STable json = SParseJSONObject(leader.executeWaitVerifyContent(status, "200", true));
         ASSERT_EQUAL(json["blockingBlockedIdentifiers"], "");
+        ASSERT_EQUAL(json["blockingGlobalBlocked"], "false");
     }
 
     void testControlCommands()
@@ -54,6 +62,9 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
         setLimits["identifierThresholdMS"] = "20000";
         setLimits["commandThresholdMS"] = "40000";
         setLimits["blockDurationMS"] = "60000";
+        setLimits["globalWindowMS"] = "60000";
+        setLimits["globalThresholdMS"] = "55000";
+        setLimits["globalBlockDurationMS"] = "60000";
         leader.executeWaitVerifyContent(setLimits, "200", true);
 
         SData status("Status");
@@ -62,6 +73,9 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
         ASSERT_EQUAL(json["blockingIdentifierThresholdMS"], "20000");
         ASSERT_EQUAL(json["blockingCommandThresholdMS"], "40000");
         ASSERT_EQUAL(json["blockingBlockDurationMS"], "60000");
+        ASSERT_EQUAL(json["blockingGlobalWindowMS"], "60000");
+        ASSERT_EQUAL(json["blockingGlobalThresholdMS"], "55000");
+        ASSERT_EQUAL(json["blockingGlobalBlockDurationMS"], "60000");
     }
 
     void testTimeRateLimiting()
@@ -138,6 +152,85 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
 
         SData resetLimit("SetBlockingQueueTimeRateLimit");
         resetLimit["identifierThresholdMS"] = "0";
+        leader.executeWaitVerifyContent(resetLimit, "200", true);
+    }
+
+    void testGlobalRateLimiting()
+    {
+        BedrockTester& leader = tester->getTester(0);
+
+        // Disable both per-sender dimensions so only the global one can reject anything, and give it a tiny
+        // threshold so a burst of conflicting commands saturates the blocking thread.
+        SData setLimits("SetBlockingQueueTimeRateLimit");
+        setLimits["identifierThresholdMS"] = "0";
+        setLimits["commandThresholdMS"] = "0";
+        setLimits["globalWindowMS"] = "180000";
+        setLimits["globalThresholdMS"] = "10";
+        setLimits["globalBlockDurationMS"] = "60000";
+        leader.executeWaitVerifyContent(setLimits, "200", true);
+
+        // Force conflicts so commands escalate to the blocking queue and run on worker 0, which is what
+        // accumulates the global time.
+        SData setConflict("SetConflictParams");
+        setConflict["MaxConflictRetries"] = "1";
+        leader.executeWaitVerifyContent(setConflict, "200", true);
+
+        // Every command uses its own identifier, so neither per-sender dimension would ever see enough time to
+        // trip. Only the global dimension can reject these.
+        atomic<int> count503(0);
+        atomic<int> count200(0);
+        list<thread> threads;
+        for (int i : {0, 1, 2}) {
+            threads.emplace_back([this, i, &count503, &count200]() {
+                BedrockTester& node = tester->getTester(i);
+                vector<SData> requests;
+                for (int j = 0; j < 200; j++) {
+                    SData cmd("idcollision b4");
+                    cmd["blockingQueueRateLimitIdentifier"] = "globaluser" + to_string(i) + "-" + to_string(j);
+                    cmd["value"] = "node" + to_string(i) + "-" + to_string(j);
+                    requests.push_back(cmd);
+                }
+                auto results = node.executeWaitMultipleData(requests);
+                for (auto& result : results) {
+                    int status = SToInt(result.methodLine);
+                    if (status == 503) {
+                        count503.fetch_add(1);
+                    } else if (status == 200) {
+                        count200.fetch_add(1);
+                    }
+                }
+            });
+        }
+        for (thread& t : threads) {
+            t.join();
+        }
+
+        ASSERT_EQUAL(count200.load() + count503.load(), 600);
+
+        // Enforcement is happening, so we should see some 503s.
+        ASSERT_TRUE(count503.load() > 0);
+
+        // The global dimension did all the rejecting, so no identifier or command is blocked.
+        SData status("Status");
+        STable json = SParseJSONObject(leader.executeWaitVerifyContent(status, "200", true));
+        ASSERT_EQUAL(json["blockingGlobalBlocked"], "true");
+        ASSERT_EQUAL(json["blockingBlockedIdentifiers"], "");
+        ASSERT_EQUAL(json["blockingBlockedCommands"], "");
+
+        SData clearBlocks("SetBlockingQueueTimeRateLimit");
+        clearBlocks["ClearBlocks"] = "true";
+        leader.executeWaitVerifyContent(clearBlocks, "200", true);
+
+        json = SParseJSONObject(leader.executeWaitVerifyContent(status, "200", true));
+        ASSERT_EQUAL(json["blockingGlobalBlocked"], "false");
+
+        // Reset leader state.
+        SData resetConflict("SetConflictParams");
+        resetConflict["MaxConflictRetries"] = "3";
+        leader.executeWaitVerifyContent(resetConflict, "200", true);
+
+        SData resetLimit("SetBlockingQueueTimeRateLimit");
+        resetLimit["globalThresholdMS"] = "0";
         leader.executeWaitVerifyContent(resetLimit, "200", true);
     }
 } __BlockingQueueRateLimitTest;

--- a/test/clustertest/tests/BlockingQueueRateLimitTest.cpp
+++ b/test/clustertest/tests/BlockingQueueRateLimitTest.cpp
@@ -40,16 +40,15 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
         resetConflict["MaxConflictRetries"] = "3";
         leader.executeWaitVerifyContent(resetConflict, "200", true);
 
-        // The global dimension is on by default. Disable it so it can't reject anything in the tests that
-        // aren't about it; testGlobalRateLimiting turns it back on.
+        // The global rate limiter is on by default, so we disable it for tests unrelated to it.
         SData disableGlobal("SetBlockingQueueTimeRateLimit");
-        disableGlobal["globalThresholdMS"] = "0";
+        disableGlobal["globalRateLimiterThresholdMS"] = "0";
         leader.executeWaitVerifyContent(disableGlobal, "200", true);
 
         SData status("Status");
         STable json = SParseJSONObject(leader.executeWaitVerifyContent(status, "200", true));
         ASSERT_EQUAL(json["blockingBlockedIdentifiers"], "");
-        ASSERT_EQUAL(json["blockingGlobalBlocked"], "false");
+        ASSERT_EQUAL(json["globalRateLimiterTriggered"], "false");
     }
 
     void testControlCommands()
@@ -62,9 +61,9 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
         setLimits["identifierThresholdMS"] = "20000";
         setLimits["commandThresholdMS"] = "40000";
         setLimits["blockDurationMS"] = "60000";
-        setLimits["globalWindowMS"] = "60000";
-        setLimits["globalThresholdMS"] = "55000";
-        setLimits["globalBlockDurationMS"] = "60000";
+        setLimits["globalRateLimiterWindowMS"] = "60000";
+        setLimits["globalRateLimiterThresholdMS"] = "55000";
+        setLimits["globalRateLimiterBlockDurationMS"] = "60000";
         leader.executeWaitVerifyContent(setLimits, "200", true);
 
         SData status("Status");
@@ -73,9 +72,9 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
         ASSERT_EQUAL(json["blockingIdentifierThresholdMS"], "20000");
         ASSERT_EQUAL(json["blockingCommandThresholdMS"], "40000");
         ASSERT_EQUAL(json["blockingBlockDurationMS"], "60000");
-        ASSERT_EQUAL(json["blockingGlobalWindowMS"], "60000");
-        ASSERT_EQUAL(json["blockingGlobalThresholdMS"], "55000");
-        ASSERT_EQUAL(json["blockingGlobalBlockDurationMS"], "60000");
+        ASSERT_EQUAL(json["globalRateLimiterWindowMS"], "60000");
+        ASSERT_EQUAL(json["globalRateLimiterThresholdMS"], "55000");
+        ASSERT_EQUAL(json["globalRateLimiterBlockDurationMS"], "60000");
     }
 
     void testTimeRateLimiting()
@@ -159,24 +158,22 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
     {
         BedrockTester& leader = tester->getTester(0);
 
-        // Disable both per-sender dimensions so only the global one can reject anything, and give it a tiny
-        // threshold so a burst of conflicting commands saturates the blocking thread.
+        // Disable the identifier and command dimensions so only the global rate limiter can reject
+        // anything, with a tiny threshold so a small burst trips it.
         SData setLimits("SetBlockingQueueTimeRateLimit");
         setLimits["identifierThresholdMS"] = "0";
         setLimits["commandThresholdMS"] = "0";
-        setLimits["globalWindowMS"] = "180000";
-        setLimits["globalThresholdMS"] = "10";
-        setLimits["globalBlockDurationMS"] = "60000";
+        setLimits["globalRateLimiterWindowMS"] = "180000";
+        setLimits["globalRateLimiterThresholdMS"] = "10";
+        setLimits["globalRateLimiterBlockDurationMS"] = "60000";
         leader.executeWaitVerifyContent(setLimits, "200", true);
 
-        // Force conflicts so commands escalate to the blocking queue and run on worker 0, which is what
-        // accumulates the global time.
+        // Force conflicts so these run on worker 0, which is what accumulates the time.
         SData setConflict("SetConflictParams");
         setConflict["MaxConflictRetries"] = "1";
         leader.executeWaitVerifyContent(setConflict, "200", true);
 
-        // Every command uses its own identifier, so neither per-sender dimension would ever see enough time to
-        // trip. Only the global dimension can reject these.
+        // Every command uses its own identifier, so only the global rate limiter can reject these.
         atomic<int> count503(0);
         atomic<int> count200(0);
         list<thread> threads;
@@ -210,10 +207,10 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
         // Enforcement is happening, so we should see some 503s.
         ASSERT_TRUE(count503.load() > 0);
 
-        // The global dimension did all the rejecting, so no identifier or command is blocked.
+        // The global rate limiter did all the rejecting, so no identifier or command is blocked.
         SData status("Status");
         STable json = SParseJSONObject(leader.executeWaitVerifyContent(status, "200", true));
-        ASSERT_EQUAL(json["blockingGlobalBlocked"], "true");
+        ASSERT_EQUAL(json["globalRateLimiterTriggered"], "true");
         ASSERT_EQUAL(json["blockingBlockedIdentifiers"], "");
         ASSERT_EQUAL(json["blockingBlockedCommands"], "");
 
@@ -222,7 +219,7 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
         leader.executeWaitVerifyContent(clearBlocks, "200", true);
 
         json = SParseJSONObject(leader.executeWaitVerifyContent(status, "200", true));
-        ASSERT_EQUAL(json["blockingGlobalBlocked"], "false");
+        ASSERT_EQUAL(json["globalRateLimiterTriggered"], "false");
 
         // Reset leader state.
         SData resetConflict("SetConflictParams");
@@ -230,7 +227,7 @@ struct BlockingQueueRateLimitTest : tpunit::TestFixture
         leader.executeWaitVerifyContent(resetConflict, "200", true);
 
         SData resetLimit("SetBlockingQueueTimeRateLimit");
-        resetLimit["globalThresholdMS"] = "0";
+        resetLimit["globalRateLimiterThresholdMS"] = "0";
         leader.executeWaitVerifyContent(resetLimit, "200", true);
     }
 } __BlockingQueueRateLimitTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -53,7 +53,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
                                                      TEST(BlockingCommandQueueTest::testGlobalOverThresholdBlocksEveryone),
                                                      TEST(BlockingCommandQueueTest::testGlobalRejectsOnPushAndDequeue),
                                                      TEST(BlockingCommandQueueTest::testGlobalBlockTakesPrecedence),
-                                                     TEST(BlockingCommandQueueTest::testGlobalWindowIsIndependent))
+                                                     TEST(BlockingCommandQueueTest::testGlobalWindowIsIndependent),
+                                                     TEST(BlockingCommandQueueTest::testGlobalBlockDurationHoldsThenClears))
     {
     }
 
@@ -407,5 +408,26 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1500);
         queue.recordExecutionTime("acct1", "cmd", 30);
         ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "global");
+    }
+
+    void testGlobalBlockDurationHoldsThenClears()
+    {
+        TestBlockingCommandQueue queue;
+        queue.setIdentifierThreshold(0);
+        queue.setCommandThreshold(0);
+        queue.setGlobalWindow(100);
+        queue.setGlobalThreshold(50);
+        queue.setGlobalBlockDuration(500);
+        queue.setNow(1000);
+
+        queue.recordExecutionTime("acct1", "cmd", 60);
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "global");
+
+        // The sample has aged out of the window, but the block still holds for its fixed duration.
+        queue.setNow(1200);
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "global");
+
+        queue.setNow(1600);
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
     }
 } __BlockingCommandQueueTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -50,7 +50,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
                                                      TEST(BlockingCommandQueueTest::testBlockDurationHoldsThenClears),
                                                      TEST(BlockingCommandQueueTest::testDisabledThresholdsNeverBlock),
                                                      TEST(BlockingCommandQueueTest::testClearResets),
-                                                     TEST(BlockingCommandQueueTest::testGlobalOverThresholdBlocksEveryone))
+                                                     TEST(BlockingCommandQueueTest::testGlobalOverThresholdBlocksEveryone),
+                                                     TEST(BlockingCommandQueueTest::testGlobalRejectsOnPushAndDequeue))
     {
     }
 
@@ -331,5 +332,37 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         ASSERT_EQUAL(queue.getBlockingDimension("acct2", "cmd2"), "global");
         ASSERT_EQUAL(queue.getBlockingDimension("acct3", "cmd3"), "global");
         ASSERT_EQUAL(queue.getBlockingDimension("", ""), "global");
+    }
+
+    void testGlobalRejectsOnPushAndDequeue()
+    {
+        TestBlockingCommandQueue pushQueue;
+        pushQueue.setIdentifierThreshold(0);
+        pushQueue.setCommandThreshold(0);
+        pushQueue.setGlobalThreshold(50);
+        pushQueue.setNow(1000);
+        pushQueue.recordExecutionTime("acct1", "cmd", 60);
+
+        bool pushRejected = false;
+        try {
+            pushQueue.push(pushQueue.makeCommand("acct2", "otherCmd"));
+        } catch (const SException& e) {
+            pushRejected = true;
+            ASSERT_EQUAL(string(e.what()), "503 Blocking queue rate limited (global)");
+        }
+        ASSERT_TRUE(pushRejected);
+
+        // Commands that were already queued are rejected on the way out, so a backlog drains instead of running.
+        TestBlockingCommandQueue dequeueQueue;
+        dequeueQueue.setIdentifierThreshold(0);
+        dequeueQueue.setCommandThreshold(0);
+        dequeueQueue.setGlobalThreshold(50);
+        dequeueQueue.setNow(1000);
+        dequeueQueue.push(dequeueQueue.makeCommand("acct2", "otherCmd"));
+        dequeueQueue.recordExecutionTime("acct1", "cmd", 60);
+
+        auto command = dequeueQueue.get(1'000'000);
+        ASSERT_TRUE(command->complete);
+        ASSERT_EQUAL(command->response.methodLine, "503 Blocking queue rate limited (global)");
     }
 } __BlockingCommandQueueTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -51,7 +51,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
                                                      TEST(BlockingCommandQueueTest::testDisabledThresholdsNeverBlock),
                                                      TEST(BlockingCommandQueueTest::testClearResets),
                                                      TEST(BlockingCommandQueueTest::testGlobalOverThresholdBlocksEveryone),
-                                                     TEST(BlockingCommandQueueTest::testGlobalRejectsOnPushAndDequeue))
+                                                     TEST(BlockingCommandQueueTest::testGlobalRejectsOnPushAndDequeue),
+                                                     TEST(BlockingCommandQueueTest::testGlobalBlockTakesPrecedence))
     {
     }
 
@@ -364,5 +365,23 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         auto command = dequeueQueue.get(1'000'000);
         ASSERT_TRUE(command->complete);
         ASSERT_EQUAL(command->response.methodLine, "503 Blocking queue rate limited (global)");
+    }
+
+    void testGlobalBlockTakesPrecedence()
+    {
+        // One command can trip the identifier and the global dimension at once. The reject reports global,
+        // because that is the one that also rejects everybody else.
+        TestBlockingCommandQueue queue;
+        queue.setWindow(100);
+        queue.setIdentifierThreshold(50);
+        queue.setCommandThreshold(0);
+        queue.setBlockDuration(1000);
+        queue.setGlobalWindow(100);
+        queue.setGlobalThreshold(50);
+        queue.setGlobalBlockDuration(1000);
+        queue.setNow(1000);
+
+        queue.recordExecutionTime("acct1", "cmd", 60);
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "global");
     }
 } __BlockingCommandQueueTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -52,7 +52,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
                                                      TEST(BlockingCommandQueueTest::testClearResets),
                                                      TEST(BlockingCommandQueueTest::testGlobalOverThresholdBlocksEveryone),
                                                      TEST(BlockingCommandQueueTest::testGlobalRejectsOnPushAndDequeue),
-                                                     TEST(BlockingCommandQueueTest::testGlobalBlockTakesPrecedence))
+                                                     TEST(BlockingCommandQueueTest::testGlobalBlockTakesPrecedence),
+                                                     TEST(BlockingCommandQueueTest::testGlobalWindowIsIndependent))
     {
     }
 
@@ -382,6 +383,29 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "global");
+    }
+
+    void testGlobalWindowIsIndependent()
+    {
+        // The global dimension has its own window, so a sample that has aged out of the shared window can still
+        // count toward the global threshold.
+        TestBlockingCommandQueue queue;
+        queue.setWindow(100);
+        queue.setIdentifierThreshold(0);
+        queue.setCommandThreshold(0);
+        queue.setGlobalWindow(1000);
+        queue.setGlobalThreshold(50);
+        queue.setGlobalBlockDuration(1000);
+        queue.setNow(1000);
+
+        queue.recordExecutionTime("acct1", "cmd", 30);
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
+
+        // 500us later the first sample is far outside the 100us shared window but inside the 1000us global
+        // window, so all 30us of it still counts and the second sample takes the total to 60 (> 50).
+        queue.setNow(1500);
+        queue.recordExecutionTime("acct1", "cmd", 30);
         ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "global");
     }
 } __BlockingCommandQueueTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -49,7 +49,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
                                                      TEST(BlockingCommandQueueTest::testPartialCredit),
                                                      TEST(BlockingCommandQueueTest::testBlockDurationHoldsThenClears),
                                                      TEST(BlockingCommandQueueTest::testDisabledThresholdsNeverBlock),
-                                                     TEST(BlockingCommandQueueTest::testClearResets))
+                                                     TEST(BlockingCommandQueueTest::testClearResets),
+                                                     TEST(BlockingCommandQueueTest::testGlobalOverThresholdBlocksEveryone))
     {
     }
 
@@ -309,5 +310,26 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
 
         queue.clearRateLimits();
         ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
+    }
+
+    void testGlobalOverThresholdBlocksEveryone()
+    {
+        // The global dimension counts every command, so a burst spread over several identifiers trips it even
+        // though no single identifier or command is over a limit of its own.
+        TestBlockingCommandQueue queue;
+        queue.setIdentifierThreshold(0);
+        queue.setCommandThreshold(0);
+        queue.setGlobalWindow(100);
+        queue.setGlobalThreshold(50);
+        queue.setGlobalBlockDuration(1000);
+        queue.setNow(1000);
+
+        queue.recordExecutionTime("acct1", "cmd1", 30);
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd1"), "");
+
+        queue.recordExecutionTime("acct2", "cmd2", 30);
+        ASSERT_EQUAL(queue.getBlockingDimension("acct2", "cmd2"), "global");
+        ASSERT_EQUAL(queue.getBlockingDimension("acct3", "cmd3"), "global");
+        ASSERT_EQUAL(queue.getBlockingDimension("", ""), "global");
     }
 } __BlockingCommandQueueTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -54,7 +54,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
                                                      TEST(BlockingCommandQueueTest::testGlobalRejectsOnPushAndDequeue),
                                                      TEST(BlockingCommandQueueTest::testGlobalBlockTakesPrecedence),
                                                      TEST(BlockingCommandQueueTest::testGlobalWindowIsIndependent),
-                                                     TEST(BlockingCommandQueueTest::testGlobalBlockDurationHoldsThenClears))
+                                                     TEST(BlockingCommandQueueTest::testGlobalBlockDurationHoldsThenClears),
+                                                     TEST(BlockingCommandQueueTest::testClearResetsGlobalBlock))
     {
     }
 
@@ -428,6 +429,23 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "global");
 
         queue.setNow(1600);
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
+    }
+
+    void testClearResetsGlobalBlock()
+    {
+        TestBlockingCommandQueue queue;
+        queue.setIdentifierThreshold(0);
+        queue.setCommandThreshold(0);
+        queue.setGlobalWindow(100);
+        queue.setGlobalThreshold(50);
+        queue.setGlobalBlockDuration(1000);
+        queue.setNow(1000);
+
+        queue.recordExecutionTime("acct1", "cmd", 60);
+        ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "global");
+
+        queue.clearRateLimits();
         ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
     }
 } __BlockingCommandQueueTest;

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -295,6 +295,7 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         queue.setWindow(100);
         queue.setIdentifierThreshold(0);
         queue.setCommandThreshold(0);
+        queue.setGlobalThreshold(0);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 1000000);

--- a/test/tests/BlockingCommandQueueTest.cpp
+++ b/test/tests/BlockingCommandQueueTest.cpp
@@ -50,22 +50,22 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
                                                      TEST(BlockingCommandQueueTest::testBlockDurationHoldsThenClears),
                                                      TEST(BlockingCommandQueueTest::testDisabledThresholdsNeverBlock),
                                                      TEST(BlockingCommandQueueTest::testClearResets),
-                                                     TEST(BlockingCommandQueueTest::testGlobalOverThresholdBlocksEveryone),
-                                                     TEST(BlockingCommandQueueTest::testGlobalRejectsOnPushAndDequeue),
-                                                     TEST(BlockingCommandQueueTest::testGlobalBlockTakesPrecedence),
-                                                     TEST(BlockingCommandQueueTest::testGlobalWindowIsIndependent),
-                                                     TEST(BlockingCommandQueueTest::testGlobalBlockDurationHoldsThenClears),
-                                                     TEST(BlockingCommandQueueTest::testClearResetsGlobalBlock))
+                                                     TEST(BlockingCommandQueueTest::testGlobalRateLimiterOverThresholdBlocksEveryone),
+                                                     TEST(BlockingCommandQueueTest::testGlobalRateLimiterRejectsOnPushAndDequeue),
+                                                     TEST(BlockingCommandQueueTest::testGlobalRateLimiterTakesPrecedence),
+                                                     TEST(BlockingCommandQueueTest::testGlobalRateLimiterWindowIsIndependent),
+                                                     TEST(BlockingCommandQueueTest::testGlobalRateLimiterBlockDurationHoldsThenClears),
+                                                     TEST(BlockingCommandQueueTest::testClearResetsGlobalRateLimiter))
     {
     }
 
     void testIdentifierOverThresholdBlocks()
     {
         TestBlockingCommandQueue queue;
-        queue.setWindow(100);
-        queue.setIdentifierThreshold(50);
-        queue.setCommandThreshold(0);
-        queue.setBlockDuration(1000);
+        queue.setSharedRateLimiterWindow(100);
+        queue.setBlockingIdentifierThreshold(50);
+        queue.setBlockingCommandThreshold(0);
+        queue.setSharedRateLimiterBlockDuration(1000);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 30);
@@ -78,9 +78,9 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
     void testUnderThresholdNotBlocked()
     {
         TestBlockingCommandQueue queue;
-        queue.setWindow(100);
-        queue.setIdentifierThreshold(50);
-        queue.setCommandThreshold(0);
+        queue.setSharedRateLimiterWindow(100);
+        queue.setBlockingIdentifierThreshold(50);
+        queue.setBlockingCommandThreshold(0);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 40);
@@ -90,9 +90,9 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
     void testIdentifiersAreIndependent()
     {
         TestBlockingCommandQueue queue;
-        queue.setWindow(100);
-        queue.setIdentifierThreshold(50);
-        queue.setCommandThreshold(0);
+        queue.setSharedRateLimiterWindow(100);
+        queue.setBlockingIdentifierThreshold(50);
+        queue.setBlockingCommandThreshold(0);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
@@ -104,9 +104,9 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
     {
         // With the identifier dimension disabled, a command over its threshold blocks for every identifier.
         TestBlockingCommandQueue queue;
-        queue.setWindow(100);
-        queue.setIdentifierThreshold(0);
-        queue.setCommandThreshold(50);
+        queue.setSharedRateLimiterWindow(100);
+        queue.setBlockingIdentifierThreshold(0);
+        queue.setBlockingCommandThreshold(50);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
@@ -118,8 +118,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
     void testPushReportsRateLimitDimensions()
     {
         TestBlockingCommandQueue identifierQueue;
-        identifierQueue.setIdentifierThreshold(50);
-        identifierQueue.setCommandThreshold(0);
+        identifierQueue.setBlockingIdentifierThreshold(50);
+        identifierQueue.setBlockingCommandThreshold(0);
         identifierQueue.setNow(1000);
         identifierQueue.recordExecutionTime("acct1", "cmd", 60);
 
@@ -133,8 +133,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         ASSERT_TRUE(identifierRejected);
 
         TestBlockingCommandQueue commandQueue;
-        commandQueue.setIdentifierThreshold(0);
-        commandQueue.setCommandThreshold(50);
+        commandQueue.setBlockingIdentifierThreshold(0);
+        commandQueue.setBlockingCommandThreshold(50);
         commandQueue.setNow(1000);
         commandQueue.recordExecutionTime("acct1", "cmd", 60);
 
@@ -148,8 +148,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         ASSERT_TRUE(commandRejected);
 
         TestBlockingCommandQueue bothDimensionsQueue;
-        bothDimensionsQueue.setIdentifierThreshold(50);
-        bothDimensionsQueue.setCommandThreshold(50);
+        bothDimensionsQueue.setBlockingIdentifierThreshold(50);
+        bothDimensionsQueue.setBlockingCommandThreshold(50);
         bothDimensionsQueue.setNow(1000);
         bothDimensionsQueue.recordExecutionTime("acct1", "cmd", 60);
 
@@ -166,8 +166,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
     void testDequeueReportsRateLimitDimensions()
     {
         TestBlockingCommandQueue identifierQueue;
-        identifierQueue.setIdentifierThreshold(50);
-        identifierQueue.setCommandThreshold(0);
+        identifierQueue.setBlockingIdentifierThreshold(50);
+        identifierQueue.setBlockingCommandThreshold(0);
         identifierQueue.setNow(1000);
         identifierQueue.push(identifierQueue.makeCommand("acct1", "cmd"));
         identifierQueue.recordExecutionTime("acct1", "cmd", 60);
@@ -177,8 +177,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         ASSERT_EQUAL(identifierCommand->response.methodLine, "503 Blocking queue rate limited (identifier)");
 
         TestBlockingCommandQueue commandQueue;
-        commandQueue.setIdentifierThreshold(0);
-        commandQueue.setCommandThreshold(50);
+        commandQueue.setBlockingIdentifierThreshold(0);
+        commandQueue.setBlockingCommandThreshold(50);
         commandQueue.setNow(1000);
         commandQueue.push(commandQueue.makeCommand("acct2", "cmd"));
         commandQueue.recordExecutionTime("acct1", "cmd", 60);
@@ -193,8 +193,8 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         // `_dequeue()`'s prefix is scoped, so it must be gone once `get()` returns: the blocking worker sets its own
         // prefix after `get()` and would otherwise inherit a stale one.
         TestBlockingCommandQueue queue;
-        queue.setIdentifierThreshold(50);
-        queue.setCommandThreshold(0);
+        queue.setBlockingIdentifierThreshold(50);
+        queue.setBlockingCommandThreshold(0);
         queue.setNow(1000);
         queue.push(queue.makeCommand("acct1", "cmd", "rejected1", "rejected@example.com"));
         queue.recordExecutionTime("acct1", "cmd", 60);
@@ -217,9 +217,9 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
     {
         // An empty identifier is skipped, but the command dimension still applies.
         TestBlockingCommandQueue queue;
-        queue.setWindow(100);
-        queue.setIdentifierThreshold(50);
-        queue.setCommandThreshold(50);
+        queue.setSharedRateLimiterWindow(100);
+        queue.setBlockingIdentifierThreshold(50);
+        queue.setBlockingCommandThreshold(50);
         queue.setNow(1000);
 
         queue.recordExecutionTime("", "cmd", 60);
@@ -230,10 +230,10 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
     {
         // A sample older than the window no longer counts toward the threshold.
         TestBlockingCommandQueue queue;
-        queue.setWindow(100);
-        queue.setIdentifierThreshold(50);
-        queue.setCommandThreshold(0);
-        queue.setBlockDuration(1000);
+        queue.setSharedRateLimiterWindow(100);
+        queue.setBlockingIdentifierThreshold(50);
+        queue.setBlockingCommandThreshold(0);
+        queue.setSharedRateLimiterBlockDuration(1000);
         queue.setNow(1000);
 
         // One 40us sample, under the 50us threshold on its own.
@@ -251,10 +251,10 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
     {
         // A sample counts only for the part that still lies inside the window.
         TestBlockingCommandQueue queue;
-        queue.setWindow(100);
-        queue.setIdentifierThreshold(35);
-        queue.setCommandThreshold(0);
-        queue.setBlockDuration(1000);
+        queue.setSharedRateLimiterWindow(100);
+        queue.setBlockingIdentifierThreshold(35);
+        queue.setBlockingCommandThreshold(0);
+        queue.setSharedRateLimiterBlockDuration(1000);
         queue.setNow(1000);
 
         // 30us sample, under the 35us threshold.
@@ -271,10 +271,10 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
     void testBlockDurationHoldsThenClears()
     {
         TestBlockingCommandQueue queue;
-        queue.setWindow(100);
-        queue.setIdentifierThreshold(50);
-        queue.setCommandThreshold(0);
-        queue.setBlockDuration(500);
+        queue.setSharedRateLimiterWindow(100);
+        queue.setBlockingIdentifierThreshold(50);
+        queue.setBlockingCommandThreshold(0);
+        queue.setSharedRateLimiterBlockDuration(500);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
@@ -292,10 +292,10 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
     void testDisabledThresholdsNeverBlock()
     {
         TestBlockingCommandQueue queue;
-        queue.setWindow(100);
-        queue.setIdentifierThreshold(0);
-        queue.setCommandThreshold(0);
-        queue.setGlobalThreshold(0);
+        queue.setSharedRateLimiterWindow(100);
+        queue.setBlockingIdentifierThreshold(0);
+        queue.setBlockingCommandThreshold(0);
+        queue.setGlobalRateLimiterThreshold(0);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 1000000);
@@ -305,10 +305,10 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
     void testClearResets()
     {
         TestBlockingCommandQueue queue;
-        queue.setWindow(100);
-        queue.setIdentifierThreshold(50);
-        queue.setCommandThreshold(0);
-        queue.setBlockDuration(1000);
+        queue.setSharedRateLimiterWindow(100);
+        queue.setBlockingIdentifierThreshold(50);
+        queue.setBlockingCommandThreshold(0);
+        queue.setSharedRateLimiterBlockDuration(1000);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
@@ -318,16 +318,16 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
     }
 
-    void testGlobalOverThresholdBlocksEveryone()
+    void testGlobalRateLimiterOverThresholdBlocksEveryone()
     {
-        // The global dimension counts every command, so a burst spread over several identifiers trips it even
+        // The global rate limiter counts every command, so a burst of commands with different identifiers trips it even
         // though no single identifier or command is over a limit of its own.
         TestBlockingCommandQueue queue;
-        queue.setIdentifierThreshold(0);
-        queue.setCommandThreshold(0);
-        queue.setGlobalWindow(100);
-        queue.setGlobalThreshold(50);
-        queue.setGlobalBlockDuration(1000);
+        queue.setBlockingIdentifierThreshold(0);
+        queue.setBlockingCommandThreshold(0);
+        queue.setGlobalRateLimiterWindow(100);
+        queue.setGlobalRateLimiterThreshold(50);
+        queue.setGlobalRateLimiterBlockDuration(1000);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd1", 30);
@@ -339,12 +339,12 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         ASSERT_EQUAL(queue.getBlockingDimension("", ""), "global");
     }
 
-    void testGlobalRejectsOnPushAndDequeue()
+    void testGlobalRateLimiterRejectsOnPushAndDequeue()
     {
         TestBlockingCommandQueue pushQueue;
-        pushQueue.setIdentifierThreshold(0);
-        pushQueue.setCommandThreshold(0);
-        pushQueue.setGlobalThreshold(50);
+        pushQueue.setBlockingIdentifierThreshold(0);
+        pushQueue.setBlockingCommandThreshold(0);
+        pushQueue.setGlobalRateLimiterThreshold(50);
         pushQueue.setNow(1000);
         pushQueue.recordExecutionTime("acct1", "cmd", 60);
 
@@ -357,11 +357,11 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         }
         ASSERT_TRUE(pushRejected);
 
-        // Commands that were already queued are rejected on the way out, so a backlog drains instead of running.
+        // Commands that were already queued get rejected on the way out, so a backlog drains instead of running.
         TestBlockingCommandQueue dequeueQueue;
-        dequeueQueue.setIdentifierThreshold(0);
-        dequeueQueue.setCommandThreshold(0);
-        dequeueQueue.setGlobalThreshold(50);
+        dequeueQueue.setBlockingIdentifierThreshold(0);
+        dequeueQueue.setBlockingCommandThreshold(0);
+        dequeueQueue.setGlobalRateLimiterThreshold(50);
         dequeueQueue.setNow(1000);
         dequeueQueue.push(dequeueQueue.makeCommand("acct2", "otherCmd"));
         dequeueQueue.recordExecutionTime("acct1", "cmd", 60);
@@ -371,55 +371,55 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         ASSERT_EQUAL(command->response.methodLine, "503 Blocking queue rate limited (global)");
     }
 
-    void testGlobalBlockTakesPrecedence()
+    void testGlobalRateLimiterTakesPrecedence()
     {
-        // One command can trip the identifier and the global dimension at once. The reject reports global,
+        // One command can trip the identifier and the global rate limiter at once. The reject reports global,
         // because that is the one that also rejects everybody else.
         TestBlockingCommandQueue queue;
-        queue.setWindow(100);
-        queue.setIdentifierThreshold(50);
-        queue.setCommandThreshold(0);
-        queue.setBlockDuration(1000);
-        queue.setGlobalWindow(100);
-        queue.setGlobalThreshold(50);
-        queue.setGlobalBlockDuration(1000);
+        queue.setSharedRateLimiterWindow(100);
+        queue.setBlockingIdentifierThreshold(50);
+        queue.setBlockingCommandThreshold(0);
+        queue.setSharedRateLimiterBlockDuration(1000);
+        queue.setGlobalRateLimiterWindow(100);
+        queue.setGlobalRateLimiterThreshold(50);
+        queue.setGlobalRateLimiterBlockDuration(1000);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
         ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "global");
     }
 
-    void testGlobalWindowIsIndependent()
+    void testGlobalRateLimiterWindowIsIndependent()
     {
-        // The global dimension has its own window, so a sample that has aged out of the shared window can still
-        // count toward the global threshold.
+        // The global rate limiter has its own window, so a sample that has aged out of the shared window can
+        // still count toward the global threshold.
         TestBlockingCommandQueue queue;
-        queue.setWindow(100);
-        queue.setIdentifierThreshold(0);
-        queue.setCommandThreshold(0);
-        queue.setGlobalWindow(1000);
-        queue.setGlobalThreshold(50);
-        queue.setGlobalBlockDuration(1000);
+        queue.setSharedRateLimiterWindow(100);
+        queue.setBlockingIdentifierThreshold(0);
+        queue.setBlockingCommandThreshold(0);
+        queue.setGlobalRateLimiterWindow(1000);
+        queue.setGlobalRateLimiterThreshold(50);
+        queue.setGlobalRateLimiterBlockDuration(1000);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 30);
         ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
 
-        // 500us later the first sample is far outside the 100us shared window but inside the 1000us global
-        // window, so all 30us of it still counts and the second sample takes the total to 60 (> 50).
+        // The clock is now 500us past the first sample, which puts it outside the 100us shared window but
+        // inside the 1000us global window. All 30us of it still counts, so the total reaches 60 (> 50).
         queue.setNow(1500);
         queue.recordExecutionTime("acct1", "cmd", 30);
         ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "global");
     }
 
-    void testGlobalBlockDurationHoldsThenClears()
+    void testGlobalRateLimiterBlockDurationHoldsThenClears()
     {
         TestBlockingCommandQueue queue;
-        queue.setIdentifierThreshold(0);
-        queue.setCommandThreshold(0);
-        queue.setGlobalWindow(100);
-        queue.setGlobalThreshold(50);
-        queue.setGlobalBlockDuration(500);
+        queue.setBlockingIdentifierThreshold(0);
+        queue.setBlockingCommandThreshold(0);
+        queue.setGlobalRateLimiterWindow(100);
+        queue.setGlobalRateLimiterThreshold(50);
+        queue.setGlobalRateLimiterBlockDuration(500);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);
@@ -433,14 +433,14 @@ struct BlockingCommandQueueTest : tpunit::TestFixture
         ASSERT_EQUAL(queue.getBlockingDimension("acct1", "cmd"), "");
     }
 
-    void testClearResetsGlobalBlock()
+    void testClearResetsGlobalRateLimiter()
     {
         TestBlockingCommandQueue queue;
-        queue.setIdentifierThreshold(0);
-        queue.setCommandThreshold(0);
-        queue.setGlobalWindow(100);
-        queue.setGlobalThreshold(50);
-        queue.setGlobalBlockDuration(1000);
+        queue.setBlockingIdentifierThreshold(0);
+        queue.setBlockingCommandThreshold(0);
+        queue.setGlobalRateLimiterWindow(100);
+        queue.setGlobalRateLimiterThreshold(50);
+        queue.setGlobalRateLimiterBlockDuration(1000);
         queue.setNow(1000);
 
         queue.recordExecutionTime("acct1", "cmd", 60);


### PR DESCRIPTION
### Details

This PR adds a new global blocking queue limit. If the blockgin queue was used for 55s from the past 60s, it will blockg everything in the next 60s.

Those numbers are all configurable by control commands.

It also refactors a bit of code so we can reuse all the code between all 3 dimentions (identifier, command and global).

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/673587

### Tests

New automated tests.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes

Compiled `auth/Auth.cpp`, `auth/command/OpenApp.cpp` and `auth/lib/OnyxDeleter.cpp` (the Auth translation units that include `BedrockServer.h`, and therefore this header) against this branch. All clean.
