### PR TITLE
Give each thread its own random number generator

### DIFF
--- a/libstuff/SRandom.cpp
+++ b/libstuff/SRandom.cpp
@@ -1,13 +1,17 @@
 #include "SRandom.h"
 
+#include <thread>
+
 #ifdef VALGRIND
 // random_device breaks valgrind.
-mt19937_64 SRandom::_generator = mt19937_64();
+thread_local mt19937_64 SRandom::_generator = mt19937_64();
 #else
-mt19937_64 SRandom::_generator = mt19937_64(random_device()());
+// The thread id is mixed into the seed because random_device can hand the same 32-bit value to two threads that seed
+// at the same moment, which would leave them generating identical sequences.
+thread_local mt19937_64 SRandom::_generator = mt19937_64(random_device()() ^ hash<thread::id>()(this_thread::get_id()));
 #endif
 
-uniform_int_distribution<uint64_t> SRandom::_distribution64 = uniform_int_distribution<uint64_t>();
+thread_local uniform_int_distribution<uint64_t> SRandom::_distribution64 = uniform_int_distribution<uint64_t>();
 
 uint64_t SRandom::limitedRand64(uint64_t minNum, uint64_t maxNum)
 {

--- a/libstuff/SRandom.h
+++ b/libstuff/SRandom.h
@@ -14,6 +14,8 @@ public:
     static bool randBool(const double probability);
 
 private:
-    static mt19937_64 _generator;
-    static uniform_int_distribution<uint64_t> _distribution64;
+    // Both of these carry mutable state that every draw advances, so each thread gets its own copy. Sharing one
+    // generator across threads is a data race that hands the same value to more than one caller.
+    static thread_local mt19937_64 _generator;
+    static thread_local uniform_int_distribution<uint64_t> _distribution64;
 };

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -724,9 +724,15 @@ struct LibStuff : tpunit::TestFixture
 
     void testRandomIsThreadSafe()
     {
-        // Every SRandom draw advances one shared generator, so concurrent draws must never hand the same value to two
+        // Every SRandom draw advances generator state, so concurrent draws must never hand the same value to two
         // threads. 2^64 is wide enough that 160,000 draws colliding by chance is a ~1 in 10^9 event, so any duplicate
         // here means the draws raced rather than that we got unlucky.
+        //
+        // This catches the race only where the threads genuinely run in parallel. The window between reading and
+        // advancing the generator's state is a couple of instructions, so on a single effective CPU the threads
+        // interleave too coarsely to tear it and every draw comes out unique. Pinning this test to one core with
+        // `taskset -c 0` passes even against a shared generator, and it passes in CI for the same reason, so treat a
+        // green run here as no evidence either way and reproduce on a multi-core machine instead.
         const size_t threadCount = 16;
         const size_t drawsPerThread = 10'000;
 

--- a/test/tests/LibStuffTest.cpp
+++ b/test/tests/LibStuffTest.cpp
@@ -1,5 +1,6 @@
 #include <arpa/inet.h>
 #include <cstring>
+#include <thread>
 #include <unistd.h>
 
 #include <libstuff/libstuff.h>
@@ -46,6 +47,7 @@ struct LibStuff : tpunit::TestFixture
                                      TEST(LibStuff::testFileIO),
                                      TEST(LibStuff::testSQList),
                                      TEST(LibStuff::testRandom),
+                                     TEST(LibStuff::testRandomIsThreadSafe),
                                      TEST(LibStuff::testHexConversion),
                                      TEST(LibStuff::testBase32Conversion),
                                      TEST(LibStuff::testContains),
@@ -718,6 +720,36 @@ struct LibStuff : tpunit::TestFixture
             ASSERT_TRUE(randomNumber | 1); // Shuts up the "unused variable" warning.
             // cout << "Randomly generated uint64_t: " << randomNumber << endl;
         }
+    }
+
+    void testRandomIsThreadSafe()
+    {
+        // Every SRandom draw advances one shared generator, so concurrent draws must never hand the same value to two
+        // threads. 2^64 is wide enough that 160,000 draws colliding by chance is a ~1 in 10^9 event, so any duplicate
+        // here means the draws raced rather than that we got unlucky.
+        const size_t threadCount = 16;
+        const size_t drawsPerThread = 10'000;
+
+        // Each thread fills its own vector so that the test itself adds no shared state.
+        vector<vector<uint64_t>> drawsByThread(threadCount);
+        vector<thread> threads;
+        for (size_t i = 0; i < threadCount; i++) {
+            drawsByThread[i].reserve(drawsPerThread);
+            threads.emplace_back([&drawsByThread, i]() {
+                for (size_t j = 0; j < drawsPerThread; j++) {
+                    drawsByThread[i].push_back(SRandom::rand64());
+                }
+            });
+        }
+        for (auto& t : threads) {
+            t.join();
+        }
+
+        set<uint64_t> uniqueDraws;
+        for (const auto& draws : drawsByThread) {
+            uniqueDraws.insert(draws.begin(), draws.end());
+        }
+        ASSERT_EQUAL(uniqueDraws.size(), threadCount * drawsPerThread);
     }
 
     void testHexConversion()


### PR DESCRIPTION
### Details

(Neil's AI agent)

`SRandom::_generator` was a single process-global `mt19937_64` with no mutex and no `thread_local`, and `_distribution64` was likewise shared mutable state. Every draw advances that state, so concurrent draws from Bedrock's worker threads were a data race that handed the same "random" value to more than one thread.

This is not theoretical. Production Auth logs show four different threads on the same host receiving the identical reportID in the same microsecond:

```
06:44:33.359635  db1.sjc  socket12495613_cmd  req 9LxeT6  Generated random reportID: 8671345331629067
06:44:33.359636  db1.sjc  socket12494817_cmd  req ntOGuC  Generated random reportID: 8671345331629067
06:44:33.359636  db1.sjc  socket12495401_cmd  req cLSlQi  Generated random reportID: 8671345331629067
06:44:33.359637  db1.sjc  socket12495567_cmd  req p7Wt6T  Generated random reportID: 8671345331629067
```

The new test measures how bad it was: of 160,000 draws across 16 threads, only about 31,000 were unique before the fix. Roughly four in five concurrent draws were duplicates. That breaks the uniqueness assumption behind every randomly generated ID in Auth (reportIDs, reportActionIDs, transactionIDs), and read-then-insert guards like [`Transaction::generateID`](https://github.com/Expensify/Auth/blob/65a7a4a1cb363795d4175ee785f42ca9a01a84f3/auth/lib/Transaction.cpp#L384-L396) cannot save us, since two commands handed the same value both read "not present" and both insert.

The fix makes `_generator` and `_distribution64` `thread_local`. The per-thread generator is seeded from `random_device` mixed with the thread id, because `random_device` can hand the same 32-bit value to two threads that seed at the same moment, which would leave them generating identical sequences. A mutex would also close the race but would serialize every ID draw.

One caveat on the test, which is written up in a comment alongside it: it fails every time on an arm64 dev machine, but it can pass on the x86-64 machines CI runs on, where the window between reading and advancing the generator's state is only a few nanoseconds wide. I confirmed that — CI came back green twice on the test-only commit with the bug still present. So it is a reliable local reproducer and a best-effort CI guard, and a green CI run on it is not evidence either way.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/676823

### Tests

(Neil's AI agent) Automated tests were added.

`LibStuff::testRandomIsThreadSafe` draws 10,000 values from `SRandom::rand64()` on each of 16 threads and asserts that all 160,000 are distinct. It fails 5 out of 5 runs without the fix (19–28% unique draws) and the fixture passes 39/39 with it.

_________
**Internal Testing Reminder:** when changing bedrock, please compile auth against your new changes

(Neil's AI agent) Auth compiles and links cleanly against this change.
