### PR TITLE
Roll back failed synchronization transactions

### DIFF
--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1324,14 +1324,14 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
                     // Also, extend our timeout so long as we're still alive
                     _stateTimeout = STimeNow() + RECV_TIMEOUT + SRandom::rand64() % STIME_US_PER_S * 5;
                 }
-            } catch (const SException& e) {
+            } catch (const exception& e) {
                 // Transaction failed
                 SWARN("Synchronization failed '" << e.what() << "', reconnecting and re-SEARCHING.");
                 _db.rollback();
                 _reconnectPeer(_syncPeer);
                 _syncPeer = nullptr;
                 _changeState(SQLiteNodeState::SEARCHING);
-                throw e;
+                STHROW(e.what());
             }
         } else if (SIEquals(message.methodLine, "SUBSCRIBE")) {
             // SUBSCRIBE: Sent by a node in the WAITING state to the current leader to begin FOLLOWING. Respond
@@ -1370,13 +1370,13 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
                 SINFO("Subscription complete, at commitCount #" << _db.getCommitCount() << " (" << _db.getCommittedHash()
                       << "), FOLLOWING");
                 _changeState(SQLiteNodeState::FOLLOWING);
-            } catch (const SException& e) {
+            } catch (const exception& e) {
                 // Transaction failed
                 SWARN("Subscription failed '" << e.what() << "', reconnecting to leader and re-SEARCHING.");
                 _db.rollback();
                 _reconnectPeer(_leadPeer);
                 _changeState(SQLiteNodeState::SEARCHING);
-                throw e;
+                STHROW(e.what());
             }
         } else if (SIEquals(message.methodLine, "TRANSACTION")) {
             if (_state != SQLiteNodeState::FOLLOWING) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1828,7 +1828,8 @@ void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message)
         if (commit.calcU64("CommitIndex") != _db.getCommitCount() + 1) {
             STHROW("commit index mismatch");
         }
-        if (!_db.beginTransaction()) {
+        // Local unreplicated writes must not invalidate the snapshot while we replay this commit.
+        if (!_db.beginTransaction(SQLite::TRANSACTION_TYPE::EXCLUSIVE)) {
             STHROW("failed to begin transaction");
         }
         if (!_db.writeUnmodified(BedrockPlugin_Compression::decompress(commit.content))) {

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1327,6 +1327,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
             } catch (const SException& e) {
                 // Transaction failed
                 SWARN("Synchronization failed '" << e.what() << "', reconnecting and re-SEARCHING.");
+                _db.rollback();
                 _reconnectPeer(_syncPeer);
                 _syncPeer = nullptr;
                 _changeState(SQLiteNodeState::SEARCHING);
@@ -1372,6 +1373,7 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
             } catch (const SException& e) {
                 // Transaction failed
                 SWARN("Subscription failed '" << e.what() << "', reconnecting to leader and re-SEARCHING.");
+                _db.rollback();
                 _reconnectPeer(_leadPeer);
                 _changeState(SQLiteNodeState::SEARCHING);
                 throw e;
@@ -1837,13 +1839,15 @@ void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message)
             STHROW("failed to prepare transaction");
         }
         if (newHash != commit["Hash"]) {
-            _db.rollback();
             STHROW("potential hash mismatch");
         }
 
         // Transaction succeeded, commit and go to the next
         SDEBUG("Committing current transaction because _recvSynchronize: " << _db.getUncommittedQuery());
-        _db.commit(stateName(_state));
+        int result = _db.commit(stateName(_state));
+        if (result != SQLITE_OK) {
+            STHROW("failed to commit synchronized transaction: " + to_string(result));
+        }
 
         // Clear the list of committed transactions. We're synchronizing, so we don't need to send these.
         _db.popCommittedTransactions();

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -249,6 +249,7 @@ struct SQLiteNodeTest : tpunit::TestFixture
             failedResponse.content = commit.serialize();
             node._onMESSAGE(peer, failedResponse);
 
+            EXPECT_TRUE(db.getLastTransactionType() == SQLite::TRANSACTION_TYPE::EXCLUSIVE);
             EXPECT_TRUE(node.getState() == SQLiteNodeState::SEARCHING);
             EXPECT_EQUAL(node._syncPeer, nullptr);
             EXPECT_EQUAL(node._leadPeer.load(), nullptr);

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -59,6 +59,7 @@ struct SQLiteNodeTest : tpunit::TestFixture
                                            TEST(SQLiteNodeTest::testGetPeerByName),
                                            TEST(SQLiteNodeTest::testSynchronizeCommitFailure),
                                            TEST(SQLiteNodeTest::testSynchronizeWriteFailure),
+                                           TEST(SQLiteNodeTest::testSynchronizeConstraintFailure),
                                            TEST(SQLiteNodeTest::testSynchronizeHashMismatch))
     {
     }
@@ -83,6 +84,8 @@ struct SQLiteNodeTest : tpunit::TestFixture
     {
         dbPool.reset();
         unlink(filename);
+        unlink((string(filename) + "-pagemap").c_str());
+        unlink((string(filename) + "-log-0").c_str());
     }
 
     void rollback()
@@ -196,6 +199,11 @@ struct SQLiteNodeTest : tpunit::TestFixture
         testSynchronizeFailure("hash");
     }
 
+    void testSynchronizeConstraintFailure()
+    {
+        testSynchronizeFailure("constraint");
+    }
+
     void testSynchronizeFailure(const string& failure)
     {
         for (bool subscribing : {false, true}) {
@@ -242,6 +250,8 @@ struct SQLiteNodeTest : tpunit::TestFixture
                 db.setCommitEnabled(false);
             } else if (failure == "write") {
                 commit.content = query + "INSERT INTO missingSyncTable VALUES (1);";
+            } else if (failure == "constraint") {
+                commit.content = query + query;
             } else {
                 commit["Hash"] = "incorrect hash";
             }

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -7,6 +7,7 @@
 
 #include <unistd.h>
 #include <cstring>
+#include <thread>
 
 class SQLiteNodeTester {
 public:
@@ -53,8 +54,12 @@ struct SQLiteNodeTest : tpunit::TestFixture
     SQLiteNodeTest() : tpunit::TestFixture("SQLiteNode",
                                            BEFORE_CLASS(SQLiteNodeTest::setup),
                                            AFTER_CLASS(SQLiteNodeTest::teardown),
+                                           AFTER(SQLiteNodeTest::rollback),
                                            TEST(SQLiteNodeTest::testFindSyncPeer),
-                                           TEST(SQLiteNodeTest::testGetPeerByName))
+                                           TEST(SQLiteNodeTest::testGetPeerByName),
+                                           TEST(SQLiteNodeTest::testSynchronizeCommitFailure),
+                                           TEST(SQLiteNodeTest::testSynchronizeWriteFailure),
+                                           TEST(SQLiteNodeTest::testSynchronizeHashMismatch))
     {
     }
 
@@ -71,12 +76,20 @@ struct SQLiteNodeTest : tpunit::TestFixture
         // This exposes just enough to test the peer selection logic.
         int fd = mkstemp(filename);
         close(fd);
-        dbPool = make_shared<SQLitePool>(10, filename, 1000000, 5000, 0);
+        dbPool = make_shared<SQLitePool>(10, filename, 1000000, 5000, 0, 0, BedrockTester::ENABLE_HCTREE);
     }
 
     void teardown()
     {
+        dbPool.reset();
         unlink(filename);
+    }
+
+    void rollback()
+    {
+        // Keep a failed assertion from leaving the fixture's shared handle locked for the next test.
+        dbPool->getBase().rollback();
+        dbPool->getBase().setCommitEnabled(true);
     }
 
     void testFindSyncPeer()
@@ -165,6 +178,116 @@ struct SQLiteNodeTest : tpunit::TestFixture
             ASSERT_EQUAL(testNode.getPeerByName("peer1")->name, "peer1");
             ASSERT_EQUAL(testNode.getPeerByName("peerBanana")->name, "peerBanana");
             ASSERT_EQUAL(testNode.getPeerByName("peer9"), nullptr);
+        }
+    }
+
+    void testSynchronizeCommitFailure()
+    {
+        testSynchronizeFailure("commit");
+    }
+
+    void testSynchronizeWriteFailure()
+    {
+        testSynchronizeFailure("write");
+    }
+
+    void testSynchronizeHashMismatch()
+    {
+        testSynchronizeFailure("hash");
+    }
+
+    void testSynchronizeFailure(const string& failure)
+    {
+        for (bool subscribing : {false, true}) {
+            SQLiteNode node(server, dbPool, "test", "", peerList, configuredPriority, 1000000000, "1.0");
+            SQLite& db = dbPool->getBase();
+            SQLite other(db);
+            SQLitePeer* peer = node.getPeerByName("peer1");
+
+            ASSERT_TRUE(db.beginTransaction());
+            ASSERT_TRUE(db.write("CREATE TABLE IF NOT EXISTS syncTest (id INTEGER PRIMARY KEY);"));
+            ASSERT_TRUE(db.write("DELETE FROM syncTest;"));
+            ASSERT_TRUE(db.prepare());
+            ASSERT_EQUAL(db.commit(), SQLITE_OK);
+            const uint64_t commitCount = db.getCommitCount();
+            const string committedHash = db.getCommittedHash();
+
+            // Prepare a valid wire payload without advancing the receiver's committed state.
+            const string query = "INSERT INTO syncTest VALUES (1);";
+            ASSERT_TRUE(db.beginTransaction());
+            ASSERT_TRUE(db.writeUnmodified(query));
+            string hash;
+            ASSERT_TRUE(db.prepare(nullptr, &hash));
+            SData commit("COMMIT");
+            commit["CommitIndex"] = to_string(commitCount + 1);
+            commit["Hash"] = hash;
+            commit.content = db.getUncommittedQuery();
+            db.rollback();
+
+            SData response(subscribing ? "SUBSCRIPTION_APPROVED" : "SYNCHRONIZE_RESPONSE");
+            response["CommitCount"] = commit["CommitIndex"];
+            response["Hash"] = hash;
+            response["NumCommits"] = "1";
+            response.content = commit.serialize();
+
+            const SQLiteNodeState state = subscribing ? SQLiteNodeState::SUBSCRIBING : SQLiteNodeState::SYNCHRONIZING;
+            node._changeState(state);
+            peer->loggedIn = true;
+            if (subscribing) {
+                node._leadPeer = peer;
+            } else {
+                node._syncPeer = peer;
+            }
+            if (failure == "commit") {
+                db.setCommitEnabled(false);
+            } else if (failure == "write") {
+                commit.content = query + "INSERT INTO missingSyncTable VALUES (1);";
+            } else {
+                commit["Hash"] = "incorrect hash";
+            }
+            SData failedResponse = response;
+            failedResponse.content = commit.serialize();
+            node._onMESSAGE(peer, failedResponse);
+
+            EXPECT_TRUE(node.getState() == SQLiteNodeState::SEARCHING);
+            EXPECT_EQUAL(node._syncPeer, nullptr);
+            EXPECT_EQUAL(node._leadPeer.load(), nullptr);
+            EXPECT_FALSE(peer->loggedIn);
+            EXPECT_FALSE(db.insideTransaction());
+            EXPECT_TRUE(sqlite3_get_autocommit(db.getDBHandle()));
+            EXPECT_TRUE(db.getUncommittedHash().empty());
+            EXPECT_TRUE(db.getUncommittedQuery().empty());
+            EXPECT_EQUAL(db.getCommitCount(), commitCount);
+            EXPECT_EQUAL(db.getCommittedHash(), committedHash);
+
+            // The commit mutex is recursive, so only another thread can detect a leaked lock.
+            bool prepared = false;
+            thread waiter([&]() {
+                if (other.beginTransaction()) {
+                    prepared = other.prepare(nullptr, nullptr, chrono::milliseconds(250));
+                }
+                other.rollback();
+            });
+            waiter.join();
+            EXPECT_TRUE(prepared);
+            ASSERT_FALSE(db.insideTransaction());
+            EXPECT_EQUAL(db.read("SELECT COUNT(*) FROM syncTest;"), "0");
+
+            // Retry the valid response on the same handle without any test-side rollback.
+            node._changeState(state);
+            peer->loggedIn = true;
+            if (subscribing) {
+                node._leadPeer = peer;
+            } else {
+                node._syncPeer = peer;
+            }
+            node._onMESSAGE(peer, response);
+            EXPECT_TRUE(node.getState() == (subscribing ? SQLiteNodeState::FOLLOWING : SQLiteNodeState::WAITING));
+            EXPECT_EQUAL(db.getCommitCount(), commitCount + 1);
+            EXPECT_EQUAL(db.getCommittedHash(), hash);
+            EXPECT_FALSE(db.insideTransaction());
+            EXPECT_TRUE(db.getUncommittedHash().empty());
+            EXPECT_EQUAL(db.read("SELECT COUNT(*) FROM syncTest;"), "1");
         }
     }
 } __SQLiteNodeTest;


### PR DESCRIPTION
### Details

We changed to EXCLUSIVE here: https://github.com/Expensify/Bedrock/pull/2758 for replication, then we allowed the deleter thread to run during SYNCHRONIZATION, so we need that for synchronization as well.

`_recvSynchronize()` ignores the result of `commit()`, and because it always assuemd it would never conflict, it doesn't handle that case. This change also fixes exception handling here.

A failed commit leaves the transaction, uncommitted hash, and commit lock open, so the node keeps warning while synchronizing and the next replay fails with "already inside transaction". Failed writes can also leave the handle in a transaction.

This checks the commit result and rolls back before reconnecting, for both `SYNCHRONIZE_RESPONSE` and `SUBSCRIPTION_APPROVED`. The handlers also catch SQLite's standard exceptions, including constraint errors. Replay takes the exclusive commit lock before beginning its snapshot, rather than waiting until prepare, so local unreplicated writes can't invalidate it. That holds the lock for the whole replayed transaction, but releases it on failure as well as success.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/679126
$ https://github.com/Expensify/Expensify/issues/679127
$ https://github.com/Expensify/Expensify/issues/679295
$ https://github.com/Expensify/Expensify/issues/679296

### Tests

Added regression coverage for failed commits, failed writes, constraint exceptions, and hash mismatches through both response paths. It checks that another thread can acquire the commit lock and that a valid retry succeeds on the same handle without test-side cleanup. The commit, write, and constraint cases failed before their corresponding fixes. Commit failure is injected with `COMMIT_DISABLED`, not a timing-dependent snapshot conflict.

AI tests run in Vagrant:

- Bedrock full build and Auth rebuild, including `authtest`: passed.
- `./test -only SQLiteNode,AfterCommitCallback,WriteLocalUnreplicated -threads 1 -q`: 13 passed.
- `./test -only SQLiteNode -threads 1 -q -enableHctree`: 6 passed.
- `./clustertest -only MultipleLeaderSync,WriteLocalUnreplicatedCluster -threads 1 -q`: 2 passed, and another 2 passed with `-enableHctree`.
- `uncrustify --check` on both changed files and `git diff --check`: passed.

Full unit, cluster, and Auth test suites were not run.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
