### PR TITLE
Accept GUID journal hashes with generation disabled

### DIFF
--- a/docs/blockchain.md
+++ b/docs/blockchain.md
@@ -9,7 +9,7 @@ Though the blockchain hype has largely come and gone, it's worth pointing out th
 To be clear, Bedrock is not a "public" blockchain, like Bitcoin -- it is not designed to synchronize a series of records between thousands or millions of anonymous peers over the open internet.  Rather, Bedrock uses a "private" blockchain, meaning that a small cluster of servers (3-6) operating in a controlled environment connect to each other on an equal footing to synchronize a historical record of commits, and apply them in the same order.
 
 ## The Journal
-Under the hood it works like this:
+With chained hashes (the default), it works like this:
 
 * Journal entries have three columns:
     * `id` - Simple monotonic index
@@ -27,6 +27,15 @@ Under the hood it works like this:
 * After two nodes have connected and confirm they agree on the history up to a point, then if one has more data than the other, it will download each commit and apply it in turn -- every time confirming that it still agrees with the hash of the peer.
 
 The sum of all this ensures that all of the cluster stays in perfect sync (and refuses to talk to those nodes that have forked), all without any of them being "in charge".  This is the heart of what makes a distributed ledger so special, and has processed (as of this writing) 4,287,514,530 successful commits on the database to date.
+
+## GUID Transaction Hashes
+The journal and replication receivers also accept `GUID:SHA1`. The GUID is 16 random bytes encoded as 32 hex characters without hyphens. The digest is the same uppercase, 40-character hex SHA1 used by chained hashes, but its input is the GUID text followed by the current transaction's uncompressed SQL, without a colon or previous hash.
+
+This format checks only the current transaction's integrity. The GUID distinguishes independently created transactions even when their SQL is identical. Fork detection compares the complete stored hash and relies on transactions being applied contiguously, in order; it does not verify a cryptographic chain across GUID entries.
+
+Both formats can appear in the same journal. A chained hash following a GUID hash uses the entire previous `GUID:SHA1` string, followed by the current SQL, as its input. Neither storage nor transmission strips the GUID.
+
+Local GUID generation is implemented but hard-disabled in `SQLite::prepare()`. Deploy mixed-format readers everywhere before enabling generation. An older binary can continue writing chained hashes on a database that already contains GUID entries, but cannot replay GUID entries it has not received. Once generation is enabled, rollback versions that may need to synchronize must retain mixed-format reading.
 
 ## Technical Notes
 The above skips over a couple important details:

--- a/docs/blockchain.md
+++ b/docs/blockchain.md
@@ -35,7 +35,7 @@ This format checks only the current transaction's integrity. The GUID distinguis
 
 Both formats can appear in the same journal. A chained hash following a GUID hash uses the entire previous `GUID:SHA1` string, followed by the current SQL, as its input. Neither storage nor transmission strips the GUID.
 
-Local GUID generation is implemented but hard-disabled in `SQLite::prepare()`. Deploy mixed-format readers everywhere before enabling generation. An older binary can continue writing chained hashes on a database that already contains GUID entries, but cannot replay GUID entries it has not received. Once generation is enabled, rollback versions that may need to synchronize must retain mixed-format reading.
+Local GUID generation is implemented but hard-disabled in `SQLiteCore::commit()`. Deploy mixed-format readers everywhere before enabling generation. An older binary can continue writing chained hashes on a database that already contains GUID entries, but cannot replay GUID entries it has not received. Once generation is enabled, rollback versions that may need to synchronize must retain mixed-format reading.
 
 ## Technical Notes
 The above skips over a couple important details:

--- a/docs/synchronization.md
+++ b/docs/synchronization.md
@@ -10,7 +10,7 @@ Bedrock's primary feature is its ability to seamlessly synchronize data between 
 
 2. All nodes attempt to connect to all other nodes.
 
-3. During this process all nodes `SYNCHRONIZE` from their peers, which means they broadcast "My most recent transaction has commitCount X, and the hash of every transaction up to that point is Y".  Anybody who has newer data will respond with the missing transactions, which are all committed in the same order on every node via a [private blockchain](https://bedrockdb.com/blockchain.html).
+3. During this process all nodes `SYNCHRONIZE` from their peers, which means they broadcast "My most recent transaction has commitCount X and stored hash Y".  Anybody who has newer data will respond with the missing transactions, which are all committed in the same order on every node. The journal accepts both [chained hashes and GUID transaction hashes](https://bedrockdb.com/blockchain.html).
 
 4. Any two nodes that disagree on what the hash of a given transaction should be will immediately disconnect from each other.  This means that any node that has "forked" away from the cluster will be excluded from participation.
 

--- a/libstuff/SRandom.cpp
+++ b/libstuff/SRandom.cpp
@@ -1,23 +1,33 @@
 #include "SRandom.h"
 
-#ifdef VALGRIND
-// random_device breaks valgrind.
-mt19937_64 SRandom::_generator = mt19937_64();
-#else
-mt19937_64 SRandom::_generator = mt19937_64(random_device()());
-#endif
+#include <atomic>
+#include <memory>
 
-uniform_int_distribution<uint64_t> SRandom::_distribution64 = uniform_int_distribution<uint64_t>();
+mt19937_64& SRandom::_getGenerator()
+{
+    static thread_local auto generator = [] {
+#ifdef VALGRIND
+        // random_device breaks valgrind; use distinct seeds so fresh threads do not repeat the same stream.
+        static atomic<uint64_t> nextSeed{mt19937_64::default_seed};
+        return make_unique<mt19937_64>(nextSeed.fetch_add(1, memory_order_relaxed));
+#else
+        random_device rd;
+        seed_seq seed{rd(), rd(), rd(), rd(), rd(), rd(), rd(), rd()};
+        return make_unique<mt19937_64>(seed);
+#endif
+    }();
+    return *generator;
+}
 
 uint64_t SRandom::limitedRand64(uint64_t minNum, uint64_t maxNum)
 {
     uniform_int_distribution<uint64_t> limitedRandom(minNum, maxNum);
-    return limitedRandom(_generator);
+    return limitedRandom(_getGenerator());
 }
 
 uint64_t SRandom::rand64()
 {
-    return _distribution64(_generator);
+    return _getGenerator()();
 }
 
 string SRandom::randStr(unsigned length)
@@ -34,5 +44,5 @@ string SRandom::randStr(unsigned length)
 
 bool SRandom::randBool(const double probability)
 {
-    return bernoulli_distribution(probability)(_generator);
+    return bernoulli_distribution(probability)(_getGenerator());
 }

--- a/libstuff/SRandom.h
+++ b/libstuff/SRandom.h
@@ -5,7 +5,7 @@
 
 using namespace std;
 
-// Random number generator class.
+// Non-cryptographic random number generator, allocated and seeded on first use in each thread.
 class SRandom {
 public:
     static uint64_t rand64();
@@ -14,6 +14,5 @@ public:
     static bool randBool(const double probability);
 
 private:
-    static mt19937_64 _generator;
-    static uniform_int_distribution<uint64_t> _distribution64;
+    static mt19937_64& _getGenerator();
 };

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -952,9 +952,19 @@ bool SQLite::_writeIdempotent(const string& query, const map<string, Parameter>&
     return true;
 }
 
-bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::microseconds commitLockTimeout, atomic<bool>* abortPtr)
+bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::microseconds commitLockTimeout, atomic<bool>* abortPtr, const string& replicationHash)
 {
     SASSERT(_insideTransaction);
+
+    string guid;
+    if (replicationHash.find(':') != string::npos) {
+        if (replicationHash.size() != 73 || replicationHash[32] != ':' ||
+            replicationHash.substr(0, 32).find_first_not_of("0123456789ABCDEFabcdef") != string::npos) {
+            SWARN("Invalid GUID transaction hash format");
+            return false;
+        }
+        guid = replicationHash.substr(0, 32);
+    }
 
     // Pick a journal for this transaction.
     const int64_t journalID = _sharedData.nextJournalCount++;
@@ -1060,8 +1070,12 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
     commitCount = _sharedData.commitCount;
 
     // Queue up the journal entry
-    string lastCommittedHash = getCommittedHash(); // This is why we need the lock.
-    _uncommittedHash = SToHex(SHashSHA1(lastCommittedHash + _uncommittedQuery));
+    if (guid.empty()) {
+        // Legacy commits chain from the entire previous hash, including GUID:SHA1 when present.
+        _uncommittedHash = SToHex(SHashSHA1(getCommittedHash() + _uncommittedQuery));
+    } else {
+        _uncommittedHash = guid + ":" + SToHex(SHashSHA1(guid + _uncommittedQuery));
+    }
     uint64_t before = STimeNow();
 
     // Update the passed-in reference values

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -966,6 +966,14 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
         guid = replicationHash.substr(0, 32);
     }
 
+    // Keep local generation disabled until every node can receive GUID hashes, including rollback versions.
+    static constexpr bool generateGUIDHashes = false;
+    if (replicationHash.empty() && generateGUIDHashes) {
+        string randomBytes(16, '\0');
+        sqlite3_randomness(static_cast<int>(randomBytes.size()), randomBytes.data());
+        guid = SToHex(randomBytes);
+    }
+
     // Pick a journal for this transaction.
     const int64_t journalID = _sharedData.nextJournalCount++;
     _journalName = _journalNames[journalID % _journalNames.size()];

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -952,26 +952,13 @@ bool SQLite::_writeIdempotent(const string& query, const map<string, Parameter>&
     return true;
 }
 
-bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::microseconds commitLockTimeout, atomic<bool>* abortPtr, const string& replicationHash)
+bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::microseconds commitLockTimeout, atomic<bool>* abortPtr, const string& guid)
 {
     SASSERT(_insideTransaction);
 
-    string guid;
-    if (replicationHash.find(':') != string::npos) {
-        if (replicationHash.size() != 73 || replicationHash[32] != ':' ||
-            replicationHash.substr(0, 32).find_first_not_of("0123456789ABCDEFabcdef") != string::npos) {
-            SWARN("Invalid GUID transaction hash format");
-            return false;
-        }
-        guid = replicationHash.substr(0, 32);
-    }
-
-    // Keep local generation disabled until every node can receive GUID hashes, including rollback versions.
-    static constexpr bool generateGUIDHashes = false;
-    if (replicationHash.empty() && generateGUIDHashes) {
-        string randomBytes(16, '\0');
-        sqlite3_randomness(static_cast<int>(randomBytes.size()), randomBytes.data());
-        guid = SToHex(randomBytes);
+    if (!guid.empty() && (guid.size() != 32 || guid.find_first_not_of("0123456789ABCDEFabcdef") != string::npos)) {
+        SWARN("Invalid transaction GUID");
+        return false;
     }
 
     // Pick a journal for this transaction.

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -179,9 +179,9 @@ public:
     // The commitLockTimeout, if passed, will limit the time we wait for the lock. If not, we'll use 24 hours, which
     // is effectively no timeout.
     // Note that if this transaction fails to commit, these will not ultimately be accurate.
-    // replicationHash selects the received hash format and GUID. The caller must compare the prepared hash with it
-    // before committing, so corrupted queries or hashes are rejected.
-    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr, chrono::microseconds commitLockTimeout = chrono::hours(24), atomic<bool>* abortPtr = nullptr, const string& replicationHash = "");
+    // A nonempty guid must be 32 hex characters and selects GUID:SHA1 hashing; an empty guid selects chained SHA1.
+    // Replication callers must compare the prepared hash with the received hash before committing.
+    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr, chrono::microseconds commitLockTimeout = chrono::hours(24), atomic<bool>* abortPtr = nullptr, const string& guid = "");
 
     // This enables or disables automatic re-writing. This feature is to support mocked requests and load testing. This
     // overloads set_authorizer to allow a plugin to deny certain queries from running (currently based only on the

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -179,7 +179,9 @@ public:
     // The commitLockTimeout, if passed, will limit the time we wait for the lock. If not, we'll use 24 hours, which
     // is effectively no timeout.
     // Note that if this transaction fails to commit, these will not ultimately be accurate.
-    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr, chrono::microseconds commitLockTimeout = chrono::hours(24), atomic<bool>* abortPtr = nullptr);
+    // replicationHash selects the received hash format and GUID. The caller must compare the prepared hash with it
+    // before committing, so corrupted queries or hashes are rejected.
+    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr, chrono::microseconds commitLockTimeout = chrono::hours(24), atomic<bool>* abortPtr = nullptr, const string& replicationHash = "");
 
     // This enables or disables automatic re-writing. This feature is to support mocked requests and load testing. This
     // overloads set_authorizer to allow a plugin to deny certain queries from running (currently based only on the
@@ -254,7 +256,7 @@ public:
     // Returns the number of WAL frames that are currently waiting to be checkpointed.
     uint64_t getOutstandingFramesToCheckpoint() const;
 
-    // Returns the current state of the database, as a SHA1 hash of all queries committed.
+    // Returns the latest commit's hash: a chained SHA1 or GUID:SHA1 identifying and checking that transaction only.
     string getCommittedHash();
 
     // Returns what the new state will be of the database if the current transaction is committed.

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -1,4 +1,5 @@
 #include <libstuff/AutoScopeOnPrepare.h>
+#include <libstuff/SRandom.h>
 #include <libstuff/libstuff.h>
 #include "SQLiteCore.h"
 #include "SQLite.h"
@@ -20,9 +21,7 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
         static constexpr bool generateGUIDHashes = false;
         string guid;
         if (generateGUIDHashes) {
-            string randomBytes(16, '\0');
-            sqlite3_randomness(static_cast<int>(randomBytes.size()), randomBytes.data());
-            guid = SToHex(randomBytes);
+            guid = SToHex(SRandom::rand64(), 16) + SToHex(SRandom::rand64(), 16);
         }
 
         // This will fail only if we can't acquire the commit lock respecting the command timeout, or the command is aborted while waiting for it.

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -16,9 +16,18 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
     {
         AutoScopeOnPrepare onPrepare(needsPluginNotification, _db, notificationHandler);
 
+        // Keep local generation disabled until every node can receive GUID hashes, including rollback versions.
+        static constexpr bool generateGUIDHashes = false;
+        string guid;
+        if (generateGUIDHashes) {
+            string randomBytes(16, '\0');
+            sqlite3_randomness(static_cast<int>(randomBytes.size()), randomBytes.data());
+            guid = SToHex(randomBytes);
+        }
+
         // This will fail only if we can't acquire the commit lock respecting the command timeout, or the command is aborted while waiting for it.
         // In this case, we want to roll back and return false, which will make the caller return the appropriate exception.
-        if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout, abortPtr)) {
+        if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout, abortPtr, guid)) {
             _db.rollback(commandName);
             return false;
         }

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1836,7 +1836,7 @@ void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message)
             STHROW("failed to write transaction");
         }
         string newHash;
-        if (!_db.prepare(nullptr, &newHash)) {
+        if (!_db.prepare(nullptr, &newHash, chrono::hours(24), nullptr, commit["Hash"])) {
             STHROW("failed to prepare transaction");
         }
         if (newHash != commit["Hash"]) {
@@ -2037,7 +2037,7 @@ bool SQLiteNode::_handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const S
     }
 
     bool success = true;
-    if (!db.prepare()) {
+    if (!db.prepare(nullptr, nullptr, chrono::hours(24), nullptr, message["NewHash"])) {
         SALERT("failed to prepare transaction");
         success = false;
         db.rollback();

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1389,9 +1389,11 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
                 return;
             }
 
-            // GUID hashes do not bind to previous history, so only our selected leader may extend it.
+            // Transactions from a previous leader may still arrive after we switch leaders.
+            // Only our selected leader may extend our transaction history.
             if (peer != _leadPeer) {
-                STHROW("transaction from non-leader");
+                PINFO("Ignoring transaction from non-leader");
+                return;
             }
 
             bool isReplicationRunning = false;

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1795,6 +1795,17 @@ void SQLiteNode::_queueSynchronize(const SQLiteNode* const node, SQLitePeer* pee
     }
 }
 
+string SQLiteNode::_getTransactionGUID(const string& hash)
+{
+    if (hash.find(':') == string::npos) {
+        return "";
+    }
+    if (hash.size() != 73 || hash[32] != ':') {
+        STHROW("Invalid GUID transaction hash format");
+    }
+    return hash.substr(0, 32);
+}
+
 void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message)
 {
     if (message.isSet("ShuttingDown")) {
@@ -1841,7 +1852,7 @@ void SQLiteNode::_recvSynchronize(SQLitePeer* peer, const SData& message)
             STHROW("failed to write transaction");
         }
         string newHash;
-        if (!_db.prepare(nullptr, &newHash, chrono::hours(24), nullptr, commit["Hash"])) {
+        if (!_db.prepare(nullptr, &newHash, chrono::hours(24), nullptr, _getTransactionGUID(commit["Hash"]))) {
             STHROW("failed to prepare transaction");
         }
         if (newHash != commit["Hash"]) {
@@ -2042,7 +2053,7 @@ bool SQLiteNode::_handlePrepareTransaction(SQLite& db, SQLitePeer* peer, const S
     }
 
     bool success = true;
-    if (!db.prepare(nullptr, nullptr, chrono::hours(24), nullptr, message["NewHash"])) {
+    if (!db.prepare(nullptr, nullptr, chrono::hours(24), nullptr, _getTransactionGUID(message["NewHash"]))) {
         SALERT("failed to prepare transaction");
         success = false;
         db.rollback();

--- a/sqlitecluster/SQLiteNode.cpp
+++ b/sqlitecluster/SQLiteNode.cpp
@@ -1389,6 +1389,11 @@ void SQLiteNode::_onMESSAGE(SQLitePeer* peer, const SData& message)
                 return;
             }
 
+            // GUID hashes do not bind to previous history, so only our selected leader may extend it.
+            if (peer != _leadPeer) {
+                STHROW("transaction from non-leader");
+            }
+
             bool isReplicationRunning = false;
             {
                 lock_guard<mutex> lock(_replicateMutex);

--- a/sqlitecluster/SQLiteNode.h
+++ b/sqlitecluster/SQLiteNode.h
@@ -192,6 +192,10 @@ private:
 
     string _getLostQuorumLogMessage() const;
 
+    // Extracts the GUID from a message's transaction hash, or returns empty for a legacy hash.
+    // Throws if a hash containing a colon does not have the GUID:SHA1 lengths and separator position.
+    static string _getTransactionGUID(const string& hash);
+
     // Handlers for transaction messages.
     void _handleBeginTransaction(SQLite& db, SQLitePeer* peer, const SData& message);
 

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -1,4 +1,5 @@
 #include <libstuff/libstuff.h>
+#include <plugins/Compression.h>
 #include <sqlitecluster/SQLiteCommand.h>
 #include <sqlitecluster/SQLiteNode.h>
 #include <sqlitecluster/SQLitePeer.h>
@@ -57,6 +58,8 @@ struct SQLiteNodeTest : tpunit::TestFixture
                                            AFTER(SQLiteNodeTest::rollback),
                                            TEST(SQLiteNodeTest::testFindSyncPeer),
                                            TEST(SQLiteNodeTest::testGetPeerByName),
+                                           TEST(SQLiteNodeTest::testMixedHashHistory),
+                                           TEST(SQLiteNodeTest::testGUIDHashFailures),
                                            TEST(SQLiteNodeTest::testSynchronizeCommitFailure),
                                            TEST(SQLiteNodeTest::testSynchronizeWriteFailure),
                                            TEST(SQLiteNodeTest::testSynchronizeConstraintFailure),
@@ -186,27 +189,153 @@ struct SQLiteNodeTest : tpunit::TestFixture
 
     void testSynchronizeCommitFailure()
     {
-        testSynchronizeFailure("commit");
+        testReplicationFailure("commit");
     }
 
     void testSynchronizeWriteFailure()
     {
-        testSynchronizeFailure("write");
+        testReplicationFailure("write");
     }
 
     void testSynchronizeHashMismatch()
     {
-        testSynchronizeFailure("hash");
+        testReplicationFailure("hash");
     }
 
     void testSynchronizeConstraintFailure()
     {
-        testSynchronizeFailure("constraint");
+        testReplicationFailure("constraint");
     }
 
-    void testSynchronizeFailure(const string& failure)
+    void testMixedHashHistory()
     {
-        for (bool subscribing : {false, true}) {
+        const vector<string> queries = {
+            "CREATE TABLE IF NOT EXISTS hashTest (value INTEGER);DELETE FROM hashTest;",
+            "INSERT INTO hashTest VALUES (1);",
+            "INSERT INTO hashTest VALUES (1);",
+            "INSERT INTO hashTest VALUES (2);",
+            "",
+        };
+        const vector<string> guids = {
+            "", "00000000000000000000000000aBcDeF", "00000000000000000000000000abcde0", "",
+            "00000000000000000000000000000001",
+        };
+        for (const string mode : {"live", "sync", "subscription"}) {
+            SQLiteNode node(server, dbPool, "test", "", peerList, configuredPriority, 1000000000, "1.0");
+            SQLite& db = dbPool->getBase();
+            SQLitePeer* peer = node.getPeerByName("peer1");
+            const uint64_t commitCount = db.getCommitCount();
+            string previousHash = db.getCommittedHash();
+            vector<string> hashes;
+            const bool live = mode == "live";
+            const bool subscribing = mode == "subscription";
+            node._changeState(live ? SQLiteNodeState::FOLLOWING :
+                              subscribing ? SQLiteNodeState::SUBSCRIBING : SQLiteNodeState::SYNCHRONIZING);
+            peer->loggedIn = true;
+            if (live || subscribing) {
+                node._leadPeer = peer;
+            } else {
+                node._syncPeer = peer;
+            }
+            SData response(subscribing ? "SUBSCRIPTION_APPROVED" : "SYNCHRONIZE_RESPONSE");
+            for (size_t i = 0; i < queries.size(); ++i) {
+                const string hash = guids[i].empty() ? SToHex(SHashSHA1(previousHash + queries[i])) :
+                    guids[i] + ":" + SToHex(SHashSHA1(guids[i] + queries[i]));
+                hashes.push_back(hash);
+                previousHash = hash;
+                string content = queries[i];
+                // Mix raw and compressed wire SQL without changing the global journal compression setting.
+                if (i == 2 || i == 3) {
+                    content.resize(ZSTD_compressBound(queries[i].size()));
+                    const size_t size = ZSTD_compress(content.data(), content.size(), queries[i].data(), queries[i].size(), 3);
+                    ASSERT_FALSE(ZSTD_isError(size));
+                    content.resize(size);
+                }
+                if (live) {
+                    SData transaction("TRANSACTION");
+                    transaction["ID"] = to_string(commitCount + i + 1);
+                    transaction["NewCount"] = transaction["ID"];
+                    transaction["NewHash"] = hash;
+                    transaction.content = content;
+                    node._handleBeginTransaction(db, peer, transaction);
+                    ASSERT_TRUE(node._handlePrepareTransaction(db, peer, transaction, STimeNow()));
+                    EXPECT_EQUAL(db.getUncommittedHash(), hash);
+                    ASSERT_EQUAL(node._handleCommitTransaction(db, peer, commitCount + i + 1, hash), SQLITE_OK);
+                    EXPECT_EQUAL(db.getCommittedHash(), hash);
+                } else {
+                    SData commit("COMMIT");
+                    commit["CommitIndex"] = to_string(commitCount + i + 1);
+                    commit["Hash"] = hash;
+                    commit.content = content;
+                    response.content += commit.serialize();
+                }
+            }
+            if (!live) {
+                response["CommitCount"] = to_string(commitCount + queries.size());
+                response["Hash"] = hashes.back();
+                response["NumCommits"] = to_string(queries.size());
+                node._onMESSAGE(peer, response);
+            }
+            EXPECT_TRUE(node.getState() == (live || subscribing ? SQLiteNodeState::FOLLOWING : SQLiteNodeState::WAITING));
+            EXPECT_EQUAL(db.getCommitCount(), commitCount + queries.size());
+            EXPECT_EQUAL(db.getCommittedHash(), hashes.back());
+            EXPECT_NOT_EQUAL(hashes[1], hashes[2]);
+            EXPECT_FALSE(db.insideTransaction());
+            EXPECT_EQUAL(db.read("SELECT COUNT(*) FROM hashTest;"), "3");
+            for (size_t i = 0; i < queries.size(); ++i) {
+                string query, hash;
+                ASSERT_TRUE(db.getCommit(commitCount + i + 1, &query, &hash));
+                EXPECT_EQUAL(query, queries[i]);
+                EXPECT_EQUAL(hash, hashes[i]);
+            }
+        }
+
+        const uint64_t commitCount = dbPool->getBase().getCommitCount();
+        const string committedHash = dbPool->getBase().getCommittedHash();
+        ASSERT_EQUAL(committedHash, guids.back() + ":" + SToHex(SHashSHA1(guids.back())));
+        // SharedData is cached by filename forever. A fresh path forces the tail to be loaded from the journal.
+        char restartedFilename[sizeof(filename)] = "br_sync_dbXXXXXX";
+        const int fd = mkstemp(restartedFilename);
+        ASSERT_TRUE(fd >= 0);
+        close(fd);
+        dbPool.reset();
+        for (const string suffix : {"", "-pagemap", "-log-0"}) {
+            if (suffix.empty() || access((string(filename) + suffix).c_str(), F_OK) == 0) {
+                const int result = rename((string(filename) + suffix).c_str(), (string(restartedFilename) + suffix).c_str());
+                EXPECT_EQUAL(result, 0);
+            }
+        }
+        memcpy(filename, restartedFilename, sizeof(filename));
+        dbPool = make_shared<SQLitePool>(10, filename, 1000000, 5000, 0, 0, BedrockTester::ENABLE_HCTREE);
+        SQLite& db = dbPool->getBase();
+        EXPECT_EQUAL(db.getCommitCount(), commitCount);
+        EXPECT_EQUAL(db.getCommittedHash(), committedHash);
+        const string query = "INSERT INTO hashTest VALUES (3);";
+        ASSERT_TRUE(db.beginTransaction());
+        ASSERT_TRUE(db.writeUnmodified(query));
+        ASSERT_TRUE(db.prepare());
+        const string legacyHash = SToHex(SHashSHA1(committedHash + query));
+        EXPECT_EQUAL(db.getUncommittedHash().size(), (size_t) 40);
+        EXPECT_EQUAL(db.getUncommittedHash(), legacyHash);
+        ASSERT_EQUAL(db.commit(), SQLITE_OK);
+        string storedHash;
+        ASSERT_TRUE(db.getCommit(commitCount + 1, nullptr, &storedHash));
+        EXPECT_EQUAL(storedHash, legacyHash);
+        EXPECT_EQUAL(db.read("SELECT COUNT(*) FROM hashTest;"), "4");
+    }
+
+    void testGUIDHashFailures()
+    {
+        for (const string failure : {"guid-value", "guid-digest", "guid-query", "guid-short", "guid-long", "guid-nonhex"}) {
+            testReplicationFailure(failure);
+        }
+    }
+
+    void testReplicationFailure(const string& failure)
+    {
+        for (const string mode : {"sync", "subscription", "live"}) {
+            const bool live = mode == "live";
+            const bool subscribing = mode == "subscription";
             SQLiteNode node(server, dbPool, "test", "", peerList, configuredPriority, 1000000000, "1.0");
             SQLite& db = dbPool->getBase();
             SQLite other(db);
@@ -222,15 +351,21 @@ struct SQLiteNodeTest : tpunit::TestFixture
 
             // Prepare a valid wire payload without advancing the receiver's committed state.
             const string query = "INSERT INTO syncTest VALUES (1);";
+            const string guid = "00000000000000000000000000aBcDeF";
+            const string expectedHash = failure.find("guid-") == 0 ? guid + ":" + SToHex(SHashSHA1(guid + query)) : "";
             ASSERT_TRUE(db.beginTransaction());
             ASSERT_TRUE(db.writeUnmodified(query));
             string hash;
-            ASSERT_TRUE(db.prepare(nullptr, &hash));
+            ASSERT_TRUE(db.prepare(nullptr, &hash, chrono::hours(24), nullptr, expectedHash));
+            if (!expectedHash.empty()) {
+                EXPECT_EQUAL(hash, expectedHash);
+            }
             SData commit("COMMIT");
             commit["CommitIndex"] = to_string(commitCount + 1);
             commit["Hash"] = hash;
             commit.content = db.getUncommittedQuery();
             db.rollback();
+            const SData validCommit = commit;
 
             SData response(subscribing ? "SUBSCRIPTION_APPROVED" : "SYNCHRONIZE_RESPONSE");
             response["CommitCount"] = commit["CommitIndex"];
@@ -238,10 +373,11 @@ struct SQLiteNodeTest : tpunit::TestFixture
             response["NumCommits"] = "1";
             response.content = commit.serialize();
 
-            const SQLiteNodeState state = subscribing ? SQLiteNodeState::SUBSCRIBING : SQLiteNodeState::SYNCHRONIZING;
+            const SQLiteNodeState state = live ? SQLiteNodeState::FOLLOWING :
+                subscribing ? SQLiteNodeState::SUBSCRIBING : SQLiteNodeState::SYNCHRONIZING;
             node._changeState(state);
             peer->loggedIn = true;
-            if (subscribing) {
+            if (live || subscribing) {
                 node._leadPeer = peer;
             } else {
                 node._syncPeer = peer;
@@ -252,18 +388,59 @@ struct SQLiteNodeTest : tpunit::TestFixture
                 commit.content = query + "INSERT INTO missingSyncTable VALUES (1);";
             } else if (failure == "constraint") {
                 commit.content = query + query;
+            } else if (failure == "guid-value") {
+                commit["Hash"][0] = '1';
+            } else if (failure == "guid-digest") {
+                commit["Hash"].back() = hash.back() == '0' ? '1' : '0';
+            } else if (failure == "guid-query") {
+                commit.content = "INSERT INTO syncTest VALUES (2);";
+            } else if (failure == "guid-short" || failure == "guid-long" || failure == "guid-nonhex") {
+                const string invalidGUID = failure == "guid-short" ? guid.substr(1) :
+                    failure == "guid-long" ? guid + "0" : guid.substr(0, 31) + "g";
+                // The digest is correct for this invalid GUID, so rejection must not rely on a hash mismatch alone.
+                commit["Hash"] = invalidGUID + ":" + SToHex(SHashSHA1(invalidGUID + query));
             } else {
                 commit["Hash"] = "incorrect hash";
             }
-            SData failedResponse = response;
-            failedResponse.content = commit.serialize();
-            node._onMESSAGE(peer, failedResponse);
+            string replicationError;
+            auto receive = [&](const SData& incoming) {
+                if (!live) {
+                    SData incomingResponse = response;
+                    incomingResponse.content = incoming.serialize();
+                    node._onMESSAGE(peer, incomingResponse);
+                    return;
+                }
+                SData transaction("TRANSACTION");
+                transaction["ID"] = incoming["CommitIndex"];
+                transaction["NewCount"] = incoming["CommitIndex"];
+                transaction["NewHash"] = incoming["Hash"];
+                transaction.content = incoming.content;
+                try {
+                    node._handleBeginTransaction(db, peer, transaction);
+                    if (!node._handlePrepareTransaction(db, peer, transaction, STimeNow())) {
+                        STHROW("prepare failed");
+                    }
+                    if (node._handleCommitTransaction(db, peer, transaction.calcU64("NewCount"), transaction["NewHash"]) != SQLITE_OK) {
+                        STHROW("commit failed");
+                    }
+                } catch (const exception& e) {
+                    // Exercise the same cleanup as the replication worker, without starting an asynchronous thread.
+                    replicationError = e.what();
+                    node._onReplicationError(db, peer, transaction, e.what());
+                }
+            };
+            receive(commit);
 
             EXPECT_TRUE(db.getLastTransactionType() == SQLite::TRANSACTION_TYPE::EXCLUSIVE);
-            EXPECT_TRUE(node.getState() == SQLiteNodeState::SEARCHING);
-            EXPECT_EQUAL(node._syncPeer, nullptr);
-            EXPECT_EQUAL(node._leadPeer.load(), nullptr);
-            EXPECT_FALSE(peer->loggedIn);
+            EXPECT_TRUE(node.getState() == (live ? SQLiteNodeState::FOLLOWING : SQLiteNodeState::SEARCHING));
+            if (live && (failure == "hash" || failure == "guid-value" || failure == "guid-digest" || failure == "guid-query")) {
+                EXPECT_TRUE(SContains(replicationError, "hash mismatch:"));
+            }
+            if (!live) {
+                EXPECT_EQUAL(node._syncPeer, nullptr);
+                EXPECT_EQUAL(node._leadPeer.load(), nullptr);
+                EXPECT_FALSE(peer->loggedIn);
+            }
             EXPECT_FALSE(db.insideTransaction());
             EXPECT_TRUE(sqlite3_get_autocommit(db.getDBHandle()));
             EXPECT_TRUE(db.getUncommittedHash().empty());
@@ -285,20 +462,24 @@ struct SQLiteNodeTest : tpunit::TestFixture
             EXPECT_EQUAL(db.read("SELECT COUNT(*) FROM syncTest;"), "0");
 
             // Retry the valid response on the same handle without any test-side rollback.
+            db.setCommitEnabled(true);
             node._changeState(state);
             peer->loggedIn = true;
-            if (subscribing) {
+            if (live || subscribing) {
                 node._leadPeer = peer;
             } else {
                 node._syncPeer = peer;
             }
-            node._onMESSAGE(peer, response);
-            EXPECT_TRUE(node.getState() == (subscribing ? SQLiteNodeState::FOLLOWING : SQLiteNodeState::WAITING));
+            receive(validCommit);
+            EXPECT_TRUE(node.getState() == (live || subscribing ? SQLiteNodeState::FOLLOWING : SQLiteNodeState::WAITING));
             EXPECT_EQUAL(db.getCommitCount(), commitCount + 1);
             EXPECT_EQUAL(db.getCommittedHash(), hash);
             EXPECT_FALSE(db.insideTransaction());
             EXPECT_TRUE(db.getUncommittedHash().empty());
             EXPECT_EQUAL(db.read("SELECT COUNT(*) FROM syncTest;"), "1");
+            string storedHash;
+            ASSERT_TRUE(db.getCommit(commitCount + 1, nullptr, &storedHash));
+            EXPECT_EQUAL(storedHash, hash);
         }
     }
 } __SQLiteNodeTest;

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -381,15 +381,14 @@ struct SQLiteNodeTest : tpunit::TestFixture
 
             // Prepare a valid wire payload without advancing the receiver's committed state.
             const string query = "INSERT INTO syncTest VALUES (1);";
-            const string guid = "00000000000000000000000000aBcDeF";
-            const string expectedHash = failure.find("guid-") == 0 ? guid + ":" + SToHex(SHashSHA1(guid + query)) : "";
+            const string guid = failure.find("guid-") == 0 ? "00000000000000000000000000aBcDeF" : "";
+            const string expectedHash = guid.empty() ? SToHex(SHashSHA1(committedHash + query)) :
+                guid + ":" + SToHex(SHashSHA1(guid + query));
             ASSERT_TRUE(db.beginTransaction());
             ASSERT_TRUE(db.writeUnmodified(query));
             string hash;
-            ASSERT_TRUE(db.prepare(nullptr, &hash, chrono::hours(24), nullptr, expectedHash));
-            if (!expectedHash.empty()) {
-                EXPECT_EQUAL(hash, expectedHash);
-            }
+            ASSERT_TRUE(db.prepare(nullptr, &hash, chrono::hours(24), nullptr, guid));
+            EXPECT_EQUAL(hash, expectedHash);
             SData commit("COMMIT");
             commit["CommitIndex"] = to_string(commitCount + 1);
             commit["Hash"] = hash;

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -58,6 +58,7 @@ struct SQLiteNodeTest : tpunit::TestFixture
                                            AFTER(SQLiteNodeTest::rollback),
                                            TEST(SQLiteNodeTest::testFindSyncPeer),
                                            TEST(SQLiteNodeTest::testGetPeerByName),
+                                           TEST(SQLiteNodeTest::testPrepareGUID),
                                            TEST(SQLiteNodeTest::testMixedHashHistory),
                                            TEST(SQLiteNodeTest::testGUIDHashFailures),
                                            TEST(SQLiteNodeTest::testReplicationRequiresLeader),
@@ -208,6 +209,35 @@ struct SQLiteNodeTest : tpunit::TestFixture
         testReplicationFailure("constraint");
     }
 
+    void testPrepareGUID()
+    {
+        SQLite& db = dbPool->getBase();
+        const uint64_t commitCount = db.getCommitCount();
+        const string committedHash = db.getCommittedHash();
+        const string query = "CREATE TABLE prepareGUIDTest (id INTEGER);";
+        for (const string guid : {"00000000000000000000000000aBcDeF", "", "00000000000000000000000000abcde0"}) {
+            ASSERT_TRUE(db.beginTransaction());
+            ASSERT_TRUE(db.writeUnmodified(query));
+            string hash;
+            ASSERT_TRUE(db.prepare(nullptr, &hash, chrono::hours(24), nullptr, guid));
+            const string expectedHash = guid.empty() ? SToHex(SHashSHA1(committedHash + query)) :
+                guid + ":" + SToHex(SHashSHA1(guid + query));
+            EXPECT_EQUAL(hash, expectedHash);
+            EXPECT_EQUAL(db.getUncommittedHash(), expectedHash);
+            EXPECT_EQUAL(db.getCommittedHash(), committedHash);
+            EXPECT_EQUAL(db.getCommitCount(), commitCount);
+            db.rollback();
+            EXPECT_TRUE(db.getUncommittedHash().empty());
+        }
+        for (const string& guid : {string(31, '0'), string(33, '0'), string(31, '0') + "g", string(32, '0') + ":" + string(40, '0')}) {
+            ASSERT_TRUE(db.beginTransaction());
+            ASSERT_TRUE(db.writeUnmodified(query));
+            EXPECT_FALSE(db.prepare(nullptr, nullptr, chrono::hours(24), nullptr, guid));
+            EXPECT_TRUE(db.getUncommittedHash().empty());
+            db.rollback();
+        }
+    }
+
     void testMixedHashHistory()
     {
         const vector<string> queries = {
@@ -327,7 +357,7 @@ struct SQLiteNodeTest : tpunit::TestFixture
 
     void testGUIDHashFailures()
     {
-        for (const string failure : {"guid-value", "guid-digest", "guid-query", "guid-short", "guid-long", "guid-nonhex"}) {
+        for (const string failure : {"guid-value", "guid-digest", "guid-query", "guid-short", "guid-long", "guid-nonhex", "guid-separator", "guid-no-separator"}) {
             testReplicationFailure(failure);
         }
     }
@@ -423,6 +453,11 @@ struct SQLiteNodeTest : tpunit::TestFixture
                 commit["Hash"].back() = hash.back() == '0' ? '1' : '0';
             } else if (failure == "guid-query") {
                 commit.content = "INSERT INTO syncTest VALUES (2);";
+            } else if (failure == "guid-separator") {
+                commit["Hash"][31] = ':';
+                commit["Hash"][32] = '0';
+            } else if (failure == "guid-no-separator") {
+                commit["Hash"].erase(32, 1);
             } else if (failure == "guid-short" || failure == "guid-long" || failure == "guid-nonhex") {
                 const string invalidGUID = failure == "guid-short" ? guid.substr(1) :
                     failure == "guid-long" ? guid + "0" : guid.substr(0, 31) + "g";

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -372,6 +372,10 @@ struct SQLiteNodeTest : tpunit::TestFixture
         node._leadPeer = node.getPeerByName("peer1");
         SQLitePeer* otherPeer = node.getPeerByName("peer2");
         otherPeer->loggedIn = true;
+        // Keep outgoing messages buffered without a transport, so an unexpected RECONNECT is observable.
+        auto socket = make_unique<STCPManager::Socket>(-1, STCPManager::Socket::CONNECTED);
+        ASSERT_TRUE(otherPeer->setSocket(socket.get()));
+        auto* peerSocket = socket.release(); // The peer owns the socket.
 
         SData transaction("TRANSACTION");
         transaction["CommitCount"] = to_string(commitCount + 1);
@@ -383,6 +387,8 @@ struct SQLiteNodeTest : tpunit::TestFixture
         transaction["Hash"] = transaction["NewHash"];
         node._onMESSAGE(otherPeer, transaction);
 
+        EXPECT_TRUE(otherPeer->connected());
+        EXPECT_TRUE(peerSocket->sendBufferEmpty());
         EXPECT_EQUAL(node._replicateThread, nullptr);
         EXPECT_TRUE(node._replicateQueue.empty());
         EXPECT_FALSE(db.insideTransaction());

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -60,6 +60,7 @@ struct SQLiteNodeTest : tpunit::TestFixture
                                            TEST(SQLiteNodeTest::testGetPeerByName),
                                            TEST(SQLiteNodeTest::testMixedHashHistory),
                                            TEST(SQLiteNodeTest::testGUIDHashFailures),
+                                           TEST(SQLiteNodeTest::testReplicationRequiresLeader),
                                            TEST(SQLiteNodeTest::testSynchronizeCommitFailure),
                                            TEST(SQLiteNodeTest::testSynchronizeWriteFailure),
                                            TEST(SQLiteNodeTest::testSynchronizeConstraintFailure),
@@ -329,6 +330,35 @@ struct SQLiteNodeTest : tpunit::TestFixture
         for (const string failure : {"guid-value", "guid-digest", "guid-query", "guid-short", "guid-long", "guid-nonhex"}) {
             testReplicationFailure(failure);
         }
+    }
+
+    void testReplicationRequiresLeader()
+    {
+        SQLiteNode node(server, dbPool, "test", "", peerList, configuredPriority, 1000000000, "1.0");
+        SQLite& db = dbPool->getBase();
+        const uint64_t commitCount = db.getCommitCount();
+        const string committedHash = db.getCommittedHash();
+        node._changeState(SQLiteNodeState::FOLLOWING);
+        node._leadPeer = node.getPeerByName("peer1");
+        SQLitePeer* otherPeer = node.getPeerByName("peer2");
+        otherPeer->loggedIn = true;
+
+        SData transaction("TRANSACTION");
+        transaction["CommitCount"] = to_string(commitCount + 1);
+        transaction["NewCount"] = transaction["CommitCount"];
+        transaction["ID"] = transaction["CommitCount"];
+        transaction.content = "CREATE TABLE nonLeaderTransaction (id INTEGER);";
+        const string guid = "00000000000000000000000000000001";
+        transaction["NewHash"] = guid + ":" + SToHex(SHashSHA1(guid + transaction.content));
+        transaction["Hash"] = transaction["NewHash"];
+        node._onMESSAGE(otherPeer, transaction);
+
+        EXPECT_EQUAL(node._replicateThread, nullptr);
+        EXPECT_TRUE(node._replicateQueue.empty());
+        EXPECT_FALSE(db.insideTransaction());
+        EXPECT_EQUAL(db.getCommitCount(), commitCount);
+        EXPECT_EQUAL(db.getCommittedHash(), committedHash);
+        EXPECT_EQUAL(db.read("SELECT COUNT(*) FROM sqlite_master WHERE name = 'nonLeaderTransaction';"), "0");
     }
 
     void testReplicationFailure(const string& failure)

--- a/test/tests/SRandomTest.cpp
+++ b/test/tests/SRandomTest.cpp
@@ -1,0 +1,96 @@
+#include <libstuff/SRandom.h>
+#include <test/lib/tpunit++.hpp>
+
+#include <array>
+#include <cstdint>
+#include <latch>
+#include <limits>
+#include <set>
+#include <string>
+#include <thread>
+
+struct SRandomTest : tpunit::TestFixture
+{
+    SRandomTest()
+        : tpunit::TestFixture("SRandom",
+                              TEST(SRandomTest::testBounds),
+                              TEST(SRandomTest::testStringsAndBooleans),
+                              TEST(SRandomTest::testConcurrentThreadWaves))
+    {
+    }
+
+    static constexpr const char* alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    void testBounds()
+    {
+        constexpr uint64_t maximum = std::numeric_limits<uint64_t>::max();
+        for (uint64_t endpoint : {uint64_t{0}, uint64_t{42}, maximum}) {
+            ASSERT_EQUAL(SRandom::limitedRand64(endpoint, endpoint), endpoint);
+        }
+        const uint64_t ranges[][2] = {{0, 1}, {7, 19}, {maximum - 1, maximum}, {0, maximum}};
+        for (const auto& [min, max] : ranges) {
+            for (int i = 0; i < 500; ++i) {
+                const auto value = SRandom::limitedRand64(min, max);
+                ASSERT_EQUAL(value >= min && value <= max, true);
+            }
+        }
+    }
+
+    void testStringsAndBooleans()
+    {
+        for (unsigned length : {0U, 1U, 16U, 256U}) {
+            const auto value = SRandom::randStr(length);
+            ASSERT_EQUAL(value.size(), length);
+            ASSERT_EQUAL(value.find_first_not_of(alphabet), std::string::npos);
+        }
+        for (int i = 0; i < 500; ++i) {
+            ASSERT_EQUAL(SRandom::randBool(0.0), false);
+            ASSERT_EQUAL(SRandom::randBool(1.0), true);
+        }
+    }
+
+    void testConcurrentThreadWaves()
+    {
+        struct Result {
+            std::array<uint64_t, 4> first{};
+            bool valid = true;
+        };
+        std::set<std::array<uint64_t, 4>> prefixes;
+        for (int wave = 0; wave < 2; ++wave) {
+            std::array<Result, 16> results{};
+            std::array<std::thread, 16> threads;
+            std::latch start(threads.size());
+            for (size_t t = 0; t < threads.size(); ++t) {
+                threads[t] = std::thread([&, t] {
+                    start.arrive_and_wait();
+                    auto& result = results[t];
+                    try {
+                        for (auto& value : result.first) {
+                            value = SRandom::rand64();
+                        }
+                        for (unsigned i = 0; i < 500; ++i) {
+                            SRandom::rand64();
+                            const auto bounded = SRandom::limitedRand64(7, 19);
+                            const auto text = SRandom::randStr(i % 33);
+                            result.valid &= bounded >= 7 && bounded <= 19;
+                            result.valid &= text.size() == i % 33 && text.find_first_not_of(alphabet) == std::string::npos;
+                            result.valid &= !SRandom::randBool(0.0);
+                            result.valid &= SRandom::randBool(1.0);
+                        }
+                    } catch (...) {
+                        result.valid = false;
+                    }
+                });
+            }
+            for (auto& thread : threads) {
+                thread.join();
+            }
+            // Compare prefixes across both waves to catch duplicate seeds and resets on thread recreation.
+            for (const auto& result : results) {
+                ASSERT_EQUAL(result.valid, true);
+                const bool unique = prefixes.insert(result.first).second;
+                ASSERT_EQUAL(unique, true);
+            }
+        }
+    }
+} __SRandomTest;

--- a/test/tests/SRandomTest.cpp
+++ b/test/tests/SRandomTest.cpp
@@ -23,7 +23,7 @@ struct SRandomTest : tpunit::TestFixture
 
     void testBounds()
     {
-        constexpr uint64_t maximum = std::numeric_limits<uint64_t>::max();
+        constexpr uint64_t maximum = numeric_limits<uint64_t>::max();
         for (uint64_t endpoint : {uint64_t{0}, uint64_t{42}, maximum}) {
             ASSERT_EQUAL(SRandom::limitedRand64(endpoint, endpoint), endpoint);
         }
@@ -41,7 +41,7 @@ struct SRandomTest : tpunit::TestFixture
         for (unsigned length : {0U, 1U, 16U, 256U}) {
             const auto value = SRandom::randStr(length);
             ASSERT_EQUAL(value.size(), length);
-            ASSERT_EQUAL(value.find_first_not_of(alphabet), std::string::npos);
+            ASSERT_EQUAL(value.find_first_not_of(alphabet), string::npos);
         }
         for (int i = 0; i < 500; ++i) {
             ASSERT_EQUAL(SRandom::randBool(0.0), false);
@@ -51,17 +51,18 @@ struct SRandomTest : tpunit::TestFixture
 
     void testConcurrentThreadWaves()
     {
-        struct Result {
-            std::array<uint64_t, 4> first{};
+        struct Result
+        {
+            array<uint64_t, 4> first{};
             bool valid = true;
         };
-        std::set<std::array<uint64_t, 4>> prefixes;
+        set<array<uint64_t, 4>> prefixes;
         for (int wave = 0; wave < 2; ++wave) {
-            std::array<Result, 16> results{};
-            std::array<std::thread, 16> threads;
-            std::latch start(threads.size());
+            array<Result, 16> results{};
+            array<thread, 16> threads;
+            latch start(threads.size());
             for (size_t t = 0; t < threads.size(); ++t) {
-                threads[t] = std::thread([&, t] {
+                threads[t] = thread([&, t] {
                     start.arrive_and_wait();
                     auto& result = results[t];
                     try {
@@ -73,7 +74,7 @@ struct SRandomTest : tpunit::TestFixture
                             const auto bounded = SRandom::limitedRand64(7, 19);
                             const auto text = SRandom::randStr(i % 33);
                             result.valid &= bounded >= 7 && bounded <= 19;
-                            result.valid &= text.size() == i % 33 && text.find_first_not_of(alphabet) == std::string::npos;
+                            result.valid &= text.size() == i % 33 && text.find_first_not_of(alphabet) == string::npos;
                             result.valid &= !SRandom::randBool(0.0);
                             result.valid &= SRandom::randBool(1.0);
                         }


### PR DESCRIPTION
### Details
This is the reader-first part of replacing chained hashes for parallel commits. The journal can now contain either the existing chained SHA1 or `GUID:SHA1`, where the GUID is a hex-encoded 128-bit random number and the digest is `SHA1(GUID + uncompressed SQL)`. The new format checks the current transaction only, not its history. Both live replication and synchronization accept it. `prepare()` takes just the optional GUID; callers extract it from messages and still verify the complete hash before committing. Local generation is implemented but hard-disabled until these readers are deployed everywhere.

The formats can be intermixed. When we switch back to chained hashes, the next hash includes the entire previous `GUID:SHA1`, so an older leader can continue from GUID entries already in its database. It still cannot catch up through GUID entries it has not received; rollback versions that need to synchronize must support reading them. We also reject live transactions from peers other than the selected leader, since the new hashes no longer detect a mismatched previous history.

GUID generation uses two `SRandom::rand64()` draws. To make those safe without a shared lock, `SRandom` now owns its engine through a thread-local `unique_ptr`, allocated and seeded only on that thread's first use and destroyed at thread exit. Normal draws use no shared mutable state. Initialization uses eight `random_device` draws through `seed_seq`; Valgrind builds use a seed counter so new threads do not all repeat the same sequence. The public API is unchanged and the generator remains non-cryptographic.

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/337537

### Tests
Added coverage for mixed-format histories, identical SQL with different GUIDs, compressed and empty transactions, corruption and malformed GUID rejection, rollback/retry, reopening a GUID-tailed journal and resuming legacy hashes, and rejecting non-leader transactions. The RNG tests cover bounds, strings, boolean endpoints, concurrent calls to all four APIs, and distinct streams across two waves of new threads.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
