### PR TITLE
Trim journal tables from a background deleter thread

### DIFF
--- a/BedrockJournalDeleter.cpp
+++ b/BedrockJournalDeleter.cpp
@@ -1,0 +1,121 @@
+#include "BedrockJournalDeleter.h"
+
+#include <BedrockServer.h>
+#include <sqlitecluster/SQLitePool.h>
+
+BedrockJournalDeleter::BedrockJournalDeleter(BedrockServer& server) : _server(server)
+{
+}
+
+BedrockJournalDeleter::~BedrockJournalDeleter()
+{
+    stop();
+}
+
+void BedrockJournalDeleter::wake()
+{
+    {
+        lock_guard<decltype(_wakeMutex)> lock(_wakeMutex);
+        _wakeRequested = true;
+    }
+    _cv.notify_one();
+}
+
+bool BedrockJournalDeleter::isTrimmableState(SQLiteNodeState state)
+{
+    // We also commit while SYNCHRONIZING, but a node catching up drains what it accumulated once it is FOLLOWING.
+    return state == SQLiteNodeState::LEADING || state == SQLiteNodeState::FOLLOWING || state == SQLiteNodeState::STANDINGDOWN;
+}
+
+void BedrockJournalDeleter::start(SQLiteNodeState state)
+{
+    if (!enableDeleterThread || !isTrimmableState(state)) {
+        return;
+    }
+
+    lock_guard<decltype(_lifecycleMutex)> lifecycleLock(_lifecycleMutex);
+    if (_thread) {
+        return;
+    }
+
+    // Set before the thread exists, and any previous one was joined under _lifecycleMutex, so nothing reads this
+    // while we write it. A wake left over from while we were stopped just costs one trim.
+    _stop = false;
+    _thread = make_unique<thread>([this]() {
+        SInitialize("journalDeleter");
+        SThreadLogCommand = "JournalDeleter";
+        while (true) {
+            {
+                unique_lock<decltype(_wakeMutex)> lock(_wakeMutex);
+
+                // No timeout on purpose: a cluster that isn't committing has nothing to trim.
+                _cv.wait(lock, [this]() {
+                    return _stop || _wakeRequested;
+                });
+                if (_stop) {
+                    return;
+                }
+                _wakeRequested = false;
+            }
+
+            if (!isTrimmableState(_server.getState())) {
+                continue;
+            }
+
+            // A failed trim throws, and this is a thread entry point, so letting it bubble up would terminate Bedrock.
+            try {
+                shared_ptr<SQLitePool> dbPool = _server.getDBPool();
+                if (!dbPool) {
+                    continue;
+                }
+                SQLiteScopedHandle dbScope(*dbPool, dbPool->getIndex());
+                trimNextTable(dbScope.db());
+            } catch (const exception& e) {
+                SWARN("Journal trim failed, will retry on a later wake.", {{"what", e.what()}});
+            } catch (...) {
+                SWARN("Journal trim failed with an unknown exception, will retry on a later wake.");
+            }
+        }
+    });
+}
+
+void BedrockJournalDeleter::stop()
+{
+    lock_guard<decltype(_lifecycleMutex)> lifecycleLock(_lifecycleMutex);
+
+    unique_ptr<thread> localThread;
+    {
+        lock_guard<decltype(_wakeMutex)> lock(_wakeMutex);
+        if (!_thread) {
+            return;
+        }
+        _stop = true;
+        localThread = move(_thread);
+    }
+    _cv.notify_one();
+
+    // Joined outside the lock so the thread can take it on its way out.
+    localThread->join();
+}
+
+void BedrockJournalDeleter::trimNextTable(SQLite& db)
+{
+    const size_t tableIndex = _nextTable++ % db.getJournalTableCount();
+    const uint64_t start = STimeNow();
+    if (!db.trimJournalTable(tableIndex, deleterBatchSize)) {
+        // A commit landing underneath us surfaces as a failed COMMIT, which is expected under load.
+        SINFO("Journal trim did not commit, will retry on a later pass.", {{"journalTableIndex", to_string(tableIndex)}});
+        return;
+    }
+
+    const uint64_t timeSpent = STimeNow() - start;
+
+    // This runs on every commit, so only log the slow ones.
+    if (timeSpent > 100'000) {
+        SINFO("Journal trim timing info", {
+            {"totalTransactionElapsed", to_string(timeSpent / 1000)},
+            {"journalTableIndex", to_string(tableIndex)},
+            {"deleted", to_string(db.getLastWriteChangeCount())},
+        });
+    }
+}

--- a/BedrockJournalDeleter.cpp
+++ b/BedrockJournalDeleter.cpp
@@ -23,8 +23,9 @@ void BedrockJournalDeleter::wake()
 
 bool BedrockJournalDeleter::isTrimmableState(SQLiteNodeState state)
 {
-    // We also commit while SYNCHRONIZING, but a node catching up drains what it accumulated once it is FOLLOWING.
-    return state == SQLiteNodeState::LEADING || state == SQLiteNodeState::FOLLOWING || state == SQLiteNodeState::STANDINGDOWN;
+    // These are the states we commit in, and a node catching up journals faster than any other.
+    return state == SQLiteNodeState::LEADING || state == SQLiteNodeState::FOLLOWING ||
+           state == SQLiteNodeState::STANDINGDOWN || state == SQLiteNodeState::SYNCHRONIZING;
 }
 
 void BedrockJournalDeleter::start(SQLiteNodeState state)
@@ -35,8 +36,8 @@ void BedrockJournalDeleter::start(SQLiteNodeState state)
 
     lock_guard<decltype(_lifecycleMutex)> lifecycleLock(_lifecycleMutex);
     if (_thread) {
-        // The thread clears a wake without trimming while the state isn't trimmable, so whatever the node journaled
-        // while it was catching up is still waiting. Wake it rather than leaving that until the next commit.
+        // The thread clears a wake without trimming while the state isn't trimmable, so anything the node journaled
+        // in one of those states is still waiting. Wake it rather than leaving that until the next commit.
         wake();
         return;
     }

--- a/BedrockJournalDeleter.cpp
+++ b/BedrockJournalDeleter.cpp
@@ -27,15 +27,14 @@ bool BedrockJournalDeleter::isTrimmableState(SQLiteNodeState state)
            state == SQLiteNodeState::STANDINGDOWN || state == SQLiteNodeState::SYNCHRONIZING;
 }
 
-void BedrockJournalDeleter::start(SQLiteNodeState state)
+void BedrockJournalDeleter::start()
 {
-    if (!enableDeleterThread || !isTrimmableState(state)) {
+    if (!enableDeleterThread) {
         return;
     }
 
     lock_guard<decltype(_lifecycleMutex)> lifecycleLock(_lifecycleMutex);
     if (_thread) {
-        wake();
         return;
     }
 

--- a/BedrockJournalDeleter.cpp
+++ b/BedrockJournalDeleter.cpp
@@ -35,6 +35,9 @@ void BedrockJournalDeleter::start(SQLiteNodeState state)
 
     lock_guard<decltype(_lifecycleMutex)> lifecycleLock(_lifecycleMutex);
     if (_thread) {
+        // The thread clears a wake without trimming while the state isn't trimmable, so whatever the node journaled
+        // while it was catching up is still waiting. Wake it rather than leaving that until the next commit.
+        wake();
         return;
     }
 

--- a/BedrockJournalDeleter.cpp
+++ b/BedrockJournalDeleter.cpp
@@ -23,7 +23,6 @@ void BedrockJournalDeleter::wake()
 
 bool BedrockJournalDeleter::isTrimmableState(SQLiteNodeState state)
 {
-    // These are the states we commit in, and a node catching up journals faster than any other.
     return state == SQLiteNodeState::LEADING || state == SQLiteNodeState::FOLLOWING ||
            state == SQLiteNodeState::STANDINGDOWN || state == SQLiteNodeState::SYNCHRONIZING;
 }
@@ -36,8 +35,6 @@ void BedrockJournalDeleter::start(SQLiteNodeState state)
 
     lock_guard<decltype(_lifecycleMutex)> lifecycleLock(_lifecycleMutex);
     if (_thread) {
-        // The thread clears a wake without trimming while the state isn't trimmable, so anything the node journaled
-        // in one of those states is still waiting. Wake it rather than leaving that until the next commit.
         wake();
         return;
     }

--- a/BedrockJournalDeleter.h
+++ b/BedrockJournalDeleter.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include <libstuff/libstuff.h>
+#include <sqlitecluster/SQLiteNode.h>
+
+class BedrockServer;
+class SQLite;
+
+// Trims old rows out of the journal tables. One thread, so the deletes cannot conflict with each other, and a delete
+// that does conflict with a commit costs nothing but a retry on a later pass.
+class BedrockJournalDeleter {
+public:
+    BedrockJournalDeleter(BedrockServer& server);
+    ~BedrockJournalDeleter();
+
+    static inline atomic<bool> enableDeleterThread{true};
+    static inline atomic<int64_t> deleterBatchSize{1000};
+
+    // Runs on the committing thread: must not block or touch the database.
+    void wake();
+
+    // Does nothing unless the flag is on and the state is trimmable. Never stops the thread: this runs on the sync
+    // thread, where a join could stall a failover, so the shutdown path is what actually stops it.
+    void start(SQLiteNodeState state);
+
+    void stop();
+
+    void trimNextTable(SQLite& db);
+
+private:
+    static bool isTrimmableState(SQLiteNodeState state);
+
+    BedrockServer& _server;
+    size_t _nextTable = 0;
+
+    // Serializes start against stop, so a restart can't clear _stop while stop() is still joining the old thread.
+    mutex _lifecycleMutex;
+
+    unique_ptr<thread> _thread;
+
+    // Guards the two fields below between wake() and the thread's wait predicate.
+    mutex _wakeMutex;
+    condition_variable _cv;
+
+    // A flag, not a count: a burst of commits collapses into one trim, and the next commit takes what is left.
+    bool _wakeRequested = false;
+    bool _stop = false;
+};

--- a/BedrockJournalDeleter.h
+++ b/BedrockJournalDeleter.h
@@ -17,14 +17,13 @@ public:
     ~BedrockJournalDeleter();
 
     static inline atomic<bool> enableDeleterThread{true};
-    static inline atomic<int64_t> deleterBatchSize{1000};
+    static inline atomic<int64_t> deleterBatchSize{10};
 
     // Runs on the committing thread: must not block or touch the database.
     void wake();
 
-    // Does nothing unless the flag is on and the state is trimmable. Never stops the thread: this runs on the sync
-    // thread, where a join could stall a failover, so the shutdown path is what actually stops it.
-    void start(SQLiteNodeState state);
+    // Does nothing unless the flag is on. The thread checks the node's state itself, on every wake.
+    void start();
 
     void stop();
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -105,12 +105,18 @@ void BedrockServer::sync()
     // We use fewer FDs on test machines that have other resource restrictions in place.
 
     SQLite::journalZstdDictionaryID = args.calc("-journalZstdDictionaryID");
+    if (args.isSet("-journalDeleterBatchSize")) {
+        BedrockJournalDeleter::deleterBatchSize = args.calc64("-journalDeleterBatchSize");
+    }
     vector<function<void()>> callbacks;
     for (const auto& plugin : plugins) {
         if (plugin.second->afterCommitCallback) {
             callbacks.emplace_back(plugin.second->afterCommitCallback);
         }
     }
+    callbacks.emplace_back([this]() {
+        _journalDeleter.wake();
+    });
     SINFO("Setting dbPool size to: " << _dbPoolSize);
     _dbPool = make_shared<SQLitePool>(_dbPoolSize, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), journalTables, mmapSizeGB, args.isSet("-newDBsUseHctree"), args["-checkpointMode"], callbacks);
     SQLite& db = _dbPool->getBase();
@@ -390,6 +396,8 @@ void BedrockServer::sync()
     for (auto plugin : plugins) {
         plugin.second->serverStopping();
     }
+
+    _journalDeleter.stop();
 
     // We clear this before the _syncNode that it references.
     _clusterMessenger.reset();
@@ -1015,12 +1023,12 @@ void BedrockServer::_resetServer()
 }
 
 BedrockServer::BedrockServer(SQLiteNodeState state, const SData& args_)
-    : SQLiteServer(), args(args_), _syncNode(nullptr), _configuredPriority(args.calc("-priority")), _clusterMessenger(nullptr)
+    : SQLiteServer(), args(args_), _journalDeleter(*this), _syncNode(nullptr), _configuredPriority(args.calc("-priority")), _clusterMessenger(nullptr)
 {
 }
 
 BedrockServer::BedrockServer(const SData& args_)
-    : SQLiteServer(), shutdownWhileDetached(false), args(args_), _requestCount(0),
+    : SQLiteServer(), shutdownWhileDetached(false), args(args_), _journalDeleter(*this), _requestCount(0),
     _isCommandPortLikelyBlocked(false),
     _syncLoopShouldBeRunning(true), _syncNode(nullptr), _configuredPriority(args.calc("-priority")), _clusterMessenger(nullptr), _shutdownState(RUNNING),
     _enableConflictPageLocks(args.test("-enableConflictPageLocks")), _shouldBackup(false), _detach(args.isSet("-bootstrap")),
@@ -1643,6 +1651,7 @@ bool BedrockServer::_isControlCommand(const unique_ptr<BedrockCommand>& command)
         SIEquals(command->request.methodLine, "SetConflictParams") ||
         SIEquals(command->request.methodLine, "SetConflictPageLocks") ||
         SIEquals(command->request.methodLine, "EnableSQLTracing") ||
+        SIEquals(command->request.methodLine, "SetJournalDeleter") ||
         SIEquals(command->request.methodLine, "BlockWrites") ||
         SIEquals(command->request.methodLine, "UnblockWrites") ||
         SIEquals(command->request.methodLine, "SetMaxSocketThreads") ||
@@ -1722,6 +1731,24 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
             _syncLoopShouldBeRunning = true;
             _detach = false;
         }
+    } else if (SIEquals(command->request.methodLine, "SetJournalDeleter")) {
+        response["oldEnabled"] = BedrockJournalDeleter::enableDeleterThread ? "true" : "false";
+        response["oldBatchSize"] = to_string(BedrockJournalDeleter::deleterBatchSize.load());
+        if (command->request.isSet("batchSize")) {
+            BedrockJournalDeleter::deleterBatchSize.store(command->request.calc64("batchSize"));
+        }
+        if (command->request.isSet("enable")) {
+            BedrockJournalDeleter::enableDeleterThread.store(command->request.test("enable"));
+
+            // The thread otherwise only starts on a state change, and only stops on shutdown.
+            if (BedrockJournalDeleter::enableDeleterThread) {
+                _journalDeleter.start(getState());
+            } else {
+                _journalDeleter.stop();
+            }
+        }
+        response["newEnabled"] = BedrockJournalDeleter::enableDeleterThread ? "true" : "false";
+        response["newBatchSize"] = to_string(BedrockJournalDeleter::deleterBatchSize.load());
     } else if (SIEquals(command->request.methodLine, "EnableSQLTracing")) {
         response["oldValue"] = SQLite::enableTrace ? "true" : "false";
         if (command->request.isSet("enable")) {
@@ -2461,6 +2488,7 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
 
 void BedrockServer::notifyStateChangeToPlugins(SQLite& db, SQLiteNodeState newState)
 {
+    _journalDeleter.start(newState);
     for (auto plugin : plugins) {
         plugin.second->stateChanged(db, newState);
     }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -107,10 +107,10 @@ void BedrockServer::sync()
     SQLite::journalZstdDictionaryID = args.calc("-journalZstdDictionaryID");
     if (args.isSet("-journalDeleterBatchSize")) {
         const int64_t journalDeleterBatchSize = args.calc64("-journalDeleterBatchSize");
-        if (journalDeleterBatchSize > 0) {
+        if (journalDeleterBatchSize >= 0) {
             BedrockJournalDeleter::deleterBatchSize = journalDeleterBatchSize;
         } else {
-            SWARN("Ignoring -journalDeleterBatchSize '" << args["-journalDeleterBatchSize"] << "', it must be greater than 0.");
+            SWARN("Ignoring -journalDeleterBatchSize '" << args["-journalDeleterBatchSize"] << "', it can't be negative.");
         }
     }
     vector<function<void()>> callbacks;
@@ -1737,10 +1737,11 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
             _detach = false;
         }
     } else if (SIEquals(command->request.methodLine, "SetJournalDeleter")) {
-        // `LIMIT 0` would silently stop trimming, and SQLite reads a negative limit as no limit at all.
+        // Zero pauses trimming, but SQLite reads a negative limit as no limit at all, which would delete a whole
+        // journal table in one transaction.
         const int64_t batchSize = command->request.calc64("batchSize");
-        if (command->request.isSet("batchSize") && batchSize <= 0) {
-            response.methodLine = "400 batchSize must be greater than 0";
+        if (command->request.isSet("batchSize") && batchSize < 0) {
+            response.methodLine = "400 batchSize can't be negative";
             return;
         }
 

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -125,6 +125,7 @@ void BedrockServer::sync()
     SINFO("Setting dbPool size to: " << _dbPoolSize);
     _dbPool = make_shared<SQLitePool>(_dbPoolSize, args["-db"], args.calc("-cacheSize"), args.calc("-maxJournalSize"), journalTables, mmapSizeGB, args.isSet("-newDBsUseHctree"), args["-checkpointMode"], callbacks);
     SQLite& db = _dbPool->getBase();
+    _journalDeleter.start();
 
     // Allow plugins to read from the DB at startup.
     for (auto plugin : plugins) {
@@ -1753,9 +1754,9 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
         if (command->request.isSet("enable")) {
             BedrockJournalDeleter::enableDeleterThread.store(command->request.test("enable"));
 
-            // The thread otherwise only starts on a state change, and only stops on shutdown.
+            // The thread otherwise only starts with the sync loop, and only stops on shutdown.
             if (BedrockJournalDeleter::enableDeleterThread) {
-                _journalDeleter.start(getState());
+                _journalDeleter.start();
             } else {
                 _journalDeleter.stop();
             }
@@ -2501,7 +2502,6 @@ void BedrockServer::handleSocket(Socket&& socket, bool fromControlPort, bool fro
 
 void BedrockServer::notifyStateChangeToPlugins(SQLite& db, SQLiteNodeState newState)
 {
-    _journalDeleter.start(newState);
     for (auto plugin : plugins) {
         plugin.second->stateChanged(db, newState);
     }

--- a/BedrockServer.cpp
+++ b/BedrockServer.cpp
@@ -106,7 +106,12 @@ void BedrockServer::sync()
 
     SQLite::journalZstdDictionaryID = args.calc("-journalZstdDictionaryID");
     if (args.isSet("-journalDeleterBatchSize")) {
-        BedrockJournalDeleter::deleterBatchSize = args.calc64("-journalDeleterBatchSize");
+        const int64_t journalDeleterBatchSize = args.calc64("-journalDeleterBatchSize");
+        if (journalDeleterBatchSize > 0) {
+            BedrockJournalDeleter::deleterBatchSize = journalDeleterBatchSize;
+        } else {
+            SWARN("Ignoring -journalDeleterBatchSize '" << args["-journalDeleterBatchSize"] << "', it must be greater than 0.");
+        }
     }
     vector<function<void()>> callbacks;
     for (const auto& plugin : plugins) {
@@ -1732,10 +1737,17 @@ void BedrockServer::_control(unique_ptr<BedrockCommand>& command)
             _detach = false;
         }
     } else if (SIEquals(command->request.methodLine, "SetJournalDeleter")) {
+        // `LIMIT 0` would silently stop trimming, and SQLite reads a negative limit as no limit at all.
+        const int64_t batchSize = command->request.calc64("batchSize");
+        if (command->request.isSet("batchSize") && batchSize <= 0) {
+            response.methodLine = "400 batchSize must be greater than 0";
+            return;
+        }
+
         response["oldEnabled"] = BedrockJournalDeleter::enableDeleterThread ? "true" : "false";
         response["oldBatchSize"] = to_string(BedrockJournalDeleter::deleterBatchSize.load());
         if (command->request.isSet("batchSize")) {
-            BedrockJournalDeleter::deleterBatchSize.store(command->request.calc64("batchSize"));
+            BedrockJournalDeleter::deleterBatchSize.store(batchSize);
         }
         if (command->request.isSet("enable")) {
             BedrockJournalDeleter::enableDeleterThread.store(command->request.test("enable"));

--- a/BedrockServer.h
+++ b/BedrockServer.h
@@ -7,6 +7,7 @@
 #include "BedrockPlugin.h"
 #include "BedrockCommandQueue.h"
 #include "BedrockConflictManager.h"
+#include "BedrockJournalDeleter.h"
 #include "BedrockBlockingCommandQueue.h"
 
 class SQLitePeer;
@@ -285,6 +286,9 @@ private:
     BedrockCommandQueue _commandQueue;
 
     BedrockConflictManager _conflictManager;
+
+    // Trims the journal tables in the background, so commands don't have to do it inside their own transactions.
+    BedrockJournalDeleter _journalDeleter;
 
     // These are commands that will be processed in a blacking fashion.
     BedrockBlockingCommandQueue _blockingCommandQueue;

--- a/main.cpp
+++ b/main.cpp
@@ -254,6 +254,8 @@ int main(int argc, char* argv[])
         << endl;
         cout << "-maxJournalSize <#commits>  Number of commits to retain in the historical journal (default 1000000)"
         << endl;
+        cout << "-journalDeleterBatchSize <#rows>  Number of journal rows the background deleter removes per pass (default 1000)"
+        << endl;
         cout << "-checkpointMode <mode>      Accepts PASSIVE|FULL|RESTART|TRUNCATE, which is the value passed to https://www.sqlite.org/c3ref/wal_checkpoint_v2.html" << endl;
         cout << endl;
         cout << "Quick Start Tips:" << endl;
@@ -330,6 +332,7 @@ int main(int argc, char* argv[])
     SETDEFAULT("-plugins", "db,jobs,cache,mysql,compression");
     SETDEFAULT("-priority", "100");
     SETDEFAULT("-maxJournalSize", "1000000");
+    SETDEFAULT("-journalDeleterBatchSize", "1000");
     SETDEFAULT("-queryLog", "queryLog.csv");
     SETDEFAULT("-journalZstdDictionaryID", "0");
 

--- a/main.cpp
+++ b/main.cpp
@@ -254,7 +254,7 @@ int main(int argc, char* argv[])
         << endl;
         cout << "-maxJournalSize <#commits>  Number of commits to retain in the historical journal (default 1000000)"
         << endl;
-        cout << "-journalDeleterBatchSize <#rows>  Number of journal rows the background deleter removes per pass, 0 to pause trimming (default 1000)"
+        cout << "-journalDeleterBatchSize <#rows>  Number of journal rows the background deleter removes per pass, 0 to pause trimming (default 10)"
         << endl;
         cout << "-checkpointMode <mode>      Accepts PASSIVE|FULL|RESTART|TRUNCATE, which is the value passed to https://www.sqlite.org/c3ref/wal_checkpoint_v2.html" << endl;
         cout << endl;
@@ -332,7 +332,7 @@ int main(int argc, char* argv[])
     SETDEFAULT("-plugins", "db,jobs,cache,mysql,compression");
     SETDEFAULT("-priority", "100");
     SETDEFAULT("-maxJournalSize", "1000000");
-    SETDEFAULT("-journalDeleterBatchSize", "1000");
+    SETDEFAULT("-journalDeleterBatchSize", "10");
     SETDEFAULT("-queryLog", "queryLog.csv");
     SETDEFAULT("-journalZstdDictionaryID", "0");
 

--- a/main.cpp
+++ b/main.cpp
@@ -254,7 +254,7 @@ int main(int argc, char* argv[])
         << endl;
         cout << "-maxJournalSize <#commits>  Number of commits to retain in the historical journal (default 1000000)"
         << endl;
-        cout << "-journalDeleterBatchSize <#rows>  Number of journal rows the background deleter removes per pass (default 1000)"
+        cout << "-journalDeleterBatchSize <#rows>  Number of journal rows the background deleter removes per pass, 0 to pause trimming (default 1000)"
         << endl;
         cout << "-checkpointMode <mode>      Accepts PASSIVE|FULL|RESTART|TRUNCATE, which is the value passed to https://www.sqlite.org/c3ref/wal_checkpoint_v2.html" << endl;
         cout << endl;

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -863,6 +863,39 @@ bool SQLite::writeLocalUnreplicated(const string& query)
     return true;
 }
 
+size_t SQLite::getJournalTableCount() const
+{
+    return _journalNames.size();
+}
+
+bool SQLite::trimJournalTable(size_t journalTableIndex, int64_t batchSize)
+{
+    const string& journalName = _journalNames[journalTableIndex % _journalNames.size()];
+
+    // If the commitCount is less than the max journal size, keep everything. Otherwise, keep everything from
+    // commitCount - _maxJournalSize forward. We can't just do the last subtraction part because it overflows our
+    // unsigned int.
+    const uint64_t commitCount = getCommitCount();
+    const uint64_t oldestCommitToKeep = commitCount < _maxJournalSize ? 0 : commitCount - _maxJournalSize;
+    if (!oldestCommitToKeep) {
+        return true;
+    }
+
+    // MIN(id) is NULL on an empty table, which is not something we need to delete from.
+    SQResult journalLookupResult;
+    if (!read("SELECT MIN(id) FROM " + journalName + ";", journalLookupResult)) {
+        return false;
+    }
+    if (journalLookupResult.empty() || journalLookupResult[0][0].empty()) {
+        return true;
+    }
+    if (SToUInt64(journalLookupResult[0][0]) >= oldestCommitToKeep) {
+        return true;
+    }
+
+    return writeLocalUnreplicated("DELETE FROM " + journalName + " WHERE id < " + SQ(oldestCommitToKeep) + " LIMIT " + SQ(batchSize) + ";");
+}
+
 bool SQLite::_writeIdempotent(const string& query, const map<string, Parameter>& params, SQResult& result, bool alwaysKeepQueries)
 {
     if (!_insideTransaction) {
@@ -947,29 +980,6 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
     const int64_t journalID = _sharedData.nextJournalCount++;
     _journalName = _journalNames[journalID % _journalNames.size()];
 
-    // Look up the oldest commit in our chosen journal, and compute the oldest commit we intend to keep.
-    SQResult journalLookupResult;
-    SASSERT(!SQuery(_db, "SELECT MIN(id) FROM " + _journalName, journalLookupResult));
-    uint64_t minJournalEntry = journalLookupResult.size() ? SToUInt64(journalLookupResult[0][0]) : 0;
-
-    // Note that this can change before we hold the lock on _sharedData.commitLock, but it doesn't matter yet, as we're only
-    // using it to truncate the journal. We'll reset this value once we acquire that lock.
-    uint64_t commitCount = _sharedData.commitCount;
-
-    // If the commitCount is less than the max journal size, keep everything. Otherwise, keep everything from
-    // commitCount - _maxJournalSize forward. We can't just do the last subtraction part because it overflows our unsigned
-    // int.
-    uint64_t oldestCommitToKeep = commitCount < _maxJournalSize ? 0 : commitCount - _maxJournalSize;
-
-    // We limit deletions to a relatively small number to avoid making this extremely slow for some transactions in the case
-    // where this journal in particular has accumulated a large backlog.
-    static const size_t deleteLimit = 10;
-    if (minJournalEntry < oldestCommitToKeep) {
-        shared_lock<shared_mutex> lock(_sharedData.writeLock);
-        string query = "DELETE FROM " + _journalName + " WHERE id < " + SQ(oldestCommitToKeep) + " LIMIT " + SQ(deleteLimit);
-        SASSERT(!SQuery(_db, query));
-    }
-
     // We lock this here, so that we can guarantee the order in which commits show up in the database.
     if (!_mutexLocked) {
         auto start = chrono::steady_clock::now();
@@ -1043,7 +1053,7 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
 
     // Now that we've locked anybody else from committing, look up the state of the database. We don't need to lock the
     // SharedData object to get these values as we know it can't currently change.
-    commitCount = _sharedData.commitCount;
+    const uint64_t commitCount = _sharedData.commitCount;
 
     // Queue up the journal entry
     string lastCommittedHash = getCommittedHash(); // This is why we need the lock.

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -870,6 +870,11 @@ size_t SQLite::getJournalTableCount() const
 
 bool SQLite::trimJournalTable(size_t journalTableIndex, int64_t batchSize)
 {
+    // A batch size of zero deletes nothing, which is how the deleter pauses without stopping its thread.
+    if (!batchSize) {
+        return true;
+    }
+
     const string& journalName = _journalNames[journalTableIndex % _journalNames.size()];
 
     // If the commitCount is less than the max journal size, keep everything. Otherwise, keep everything from

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -167,6 +167,14 @@ public:
     // truncating old journal entries. This function will not call runAfterCommit callbacks.
     bool writeLocalUnreplicated(const string& query);
 
+    // Deletes up to `batchSize` rows from one journal table, keeping the newest `-maxJournalSize` commits. Returns
+    // false if the delete did not commit, which happens when another commit lands underneath it. Must be called
+    // outside of a transaction.
+    bool trimJournalTable(size_t journalTableIndex, int64_t batchSize);
+
+    // The number of journal tables in this database. Any index passed to `trimJournalTable` is taken modulo this.
+    size_t getJournalTableCount() const;
+
     // Enable or disable update-noop mode.
     void setUpdateNoopMode(bool enabled);
     bool getUpdateNoopMode() const;

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -167,9 +167,9 @@ public:
     // truncating old journal entries. This function will not call runAfterCommit callbacks.
     bool writeLocalUnreplicated(const string& query);
 
-    // Deletes up to `batchSize` rows from one journal table, keeping the newest `-maxJournalSize` commits. Returns
-    // false if the delete did not commit, which happens when another commit lands underneath it. Must be called
-    // outside of a transaction.
+    // Deletes up to `batchSize` rows from one journal table, keeping the newest `-maxJournalSize` commits. A
+    // `batchSize` of zero deletes nothing. Returns false if the delete did not commit, which happens when another
+    // commit lands underneath it. Must be called outside of a transaction.
     bool trimJournalTable(size_t journalTableIndex, int64_t batchSize);
 
     // The number of journal tables in this database. Any index passed to `trimJournalTable` is taken modulo this.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -169,7 +169,7 @@ public:
 
     // Deletes up to `batchSize` rows from one journal table, keeping the newest `-maxJournalSize` commits. A
     // `batchSize` of zero deletes nothing. Returns false if the delete did not commit, which happens when another
-    // commit lands underneath it. Must be called outside of a transaction.
+    // commit conflicts.
     bool trimJournalTable(size_t journalTableIndex, int64_t batchSize);
 
     // The number of journal tables in this database. Any index passed to `trimJournalTable` is taken modulo this.

--- a/test/tests/JournalDeleterTest.cpp
+++ b/test/tests/JournalDeleterTest.cpp
@@ -1,0 +1,123 @@
+#include <unistd.h>
+
+#include <libstuff/libstuff.h>
+#include <sqlitecluster/SQLite.h>
+#include <test/lib/BedrockTester.h>
+
+struct JournalDeleterTempDBFile
+{
+    char filename[16] = "br_jd_dbXXXXXXX";
+    JournalDeleterTempDBFile()
+    {
+        int fd = mkstemp(filename);
+        close(fd);
+    }
+
+    ~JournalDeleterTempDBFile()
+    {
+        unlink(filename);
+    }
+};
+
+struct JournalDeleterTest : tpunit::TestFixture
+{
+    JournalDeleterTest()
+        : tpunit::TestFixture("JournalDeleter",
+                              TEST(JournalDeleterTest::prepareLeavesTheJournalUntouched),
+                              TEST(JournalDeleterTest::trimRemovesEntriesOlderThanTheMax),
+                              TEST(JournalDeleterTest::trimKeepsEverythingWhenUnderTheMax),
+                              TEST(JournalDeleterTest::trimHonoursTheBatchSize))
+    {
+    }
+
+    // Small enough that a handful of commits is already over the limit.
+    static const int maxJournalSize = 5;
+
+    // Commits `count` transactions, including the one that creates the table.
+    void commitTransactions(SQLite& db, int count)
+    {
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+        db.write("CREATE TABLE testTable(id INTEGER PRIMARY KEY, value INTEGER);");
+        db.prepare();
+        ASSERT_EQUAL(db.commit(), SQLITE_OK);
+
+        for (int i = 2; i <= count; i++) {
+            db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE);
+            db.write("INSERT INTO testTable VALUES(" + SToStr(i) + ", 1);");
+            db.prepare();
+            ASSERT_EQUAL(db.commit(), SQLITE_OK);
+        }
+        ASSERT_EQUAL(db.getCommitCount(), (uint64_t) count);
+    }
+
+    int64_t countJournalRows(SQLite& db, const string& where = "1")
+    {
+        SQResult result;
+        db.beginTransaction(SQLite::TRANSACTION_TYPE::SHARED);
+        db.read("SELECT COUNT(*) FROM journalEntries WHERE " + where + ";", result);
+        db.rollback();
+        return SToInt64(result[0][0]);
+    }
+
+    // Deletes everything the deleter thread would eventually delete.
+    void trimEverything(SQLite& db)
+    {
+        for (size_t round = 0; round < 10; round++) {
+            for (size_t table = 0; table < db.getJournalTableCount(); table++) {
+                ASSERT_TRUE(db.trimJournalTable(table, 1000));
+            }
+        }
+    }
+
+    void prepareLeavesTheJournalUntouched()
+    {
+        JournalDeleterTempDBFile dbFile;
+        SQLite db(dbFile.filename, 1000, maxJournalSize, 1);
+        commitTransactions(db, 20);
+
+        // Committing is well past `maxJournalSize`, and every commit is still journaled: trimming is somebody else's
+        // job now.
+        ASSERT_EQUAL(countJournalRows(db), 20);
+    }
+
+    void trimRemovesEntriesOlderThanTheMax()
+    {
+        JournalDeleterTempDBFile dbFile;
+        SQLite db(dbFile.filename, 1000, maxJournalSize, 1);
+        commitTransactions(db, 30);
+
+        const uint64_t oldestCommitToKeep = db.getCommitCount() - maxJournalSize;
+        trimEverything(db);
+
+        ASSERT_EQUAL(countJournalRows(db, "id < " + SQ(oldestCommitToKeep)), 0);
+        ASSERT_EQUAL(countJournalRows(db), maxJournalSize + 1);
+    }
+
+    void trimKeepsEverythingWhenUnderTheMax()
+    {
+        JournalDeleterTempDBFile dbFile;
+        SQLite db(dbFile.filename, 1000, 1000, 1);
+        commitTransactions(db, 10);
+
+        trimEverything(db);
+        ASSERT_EQUAL(countJournalRows(db), 10);
+    }
+
+    void trimHonoursTheBatchSize()
+    {
+        JournalDeleterTempDBFile dbFile;
+        SQLite db(dbFile.filename, 1000, maxJournalSize, 1);
+        commitTransactions(db, 30);
+
+        // 24 rows are old enough to delete, spread evenly over the journal tables, so every table has some.
+        const uint64_t oldestCommitToKeep = db.getCommitCount() - maxJournalSize;
+        const string oldRows = "id < " + SQ(oldestCommitToKeep);
+        const int64_t oldRowsBefore = countJournalRows(db, oldRows);
+
+        for (size_t table = 0; table < db.getJournalTableCount(); table++) {
+            ASSERT_TRUE(db.trimJournalTable(table, 1));
+        }
+
+        ASSERT_EQUAL(countJournalRows(db, oldRows), oldRowsBefore - (int64_t) db.getJournalTableCount());
+    }
+} __JournalDeleterTest;

--- a/test/tests/JournalDeleterTest.cpp
+++ b/test/tests/JournalDeleterTest.cpp
@@ -26,7 +26,8 @@ struct JournalDeleterTest : tpunit::TestFixture
                               TEST(JournalDeleterTest::prepareLeavesTheJournalUntouched),
                               TEST(JournalDeleterTest::trimRemovesEntriesOlderThanTheMax),
                               TEST(JournalDeleterTest::trimKeepsEverythingWhenUnderTheMax),
-                              TEST(JournalDeleterTest::trimHonoursTheBatchSize))
+                              TEST(JournalDeleterTest::trimHonoursTheBatchSize),
+                              TEST(JournalDeleterTest::aZeroBatchSizeDeletesNothing))
     {
     }
 
@@ -119,5 +120,17 @@ struct JournalDeleterTest : tpunit::TestFixture
         }
 
         ASSERT_EQUAL(countJournalRows(db, oldRows), oldRowsBefore - (int64_t) db.getJournalTableCount());
+    }
+    void aZeroBatchSizeDeletesNothing()
+    {
+        JournalDeleterTempDBFile dbFile;
+        SQLite db(dbFile.filename, 1000, maxJournalSize, 1);
+        commitTransactions(db, 30);
+
+        for (size_t table = 0; table < db.getJournalTableCount(); table++) {
+            ASSERT_TRUE(db.trimJournalTable(table, 0));
+        }
+
+        ASSERT_EQUAL(countJournalRows(db), 30);
     }
 } __JournalDeleterTest;

--- a/test/tests/JournalDeleterTest.cpp
+++ b/test/tests/JournalDeleterTest.cpp
@@ -121,6 +121,7 @@ struct JournalDeleterTest : tpunit::TestFixture
 
         ASSERT_EQUAL(countJournalRows(db, oldRows), oldRowsBefore - (int64_t) db.getJournalTableCount());
     }
+
     void aZeroBatchSizeDeletesNothing()
     {
         JournalDeleterTempDBFile dbFile;


### PR DESCRIPTION
### Details

Journal rows were deleted inside whatever command's transaction happened to trigger the cleanup. 

Because `id` is an INTEGER PRIMARY KEY, CONCURRENT mode records the read range of `DELETE FROM <journal> WHERE id < X` as everything below `X`, so two commands that pick the same journal table conflict with each other. A command that did a lot of real work then gets retried purely because it could not delete some old journal rows, and journal conflicts hit every customer rather than only the people touching one report.

This moves the deletion into a single background thread. 

`-journalDeleterBatchSize` (default 1000) sets how many rows a pass removes, and the `SetJournalDeleter` control command takes `enable` and `batchSize` so the thread can be turned off without a deploy.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/678886

### Tests

New automated tests.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
