### PR TITLE
Always generate GUID journal hashes

### DIFF
--- a/docs/blockchain.md
+++ b/docs/blockchain.md
@@ -9,7 +9,7 @@ Though the blockchain hype has largely come and gone, it's worth pointing out th
 To be clear, Bedrock is not a "public" blockchain, like Bitcoin -- it is not designed to synchronize a series of records between thousands or millions of anonymous peers over the open internet.  Rather, Bedrock uses a "private" blockchain, meaning that a small cluster of servers (3-6) operating in a controlled environment connect to each other on an equal footing to synchronize a historical record of commits, and apply them in the same order.
 
 ## The Journal
-With chained hashes (the default), it works like this:
+New local commits use the GUID transaction hashes described below. Existing journals can also contain legacy chained hashes, which work like this:
 
 * Journal entries have three columns:
     * `id` - Simple monotonic index
@@ -29,13 +29,13 @@ With chained hashes (the default), it works like this:
 The sum of all this ensures that all of the cluster stays in perfect sync (and refuses to talk to those nodes that have forked), all without any of them being "in charge".  This is the heart of what makes a distributed ledger so special, and has processed (as of this writing) 4,287,514,530 successful commits on the database to date.
 
 ## GUID Transaction Hashes
-The journal and replication receivers also accept `GUID:SHA1`. The GUID is 16 random bytes encoded as 32 hex characters without hyphens. The digest is the same uppercase, 40-character hex SHA1 used by chained hashes, but its input is the GUID text followed by the current transaction's uncompressed SQL, without a colon or previous hash.
+Local transactions always generate `GUID:SHA1`. The GUID is 16 random bytes encoded as 32 hex characters without hyphens. The digest is the same uppercase, 40-character hex SHA1 used by chained hashes, but its input is the GUID text followed by the current transaction's uncompressed SQL, without a colon or previous hash.
 
 This format checks only the current transaction's integrity. The GUID distinguishes independently created transactions even when their SQL is identical. Fork detection compares the complete stored hash and relies on transactions being applied contiguously, in order; it does not verify a cryptographic chain across GUID entries.
 
 Both formats can appear in the same journal. A chained hash following a GUID hash uses the entire previous `GUID:SHA1` string, followed by the current SQL, as its input. Neither storage nor transmission strips the GUID.
 
-Local GUID generation is implemented but hard-disabled in `SQLiteCore::commit()`. Deploy mixed-format readers everywhere before enabling generation. An older binary can continue writing chained hashes on a database that already contains GUID entries, but cannot replay GUID entries it has not received. Once generation is enabled, rollback versions that may need to synchronize must retain mixed-format reading.
+`SQLite::prepare()` generates a GUID unless replication supplies the received GUID or an explicit empty string for a legacy chained hash. Both live replication and synchronization recompute and validate the complete received hash, preserving either format in the journal. Deploy mixed-format readers everywhere before deploying GUID generation; rollback versions that may need to synchronize must also retain mixed-format reading.
 
 ## Technical Notes
 The above skips over a couple important details:

--- a/sqlitecluster/SQLite.cpp
+++ b/sqlitecluster/SQLite.cpp
@@ -7,6 +7,7 @@
 
 #include <libstuff/libstuff.h>
 #include <libstuff/SDeburr.h>
+#include <libstuff/SRandom.h>
 #include <plugins/Compression.h>
 #include <libstuff/SQResult.h>
 #include <string>
@@ -990,10 +991,12 @@ bool SQLite::_writeIdempotent(const string& query, const map<string, Parameter>&
     return true;
 }
 
-bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::microseconds commitLockTimeout, atomic<bool>* abortPtr, const string& guid)
+bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::microseconds commitLockTimeout, atomic<bool>* abortPtr, const optional<string>& replicationGUID)
 {
     SASSERT(_insideTransaction);
 
+    const string guid = replicationGUID.has_value() ? replicationGUID.value() :
+        SToHex(SRandom::rand64(), 16) + SToHex(SRandom::rand64(), 16);
     if (!guid.empty() && (guid.size() != 32 || guid.find_first_not_of("0123456789ABCDEFabcdef") != string::npos)) {
         SWARN("Invalid transaction GUID");
         return false;
@@ -1081,7 +1084,7 @@ bool SQLite::prepare(uint64_t* transactionID, string* transactionhash, chrono::m
 
     // Queue up the journal entry
     if (guid.empty()) {
-        // Legacy commits chain from the entire previous hash, including GUID:SHA1 when present.
+        // Replaying legacy commits requires the entire previous hash, including GUID:SHA1 when present.
         _uncommittedHash = SToHex(SHashSHA1(getCommittedHash() + _uncommittedQuery));
     } else {
         _uncommittedHash = guid + ":" + SToHex(SHashSHA1(guid + _uncommittedQuery));

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -4,6 +4,7 @@
 #include <libstuff/SQResult.h>
 #include <libstuff/SPerformanceTimer.h>
 
+#include <optional>
 #include <shared_mutex>
 
 class SQLite {
@@ -187,9 +188,10 @@ public:
     // The commitLockTimeout, if passed, will limit the time we wait for the lock. If not, we'll use 24 hours, which
     // is effectively no timeout.
     // Note that if this transaction fails to commit, these will not ultimately be accurate.
-    // A nonempty guid must be 32 hex characters and selects GUID:SHA1 hashing; an empty guid selects chained SHA1.
+    // Local transactions generate a new GUID. Replication supplies the received GUID (32 hex characters), or an
+    // explicit empty string to recompute a legacy chained SHA1.
     // Replication callers must compare the prepared hash with the received hash before committing.
-    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr, chrono::microseconds commitLockTimeout = chrono::hours(24), atomic<bool>* abortPtr = nullptr, const string& guid = "");
+    bool prepare(uint64_t* transactionID = nullptr, string* transactionHash = nullptr, chrono::microseconds commitLockTimeout = chrono::hours(24), atomic<bool>* abortPtr = nullptr, const optional<string>& replicationGUID = nullopt);
 
     // This enables or disables automatic re-writing. This feature is to support mocked requests and load testing. This
     // overloads set_authorizer to allow a plugin to deny certain queries from running (currently based only on the

--- a/sqlitecluster/SQLiteCore.cpp
+++ b/sqlitecluster/SQLiteCore.cpp
@@ -1,5 +1,4 @@
 #include <libstuff/AutoScopeOnPrepare.h>
-#include <libstuff/SRandom.h>
 #include <libstuff/libstuff.h>
 #include "SQLiteCore.h"
 #include "SQLite.h"
@@ -17,16 +16,9 @@ bool SQLiteCore::commit(const SQLiteNode& node, uint64_t& commitID, string& tran
     {
         AutoScopeOnPrepare onPrepare(needsPluginNotification, _db, notificationHandler);
 
-        // Keep local generation disabled until every node can receive GUID hashes, including rollback versions.
-        static constexpr bool generateGUIDHashes = false;
-        string guid;
-        if (generateGUIDHashes) {
-            guid = SToHex(SRandom::rand64(), 16) + SToHex(SRandom::rand64(), 16);
-        }
-
         // This will fail only if we can't acquire the commit lock respecting the command timeout, or the command is aborted while waiting for it.
         // In this case, we want to roll back and return false, which will make the caller return the appropriate exception.
-        if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout, abortPtr, guid)) {
+        if (!_db.prepare(&commitID, &transactionHash, commitLockTimeout, abortPtr)) {
             _db.rollback(commandName);
             return false;
         }

--- a/test/tests/SQLiteNodeTest.cpp
+++ b/test/tests/SQLiteNodeTest.cpp
@@ -1,6 +1,7 @@
 #include <libstuff/libstuff.h>
 #include <plugins/Compression.h>
 #include <sqlitecluster/SQLiteCommand.h>
+#include <sqlitecluster/SQLiteCore.h>
 #include <sqlitecluster/SQLiteNode.h>
 #include <sqlitecluster/SQLitePeer.h>
 #include <sqlitecluster/SQLiteServer.h>
@@ -59,6 +60,7 @@ struct SQLiteNodeTest : tpunit::TestFixture
                                            TEST(SQLiteNodeTest::testFindSyncPeer),
                                            TEST(SQLiteNodeTest::testGetPeerByName),
                                            TEST(SQLiteNodeTest::testPrepareGUID),
+                                           TEST(SQLiteNodeTest::testGenerateGUID),
                                            TEST(SQLiteNodeTest::testMixedHashHistory),
                                            TEST(SQLiteNodeTest::testGUIDHashFailures),
                                            TEST(SQLiteNodeTest::testReplicationRequiresLeader),
@@ -238,6 +240,51 @@ struct SQLiteNodeTest : tpunit::TestFixture
         }
     }
 
+    void testGenerateGUID()
+    {
+        SQLiteNode node(server, dbPool, "test", "", peerList, configuredPriority, 1000000000, "1.0");
+        node._changeState(SQLiteNodeState::LEADING);
+        SQLite& db = dbPool->getBase();
+        SQLiteCore core(db);
+        set<string> guids;
+        for (const string query : {"CREATE TABLE IF NOT EXISTS generatedGUIDTest (id INTEGER);", ""}) {
+            // Retry identical SQL after rollback, then commit it through the local leader path.
+            for (int attempt = 0; attempt < 3; ++attempt) {
+                const uint64_t commitCount = db.getCommitCount();
+                const string committedHash = db.getCommittedHash();
+                ASSERT_TRUE(db.beginTransaction());
+                ASSERT_TRUE(db.writeUnmodified(query));
+                uint64_t commitID;
+                string hash;
+                if (attempt == 2) {
+                    ASSERT_TRUE(core.commit(node, commitID, hash, "testGenerateGUID", false));
+                } else {
+                    ASSERT_TRUE(db.prepare(&commitID, &hash));
+                }
+                ASSERT_EQUAL(hash.size(), (size_t) 73);
+                EXPECT_EQUAL(hash[32], ':');
+                const string guid = hash.substr(0, 32);
+                EXPECT_EQUAL(guid.find_first_not_of("0123456789ABCDEFabcdef"), string::npos);
+                EXPECT_TRUE(guids.insert(guid).second);
+                EXPECT_EQUAL(hash, guid + ":" + SToHex(SHashSHA1(guid + query)));
+                EXPECT_EQUAL(commitID, commitCount + 1);
+                if (attempt == 2) {
+                    EXPECT_EQUAL(db.getCommittedHash(), hash);
+                    string storedQuery, storedHash;
+                    ASSERT_TRUE(db.getCommit(commitID, &storedQuery, &storedHash));
+                    EXPECT_EQUAL(storedQuery, query);
+                    EXPECT_EQUAL(storedHash, hash);
+                } else {
+                    EXPECT_EQUAL(db.getUncommittedHash(), hash);
+                    EXPECT_EQUAL(db.getCommittedHash(), committedHash);
+                    EXPECT_EQUAL(db.getCommitCount(), commitCount);
+                    db.rollback();
+                }
+                EXPECT_TRUE(db.getUncommittedHash().empty());
+            }
+        }
+    }
+
     void testMixedHashHistory()
     {
         const vector<string> queries = {
@@ -345,13 +392,14 @@ struct SQLiteNodeTest : tpunit::TestFixture
         ASSERT_TRUE(db.beginTransaction());
         ASSERT_TRUE(db.writeUnmodified(query));
         ASSERT_TRUE(db.prepare());
-        const string legacyHash = SToHex(SHashSHA1(committedHash + query));
-        EXPECT_EQUAL(db.getUncommittedHash().size(), (size_t) 40);
-        EXPECT_EQUAL(db.getUncommittedHash(), legacyHash);
+        const string hash = db.getUncommittedHash();
+        ASSERT_EQUAL(hash.size(), (size_t) 73);
+        const string guid = hash.substr(0, 32);
+        EXPECT_EQUAL(hash, guid + ":" + SToHex(SHashSHA1(guid + query)));
         ASSERT_EQUAL(db.commit(), SQLITE_OK);
         string storedHash;
         ASSERT_TRUE(db.getCommit(commitCount + 1, nullptr, &storedHash));
-        EXPECT_EQUAL(storedHash, legacyHash);
+        EXPECT_EQUAL(storedHash, hash);
         EXPECT_EQUAL(db.read("SELECT COUNT(*) FROM hashTest;"), "4");
     }
 


### PR DESCRIPTION
~HOLD for:
https://github.com/Expensify/Bedrock/pull/2777~

Needs to be fully deployed.

### Details
This is the writer follow-up to [the mixed-format readers](https://github.com/Expensify/Bedrock/pull/2777). Local transactions always generate `GUID:SHA1` in `SQLite::prepare()`, and the disabled generation gate in `SQLiteCore` is removed. Replication still supplies the received GUID, or an explicit empty string for a chained hash, so live replication and synchronization continue to recompute and validate both formats.

This must wait until the mixed-format readers are deployed everywhere. Any rollback version that may need to synchronize must also support them.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/337537

### Tests
Added coverage for automatic GUID generation through both `prepare()` and leader commits, distinct GUIDs when retrying identical SQL, empty transactions, persisted hashes, and continuing with GUID hashes after reopening the journal. Existing mixed-history and corruption-rejection tests still run for live replication, synchronization, and subscription.

### AI Tests
- Reproduced the new tests failing before the implementation: both default preparation and post-restart commits produced 40-character hashes instead of 73.
- Rebuilt Bedrock, both test binaries, and the test plugin with Clang 18 in the Vagrant VM. JSON symbol checks passed.
- Rebuilt Auth against this Bedrock worktree successfully.
- `./test -only SQLiteNode,SRandom,LibStuff,AfterCommitCallback,WriteLocalUnreplicated,JournalDeleter -threads 4`: 64 passed, 0 failed, in both WAL and HCTree modes.
- `./clustertest -only ForkCheck,Compression,MultipleLeaderSync,BoundParameters,GracefulFailover -threads 4`: 8 passed, 0 failed, in WAL mode. The first invocation exceeded the 120-second command timeout; the rerun with a longer timeout completed successfully.
- `git diff --check` passed. Full suites and HCTree cluster tests were not run.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes
