### PR TITLE
Reduce unnecessary Bedrock compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ JSONOBJ = $(JSONCPP:%.cpp=$(INTERMEDIATEDIR)/%.o)
 JSONDEP = $(JSONCPP:%.cpp=$(INTERMEDIATEDIR)/%.d)
 
 # The same for libbedrock.
-LIBBEDROCKCPP = $(shell find * -name '*.cpp' -not -name main.cpp -not -path 'test*' -not -path 'libstuff*')
+LIBBEDROCKCPP = $(shell find * -name '*.cpp' -not -name main.cpp -not -path 'test*' -not -path 'libstuff*' -not -path 'benchmarks*')
 LIBBEDROCKOBJ = $(LIBBEDROCKCPP:%.cpp=$(INTERMEDIATEDIR)/%.o)
 LIBBEDROCKDEP = $(LIBBEDROCKCPP:%.cpp=$(INTERMEDIATEDIR)/%.d)
 
@@ -159,7 +159,7 @@ $(INTERMEDIATEDIR)/plugins/MySQL.d $(INTERMEDIATEDIR)/plugins/MySQL.o: plugins/M
 # This builds both the dependencies and the object file from the cpp.
 # We include one of the mbedtls files as a dependency because building it will cause our header files to get created,
 # which many of our cpp files will reference.
-$(INTERMEDIATEDIR)/%.d $(INTERMEDIATEDIR)/%.o: %.cpp mbedtls/library/libmbedcrypto.a
+$(INTERMEDIATEDIR)/%.d $(INTERMEDIATEDIR)/%.o: %.cpp | mbedtls/library/libmbedcrypto.a
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -MMD -MF $(INTERMEDIATEDIR)/$*.d -MT $(INTERMEDIATEDIR)/$*.o -o $(INTERMEDIATEDIR)/$*.o -c $<
 
@@ -169,14 +169,25 @@ $(INTERMEDIATEDIR)/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) -g $(BEDROCK_OPTIM_COMPILE_FLAG) -fPIC $(AMALGAMATION_FLAGS) -std=gnu23 -o $@ -c $<
 
-# Bring in the dependency files. This will cause them to be created if necessary. This is skipped if we're cleaning, as
-# they'll just get deleted anyway.
-ifneq ($(MAKECMDGOALS),clean)
--include $(LIBBEDROCKDEP)
--include $(STUFFDEP)
--include $(JSONDEP)
--include $(TESTDEP)
--include $(CLUSTERTESTDEP)
--include $(BEDROCKDEP)
--include $(TESTPLUGINTDEP)
+# Bring in dependency files for the requested targets. Missing included dependency files are rebuilt along with their
+# object files, so including test dependencies in a production-only build unnecessarily compiles the tests.
+REQUESTED_GOALS := $(if $(strip $(MAKECMDGOALS)),$(MAKECMDGOALS),all)
+DEPS_TO_INCLUDE := $(LIBBEDROCKDEP) $(STUFFDEP) $(JSONDEP) $(BEDROCKDEP)
+DEPS_TO_INCLUDE += $(patsubst %.o,%.d,$(filter $(INTERMEDIATEDIR)/%.o,$(REQUESTED_GOALS)))
+
+ifneq ($(filter all test test/test,$(REQUESTED_GOALS)),)
+DEPS_TO_INCLUDE += $(TESTDEP)
+endif
+ifneq ($(filter all clustertest test/clustertest/clustertest,$(REQUESTED_GOALS)),)
+DEPS_TO_INCLUDE += $(CLUSTERTESTDEP)
+endif
+ifneq ($(filter all clustertest testplugin test/clustertest/testplugin/testplugin.so,$(REQUESTED_GOALS)),)
+DEPS_TO_INCLUDE += $(TESTPLUGINTDEP)
+endif
+ifneq ($(filter bench,$(REQUESTED_GOALS)),)
+DEPS_TO_INCLUDE += $(BENCHDEP)
+endif
+
+ifeq ($(filter clean,$(REQUESTED_GOALS)),)
+-include $(sort $(DEPS_TO_INCLUDE))
 endif

--- a/libstuff/libstuff.cpp
+++ b/libstuff/libstuff.cpp
@@ -30,6 +30,7 @@
 #include <libstuff/SData.h>
 #include <libstuff/SFastBuffer.h>
 #include <libstuff/SFluentdLogger.h>
+#include <libstuff/qrf.h>
 #include <libstuff/sqlite3.h>
 
 // Additional headers

--- a/libstuff/libstuff.h
+++ b/libstuff/libstuff.h
@@ -1,11 +1,11 @@
 #ifndef LIBSTUFF_H
 #define LIBSTUFF_H
-#include "libstuff/qrf.h"
 #include "libstuff/SQliteParameter.h"
 
 #include <netinet/in.h>
 #include <poll.h>
 #include <libgen.h>
+#include <stdlib.h>
 #include <syslog.h>
 
 #include <algorithm>
@@ -25,6 +25,7 @@
 struct sockaddr_in;
 struct pollfd;
 struct sqlite3;
+struct sqlite3_qrf_spec;
 class SQResult;
 class SFastBuffer;
 struct SData;

--- a/plugins/DB.h
+++ b/plugins/DB.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <libstuff/qrf.h>
 #include <libstuff/SQliteParameter.h>
 #include <libstuff/libstuff.h>
 #include "../BedrockPlugin.h"

--- a/sqlitecluster/SQLite.h
+++ b/sqlitecluster/SQLite.h
@@ -6,6 +6,8 @@
 
 #include <shared_mutex>
 
+struct sqlite3_qrf_spec;
+
 class SQLite {
 public:
     // Re-export SQliteParameter as SQLite::Parameter so callers can write SQLite::Parameter::text("foo") etc.


### PR DESCRIPTION
### Details

`make bedrock` currently remakes every missing included test dependency file and its paired object, so a clean production-only build compiles 84 unrelated test translation units. This scopes dependency includes to requested goals, excludes benchmark sources from `libbedrock.a`, keeps the mbedTLS archive as an ordering dependency, and removes QRF's 702 KB SQLite include from the ubiquitous `libstuff.h` path. On a 6-vCPU VM, three alternating clean production runs improved from a 27.99s median to 10.48s (62.6%); QRF invalidation improved from 24.91s to 3.61s, and mbedTLS archive invalidation from 25.09s to 0.87s. A full `make all` also improved from 21.92s to 20.99s while retaining the complete test build.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/661690

### Tests
Compilation only.